### PR TITLE
Fixed: test_colorspace(Image_Attributes_UT) in Image_attributes.rb fails #75

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -163,7 +163,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
     def test_colorspace
         assert_nothing_raised { @img.colorspace }
         assert_instance_of(Magick::ColorspaceType, @img.colorspace)
-        assert_equal(Magick::SRGBColorspace, @img.colorspace)
+        if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
+          assert_equal(Magick::RGBColorspace, @img.colorspace)
+        else
+          assert_equal(Magick::SRGBColorspace, @img.colorspace)
+        end
         img = @img.copy
         assert_nothing_raised { img.colorspace = Magick::GRAYColorspace }
         assert_equal(Magick::GRAYColorspace, img.colorspace)

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -14,6 +14,12 @@ FILES = Dir[IMAGES_DIR+'/Button_*.gif'].sort
 FLOWER_HAT = IMAGES_DIR+'/Flower_Hat.jpg'
 IMAGE_WITH_PROFILE = IMAGES_DIR+'/image_with_profile.jpg'
 
+Magick::Magick_version =~ /ImageMagick (\d+\.\d+\.\d+)-(\d+) /
+abort "Unable to get ImageMagick version" unless $1 && $2
+
+IM_VERSION = Gem::Version.new($1)
+IM_REVISION = Gem::Version.new($2)
+
 require 'Image1.rb'
 require 'Image2.rb'
 require 'Image3.rb'


### PR DESCRIPTION
correct: sRGBColorspace (results)
incorrect: RGBColorspace (Image_attributes.rb)

> Color management has changed significantly between ImageMagick version 6.7.5-5 and 6.8.0-3 in order to better conform to color and grayscale standards.
> The first major change was to swap -colorspace RGB and -colorspace sRGB.

<cite>[ImageMagick: Color Management](http://www.imagemagick.org/script/color-management.php)</cite>

Then, I checked the Colorspace by indentify

```
C:\ruby\rmagick-2.13.3\doc\ex\images>identify -format "%[colorspace]" image_with_profile.jpg
sRGB
```
