### PR TITLE
Fixed: test_export_pixels_to_str(Image2_UT) in Image2.rb fails

### DIFF
--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -582,7 +582,7 @@ class Image2_UT < Test::Unit::TestCase
         end
         assert_nothing_raised do
             res = @img.export_pixels_to_str(0, 0, 10, 10, "I", Magick::LongPixel)
-            assert_equal(10*10*8, res.length)
+            assert_equal(10*10*[1].pack("L!").length, res.length)
         end
         assert_nothing_raised do
             res = @img.export_pixels_to_str(0, 0, 10, 10, "I", Magick::FloatPixel)


### PR DESCRIPTION
# Failure

On x86 or windows x64:

```
Failure:
test_export_pixels_to_str(Image2_UT)
Image2.rb:585:in `block in test_export_pixels_to_str'
Image2.rb:583:in `test_export_pixels_to_str'
     580:             res = @img.export_pixels_to_str(0, 0, 10, 10, "I", Magick::IntegerPixel)
     581:             assert_equal(10*10*4, res.length)
     582:         end
  => 583:         assert_nothing_raised do
     584:             res = @img.export_pixels_to_str(0, 0, 10, 10, "I", Magick::LongPixel)
     585:             assert_equal(10*10*8, res.length)
     586:         end
<800> expected but was
<400>

diff:
? 800
? 4
```
# LongPixel

LongPixel is unsigned long, so it should be 400 on x86 and windows x64.

```
        case LongPixel:
            sz = sizeof(unsigned long);
            break;
```

<cite>[rmagick/rmimage.c at 962d56cba3a132d590be1dd062f2a3a2efa48545 · gemhome/rmagick](https://github.com/gemhome/rmagick/blob/962d56cba3a132d590be1dd062f2a3a2efa48545/ext/RMagick/rmimage.c#L6041)</cite>
# Changed

10_10_8 -> 10_10_[1].pack("L!").length

> exclamation mark (“!”) to use the underlying platform’s native size for the specified type;
> 
>   L_, L!    | Integer | unsigned long, native endian

<cite>[Class: Array (Ruby 2.1.2)](http://www.ruby-doc.org/core-2.1.2/Array.html#method-i-pack)</cite>
