### PR TITLE
Fix #148; More robust feature detection

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1719,9 +1719,16 @@ features_constant(void)
     volatile VALUE features;
 
 #if defined(HAVE_GETMAGICKFEATURES)
+    // 6.5.7 - latest (7.0.0)
     features = rb_str_new2(GetMagickFeatures());
-#else
+#elif defined(MagickFeatures)
+    // 6.5.7 - latest (7.0.0)
+    features = rb_str_new2(MagickFeatures);
+#elif defined(MagickSuuport)
+    // 6.5.5 - 6.5.6
     features = rb_str_new2(MagickSupport);
+#else
+    features = rb_str_new("unknown",7);
 #endif
 
     rb_obj_freeze(features);


### PR DESCRIPTION
PR #125 added the string Magick::Magick_features

Issue #148 reported compilation failures on

``` plain
  Mac OSX Yosemite
  Rails 4.2.0.beta4
  rake, version 10.4.0
  ImageMagick 6.8.9-8 Q16 x86_64 (via macports)

in rmmain.c:1724:28:
error: use of undeclared identifier 'MagickSupport'

This PR now makes the flow to use if defined:
GetMagickFeatures() or
  MagickFeatures or
  MagickSupport or
  "unknown"
```
