### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,16 @@ matrix:
     - rvm: 2.0
       env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
   allow_failures:
-    - rvm: 1.8
-    - rvm: 2.2
     - env: IMAGEMAGICK_VERSION=6.7.7-10
     - env: IMAGEMAGICK_VERSION=6.7.9-10
+      rvm: 2.1
+    - env: IMAGEMAGICK_VERSION=6.7.9-10
+      rvm: 2.2
+    - env: IMAGEMAGICK_VERSION=6.8.9-10
+      rvm: 2.1
     - env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
+      rvm: 2.1
+    - env: IMAGEMAGICK_VERSION=latest
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 
 env:
   # Currently successful release
-  - IMAGEMAGICK_VERSION=6.6.9-10
   - IMAGEMAGICK_VERSION=6.6.9-10 STYLE_CHECKS=true
   # Ubuntu's current stable release
   - IMAGEMAGICK_VERSION=6.7.7-10
@@ -55,7 +54,6 @@ matrix:
   allow_failures:
     - rvm: 1.8
     - rvm: 2.2
-    - env: IMAGEMAGICK_VERSION=6.6.9-10 STYLE_CHECKS=true
     - env: IMAGEMAGICK_VERSION=6.7.7-10
     - env: IMAGEMAGICK_VERSION=6.7.9-10
     - env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 os:
   - linux
 
+sudo: required
+
 env:
   # Currently successful release
   - IMAGEMAGICK_VERSION=6.6.9-10 STYLE_CHECKS=true

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -5,13 +5,13 @@ sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev libpng
 sudo apt-get build-dep -y imagemagick
 case $IMAGEMAGICK_VERSION in
     latest)
-        wget http://www.imagemagick.org/download/ImageMagick.tar.gz
-        tar -xzvf ImageMagick.tar.gz
+        wget http://www.imagemagick.org/download/ImageMagick.tar.xz
+        tar -xf ImageMagick.tar.xz
         cd ImageMagick-*
     ;;
     *)
-        wget http://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz
-        tar -xzvf ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz
+        wget http://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+        tar -xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
         cd ImageMagick-${IMAGEMAGICK_VERSION}
     ;;
 esac

--- a/doc/ex/gravity.rb
+++ b/doc/ex/gravity.rb
@@ -5,7 +5,8 @@
 
 require 'rmagick'
 
-x, y = 100, 100
+x = 100
+y = 100
 
 begin
 

--- a/lib/rvg/embellishable.rb
+++ b/lib/rvg/embellishable.rb
@@ -186,10 +186,12 @@ module Magick
                 if @align == 'none'
                     # Let RMagick do the scaling
                     scale = 1.0
-                    width, height = @width, @height
+                    width = @width
+                    height = @height
                 elsif @meet_or_slice == 'meet'
                     scale = [@width/@image.columns, @height/@image.rows].min
-                    width, height = @image.columns, @image.rows
+                    width = @image.columns
+                    height = @image.rows
                 else
                     # Establish clipping path around the current viewport
                     name = __id__.to_s
@@ -199,7 +201,8 @@ module Magick
 
                     gc.clip_path(name)
                     scale = [@width/@image.columns, @height/@image.rows].max
-                    width, height = @image.columns, @image.rows
+                    width = @image.columns
+                    height = @image.rows
                 end
                 tx, ty = align_to_viewport(scale)
                 gc.composite(@x+tx, @y+ty, width*scale, height*scale, @image)
@@ -207,7 +210,8 @@ module Magick
 
             def init_viewbox
                 @align = nil
-                @vbx_width, @vbx_height = @image.columns, @image.rows
+                @vbx_width = @image.columns
+                @vbx_height = @image.rows
                 @meet_or_slice = 'meet'
             end
 
@@ -331,7 +335,8 @@ module Magick
             def rvg(cols, rows, x=0, y=0, &block)
                 rvg = Magick::RVG.new(cols, rows, &block)
                 begin
-                    x, y = Float(x), Float(y)
+                    x = Float(x)
+                    y = Float(y)
                 rescue ArgumentError
                     args = [cols, rows, x, y]
                     raise ArgumentError, "at least one argument is not convertable to Float (got #{args.collect {|a| a.class}.join(', ')})"

--- a/lib/rvg/misc.rb
+++ b/lib/rvg/misc.rb
@@ -625,7 +625,8 @@ module Magick
                 def scale(sx, sy)
                     sx, sy = Magick::RVG.convert_to_float(sx, sy)
                     @gc.scale(sx, sy)
