### PR TITLE
Add .editorconfig to make a default indentation style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# @see http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = spaces
+tab_width = 2
+
+[{*.{rb,yml,sh,md}]
+indent_size = 2


### PR DESCRIPTION
@vassilevsky, @u338steven, @bf4

I'm thinking about refactoring the indentation style, based on:

https://github.com/styleguide/ruby
https://github.com/bbatsov/ruby-style-guide
So this first pull-request is adds an .editorconfig file to formalize the coding-style based on the guides above.