### PR TITLE
Fixed: test_from_hsla(Pixel_UT) in Pixel.rb fails #87

### DIFF
--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -911,7 +911,7 @@ Pixel_to_hsla(VALUE self)
     }
     else
     {
-        alpha = ROUND_TO_QUANTUM(QuantumRange - (pixel->opacity / QuantumRange));
+        alpha = (double)(QuantumRange - pixel->opacity) / (double)QuantumRange;
     }
 
     hsla = rb_ary_new3(4, rb_float_new(hue), rb_float_new(sat), rb_float_new(lum), rb_float_new(alpha));

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -65,7 +65,7 @@ class Pixel_UT < Test::Unit::TestCase
         25.times do |s|
           25.times do |l|
             5.times do |a|
-              args = [20*h, s+25, l+25, a/5]
+              args = [20*h, s+25, l+25, a/5.0]
               px = Magick::Pixel.from_hsla(*args)
               hsla = px.to_hsla()
               #puts "[#{args.join(', ')}] = [#{hsla.join(', ')}]"


### PR DESCRIPTION
2 fixes
1. Fixed Pixel.rb: improper test
2. Fixed rmpixel.c: same as issue #87
### 1. Fixed Pixel.rb: improper test

"a/5" is not good.

Pixel.rb L67-68

```
            5.times do |a|
              args = [20*h, s+25, l+25, a/5]
```

```
[4] pry(main)> 5.times {|a| p a/5}
0
0
0
0
0
=> 5
[5] pry(main)> 5.times {|a| p a/5.0}
0.0
0.2
0.4
0.6
0.8
=> 5
[6] pry(main)>
```
### 2. Fixed rmpixel.c: same as issue #87

"alpha" should be in the range 0.0-1.0, but alpha = 65535.0

error message

```
Loaded suite test_all_basic
Started
..F
===============================================================================
Failure:
  expected [0, 25, 25, 0.2] got [0.0, 25.003891050583658, 25.000000000000004, 65535.0].
  <0.2> -/+ <0.005> expected to include
  <65535.0>.

  Relation:
  <<0.2>-<0.005>[0.195] <= <0.2>+<0.005>[0.20500000000000002] < <65535.0>>
test_from_hsla(Pixel_UT)
```

rmpixel.c

```
 * Notes:
 *   - Default alpha is 1.0
...
 *   - 0 <= alpha <= 1 (0 is transparent, 1 is opaque) OR "0%" <= alpha <= "100%"
...
Pixel_from_hsla(int argc, VALUE *argv, VALUE class)
...
    if (alpha && (a < 0.0 || a > 1.0))
    {
        rb_raise(rb_eRangeError, "alpha %g out of range [0.0, 1.0]", a);
    }
...    
```

```
 * Return [hue, saturation, lightness, alpha] in the same ranges as
 * Pixel_from_hsla.
...
Pixel_to_hsla(VALUE self)
...
    if (pixel->opacity == OpaqueOpacity)
    {
        alpha = 1.0;
    }
    else if (pixel->opacity == TransparentOpacity)
    {
        alpha = 0.0;
    }
    else
    {
        alpha = ROUND_TO_QUANTUM(QuantumRange - (pixel->opacity / QuantumRange));
    }
...
```

Let's resolve the ROUND_TO_QUANTUM macro and see what is going on.

```
#define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
#define QuantumRange  ((Quantum) 65535)
alpha = ROUND_TO_QUANTUM(QuantumRange - (pixel->opacity / QuantumRange));
```

```
#define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
alpha = ROUND_TO_QUANTUM(65535 - (pixel->opacity / 65535));
```

_pixel->opacity < 65535_

```
#define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
alpha = ROUND_TO_QUANTUM(65535 - 0);
```

```
alpha = (Quantum)(65535 + 0.5)
```

```
alpha = (unsigned short)(65535.5)
```

```
alpha = 65535
```

but, alpha should be

```
 *   - 0 <= alpha <= 1 (0 is transparent, 1 is opaque) OR "0%" <= alpha <= "100%"
```

---

rmagick.h

```
#define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
```

image.h

```
#define OpaqueOpacity  ((Quantum) 0UL)
#define TransparentOpacity  (QuantumRange)
```

magick-type.h (on my box)

```
typedef unsigned short Quantum;
#define QuantumRange  ((Quantum) 65535)
```

Therefore, 0 <= pixel->opacity <= 65535
