### PR TITLE
Fixed: test_limit_resources (Magick_UT) in Magick.rb fails #126

### DIFF
--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -292,7 +292,7 @@ class Magick_UT < Test::Unit::TestCase
 
         assert_nothing_raised {cur = Magick::limit_resource(:file, 500)}
         assert_kind_of(Integer, cur)
-        assert(cur > 1024)
+        assert(cur > 512)
         assert_nothing_raised {new = Magick::limit_resource("file")}
         assert_equal(500, new)
         Magick::limit_resource(:file, cur)


### PR DESCRIPTION
Error message:

```
Magick_UT#test_limit_resources [/home/linduxed/Documents/rmagick/test/Magick.rb:289]:
Failed assertion, no message given.
```

Magick.rb:289:

``` ruby
        assert(cur > 1024)
```

cur:

```
cur = Magick::limit_resource(:file, 500)
```

default file limit: 768 (From PR #91)

From the above:

```
assert(cur > 1024)
=> assert(768 > 1024)
=> assert(false)
=> Failed assertion
```
