### PR TITLE
Add Contributor's Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+RMagick Contributor's Guide
+===========================
+
+Welcome
+-------
+
+Thank you for considering contributing to RMagick. Your contribution is always welcome!
+
+
+Background
+----------
+
+RMagick is a Ruby gem with a C extension. The extension wraps the ImageMagick C library. Therefore, the following document may be helpful to you:
+
+[Running C in Ruby](http://silverhammermba.github.io/emberb/extend/)
+
+
+Priorities
+----------
+
+9. Green build of the gem on all operating systems. You can see the current build state on [the project page at Travis CI](https://travis-ci.org/gemhome/rmagick). You are welcome to improve it.
+9. [Open issues](https://github.com/gemhome/rmagick/issues). You are welcome to reproduce them, report current state, suggest solutions, open pull requests with fixes.


### PR DESCRIPTION
I saw this awesome link in the latest Ruby Weekly:

http://silverhammermba.github.io/emberb/

I thought that this project should advertise it somehow. But how? I thought that stuff like that goes to some kind of contributor's guide. This project didn't have a contributor's guide. So I decided to create it and insert this link there :)

It looks incomplete. I really have no idea what else to add. I think my caffeine level dropped. Suggestions?
