### PR TITLE
Fixed: test_convolve(Image2_UT) in Image2.rb fails #72

### DIFF
--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -124,7 +124,7 @@ class Image2_UT < Test::Unit::TestCase
         assert_raise(IndexError) { @img.convolve(5, kernel) }
         assert_raise(IndexError) { @img.convolve(order, "x") }
         assert_raise(TypeError) { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }
-        assert_raise(Magick::ImageMagickError) { @img.convolve(2, [1.0, 1.0, 1.0, 1.0]) }
+        assert_raise(Magick::ImageMagickError) { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }
     end
 
     def test_convolve_channel


### PR DESCRIPTION
From ImageMagick 6.8.4, this error occurred.
Because some argument validation was deleted.

deleted validation:

```
  if ((width % 2) == 0)
    ThrowImageException(OptionError,"KernelWidthMustBeAnOddNumber");
```

<cite>[effect.c (ImageMagick 6.8.3)](https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.3/magick/effect.c#L933)</cite>
<cite>[effect.c (ImageMagick 6.8.4)](https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.4/magick/effect.c#L877)</cite>

Therefore, another exception should be raised.
I selected "memory allocation failed" (Allocation size=-1)

```
assert_raise(Magick::ImageMagickError) { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }
```
