### PR TITLE
skip channel_entropy spec with unsupported ImageMagick

### DIFF
--- a/spec/rmagick/image/channel_entropy_spec.rb
+++ b/spec/rmagick/image/channel_entropy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#channel_entropy' do
   let(:img) { Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first }
 
-  it 'returns a channel entropy' do
+  it 'returns a channel entropy', supported_after('6.9.0') do
     res = img.channel_entropy
     puts "res = #{res.inspect}"
     expect(res).to eq([0.5285857222715863])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,8 @@ require 'rmagick'
 root_dir = File.expand_path('..', __dir__)
 IMAGES_DIR = File.join(root_dir, 'doc/ex/images')
 SUPPORT_DIR = File.join(root_dir, 'spec', 'support')
+
+def supported_after(version)
+  magick_lib_version = Magick::Magick_version.split[1].split('-').first
+  :skip if Gem::Version.new(magick_lib_version) < Gem::Version.new(version)
+end


### PR DESCRIPTION
channel_entropy spec always fails with older ImageMagick.

If you would run channel_entropy spec with unsupported ImageMagick version, this patch will skip it.