### PR TITLE
Drop older Ruby versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,33 +25,16 @@ before_install:
 install: bundle install --verbose
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3
   - 2.4
   - 2.5
 
 matrix:
-  exclude:
-    - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.7.7-10
-    - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.7.9-10
-    - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.8.9-10
-    - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
   allow_failures:
     - env: IMAGEMAGICK_VERSION=6.7.7-10
     - env: IMAGEMAGICK_VERSION=6.7.9-10
-      rvm: 2.1
-    - env: IMAGEMAGICK_VERSION=6.7.9-10
       rvm: 2.2
-    - env: IMAGEMAGICK_VERSION=6.8.9-10
-      rvm: 2.1
-    - env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
-      rvm: 2.1
     - env: IMAGEMAGICK_VERSION=latest
 
 notifications:


### PR DESCRIPTION
The older Ruby versions were dropped at https://github.com/rmagick/rmagick/commit/a828a434e3ccb776eb50637a5e52aeaeb1509a38

So, now it always fails at Ruby 2.0, 2.1 lanes on Travis CI, like

```
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby
    rmagick was resolved to 2.16.0, which depends on
      ruby (>= 2.2.0)
Could not find gem 'ruby (>= 2.2.0)', which is required by gem 'rmagick', in
any of the relevant sources:
  the local ruby installation
The command "bundle install --verbose" failed and exited with 6 during .
Your build has been stopped.
```
(https://travis-ci.org/rmagick/rmagick/jobs/471690003#L2014)