### PR TITLE
Fix memory leak

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3163,6 +3163,7 @@ VALUE Image_combine(int argc, VALUE *argv, VALUE self)
     ReverseImageList(&images);
     new_image = CombineImages(images, channel, exception);
     rm_check_exception(exception, images, RetainOnError);
+    (void) DestroyExceptionInfo(exception);
     rm_split(images);
 
     rm_ensure_result(new_image);
@@ -7239,6 +7240,7 @@ has_attribute(VALUE self, MagickBooleanType (attr_test)(const Image *, Exception
 
     r = (attr_test)(image, exception);
     CHECK_EXCEPTION()
+    (void) DestroyExceptionInfo(exception);
 
     return r ? Qtrue : Qfalse;
 }
@@ -12813,6 +12815,7 @@ Image_sparse_color(int argc, VALUE *argv, VALUE self)
     new_image = SparseColorImage(image, channels, method, nargs, args, exception);
     xfree(args);
     CHECK_EXCEPTION();
+    (void) DestroyExceptionInfo(exception);
     rm_ensure_result(new_image);
 
     RB_GC_GUARD(args);


### PR DESCRIPTION
`AcquireExceptionInfo()` allocates the memory area for handling exception in ImageMagick.
However, Ruby's GC does not manage its memory area.
So, `rmagick` must release them after handling exception by using `DestroyExceptionInfo()`.

### Before
```
$ ruby rmagick.rb
Process: 76636: RSS = 133 MB
```

### After
```
$ ruby rmagick.rb
Process: 77939: RSS = 10 MB
```

### Test code
```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
source = Magick::Image.new(20, 20)

100000.times do |i|
  image.gray?
  image.sparse_color(Magick::VoronoiColorInterpolate, 0, 0, 'red')
  Magick::Image.combine(image, source)

  GC.start
end

rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```