-                    @sx, @sy = sx, sy
+                    @sx = sx
+                    @sy = sy
                     concat_matrix
                     nil
                 end
@@ -688,7 +689,8 @@ module Magick
                 def translate(tx, ty)
                     tx, ty = Magick::RVG.convert_to_float(tx, ty)
                     @gc.translate(tx, ty)
-                    @tx, @ty = tx, ty
+                    @tx = tx
+                    @ty = ty
                     concat_matrix
                     nil
                 end

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -80,7 +80,8 @@ module Magick
                         when :tiled
                             Magick::Image.new(@width, @height, Magick::TextureFill.new(@background_image))
                         when :fit
-                            width, height = @width, @height
+                            width = @width
+                            height = @height
                             bgcolor = bgfill
                             @background_image.change_geometry(Magick::Geometry.new(width, height)) do |new_cols, new_rows|
                                 bg_image = @background_image.resize(new_cols, new_rows)
@@ -214,14 +215,16 @@ module Magick
         # groups unless overridden by an inner container or the object itself.
         def initialize(width=nil, height=nil)
             super
-            @width, @height = width, height
+            @width = width
+            @height = height
             @content = Content.new
             @canvas = nil
             @background_fill = nil
             @background_fill_opacity = 1.0  # applies only if background_fill= is used
             @background_position = :scaled
             @background_pattern, @background_image, @desc, @title, @metadata = nil
-            @x, @y = 0.0, 0.0
+            @x = 0.0
+            @y = 0.0
             @nested = false
             yield(self) if block_given?
         end
@@ -250,7 +253,8 @@ module Magick
         # Used by Magick::Embellishable.rvg to set non-0 x- and y-coordinates
         def corner(x, y)        #:nodoc:
             @nested = true
-            @x, @y = Float(x), Float(y)
+            @x = Float(x)
+            @y = Float(y)
             translate(@x, @y) if @x != 0.0 || @y != 0.0
         end
 

--- a/lib/rvg/stretchable.rb
+++ b/lib/rvg/stretchable.rb
@@ -40,7 +40,8 @@ module Magick
 
             # Scale to fit
             def set_viewbox_none(width, height)
-                sx, sy = 1.0, 1.0
+                sx = 1.0
+                sy = 1.0
 
                 if @vbx_width
                     sx = width / @vbx_width
@@ -95,7 +96,8 @@ module Magick
 
                 if @align == 'none'
                     sx, sy = set_viewbox_none(width, height)
-                    tx, ty = 0, 0
+                    tx = 0
+                    ty = 0
                 elsif @meet_or_slice == 'meet'
                     sx, sy = set_viewbox_meet(width, height)
                     tx, ty = align_to_viewport(width, height, sx, sy)

--- a/lib/rvg/transformable.rb
+++ b/lib/rvg/transformable.rb
@@ -86,7 +86,8 @@ module Magick
                         when 0
                             @transforms << [:rotate, [Float(angle)]]
                         when 2
-                            cx, cy = Float(args[0]), Float(args[1])
+                            cx = Float(args[0])
+                            cy = Float(args[1])
                             @transforms << [:translate, [cx, cy]]
                             @transforms << [:rotate, [angle]]
                             @transforms << [:translate, [-cx, -cy]]

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -102,7 +102,10 @@ class Magick_UT < Test::Unit::TestCase
     end
 
     def test_geometry
-      g, gs, g2, gs2 = nil, nil, nil, nil
+      g = nil
+      gs = nil
+      g2 = nil
+      gs2 = nil
       assert_nothing_raised { g = Magick::Geometry.new }
       assert_nothing_raised { gs = g.to_s }
       assert_equal('', gs)


### PR DESCRIPTION
I'm surprised to see a well known open source project with a red build for 4 months. I'm sure this will lead only to tears and misery and I think the time to fix it is well invested.

It wasn't even hard this time:

* Imagemagick doesn't offer `tar.gz` any more, so I changed it to download `tar.xz` instead
* I ran `rubocop -a`

Since no spec was failing after that, I removed everything from allowed failures.

I'd also remove Ruby 1.8 and 1.9 from Travis (and require 2.0 in the gemspec). [Quoting PragTob](https://twitter.com/PragTob/status/623172491301789696): 
> I don't think keeping compatibility with OLD gems/rubies is important. They are probably fine running an old major version of your gem too

But that's up to you to decide, I haven't changed it.