### PR TITLE
Stop preventing image attributes in texts

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1935,8 +1935,6 @@ get_type_metrics(
                 VALUE self,
                 get_type_metrics_func_t getter)
 {
-    static char attrs[] = "OPbcdefghiklmnopqrstuwxyz[@#%";
- #define ATTRS_L ((int)(sizeof(attrs)-1))
     Image *image;
     Draw *draw;
     VALUE t;
@@ -1950,34 +1948,6 @@ get_type_metrics(
     {
         case 1:                   // use default image
             text = rm_str2cstr(argv[0], &text_l);
-
-            for (x = 0; x < text_l-1; x++)
-            {
-                // Ensure text string doesn't refer to image attributes.
-                if (text[x] == '%')
-                {
-                    int y;
-                    char spec = text[x+1];
-
-                    if (spec == '%')
-                    {
-                        x++;
-                    }
-                    else
-                    {
-                        for (y = 0; y < ATTRS_L; y++)
-                        {
-                            if (spec == attrs[y])
-                            {
-                                rb_raise(rb_eArgError,
-                                         "text string contains image attribute reference `%%%c'",
-                                         spec);
-                            }
-                        }
-                    }
-                }
-            }
-
             Data_Get_Struct(get_dummy_tm_img(CLASS_OF(self)), Image, image);
             break;
         case 2:


### PR DESCRIPTION
I was unable to render `%x` in a text because RMagick doesn't want the text to include image attributes. But these image attributes do not seem to be used by the underlying process. And using a double percent as mentioned in the doc doesn't work either: it prevents the error but both percent signs are actually rendered.

So I just removed this check and it works. I can render `%x` just fine.

Maybe this behavior depends on the imagemagick library version?