### PR TITLE
Revert "Fixed: crash trying to 'test_monitor' on Windows(x64)"

### DIFF
--- a/test/Info.rb
+++ b/test/Info.rb
@@ -224,9 +224,6 @@ class Info_UT < Test::Unit::TestCase
     end
 
     def test_monitor
-      if RUBY_PLATFORM =~ /x64-mingw/
-        return
-      end
       assert_nothing_raised { @info.monitor = lambda {} }
       monitor = Proc.new do |mth, q, s|
         assert_equal("resize!", mth)


### PR DESCRIPTION
From #114
Sorry to bother you.

> Disabling OpenMP, the test was passed.
> I'm going to revert. It should be another issue.
> 
> <a href="http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=21719">ImageMagick • View topic - Disabling openMP in windows server</a>
