### PR TITLE
fix argument count in Image#morphology_channel

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -337,7 +337,7 @@ Init_RMagick2(void)
     rb_define_method(Class_Image, "convolve", Image_convolve, 2);
     rb_define_method(Class_Image, "convolve_channel", Image_convolve_channel, -1);
     rb_define_method(Class_Image, "morphology", Image_morphology, 3);
-    rb_define_method(Class_Image, "morphology_channel", Image_morphology_channel, 3);
+    rb_define_method(Class_Image, "morphology_channel", Image_morphology_channel, 4);
     rb_define_method(Class_Image, "copy", Image_copy, 0);
     rb_define_method(Class_Image, "crop", Image_crop, -1);
     rb_define_method(Class_Image, "crop!", Image_crop_bang, -1);

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -107,6 +107,21 @@ class Image2_UT < Test::Unit::TestCase
     assert_raise(ArgumentError) { @img.contrast_stretch_channel(25, 'x') }
   end
 
+  def test_morphology_channel
+    assert_raise(ArgumentError) { @img.morphology_channel }
+    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel) }
+    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }
+    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }
+    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }
+
+    kernel = Magick::KernelInfo.new("Octagon")
+    assert_nothing_raised do
+      res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
+      assert_instance_of(Magick::Image, res)
+      assert_not_same(@img, res)
+    end
+  end
+
   def test_convolve
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3


### PR DESCRIPTION
Image_morphology_channel requires 4 arguments.

https://github.com/rmagick/rmagick/blob/6759bf186355af107205c5ab98f3433856d25935/ext/RMagick/rmimage.c#L4211

If you pass 3 arguments, it causes a SEGV in RMagick.

### Sample code

```ruby
require 'rmagick'

image = Magick::ImageList.new('./Flower_Hat.jpg').first
kernel_info = Magick::KernelInfo.new("Octagon")

# new_img = image.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel_info)

# This will cause a SEGV in RMagick.
new_img = image.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2)

new_img.write('./morphology_channel.png')
```

### Result

```
$ ruby morphology_channel.rb
morphology_channel.rb:7: [BUG] Segmentation fault at 0x0000000000000000
ruby 2.3.7p456 (2018-03-28 revision 63024) [x86_64-darwin18]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0013 e:000012 CFUNC  :morphology_channel
c:0002 p:0075 s:0007 E:000d78 EVAL   morphology_channel.rb:7 [FINISH]
c:0001 p:0000 s:0002 E:001cf0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
morphology_channel.rb:7:in `<main>'
morphology_channel.rb:7:in `morphology_channel'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000014 rbx: 0x000000010621df80 rcx: 0x48f87d8948000000
 rdx: 0x00007f8e598e46c8 rdi: 0x00000001062461f8 rsi: 0x00007f8e598e46c8
 rbp: 0x00007ffee9ebf000 rsp: 0x00007ffee9ebef18  r8: 0x00000001062461f0
  r9: 0x00007f8e598de110 r10: 0x00007f8e5b085ea0 r11: 0x0000000105df3370
 r12: 0x0000000000000003 r13: 0x00007f8e5956ace0 r14: 0x00007f8e5989ce90
 r15: 0x0000000000000003 rip: 0x0000000105df3415 rfl: 0x0000000000010212

-- C level backtrace information -------------------------------------------
0   ruby                                0x0000000105efe7d9 rb_vm_bugreport + 377
1   ruby                                0x0000000105d8c8af rb_bug_context + 447
2   ruby                                0x0000000105e6c304 sigsegv + 68
3   libsystem_platform.dylib            0x00007fff6d2adb3d _sigtramp + 29
4   ruby                                0x0000000105df3415 rb_obj_is_kind_of + 165
5   ruby                                0x0000000105ef42ab vm_call_cfunc + 299
6   ruby                                0x0000000105edd89f vm_exec_core + 10671
7   ruby                                0x0000000105eee705 vm_exec + 117
8   ruby                                0x0000000105d956d6 ruby_exec_internal + 150
9   ruby                                0x0000000105d955e8 ruby_run_node + 56
10  ruby                                0x0000000105d4148f main + 79
--- snip ---
```