### PR TITLE
Add AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    - RUBY_VERSION: "24-x64"
+
+install:
+  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-6.8.9-10-Q16-x64-dll.exe
+  - ImageMagick-6.8.9-10-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-6.8.9-Q16;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - rake -rdevkit


### PR DESCRIPTION
To support Windows environment, we can use AppVeyor CI for testing.

As the first step, It works with the following combinations.

- Ruby+Devkit 2.5.3-1 (https://rubyinstaller.org/downloads/)
- ImageMagick 6.9.10.24

Example)
https://ci.appveyor.com/project/Watson1978/rmagick/builds/21991269

@mockdeep Can you add AppVeyor integration in this repository if you interest ?