### PR TITLE
Fixed: crash trying to 'test_write' on Windows (Image3.rb, ImageList2.rb)

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -1178,7 +1178,12 @@ ImageList_write(VALUE self, VALUE file)
 
         // Ensure file is open - raise error if not
         GetOpenFile(file, fptr);
+#if defined(_WIN32)
+        add_format_prefix(info, fptr->pathv);
+        SetImageInfoFile(info, NULL);
+#else
         SetImageInfoFile(info, GetReadFile(fptr));
+#endif
     }
     else
     {

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -14733,8 +14733,14 @@ Image_write(VALUE self, VALUE file)
         // Ensure file is open - raise error if not
         GetOpenFile(file, fptr);
         rb_io_check_writable(fptr);
+#if defined(_WIN32)
+        add_format_prefix(info, fptr->pathv);
+        strcpy(image->filename, info->filename);
+        SetImageInfoFile(info, NULL);
+#else
         SetImageInfoFile(info, GetWriteFile(fptr));
         memset(image->filename, 0, sizeof(image->filename));
+#endif
     }
     else
     {


### PR DESCRIPTION
### Error message

No error message and no finish message as follows

```
C:\ruby\Ruby200-x64\lib\ruby\gems\2.0.0\gems\rmagick-2.13.3\test>ruby test_all_basic.rb
C:/ruby/Ruby200-x64/lib/ruby/site_ruby/2.0.0/RMagick.rb:1836: warning: assigned but unused variable - current
2.0.0
String
C:/ruby/Ruby200-x64/lib/ruby/gems/2.0.0/gems/rmagick-2.13.3/test/Image3.rb:653: warning: assigned but unused variable -
img
Loaded suite test_all_basic
Started
.........................................................................
C:\ruby\Ruby200-x64\lib\ruby\gems\2.0.0\gems\rmagick-2.13.3\test>
```
### Cause

C Runtime libraries version incompatibility

Ruby (RubyInstaller)
![ruby200_](https://cloud.githubusercontent.com/assets/6265511/4046347/88895798-2d31-11e4-941d-7ead046e6d64.png)

ImageMagick (official binary)
![magick_](https://cloud.githubusercontent.com/assets/6265511/4046338/7d490a40-2d31-11e4-99e5-c0819fc6b843.png)

<a href="https://www.ruby-forum.com/topic/70810#96932">Win32 Extension Issues Wanted! - Ruby Forum</a>

(1) On Ruby(_msvcrt.dll_)
(2) On RMagick2.so(_msvcrt.dll_)
(3) On ImageMagick(_msvcr100.dll_)

(1) <-> (2) pass
(2) <-> (3) fail

Therefore, I fixed RMagick so that a file is opened on ImageMagick.
