### PR TITLE
Fixed: test_from_blob(ImageList2_UT) in ImageList2.rb fails (on Windows)

### DIFF
--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -100,7 +100,7 @@ class ImageList2_UT < Test::Unit::TestCase
     end
 
     def test_from_blob
-        hat = File.open(FLOWER_HAT)
+        hat = File.open(FLOWER_HAT, "rb")
         blob = hat.read
         assert_nothing_raised { @ilist.from_blob(blob) }
         assert_instance_of(Magick::Image, @ilist[0])


### PR DESCRIPTION
### Error message

```
Failure:
  Exception raised:
  Magick::ImageMagickError(<JPEG datastream contains no image `' @ error/jpeg.c/JPEGErrorHandler/322>)
test_from_blob(ImageList2_UT)
C:/ruby/Ruby200-x64/lib/ruby/gems/2.0.0/gems/rmagick-2.13.3/test/ImageList2.rb:105:in `test_from_blob'
     102:     def test_from_blob
     103:         hat = File.open(FLOWER_HAT)
     104:         blob = hat.read
  => 105:         assert_nothing_raised { @ilist.from_blob(blob) }
     106:         assert_instance_of(Magick::Image, @ilist[0])
     107:         assert_equal(0, @ilist.scene)
     108:
```

> "b"  Binary file mode
>      Suppresses EOL <-> CRLF conversion on Windows. And
>      sets external encoding to ASCII-8BIT unless explicitly
>      specified.

<cite>[Class: IO (Ruby 2.1.2)](http://www.ruby-doc.org/core-2.1.2/IO.html)</cite>
