### PR TITLE
Fix rake `undefined method `last_comment'` error

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
   s.add_development_dependency 'rake-compiler'
-  s.add_development_dependency 'rspec', '~> 3.2.0'
+  s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rubocop', '~> 0.33.0'
 
   if RUBY >= v('2.2.0')


### PR DESCRIPTION
Rake removed this method from Rake 12.0.
See:
https://github.com/ruby/rake/blob/master/History.rdoc#compatibility-changes-1
Seems rspec older than 3.4.0 require incompatible version of rake.
Rake test should be run fine by now

I found no reason why rspec should be locked by minor version, so i think latest 3 version of rspec should be working fine