### PR TITLE
check that GetImageChannelEntropy() is implemented in ImageMagick

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -353,6 +353,7 @@ END_MSWIN
        'GetAuthenticIndexQueue', # 6.4.5-6
        'GetAuthenticPixels', # 6.4.5-6
        'GetImageAlphaChannel', # 6.3.9-2
+       'GetImageChannelEntropy', # 6.9.0-0
        'GetMagickFeatures', # 6.5.7-1
        'GetVirtualPixels', # 6.4.5-6
        'LevelImageColors', # 6.4.2

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2346,6 +2346,7 @@ Image_channel_mean(int argc, VALUE *argv, VALUE self)
 VALUE
 Image_channel_entropy(int argc, VALUE *argv, VALUE self)
 {
+#if defined(HAVE_GETIMAGECHANNELENTROPY)
     Image *image;
     ChannelType channels;
     ExceptionInfo *exception;
@@ -2374,6 +2375,13 @@ Image_channel_entropy(int argc, VALUE *argv, VALUE self)
     RB_GC_GUARD(ary);
 
     return ary;
+#else
+    rm_not_implemented();
+    return (VALUE) 0;
+    argc = argc;
+    argv = argv;
+    self = self;
+#endif
 }
 
 


### PR DESCRIPTION
GetImageChannelEntropy() was implemented at ImageMagick 6.9.0-0.

If RMagick was compiled with older ImageMagick 6,
it will cause a following error when it looks up GetImageChannelEntropy symbol.

```
dyld: lazy symbol binding failed: Symbol not found: _GetImageChannelEntropy
  Referenced from: /Users/watson/prj/rmagick/lib/RMagick2.bundle
  Expected in: flat namespace

dyld: Symbol not found: _GetImageChannelEntropy
  Referenced from: /Users/watson/prj/rmagick/lib/RMagick2.bundle
  Expected in: flat namespace
```

Travis CI shows same error in https://travis-ci.org/rmagick/rmagick/jobs/436792873

<img width="896" alt="2018-10-16 19 45 15" src="https://user-images.githubusercontent.com/199156/47011153-23b4c700-d17c-11e8-9316-cdd3e1e686e2.png">
