### PR TITLE
Release the Global VM Lock on ImageList operations

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -364,6 +364,26 @@ ImageList_display(VALUE self)
     return self;
 }
 
+// Actual flatten operation without the Global VM Lock
+void *
+ImageList_flatten_no_gvl_wrapper(void *args)
+{
+  Image *new_image;
+  struct imagelist_arguments *imagelist_args = (struct imagelist_arguments *)args;
+  imagelist_args->exception = AcquireExceptionInfo();
+  #if defined(HAVE_ENUM_FLATTENLAYER)
+      new_image = MergeImageLayers(imagelist_args->images, FlattenLayer, imagelist_args->exception);
+  #else
+      new_image = FlattenImages(imagelist_args->images, imagelist_args->exception);
+  #endif
+  rm_split(imagelist_args->images);
+  rm_check_exception(imagelist_args->exception, new_image, DestroyOnError);
+  (void) DestroyExceptionInfo(imagelist_args->exception);
+
+  rm_ensure_result(new_image);
+
+  return (void *)new_image;
+}
 
 /**
  * Merge all the images into a single image.
@@ -380,23 +400,12 @@ ImageList_display(VALUE self)
 VALUE
 ImageList_flatten_images(VALUE self)
 {
-    Image *images, *new_image;
-    ExceptionInfo *exception;
+    struct imagelist_arguments imagelist_args;
+    Image *new_image;
 
-    images = images_from_imagelist(self);
-    exception = AcquireExceptionInfo();
+    imagelist_args.images = images_from_imagelist(self);
 
-#if defined(HAVE_ENUM_FLATTENLAYER)
-    new_image = MergeImageLayers(images, FlattenLayer, exception);
-#else
-    new_image = FlattenImages(images, exception);
-#endif
-
-    rm_split(images);
-    rm_check_exception(exception, new_image, DestroyOnError);
-    (void) DestroyExceptionInfo(exception);
-
-    rm_ensure_result(new_image);
+    new_image = (Image *)rb_thread_call_without_gvl(ImageList_flatten_no_gvl_wrapper, &imagelist_args, RUBY_UBF_PROCESS, NULL);
 
     return rm_image_new(new_image);
 }


### PR DESCRIPTION
I just started working on it and this PR doesn't clean resources correctly when killing a thread.
It is functionally equivalent to the original code except the fact that other ruby threads are now able to run in parallel. 
