### PR TITLE
Fixed: test_total_colors(Image_Attributes_UT) in Image_attributes.rb fails #80

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -594,7 +594,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
     def test_total_colors
         assert_nothing_raised { @hat.total_colors }
-        assert_equal(27980, @hat.total_colors)
+        if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
+          assert_equal(27980, @hat.total_colors)
+        else
+          assert_equal(27942, @hat.total_colors)
+        end
         assert_raise(NoMethodError) { @img.total_colors = 2 }
     end
 


### PR DESCRIPTION
same as #108

> RMagick 1.9.1
>    o Fixed bug #2157, Image#total_colors is now an alias of Image#number_colors

<cite>[ChangeLog](https://github.com/gemhome/rmagick/blob/7b36bdc2c67b350fa6471622bd68093bb40301d3/ChangeLog#L483)</cite>
