### PR TITLE
Fix memory leak in Draw#marshal_load

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -670,13 +670,6 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
 
     Data_Get_Struct(self, Draw, draw);
 
-    draw->info = AcquireDrawInfo();
-    if (!draw->info)
-    {
-        rb_raise(rb_eNoMemError, "not enough memory to continue");
-    }
-    GetDrawInfo(NULL, draw->info);
-
     OBJ_TO_MAGICK_STRING(draw->info->geometry, rb_hash_aref(ddraw, CSTR2SYM("geometry")));
 
     //val = rb_hash_aref(ddraw, CSTR2SYM("viewbox"));


### PR DESCRIPTION
`draw->info` was initialized at `DrawOptions_initialize()` via `Draw_initialize()`.

If allocate the memory area with `AcquireDrawInfo()` in here, the area cannot be released in `destroy_Draw()`.

* Before

```
$ ruby draw_marshal_load.rb
Process: 62978: RSS = 812 MB
```

* After

```
$ ruby draw_marshal_load.rb
Process: 7588: RSS = 24 MB
```

* Test code

```ruby
require 'rmagick'

wm = Magick::Image.read("xc:none") { self.size = "100x50" }.first

gc = Magick::Draw.new
gc.fill '#ff0000'
gc.font_weight Magick::BoldWeight
gc.font_size 18
gc.rotate 15
gc.gravity Magick::CenterGravity
gc.text 0, 0, "RMagick"
gc.draw wm

dump = gc.marshal_dump

1000000.times do
  g = Magick::Draw.new
  g.marshal_load(dump)
end

rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```