### PR TITLE
Fixed: test_rendering_intent(Image_Attributes_UT) in Image_attributes.rb fails #79

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -549,7 +549,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
     def test_rendering_intent
         assert_nothing_raised { @img.rendering_intent }
         assert_instance_of(Magick::RenderingIntent, @img.rendering_intent)
-        assert_equal(Magick::UndefinedIntent, @img.rendering_intent)
+        if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
+          assert_equal(Magick::UndefinedIntent, @img.rendering_intent)
+        else
+          assert_equal(Magick::PerceptualIntent, @img.rendering_intent)
+        end
         assert_nothing_raised { @img.rendering_intent = Magick::SaturationIntent }
         assert_nothing_raised { @img.rendering_intent = Magick::PerceptualIntent }
         assert_nothing_raised { @img.rendering_intent = Magick::AbsoluteIntent }


### PR DESCRIPTION
From ImageMagick version 6.7.5-5

changed: RGBColorspace -> sRGBColorspace
affected values: gamma, **rendering intent**, number of unique colors

> Color management has changed significantly between ImageMagick version 6.7.5-5 and 6.8.0-3 in order to better conform to color and grayscale standards.
> The first major change was to swap -colorspace RGB and -colorspace sRGB.

<cite>[ImageMagick: Color Management](http://www.imagemagick.org/script/color-management.php)</cite>

source code:
<a href="https://github.com/trevor/ImageMagick/blob/82d683349c7a6adc977f6f638f1b340e01bf0ea9/branches/ImageMagick-6.8.2/ImageMagick-6/magick/colorspace.c#L1808-L1811">ImageMagick/colorspace.c at 82d683349c7a6adc977f6f638f1b340e01bf0ea9 · trevor/ImageMagick</a>
### indentify

```
C:\ruby\rmagick-2.13.3\doc\ex\images>identify --version
Version: ImageMagick 6.8.8-7 Q16 x64 2014-02-13 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2014 ImageMagick Studio LLC
Features: DPC Modules OpenMP
Delegates: bzlib cairo freetype jbig jng jp2 jpeg lcms lqr pangocairo png ps rsvg tiff webp xml zlib


C:\ruby\rmagick-2.13.3\doc\ex\images>identify -verbose image_with_profile.jpg
Image: image_with_profile.jpg
  Format: JPEG (Joint Photographic Experts Group JFIF format)
  Mime type: image/jpeg
  Class: DirectClass
  Geometry: 261x196+0+0
  ...
  Rendering intent: Perceptual
  ...
```
### summary

ImageMagick version 6.7.5-5 or later: PerceptualIntent
else: UndefinedIntent
