### PR TITLE
Fixed: test_resample(Image3_UT) in Image3.rb fails #74

### DIFF
--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -168,6 +168,8 @@ class Image3_UT < Test::Unit::TestCase
     end
 
     def test_resample
+        @img.x_resolution = 72
+        @img.y_resolution = 72
         assert_nothing_raised { @img.resample }
         assert_nothing_raised { @img.resample(100) }
         assert_nothing_raised { @img.resample(100, 100) }


### PR DESCRIPTION
From ImageMagick 6.7.9-0:

> Initialize image->x_resolution and y_resolution to 0 in image.c (previously they were initialized to DefaultResolution, which is 72.0).

<cite>[ImageMagick: Changelog](http://www.imagemagick.org/script/changelog.php)</cite>

Therefore, width and height will become Infinity.

```
    # Corresponds to ImageMagick's -resample option
    def resample(x_res=72.0, y_res=nil)
        y_res ||= x_res
        width = x_res * columns / x_resolution + 0.5 # => Infinity
        height = y_res * rows / y_resolution + 0.5 # => Infinity
        self.x_resolution = x_res
        self.y_resolution = y_res
        resize(width, height) # <#<RangeError: float Inf out of range of integer>>.
    end
```
