### PR TITLE
Fixed: build error on Windows Ruby x64 (with ImageMagick 6.8.0-10 or Ima...

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -164,7 +164,11 @@ elsif RUBY_PLATFORM =~ /mingw/  # mingw
   `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-\d+ /
   abort "Unable to get ImageMagick version" unless $1
   $magick_version = $1
-  $LOCAL_LIBS = '-lCORE_RL_magick_ -lX11'
+  if RUBY_PLATFORM =~ /x64/
+    $LOCAL_LIBS = '-lCORE_RL_magick_'
+  else
+    $LOCAL_LIBS = '-lCORE_RL_magick_ -lX11'
+  end
 
 else  # mswin
 


### PR DESCRIPTION
Hi. Nice to see it maintained again!

Fixed: build error on Windows Ruby x64 (with ImageMagick 6.8.0-10 / ImageMagick 6.8.7-7)
  ruby 2.0.0p451 (2014-02-24) [x64-mingw32]

```
  if RUBY_PLATFORM =~ /x64/
    $LOCAL_LIBS = '-lCORE_RL_magick_'
  else
    $LOCAL_LIBS = '-lCORE_RL_magick_ -lX11'
  end
```

> For the 64-bit build, you will also need to disable X11 support.

<cite>[ImageMagick: Advanced Windows Source Installation](http://www.imagemagick.org/script/advanced-windows-installation.php)</cite>
