### PR TITLE
Fixed expected number colors in Image_attributes#test_colors

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -493,7 +493,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
         if IM_VERSION < Gem::Version.new("6.7.5") || (IM_VERSION == Gem::Version.new("6.7.5") && IM_REVISION < Gem::Version.new("5"))
           assert_equal(27980, @hat.number_colors)
         else
-          assert_equal(27942, @hat.number_colors)
+          assert_equal(28251, @hat.number_colors)
         end
         assert_raise(NoMethodError) { @hat.number_colors = 2 }
     end


### PR DESCRIPTION
According to my local imagemagick command line utility, the expectation
of this test was wrong:

   identify -format %k doc/ex/images/Flower_Hat.jpg
   28251
