### PR TITLE
Fix prerequisites

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -30,7 +30,7 @@ h2(#prereq). Prerequisites
 
 Ruby must be able to build C-Extensions (e.g. MRI, Rubinius, not JRuby)
 
-*ImageMagick* Version 6.4.9 or later. You can get ImageMagick from "www.imagemagick.org":http://www.imagemagick.org.
+*ImageMagick* Version 6.4.9 or later (6.x.x). You can get ImageMagick from "www.imagemagick.org":http://www.imagemagick.org.
 
 On Ubuntu, you can run:
 


### PR DESCRIPTION
I just solve problem with installing rmagick on OS X. I was faced with incompatible rmagick with imagemagick 7.x.x ver.
I had to downgrade the imagemagick version to 6.9.6-5.
> brew switch imagemagick 6.9.6-5