### PR TITLE
Support for ImageMagick 6.9+

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -88,13 +88,12 @@ module RMagick
 
         # From ImageMagick 6.9 binaries are split to two and we have to use
         # MagickWand instead of MagickCore
-        checking_for('newer version of ImageMagick (>= 6.9)') do
-          version_data = $magick_version.split('.').map(&:to_i)
-          $with_magick_wand = version_data[0] > 6 || (version_data[0] == 6 && version_data[1] > 8)
+        checking_for("presence of MagickWand API (ImageMagick version >= #{Magick::MIN_WAND_VERSION})") do
+          $with_magick_wand = Gem::Version.new($magick_version) >= Gem::Version.new(Magick::MIN_WAND_VERSION)
           if $with_magick_wand
-            Logging.message('Detected 6.9+ version, using MagickWand package')
+            Logging.message('Detected 6.9+ version, using MagickWand API')
           else
-            Logging.message('Older version detected, using MagickCore package')
+            Logging.message('Older version detected, using MagickCore API')
           end
         end
 

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -58,6 +58,7 @@ module RMagick
         end
 
         # ugly way to handle which config tool we're going to use...
+        $with_magick_wand = false
         $magick_config = false
         $pkg_config = false
 

--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -2,4 +2,5 @@ module Magick
   VERSION = '2.15.4'
   MIN_RUBY_VERSION = '1.8.5'
   MIN_IM_VERSION = '6.4.9'
+  MIN_WAND_VERSION = '6.9.0'
 end


### PR DESCRIPTION
With ImageMagick 6.9 binaries have been splitted into two and MagickWand package must be used in order to compile this gem.