### PR TITLE
Allow MagickCore6 from Magick-config

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -201,7 +201,7 @@ end
 
 if RUBY_PLATFORM !~ /mswin|mingw/
 
-  unless `Magick-config --libs`[/\bl\s*(MagickCore|Magick)\b/]
+  unless `Magick-config --libs`[/\bl\s*(MagickCore|Magick)6?\b/]
     exit_failure "Can't install RMagick #{RMAGICK_VERS}. " +
            "Can't find the ImageMagick library or one of the dependent libraries. " +
            "Check the mkmf.log file for more detailed information.\n"


### PR DESCRIPTION
PR for #40

I haven't tested it, but it should not break the current behavior.
