### PR TITLE
Fixed: crash trying to 'test_formats' on Windows.(Magick.rb)

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -33,7 +33,7 @@ VALUE
 Magick_colors(VALUE class)
 {
     const ColorInfo **color_info_list;
-    unsigned long number_colors, x;
+    size_t number_colors, x;
     volatile VALUE ary;
     ExceptionInfo exception;
 
@@ -82,7 +82,7 @@ VALUE
 Magick_fonts(VALUE class)
 {
     const TypeInfo **type_info;
-    unsigned long number_types, x;
+    size_t number_types, x;
     volatile VALUE ary;
     ExceptionInfo exception;
 
@@ -166,7 +166,7 @@ VALUE
 Magick_init_formats(VALUE class)
 {
     const MagickInfo **magick_info;
-    unsigned long number_formats, x;
+    size_t number_formats, x;
     volatile VALUE formats;
     ExceptionInfo exception;
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -22,7 +22,7 @@ typedef Image *(magnifier_t)(const Image *, ExceptionInfo *);
 /** Method that reads an image */
 typedef Image *(reader_t)(const Info *, ExceptionInfo *);
 /** Method that scales an image */
-typedef Image *(scaler_t)(const Image *, const unsigned long, const unsigned long, ExceptionInfo *);
+typedef Image *(scaler_t)(const Image *, const size_t, const size_t, ExceptionInfo *);
 /** Method that computes threshold on an image */
 typedef MagickBooleanType (thresholder_t)(Image *, const char *);
 /** Method that transforms an image */
@@ -2238,7 +2238,7 @@ Image_channel_extrema(int argc, VALUE *argv, VALUE self)
     Image *image;
     ChannelType channels;
     ExceptionInfo exception;
-    unsigned long min, max;
+    size_t min, max;
     volatile VALUE ary;
 
     image = rm_check_destroyed(self);
@@ -2506,7 +2506,7 @@ Image_color_histogram(VALUE self)
 {
     Image *image, *dc_copy = NULL;
     volatile VALUE hash, pixel;
-    unsigned long x, colors;
+    size_t x, colors;
     ColorPacket *histogram;
     ExceptionInfo exception;
 
@@ -6196,7 +6196,7 @@ Image_find_similar_region(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *target;
     volatile VALUE region, targ;
-    long x = 0L, y = 0L;
+    ssize_t x = 0L, y = 0L;
     ExceptionInfo exception;
     unsigned int okay;
 


### PR DESCRIPTION
### Error message

Segmentation fault

```
C:\ruby\Ruby200-x64\lib\ruby\gems\2.0.0\gems\rmagick-2.13.3\test>ruby test_all_basic.rb
C:/ruby/Ruby200-x64/lib/ruby/site_ruby/2.0.0/RMagick.rb:1836: warning: assigned but unused variable - current
2.0.0
String
C:/ruby/Ruby200-x64/lib/ruby/gems/2.0.0/gems/rmagick-2.13.3/test/Magick.rb:308: warning: assigned but unused variable -
img
Loaded suite test_all_basic
Started
...C:/ruby/Ruby200-x64/lib/ruby/site_ruby/2.0.0/RMagick.rb:20: [BUG] Segmentation fault
ruby 2.0.0p451 (2014-02-24) [x64-mingw32]

-- Control frame information -----------------------------------------------
c:0027 p:---- s:0121 e:000120 CFUNC  :init_formats
c:0026 p:0021 s:0118 e:000117 METHOD C:/ruby/Ruby200-x64/lib/ruby/site_ruby/2.0.0/RMagick.rb:20
c:0025 p:0013 s:0114 e:000113 BLOCK  C:/ruby/Ruby200-x64/lib/ruby/gems/2.0.0/gems/rmagick-2.13.3/test/Magick.rb:93

```
### Cause

type mismatch
on windows x64
-  sizeof(unsigned long) = 4
-  sizeof(size_t) = 8
### Type

>  **GetMagickInfoList(const char *,size_t *,ExceptionInfo *);

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/magick.h#L129">ImageMagick/magick.h at master · trevor/ImageMagick</a>

---

Fixed similar

>  **GetColorInfoList(const char *,size_t *,ExceptionInfo *);

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/color.h#L75">ImageMagick/color.h at master · trevor/ImageMagick</a>

---

>  **GetTypeInfoList(const char *,size_t *,ExceptionInfo *);

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/type.h#L98">ImageMagick/type.h at master · trevor/ImageMagick</a>

---

>  *SampleImage(const Image *,const size_t,const size_t,ExceptionInfo *),

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/resize.h#L40">ImageMagick/resize.h at master · trevor/ImageMagick</a>

---

>  GetImageChannelExtrema(const Image *,const ChannelType,size_t *,size_t *,
>    ExceptionInfo *),

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/statistic.h#L124-L125">ImageMagick/statistic.h at master · trevor/ImageMagick</a>

---

>  *GetImageHistogram(const Image *,size_t *,ExceptionInfo *);

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/histogram.h#L38">ImageMagick/histogram.h at master · trevor/ImageMagick</a>

---

>  IsImageSimilar(const Image *,const Image *,ssize_t *x,ssize_t *y,
>    ExceptionInfo *),

<a href="https://github.com/trevor/ImageMagick/blob/master/branches/ImageMagick-6.8.8/magick/color.h#L81-L82">ImageMagick/color.h at master · trevor/ImageMagick</a>
