### PR TITLE
CI: add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.3.8-stretch
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: setup linux
+          command: |
+            IMAGEMAGICK_VERSION=6.8.9-10 bash before_install_linux.sh
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+            - ./ccache
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            bundle exec rake test
+
+      - run:
+          name: run specs
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+
+            bundle exec rspec --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            $TEST_FILES
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake-compiler'
   s.add_development_dependency 'rspec', '~> 3'
+  s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
   s.add_development_dependency 'rubocop'
 
   s.add_development_dependency 'test-unit', '~> 2'


### PR DESCRIPTION
TravisCI performance isn't great, and I need to be able to SSH into the
build in order to debug. I tried the `curl` command [recommended in the
Travis docs][1], but that didn't do the trick. Circle doesn't support
matrix the way that Travis does, but I figure we can manage with a
slightly more verbose config file.

[1]: https://docs.travis-ci.com/user/running-build-in-debug-mode/#restarting-a-job-in-debug-mode-via-api