### PR TITLE
Fixed: crash trying to 'test_monitor' on Windows(x64)

### DIFF
--- a/test/Info.rb
+++ b/test/Info.rb
@@ -224,6 +224,9 @@ class Info_UT < Test::Unit::TestCase
     end
 
     def test_monitor
+      if RUBY_PLATFORM =~ /x64-mingw/
+        return
+      end
       assert_nothing_raised { @info.monitor = lambda {} }
       monitor = Proc.new do |mth, q, s|
         assert_equal("resize!", mth)


### PR DESCRIPTION
Info#monitor needs X11 library, but...

> For the 64-bit build, you will also need to disable X11 support.

<cite>[ImageMagick: Advanced Windows Source Installation](http://www.imagemagick.org/script/advanced-windows-installation.php)</cite>
