### PR TITLE
Change all require RMagick to rmagick

### DIFF
--- a/doc/comtasks.html
+++ b/doc/comtasks.html
@@ -78,7 +78,7 @@
   line and then prints a variety of information about each image to
   the terminal.</p>
   <pre class="example">
-require 'RMagick'
+require "rmagick"
 ARGV.each { |file|
     puts file
     img = Magick::Image::read(file).first

--- a/doc/ex/adaptive_threshold.rb
+++ b/doc/ex/adaptive_threshold.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#adaptive_threshold method
 

--- a/doc/ex/add_noise.rb
+++ b/doc/ex/add_noise.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#add_noise method
 NOISE_TYPES = [Magick::UniformNoise, Magick::GaussianNoise,

--- a/doc/ex/affine.rb
+++ b/doc/ex/affine.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the affine primitive. Transform the
 # coordinate space to put the origin in the lower

--- a/doc/ex/affine_transform.rb
+++ b/doc/ex/affine_transform.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#affine_transform method
 

--- a/doc/ex/arc.rb
+++ b/doc/ex/arc.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 i = Magick::Image.new(300, 220, Magick::HatchFill.new("white","lightcyan2"))
 gc = Magick::Draw.new

--- a/doc/ex/arcpath.rb
+++ b/doc/ex/arcpath.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the "path" drawing primitive.
 

--- a/doc/ex/average.rb
+++ b/doc/ex/average.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 # Demonstrate ImageList#average method
-require 'RMagick'
+require "rmagick"
 
 images = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif", "images/Button_C.gif")
 

--- a/doc/ex/axes.rb
+++ b/doc/ex/axes.rb
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the use of RMagick's Draw class
 # and show the default coordinate system.

--- a/doc/ex/bilevel_channel.rb
+++ b/doc/ex/bilevel_channel.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 result = img.bilevel_channel(2*Magick::QuantumRange/3, Magick::RedChannel)

--- a/doc/ex/blur_image.rb
+++ b/doc/ex/blur_image.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#blur_image method
 

--- a/doc/ex/border.rb
+++ b/doc/ex/border.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#border method
 

--- a/doc/ex/bounding_box.rb
+++ b/doc/ex/bounding_box.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.new(200,200) { self.background_color = "#ffffcc" }
 

--- a/doc/ex/cbezier1.rb
+++ b/doc/ex/cbezier1.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(390, 140, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/cbezier2.rb
+++ b/doc/ex/cbezier2.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(470, 150, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/cbezier3.rb
+++ b/doc/ex/cbezier3.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(540, 200, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/cbezier4.rb
+++ b/doc/ex/cbezier4.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(390, 360, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/cbezier5.rb
+++ b/doc/ex/cbezier5.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(390, 150, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/cbezier6.rb
+++ b/doc/ex/cbezier6.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(400, 300, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/channel.rb
+++ b/doc/ex/channel.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 imgs = Magick::ImageList.new

--- a/doc/ex/charcoal.rb
+++ b/doc/ex/charcoal.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#charcoal method
 

--- a/doc/ex/chop.rb
+++ b/doc/ex/chop.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#chop method
 

--- a/doc/ex/circle.rb
+++ b/doc/ex/circle.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(250, 250, Magick::HatchFill.new('white','LightCyan2'))

--- a/doc/ex/clip_path.rb
+++ b/doc/ex/clip_path.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 points = [145, 65, 174,151, 264,151, 192,205,
           218,291, 145,240,  72,291,  98,205,

--- a/doc/ex/coalesce.rb
+++ b/doc/ex/coalesce.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 buttons = Magick::ImageList.new
 

--- a/doc/ex/color_fill_to_border.rb
+++ b/doc/ex/color_fill_to_border.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#color_fill_to_border method
 

--- a/doc/ex/color_floodfill.rb
+++ b/doc/ex/color_floodfill.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#color_floodfill method
 

--- a/doc/ex/color_histogram.rb
+++ b/doc/ex/color_histogram.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 NUM_COLORS = 256
 HIST_HEIGHT = 200

--- a/doc/ex/color_reset.rb
+++ b/doc/ex/color_reset.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#color_reset! method
 

--- a/doc/ex/colorize.rb
+++ b/doc/ex/colorize.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#colorize method by converting
 # a full-color image to "sepia-tone"

--- a/doc/ex/colors.rb
+++ b/doc/ex/colors.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts("Creating colors.miff. This may take a few seconds...")

--- a/doc/ex/compose_mask.rb
+++ b/doc/ex/compose_mask.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 background = Magick::Image.read('images/Flower_Hat.jpg').first
 source = Magick::Image.read('pattern:checkerboard') {self.size = "#{background.columns}x#{background.rows}"}.first

--- a/doc/ex/composite.rb
+++ b/doc/ex/composite.rb
@@ -3,7 +3,7 @@
 # Demonstrate the effects of various composite operators.
 # Based on ImageMagick's composite test.
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 ROWS = 70

--- a/doc/ex/composite_layers.rb
+++ b/doc/ex/composite_layers.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 class Magick::ImageList
   # Create a shadow image for each image in the list

--- a/doc/ex/composite_tiled.rb
+++ b/doc/ex/composite_tiled.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 # Create a transparent image to tile over the background image.
 wm = Magick::Image.read("xc:none") { self.size = "100x50" }.first

--- a/doc/ex/contrast.rb
+++ b/doc/ex/contrast.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#contrast method
 

--- a/doc/ex/crop.rb
+++ b/doc/ex/crop.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#crop method
 

--- a/doc/ex/crop_with_gravity.rb
+++ b/doc/ex/crop_with_gravity.rb
@@ -7,7 +7,7 @@
 
 # Demo the use of the GravityType argument to Image#crop.
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 shorts = Image.read('images/Shorts.jpg').first

--- a/doc/ex/cycle_colormap.rb
+++ b/doc/ex/cycle_colormap.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#cycle_colormap method
 

--- a/doc/ex/dissolve.rb
+++ b/doc/ex/dissolve.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 bgnd = Magick::Image.read('images/Violin.jpg').first
 overlay = Magick::Image.read('images/Flower_Hat.jpg').first

--- a/doc/ex/drawcomp.rb
+++ b/doc/ex/drawcomp.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 # Read the snake image file and scale to 200 pixels high.
 begin

--- a/doc/ex/drop_shadow.rb
+++ b/doc/ex/drop_shadow.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Add a drop shadow to a text string. This example
 # uses a 3-image animation to show each step of the

--- a/doc/ex/edge.rb
+++ b/doc/ex/edge.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#edge method
 

--- a/doc/ex/ellipse.rb
+++ b/doc/ex/ellipse.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(360, 250, Magick::HatchFill.new('white','LightCyan2'))

--- a/doc/ex/emboss.rb
+++ b/doc/ex/emboss.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#edge method
 

--- a/doc/ex/enhance.rb
+++ b/doc/ex/enhance.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#enhance method
 

--- a/doc/ex/equalize.rb
+++ b/doc/ex/equalize.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#equalize method
 

--- a/doc/ex/fill_pattern.rb
+++ b/doc/ex/fill_pattern.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Magick::Draw#fill_pattern and #stroke_pattern attributes.
 

--- a/doc/ex/flatten_images.rb
+++ b/doc/ex/flatten_images.rb
@@ -2,7 +2,7 @@
 
 # Demonstrate flatten_images method. Create an image with a drop-shadow effect.
 
-require 'RMagick'
+require "rmagick"
 
 RMagick = 'RMagick'
 

--- a/doc/ex/flip.rb
+++ b/doc/ex/flip.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#flip method
 

--- a/doc/ex/flop.rb
+++ b/doc/ex/flop.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#flop method
 

--- a/doc/ex/fonts.rb
+++ b/doc/ex/fonts.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Compute column widths
 name_length = 0

--- a/doc/ex/frame.rb
+++ b/doc/ex/frame.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#frame method
 

--- a/doc/ex/gaussian_blur.rb
+++ b/doc/ex/gaussian_blur.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#gaussian_blur method
 

--- a/doc/ex/get_multiline_type_metrics.rb
+++ b/doc/ex/get_multiline_type_metrics.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 TEXT = 'get\nmultiline\ntype\nmetrics'
 

--- a/doc/ex/get_pixels.rb
+++ b/doc/ex/get_pixels.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate partial transparency and the get_pixels and
 # store_pixels methods by creating an image that goes from

--- a/doc/ex/get_type_metrics.rb
+++ b/doc/ex/get_type_metrics.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Add a method for drawing braces.
 module Magick

--- a/doc/ex/gradientfill.rb
+++ b/doc/ex/gradientfill.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the GradientFill class
 

--- a/doc/ex/grav.rb
+++ b/doc/ex/grav.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(400,200, Magick::HatchFill.new('white', 'lightcyan2'))

--- a/doc/ex/gravity.rb
+++ b/doc/ex/gravity.rb
@@ -3,7 +3,7 @@
 #   A RMagick version of Magick++/demo/gravity.cpp
 #
 
-require 'RMagick'
+require "rmagick"
 
 x, y = 100, 100
 

--- a/doc/ex/hatchfill.rb
+++ b/doc/ex/hatchfill.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the HatchFill class
 

--- a/doc/ex/implode.rb
+++ b/doc/ex/implode.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 

--- a/doc/ex/level.rb
+++ b/doc/ex/level.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#level method
 

--- a/doc/ex/level_colors.rb
+++ b/doc/ex/level_colors.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read("images/Flower_Hat.jpg").first
 begin

--- a/doc/ex/line.rb
+++ b/doc/ex/line.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(250, 250, Magick::HatchFill.new('white','LightCyan2'))

--- a/doc/ex/mask.rb
+++ b/doc/ex/mask.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 # This example demonstrates the mask attribute. The mask image must
 # be the same size as the image being masked. Since this mask image does

--- a/doc/ex/matte_fill_to_border.rb
+++ b/doc/ex/matte_fill_to_border.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.new(200,200)
 img.compression = Magick::LZWCompression

--- a/doc/ex/matte_floodfill.rb
+++ b/doc/ex/matte_floodfill.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.new(200,200)
 img.compression = Magick::LZWCompression

--- a/doc/ex/matte_replace.rb
+++ b/doc/ex/matte_replace.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.new(200,200)
 img.compression = Magick::LZWCompression

--- a/doc/ex/median_filter.rb
+++ b/doc/ex/median_filter.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#median_filter method
 

--- a/doc/ex/modulate.rb
+++ b/doc/ex/modulate.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#modulate method
 

--- a/doc/ex/mono.rb
+++ b/doc/ex/mono.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the ImageListImage#quantize method by converting
 # a color image into a monochrome image.

--- a/doc/ex/morph.rb
+++ b/doc/ex/morph.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the morph method
 

--- a/doc/ex/mosaic.rb
+++ b/doc/ex/mosaic.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the mosaic method
 

--- a/doc/ex/motion_blur.rb
+++ b/doc/ex/motion_blur.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#blur_image method
 

--- a/doc/ex/negate.rb
+++ b/doc/ex/negate.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#negate method
 

--- a/doc/ex/negate_channel.rb
+++ b/doc/ex/negate_channel.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#negate_channel method
 

--- a/doc/ex/normalize.rb
+++ b/doc/ex/normalize.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#normalize method
 

--- a/doc/ex/oil_paint.rb
+++ b/doc/ex/oil_paint.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#oil_paint method
 

--- a/doc/ex/opacity.rb
+++ b/doc/ex/opacity.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 canvas = Magick::Image.new(260, 125)
 gc = Magick::Draw.new

--- a/doc/ex/ordered_dither.rb
+++ b/doc/ex/ordered_dither.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#ordered_dither method
 

--- a/doc/ex/path.rb
+++ b/doc/ex/path.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(390, 240, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/pattern1.rb
+++ b/doc/ex/pattern1.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 gc = Magick::Draw.new
 gc.pattern('triangles', 0, 0, 16, 16) {

--- a/doc/ex/pattern2.rb
+++ b/doc/ex/pattern2.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 hat = Magick::Image.read("images/Flower_Hat.jpg").first
 hat.resize!(0.25)

--- a/doc/ex/polaroid.rb
+++ b/doc/ex/polaroid.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 require 'date'
 
 # Demonstrate the Image#polaroid method

--- a/doc/ex/polygon.rb
+++ b/doc/ex/polygon.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(290, 200, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/polyline.rb
+++ b/doc/ex/polyline.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(300, 100, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/posterize.rb
+++ b/doc/ex/posterize.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 result = img.posterize

--- a/doc/ex/preview.rb
+++ b/doc/ex/preview.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read("images/Flower_Hat.jpg").first
 preview = img.preview(Magick::SolarizePreview)

--- a/doc/ex/qbezierpath.rb
+++ b/doc/ex/qbezierpath.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(500, 300, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/quantize-m.rb
+++ b/doc/ex/quantize-m.rb
@@ -2,7 +2,7 @@
 
 # Demonstrate the ImageList#quantize method
 
-require 'RMagick'
+require "rmagick"
 
 snapshots = Magick::ImageList.new "images/Ballerina.jpg","images/Gold_Statue.jpg","images/Shorts.jpg"
 

--- a/doc/ex/radial_blur.rb
+++ b/doc/ex/radial_blur.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#radial_blur method
 

--- a/doc/ex/raise.rb
+++ b/doc/ex/raise.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#raise method.
 img = Magick::Image.read('images/Flower_Hat.jpg').first

--- a/doc/ex/random_threshold_channel.rb
+++ b/doc/ex/random_threshold_channel.rb
@@ -2,7 +2,7 @@
 
 # Demonstrate the random_channel_threshold method
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 

--- a/doc/ex/rectangle.rb
+++ b/doc/ex/rectangle.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(300, 200, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/reduce_noise.rb
+++ b/doc/ex/reduce_noise.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#reduce_noise method
 

--- a/doc/ex/remap.rb
+++ b/doc/ex/remap.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read("images/Flower_Hat.jpg").first
 rose = Magick::Image.read("images/Yellow_Rose.miff").first

--- a/doc/ex/remap_images.rb
+++ b/doc/ex/remap_images.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 images = Magick::ImageList.new("images/Apple.miff", "images/Rocks_On_Beach.miff", "images/Leaf.miff")
 rose = Magick::Image.read("images/Yellow_Rose.miff").first

--- a/doc/ex/resize_to_fill.rb
+++ b/doc/ex/resize_to_fill.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the crop_resize method
 

--- a/doc/ex/resize_to_fit.rb
+++ b/doc/ex/resize_to_fit.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the crop_resize method
 

--- a/doc/ex/roll.rb
+++ b/doc/ex/roll.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 

--- a/doc/ex/rotate.rb
+++ b/doc/ex/rotate.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(200, 200, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/rotate_f.rb
+++ b/doc/ex/rotate_f.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#rotate method
 

--- a/doc/ex/roundrect.rb
+++ b/doc/ex/roundrect.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(300, 200, Magick::HatchFill.new('white','LightCyan2'))

--- a/doc/ex/rubyname.rb
+++ b/doc/ex/rubyname.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the annotate method
 

--- a/doc/ex/segment.rb
+++ b/doc/ex/segment.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#segment method.
 

--- a/doc/ex/sepiatone.rb
+++ b/doc/ex/sepiatone.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 sepiatone = img.sepiatone(Magick::QuantumRange * 0.8)

--- a/doc/ex/shade.rb
+++ b/doc/ex/shade.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate Image#shade
 

--- a/doc/ex/shadow.rb
+++ b/doc/ex/shadow.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 # Draw a big red Bezier curve on a transparent background.
 img = Magick::Image.new(340, 120) {self.background_color = 'none'}

--- a/doc/ex/shave.rb
+++ b/doc/ex/shave.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#shave method
 

--- a/doc/ex/shear.rb
+++ b/doc/ex/shear.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#shear method.
 

--- a/doc/ex/sketch.rb
+++ b/doc/ex/sketch.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 

--- a/doc/ex/skewx.rb
+++ b/doc/ex/skewx.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(250, 250, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/skewy.rb
+++ b/doc/ex/skewy.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(250, 250, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/smile.rb
+++ b/doc/ex/smile.rb
@@ -1,7 +1,7 @@
 #! /usr/local/bin/ruby -w
 # RMagick version of ImageMagick's "smile.c" example program.
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 SmileWidth = 48

--- a/doc/ex/solarize.rb
+++ b/doc/ex/solarize.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#solarize method
 

--- a/doc/ex/sparse_color.rb
+++ b/doc/ex/sparse_color.rb
@@ -1,4 +1,4 @@
-require "RMagick"
+require "rmagick"
 
 def draw_centers(img, all_four = true)
    gc = Magick::Draw.new

--- a/doc/ex/splice.rb
+++ b/doc/ex/splice.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the splice method.
 

--- a/doc/ex/spread.rb
+++ b/doc/ex/spread.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#spread method
 

--- a/doc/ex/stegano.rb
+++ b/doc/ex/stegano.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#stegano method.
 

--- a/doc/ex/stroke_dasharray.rb
+++ b/doc/ex/stroke_dasharray.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(500,180, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/stroke_linecap.rb
+++ b/doc/ex/stroke_linecap.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(615, 100)

--- a/doc/ex/stroke_linejoin.rb
+++ b/doc/ex/stroke_linejoin.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(400, 150) { self.background_color = 'white' }

--- a/doc/ex/stroke_width.rb
+++ b/doc/ex/stroke_width.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(500,80, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/swirl.rb
+++ b/doc/ex/swirl.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#swirl method
 

--- a/doc/ex/text.rb
+++ b/doc/ex/text.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(190,190)

--- a/doc/ex/text_align.rb
+++ b/doc/ex/text_align.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Draw#text_align method
 

--- a/doc/ex/text_antialias.rb
+++ b/doc/ex/text_antialias.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(275, 170) { self.background_color = "white" }

--- a/doc/ex/text_undercolor.rb
+++ b/doc/ex/text_undercolor.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Draw#text_undercolor method
 

--- a/doc/ex/texture_fill_to_border.rb
+++ b/doc/ex/texture_fill_to_border.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#texture_fill_to_border method
 # This example is nearly identical to the color_fill_to_border example.

--- a/doc/ex/texture_floodfill.rb
+++ b/doc/ex/texture_floodfill.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#texture_floodfill method
 # This example is nearly identical to the color_floodfill example.

--- a/doc/ex/texturefill.rb
+++ b/doc/ex/texturefill.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Magick::TextureFill class.
 

--- a/doc/ex/threshold.rb
+++ b/doc/ex/threshold.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#threshold method
 

--- a/doc/ex/to_blob.rb
+++ b/doc/ex/to_blob.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 before = Magick::Image.read("images/Flower_Hat.jpg").first
 before.resize!(0.50)  # make it small so this example will run fast

--- a/doc/ex/translate.rb
+++ b/doc/ex/translate.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 imgl = Magick::ImageList.new
 imgl.new_image(250, 250, Magick::HatchFill.new('white','lightcyan2'))

--- a/doc/ex/transparent.rb
+++ b/doc/ex/transparent.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#transparent method.
 # Change all black pixels in the image to transparent.

--- a/doc/ex/transpose.rb
+++ b/doc/ex/transpose.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#transpose method
 

--- a/doc/ex/transverse.rb
+++ b/doc/ex/transverse.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#transverse method
 

--- a/doc/ex/trim.rb
+++ b/doc/ex/trim.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the trim method
 

--- a/doc/ex/unsharp_mask.rb
+++ b/doc/ex/unsharp_mask.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#enhance method
 

--- a/doc/ex/viewex.rb
+++ b/doc/ex/viewex.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.new(40, 40) {self.background_color = 'lightcyan2'}
 

--- a/doc/ex/vignette.rb
+++ b/doc/ex/vignette.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require 'RMagick'
+require "rmagick"
 
 # Demonstrate the Image#vignette method.
 # Compare this example with the vignette.rb script in the examples directory.

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -1,6 +1,6 @@
 #! /usr/local/bin/ruby -w
 
-require "RMagick"
+require "rmagick"
 
 img = Magick::Image.read("images/Flower_Hat.jpg").first
 

--- a/doc/ex/wave.rb
+++ b/doc/ex/wave.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'RMagick'
+require "rmagick"
 
 
 results = Magick::ImageList.new

--- a/doc/ilist.html
+++ b/doc/ilist.html
@@ -917,7 +917,7 @@ imagelist2 = imagelist1.copy
 
     <h4>Example</h4>
     <pre>
-require 'RMagick'
+require "rmagick"
 
 f = File.open('Cheetah.jpg')
 blob = f.read

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -130,7 +130,7 @@
   displays<span class="sup"><a href="#display">1</a></span> it on
   your monitor</p>
   <pre class="example">
-1. require 'RMagick'
+1. require "rmagick"
 2. include Magick
 3.
 4. cat = ImageList.new("Cheetah.jpg")
@@ -194,7 +194,7 @@
 
   <p>Going back to the example, let's make one modification.</p>
   <pre class="example">
-1. require 'RMagick'
+1. require "rmagick"
 2. include Magick
 3.
 4. cat = ImageList.new("Cheetah.jpg")
@@ -219,7 +219,7 @@
   <p>Here's how to write the small cheetah to a file in GIF
   format.</p>
   <pre class="example">
-1. require 'RMagick'
+1. require "rmagick"
 2. include Magick
 3.
 4. cat = ImageList.new("Cheetah.jpg")
@@ -293,7 +293,7 @@
   the background color of a new image to red with the
   <code>background_color=</code> method, as shown here:</p>
   <pre class="example">
-require 'RMagick'
+require "rmagick"
 include Magick
 # Create a 100x100 red image.
 f = Image.new(100,100) { self.background_color = "red" }
@@ -335,7 +335,7 @@ exit
   images) into one animated GIF file.</p>
   <pre class="example">
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 anim = ImageList.new("start.gif", "middle.gif", "finish.gif")
 anim.write("animated.gif")
 exit
@@ -1423,7 +1423,7 @@ exit
   created the circle in the center of the above image.</p>
   <pre class="example">
  1. !# /usr/local/bin/ruby -w
- 2. require 'RMagick'
+ 2. require "rmagick"
  3.
  4. canvas = Magick::ImageList.new
  5. canvas.new_image(250, 250, Magick::HatchFill.new('white', 'gray90'))
@@ -1494,7 +1494,7 @@ exit
   </div>
   <pre class="example">
  1.   #! /usr/local/bin/ruby -w
- 2.   require 'RMagick'
+ 2.   require "rmagick"
  3.
  4.   # Demonstrate the annotate method
  5.

--- a/examples/constitute.rb
+++ b/examples/constitute.rb
@@ -1,5 +1,5 @@
 #! /usr/local/bin/ruby -w
-require 'RMagick'
+require "rmagick"
 
 f = Magick::Image.read("../doc/ex/images/Flower_Hat.jpg").first
 pixels = f.dispatch(0,0,f.columns, f.rows, "RGB")

--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -7,7 +7,7 @@
 
 # Demo the use of the GravityType argument to Image#crop.
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 shorts = Image.read('../doc/ex/images/Shorts.jpg').first

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -5,7 +5,7 @@
 # Concept and algorithms lifted from Magick++ demo script written
 # by Bob Friesenhahn.
 #
-require 'RMagick'
+require "rmagick"
 include Magick
 
 #

--- a/examples/describe.rb
+++ b/examples/describe.rb
@@ -3,7 +3,7 @@
 # Usage: describe.rb filename1 [filename2...]
 # Notes: The output is similar to ImageMagick's identify command.
 
-require 'RMagick'
+require "rmagick"
 
 puts <<END_INFO
 

--- a/examples/find_similar_region.rb
+++ b/examples/find_similar_region.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 #   The Image#find_similar_region searches for a region in the image
 #   similar to the target. This example uses a rectangle from the image

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -2,7 +2,7 @@
 # from either ImageMagick 6.0.0 or GraphicsMagick 1.1
 # Specify an image filename as an argument.
 
-require 'RMagick'
+require "rmagick"
 
 class PixelColumn < Array
     def initialize(size)

--- a/examples/identify.rb
+++ b/examples/identify.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 
 module Magick
     class Image

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -1,7 +1,7 @@
 
 # Ccreate a semi-transparent title for an image.
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/examples/import_export.rb
+++ b/examples/import_export.rb
@@ -2,7 +2,7 @@
 # Demonstrate the export_pixels and import_pixels methods.
 #
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/examples/pattern_fill.rb
+++ b/examples/pattern_fill.rb
@@ -5,7 +5,7 @@
 # Usage: pattern_fill.rb <name-of-pattern>
 # Try 'checkerboard' or 'verticalsaw'
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/examples/rotating_text.rb
+++ b/examples/rotating_text.rb
@@ -2,7 +2,7 @@
 # an animated MIFF file showing a rotating text string.
 
 
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/examples/spinner.rb
+++ b/examples/spinner.rb
@@ -1,7 +1,7 @@
 # Make a 32x32 animated GIF that resembles the OS X animation.
 # This produces a very small (~2.6Kb) GIF file.
 
-require 'RMagick'
+require "rmagick"
 
 puts <<END_INFO
 This example creates an animated GIF that resembles the OS X "waiting" icon.

--- a/examples/thumbnail.rb
+++ b/examples/thumbnail.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require "rmagick"
 include Magick
 
 puts <<END_INFO

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -28,7 +28,7 @@
 #
 #++############################################################################
 
-require 'RMagick'
+require "rmagick"
 require 'rvg/misc'
 require 'rvg/describable'
 require 'rvg/stylable'


### PR DESCRIPTION
We created a deprecation warning when requiring "RMagick"

We were getting warnings when running tests

Our code required "RMagick" quite a bit.

This PR changed all the requires to "rmagick", as we recommend.

I just checked out master an ran `git grep -l require | xargs perl -pi -w -e 's/require .RMagick./require "rmagick"/g;'`
