### PR TITLE
Fixed: test_number_colors(Image_Attributes_UT) in Image_attributes.rb fails #78

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -486,7 +486,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
     def test_number_colors
         assert_nothing_raised { @hat.number_colors }
-        assert_equal(27980, @hat.number_colors)
+        if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
+          assert_equal(27980, @hat.number_colors)
+        else
+          assert_equal(27942, @hat.number_colors)
+        end
         assert_raise(NoMethodError) { @hat.number_colors = 2 }
     end
 


### PR DESCRIPTION
From ImageMagick version 6.7.5-5

changed: RGBColorspace -> sRGBColorspace
affected values: gamma, rendering intent, **number of unique colors**

> Color management has changed significantly between ImageMagick version 6.7.5-5 and 6.8.0-3 in order to better conform to color and grayscale standards.
> The first major change was to swap -colorspace RGB and -colorspace sRGB.

<cite>[ImageMagick: Color Management](http://www.imagemagick.org/script/color-management.php)</cite>

source code:

<a href="https://github.com/trevor/ImageMagick/blob/82d683349c7a6adc977f6f638f1b340e01bf0ea9/branches/ImageMagick-6.8.2/ImageMagick-6/magick/colorspace.c#L1808-L1811">ImageMagick/colorspace.c at 82d683349c7a6adc977f6f638f1b340e01bf0ea9 · trevor/ImageMagick</a>
### indentify

```
C:\ruby\rmagick-2.13.3\doc\ex\images>identify --version
Version: ImageMagick 6.8.8-7 Q16 x64 2014-02-13 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2014 ImageMagick Studio LLC
Features: DPC Modules OpenMP
Delegates: bzlib cairo freetype jbig jng jp2 jpeg lcms lqr pangocairo png ps rsvg tiff webp xml zlib


C:\ruby\rmagick-2.13.3\doc\ex\images>identify -format "%k" Flower_Hat.jpg
27942
```

>  %k   CALCULATED: number of unique colors

<cite>[ImageMagick: Format and Print Image Properties](http://www.imagemagick.org/script/escape.php)</cite>
### summary

ImageMagick version 6.7.5-5 or later: 27942
else: 27980
