### PR TITLE
Remove bad regex when checking windows version

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -120,7 +120,7 @@ module RMagick
 
       else  # mswin
 
-        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-+\d+ /
+        `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)/
         abort 'Unable to get ImageMagick version' unless $1
         $magick_version = $1
         $CFLAGS = '-W3'


### PR DESCRIPTION
I was able to successfully install the gem on Windows 7 after building with this change. I installed ImageMagick-6.9.1-7-Q16-x64-dll.exe.