### PR TITLE
Fixed: test_each_profile(Image2_UT) in Image2.rb fails #73

### DIFF
--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -444,7 +444,11 @@ class Image2_UT < Test::Unit::TestCase
             @img.each_profile do |name, value|
                 assert_equal("iptc", name)
                 # As of 6.3.1
-                assert_equal("8BIM\004\004\000\000\000\000\001\340test profile", value)
+                if IM_VERSION < Gem::Version.new("6.6.4") || (IM_VERSION == Gem::Version.new("6.6.4") && IM_REVISION < Gem::Version.new("5"))
+                    assert_equal("8BIM\004\004\000\000\000\000\001\340test profile", value)
+                else
+                    assert_equal("test profile", value)
+                end
             end
         end
     end


### PR DESCRIPTION
### Error

```
test_each_profile(Image2_UT) [/home/linduxed/Documents/ruby/rmagick/test/Image2.rb:447]:
<"8BIM\x04\x04\x00\x00\x00\x00\x01\xE0test profile"> expected but was
<"test profile">.
```
### Cause

from: ImageMagick 6.6.4-5
changed: 8bim -> iptc
ImageMagick 6.6.4-5 source: coder/jpeg.c

In ReadIPTCProfile function: 

```
-      status=SetImageProfile(image,"8bim",profile); 
+      status=SetImageProfile(image,"iptc",profile); 
```

<a href="http://trac.imagemagick.org/changeset/2667">Changeset 2667 – ImageMagick</a>

<a href="http://trac.imagemagick.org/browser/ImageMagick/trunk/coders/jpeg.c?rev=2667#L439">jpeg.c in ImageMagick/trunk/coders – ImageMagick</a>

Therefore, <"test profile"> is correct from ImageMagick 6.6.4-5.
