### PR TITLE
Accept `convert -version` format variation

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -109,7 +109,7 @@ module RMagick
 
       elsif RUBY_PLATFORM =~ /mingw/  # mingw
 
-        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-\d+ /
+        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-+\d+ /
         abort 'Unable to get ImageMagick version' unless $1
         $magick_version = $1
         if RUBY_PLATFORM =~ /x64/
@@ -120,7 +120,7 @@ module RMagick
 
       else  # mswin
 
-        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-\d+ /
+        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-+\d+ /
         abort 'Unable to get ImageMagick version' unless $1
         $magick_version = $1
         $CFLAGS = '-W3'


### PR DESCRIPTION
In Win64 ImageMagick 6.9.1-6, the version message is

>Version: ImageMagick 6.9.1--6 Q16 x64 2015-06-20 http://www.imagemagick.org

containing multiple hyphens. 

I don't know whether this notation is a bug or a feature of ImageMagick, but I think support for this notation is useful and not destructive