### PR TITLE
Fix Image#gray? method

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -295,7 +295,8 @@ END_MINGW
     def create_header_file
       have_func('snprintf', headers)
       [
-        'GetImageChannelEntropy' # 6.9.0-0
+        'GetImageChannelEntropy', # 6.9.0-0
+        'GetImageColorspaceType' # 6.9.0-0
       ].each do |func|
         have_func(func, headers)
       end

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -7143,7 +7143,22 @@ has_attribute(VALUE self, MagickBooleanType (attr_test)(const Image *, Exception
 VALUE
 Image_gray_q(VALUE self)
 {
+#if HAVE_GETIMAGECOLORSPACETYPE
+    Image *image;
+    ExceptionInfo *exception;
+    ColorspaceType colorspace;
+
+    image = rm_check_destroyed(self);
+    exception = AcquireExceptionInfo();
+
+    colorspace = GetImageColorspaceType(image, exception);
+    CHECK_EXCEPTION()
+    (void) DestroyExceptionInfo(exception);
+
+    return colorspace == GRAYColorspace ? Qtrue : Qfalse;
+#else
     return has_attribute(self, (MagickBooleanType (*)(const Image *, ExceptionInfo *))IsGrayImage);
+#endif
 }
 
 


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/issues/326

Apparently Image#gray? return expected value, we should check the image colorspace using GetImageColorspaceType().

(Sorry, I don't know the details, I did through the trial and error)