### PR TITLE
Test if RuboCop on Semaphore detects this

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -179,7 +179,7 @@ end
 task :test => :compile
 task :spec => :compile
 
-if ENV['STYLE_CHECKS']
+if ENV["STYLE_CHECKS"]
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
   task :default => [:spec, :test, :rubocop]


### PR DESCRIPTION
This is what I meant when I said it would be nice to run RuboCop as a different check.

There are plenty CI services with free offerings for open source. One of the best ones is Semaphore. I've set up a project there that simply runs the latest RuboCop against the repo.