### PR TITLE
install bundler v1.17.3 for Ruby 2.2 on Travis

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -29,4 +29,4 @@ fi
 # NoMethodError: undefined method `spec' for nil:NilClass
 # Travis uses Bundler 1.7.6 by default and it has this bug
 # https://github.com/rubygems/rubygems/issues/1419
-gem install bundler
+gem install bundler -v 1.17.3


### PR DESCRIPTION
Recently, Bundler v2 was released (https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html).
It supports Ruby 2.3+, but RMagick still supports Ruby 2.2 environment.

If it install bundler v2 on Ruby 2.2, it will cause the following error.

```
Fetching: bundler-2.0.1.gem (100%)
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
	bundler requires Ruby version >= 2.3.0. The current ruby version is 2.2.0.
The command "source before_install_$TRAVIS_OS_NAME.sh" failed and exited with 1 during .
```
(https://travis-ci.org/rmagick/rmagick/jobs/481684602#L3123)

So, this will change the version of bundler to 1.17.3 for Travis.