### PR TITLE
Fixed: test_gamma(Image_Attributes_UT) in Image_attributes.rb fails #77

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -397,7 +397,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
     def test_gamma
         assert_nothing_raised { @img.gamma }
         assert_instance_of(Float, @img.gamma)
-        assert_equal(0.0, @img.gamma)
+        if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
+          assert_equal(0.0, @img.gamma)
+        else
+          assert_equal(0.45454543828964233, @img.gamma)
+        end
         assert_nothing_raised { @img.gamma = 2.0 }
         assert_equal(2.0, @img.gamma)
         assert_raise(TypeError) { @img.gamma = 'x' }


### PR DESCRIPTION
From ImageMagick version 6.7.5-5

changed: RGBColorspace -> sRGBColorspace
affected values: **gamma**, rendering intent, number of unique colors

> Color management has changed significantly between ImageMagick version 6.7.5-5 and 6.8.0-3 in order to better conform to color and grayscale standards.
> The first major change was to swap -colorspace RGB and -colorspace sRGB.

<cite>[ImageMagick: Color Management](http://www.imagemagick.org/script/color-management.php)</cite>

source code:
<a href="https://github.com/trevor/ImageMagick/blob/82d683349c7a6adc977f6f638f1b340e01bf0ea9/branches/ImageMagick-6.8.2/ImageMagick-6/magick/colorspace.c#L1808-L1811">ImageMagick/colorspace.c at 82d683349c7a6adc977f6f638f1b340e01bf0ea9 · trevor/ImageMagick</a>
### indentify

```
C:\ruby\rmagick-2.13.3\doc\ex\images>identify --version
Version: ImageMagick 6.8.8-7 Q16 x64 2014-02-13 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2014 ImageMagick Studio LLC
Features: DPC Modules OpenMP
Delegates: bzlib cairo freetype jbig jng jp2 jpeg lcms lqr pangocairo png ps rsvg tiff webp xml zlib


C:\ruby\rmagick-2.13.3\doc\ex\images>identify -format "%[gamma]" -precision 18 image_with_profile.jpg
0.45454543828964233
```
### summary

ImageMagick version 6.7.5-5 or later: gamma = 0.45454543828964233
else:  gamma = 0.0
