### PR TITLE
Tests: remove block to handle Ruby 1.8

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -20,13 +20,4 @@ sudo make install
 cd ..
 sudo ldconfig
 
-if [[ $TRAVIS_RUBY_VERSION =~ ^1.8 ]]; then
-    echo "Set the stack size to unlimited to avoid segfault for Ruby 1.8"
-    ulimit -s unlimited
-fi
-
-# Fixes this error:
-# NoMethodError: undefined method `spec' for nil:NilClass
-# Travis uses Bundler 1.7.6 by default and it has this bug
-# https://github.com/rubygems/rubygems/issues/1419
 gem install bundler -v 1.17.3


### PR DESCRIPTION
We no longer support Ruby 1.8, so this can be removed. This was
motivated by wanting to add `set -u` to the top of the script, which was
complaining about the variable being unset.