### PR TITLE
Fix wrong relative path for lib/rmagick/version

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -1,7 +1,7 @@
 require "mkmf"
 require "date"
 
-require File.expand_path('../../../../lib/rmagick/version')
+require File.expand_path('../../lib/rmagick/version')
 RMAGICK_VERS = Magick::VERSION
 MIN_RUBY_VERS = Magick::MIN_RUBY_VERSION
 MIN_RUBY_VERS_NO = MIN_RUBY_VERS.tr(".","").to_i


### PR DESCRIPTION
Commit 5795bfb63177f92bfddb3f9263a8475b8748759a introduced this bug, which prevents this gem from being successfully installed (it fails while building the native extensions), so here is the fix.
