### PR TITLE
Add README hint for bitness under windows

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -36,7 +36,7 @@ On Ubuntu, you can run:
 
 bc. sudo apt-get install libmagickwand-dev
 
-*Note to windows users:* Please make sure that you choose an ImageMagick version that matches the bitness of your ruby version.
+*Note to Windows users:* Please make sure that you choose an ImageMagick version that matches the bitness of your Ruby version.
 
 h2(#install). Installing RMagick
 

--- a/README.textile
+++ b/README.textile
@@ -36,6 +36,8 @@ On Ubuntu, you can run:
 
 bc. sudo apt-get install libmagickwand-dev
 
+*Note to windows users:* Please make sure that you choose an ImageMagick version that matches the bitness of your ruby version.
+
 h2(#install). Installing RMagick
 
 h4. Installing via Bundler


### PR DESCRIPTION
Created after finding out about my own fault in https://github.com/rmagick/rmagick/issues/225

Since I checked the README prerequisites as first troubleshooting step, I believe that this hint could be helpful for others too.

### Side note

Your contribution guidelines state

> NOTE: GitHub suggests `rmagick-temp/rmagick` repo by default.

This is not true for me. I got `rmagick/rmagick` suggested, which is the repo I forked from.

