### PR TITLE
proof of concept for using pkg-config in place of Magick-config on debian based systems

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -176,7 +176,7 @@ if RUBY_PLATFORM !~ /mswin|mingw/
   if $pkg_config
     # Save flags
     $CFLAGS     = ENV["CFLAGS"].to_s   + " " + `pkg-config --cflags MagickCore`.chomp
-    $CPPFLAGS   = ENV["CPPFLAGS"].to_s + " " + `pkg-config -cppflags MagickCore`.chomp
+    $CPPFLAGS   = ENV["CPPFLAGS"].to_s + " " + `pkg-config --cflags MagickCore`.chomp
     $LDFLAGS    = ENV["LDFLAGS"].to_s  + " " + `pkg-config --libs MagickCore`.chomp
     $LOCAL_LIBS = ENV["LIBS"].to_s     + " " + `pkg-config --libs MagickCore`.chomp
   end


### PR DESCRIPTION
This is admittedly a pretty ugly patch for falling back to using pkg-config instead of Magick-config on newer Debian (and probably many more) systems.

I can't find a good description for what happened to Magick-config in Debian, but it's moved it's way into https://packages.debian.org/sid/graphicsmagick-libmagick-dev-compat which doesn't seem to reference the relevant headers needed for comp (ie: wand/MagickWand.h).

After spending a few days tracking this down, I stumbled across: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=761927 which seems to indicate that Magick-config is going away. Since it's just a pretty simple wrapper around pkg-config (at least on Debian anyway), this patch adds support for compilation on newer Debian systems (jessie/sid) without requiring Magick-config.

It probably makes sense to just get rid of Magick-config all together and port over to pkg-config if the situation on Debian is similar on other OS's.
