### PR TITLE
New class SolidFill in order to fill image with monochromatic background

### DIFF
--- a/lib/RMagick.rb
+++ b/lib/RMagick.rb
@@ -1958,5 +1958,17 @@ class HatchFill
    end
 end
 
+# Fill class with solid monochromatic color
+class SolidFill
+   def initialize(bgcolor)
+      @bgcolor = bgcolor
+   end
+
+   def fill(img)
+      img.background_color = @bgcolor
+      img.erase!
+   end
+end
+
 end # Magick
 


### PR DESCRIPTION
New class SolidFill in order to fill image with monochromatic background.
It allows one to write image constructors in a consistent syntax
for both gradient/hatched and for solid backgrounds instead of two
completely different syntaxes:

``` ruby
Image.new(size_x, size_y, HatchFill.new('white', 'red'))
Image.new(size_x, size_y, SolidFill.new('bisque'))
```

vs

``` ruby
Image.new(size_x,size_y, HatchFill.new('white','red'))
Image.new(size_x,size_y){ self.background_color = 'bisque' }
```
