### PR TITLE
Changed Image#resample to calling ResampleImage (related #29, #45)

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1075,6 +1075,8 @@ extern VALUE Image_read_inline(VALUE, VALUE);
 extern VALUE Image_recolor(VALUE, VALUE);
 extern VALUE Image_reduce_noise(VALUE, VALUE);
 extern VALUE Image_remap(int, VALUE *, VALUE);
+extern VALUE Image_resample(int, VALUE *, VALUE);
+extern VALUE Image_resample_bang(int, VALUE *, VALUE);
 extern VALUE Image_resize(int, VALUE *, VALUE);
 extern VALUE Image_resize_bang(int, VALUE *, VALUE);
 extern VALUE Image_roll(VALUE, VALUE, VALUE);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -431,6 +431,8 @@ Init_RMagick2(void)
     rb_define_method(Class_Image, "random_threshold_channel", Image_random_threshold_channel, -1);
     rb_define_method(Class_Image, "recolor", Image_recolor, 1);
     rb_define_method(Class_Image, "reduce_noise", Image_reduce_noise, 1);
+    rb_define_method(Class_Image, "resample", Image_resample, -1);
+    rb_define_method(Class_Image, "resample!", Image_resample_bang, -1);
     rb_define_method(Class_Image, "resize", Image_resize, -1);
     rb_define_method(Class_Image, "resize!", Image_resize_bang, -1);
     rb_define_method(Class_Image, "roll", Image_roll, 2);

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -979,16 +979,6 @@ class Image
         self
     end
 
-    # Corresponds to ImageMagick's -resample option
-    def resample(x_res=72.0, y_res=nil)
-        y_res ||= x_res
-        width = x_res * columns / x_resolution + 0.5
-        height = y_res * rows / y_resolution + 0.5
-        self.x_resolution = x_res
-        self.y_resolution = y_res
-        resize(width, height)
-    end
-
     # Force an image to exact dimensions without changing the aspect ratio.
     # Resize and crop if necessary. (Thanks to Jerett Taylor!)
     def resize_to_fill(ncols, nrows=nil, gravity=CenterGravity)


### PR DESCRIPTION
If `Image#resample` corresponds to ImageMagick's `-resample` option, we should use `ResampleImage` (ImageMagick API).

rmagick_internal.rb (before fix):

``` ruby
    # Corresponds to ImageMagick's -resample option
    def resample(x_res=72.0, y_res=nil)
        y_res ||= x_res
        width = x_res * columns / x_resolution + 0.5
        height = y_res * rows / y_resolution + 0.5
        self.x_resolution = x_res
        self.y_resolution = y_res
        resize(width, height)
    end
```

not good:
1. there is a possibility to divide by zero at `/ x_resolution` and `/ y_resolution`
2. `self.x_resolution` and `self.y_resolution` are overwritten

Related issues (fixed at the same time):
- Resolution management #29
- Infinity when no resolution or resolution 0.0 informed by the image file #45

Changed:
- Changed `Image#resample` to calling `ResampleImage`
- Added `Image#resample!`

(`Image#resample` and `Image#resample!` are implemented in the same way as [`Image#resize` and `Image#resize!`](https://github.com/u338steven/rmagick/blob/patch-20/ext/RMagick/rmimage.c#L11140-L11265))

---
#### 1. there is a possibility to divide by zero at `/ x_resolution` and `/ y_resolution`

Related issue: #45

If we use `ResampleImage`, there is no possibility about it.

resize.c:

``` c
MagickExport Image *ResampleImage(const Image *image,const double x_resolution,
  const double y_resolution,const FilterTypes filter,const double blur,
  ExceptionInfo *exception)
{
...
  width=(size_t) (x_resolution*image->columns/(image->x_resolution == 0.0 ?
    72.0 : image->x_resolution)+0.5);
  height=(size_t) (y_resolution*image->rows/(image->y_resolution == 0.0 ?
    72.0 : image->y_resolution)+0.5);
  resample_image=ResizeImage(image,width,height,filter,blur,exception);
  if (resample_image != (Image *) NULL)
    {
      resample_image->x_resolution=x_resolution;
      resample_image->y_resolution=y_resolution;
    }
  return(resample_image);
}
```

---
#### 2. `self.x_resolution` and `self.y_resolution` are overwritten

Related issue: #29

Sample script:

``` ruby
require "RMagick"

base_img = Magick::Image.new(100, 100)
base_img.density = "72x72"

new_img = base_img.resample(144.0, 144.0)

p base_img.density              # => "144x144"
p base_img.rows                 # => 100
p base_img.columns              # => 100

p new_img.density               # => "144x144"
p new_img.rows                  # => 200
p new_img.columns               # => 200
```

`base_img.density` should be `"72x72"` but `"144x144"`.
