### PR TITLE
Fix loading error on Windows

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -8,6 +8,16 @@
 #               to the classes.
 #==============================================================================
 
+if RUBY_PLATFORM =~ /mingw/i
+  begin
+    require 'ruby_installer'
+    ENV['PATH'].split(File::PATH_SEPARATOR).grep(/ImageMagick/i).each do |path|
+      RubyInstaller::Runtime.add_dll_directory(path)
+    end
+  rescue LoadError
+  end
+end
+
 require 'English'
 require 'RMagick2.so'
 


### PR DESCRIPTION
It causes the error if it requires RMagick on Windows with recent [RubyInstaller](https://rubyinstaller.org) as following.

![190113-0001](https://user-images.githubusercontent.com/199156/51085937-540fff80-1783-11e9-813e-a173a6081d79.png)

To solve this error, you need to copy the DLL accoding to article in https://medium.com/ruby-on-rails-web-application-development/install-rmagick-gem-on-windows-7-8-10-imagemagick-6-9-4-q16-hdri-5492c3fef202#f956

This Pull Request fix this error accoding to https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers

With this patch, RMagick works well on Windows, like

![190113-0002](https://user-images.githubusercontent.com/199156/51085995-40b16400-1784-11e9-98dd-d38637c8a2f1.png)
