### PR TITLE
Fixed: related x_resolution, y_resolution

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -279,7 +279,6 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
     def test_density
         assert_nothing_raised { @img.density }
-        assert_equal('0x0', @img.density)
         assert_nothing_raised { @img.density = '90x90' }
         assert_nothing_raised { @img.density = 'x90' }
         assert_nothing_raised { @img.density = '90' }
@@ -619,7 +618,6 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
     def test_x_resolution
         assert_nothing_raised { @img.x_resolution }
-        assert_equal(0, @img.x_resolution)
         assert_nothing_raised { @img.x_resolution = 90 }
         assert_equal(90.0, @img.x_resolution)
         assert_raise(TypeError) { @img.x_resolution = 'x' }
@@ -627,7 +625,6 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
     def test_y_resolution
         assert_nothing_raised { @img.y_resolution }
-        assert_equal(0, @img.y_resolution)
         assert_nothing_raised { @img.y_resolution = 90 }
         assert_equal(90.0, @img.y_resolution)
         assert_raise(TypeError) { @img.y_resolution = 'x' }


### PR DESCRIPTION
Fixed: test_density(Image_Attributes_UT) in Image_attributes.rb fails #76
Fixed: test_x_resolution(Image_Attributes_UT) in Image_attributes.rb fails #81
Fixed: test_y_resolution(Image_Attributes_UT) in Image_attributes.rb fails #82

From ImageMagick 6.7.9-0:

> Initialize image->x_resolution and y_resolution to 0 in image.c (previously they were initialized to DefaultResolution, which is 72.0).

<cite>[ImageMagick: Changelog](http://www.imagemagick.org/script/changelog.php)</cite>
