### PR TITLE
Do not test machine and OS-specific integers

### DIFF
--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -260,7 +260,6 @@ class Magick_UT < Test::Unit::TestCase
       assert_nothing_raised { Magick.set_log_format("format %d%e%f") }
     end
 
-    # put old limits back in place after testing
     def test_limit_resources
         cur = new = nil
 


### PR DESCRIPTION
These values are machine and OS-dependent.
ImageMagick 6.8.9 (r15243) has the following definitions:

magick/resource.c:110:

```
MagickULLConstant(1536)*1024*1024, /* memory limit */
MagickULLConstant(3072)*1024*1024, /* map limit */
MagickResourceInfinity,            /* disk limit */
MagickULLConstant(768),            /* file limit */
```

magick/magick-type.h:36:

```
#  define MagickULLConstant(c)  (MagickSizeType) (c ## ULL)
```

magick/magick-type.h:151:

```
typedef unsigned long long MagickSizeType;
```

When building on Windows, other definitions take place.
So, I think the initial values should not be in the tests at all.
