### PR TITLE
Imagemagick7

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -41,6 +41,8 @@ module RMagick
 
       if have_header('wand/MagickWand.h')
         headers << 'wand/MagickWand.h'
+      elsif have_header('MagickWand/MagickWand.h')
+        headers << 'MagickWand/MagickWand.h'
       else
         exit_failure "\nCan't install RMagick #{RMAGICK_VERS}. Can't find MagickWand.h."
       end

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -40,8 +40,8 @@
 #undef PACKAGE_TARNAME
 #undef WORDS_BIGENDIAN
 
-#include "magick/MagickCore.h"
-#include "magick/magick-config.h"
+#include "MagickCore/MagickCore.h"
+#include "MagickCore/magick-config.h"
 
 // Undef ImageMagick's versions of these symbols
 #undef PACKAGE_STRING


### PR DESCRIPTION
Initial port for imagemagick 7.

Only changes the import namespace. There is a whole lot more porting required.