### PR TITLE
deprecate support for ImageMagick < 6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ os:
 sudo: required
 
 env:
-  # Currently successful release
-  - IMAGEMAGICK_VERSION=6.6.9-10
-  # Ubuntu's current stable release
-  - IMAGEMAGICK_VERSION=6.7.7-10
-  # Latest 6.7 release
-  - IMAGEMAGICK_VERSION=6.7.9-10
-  # Latest 6.8 release
   - IMAGEMAGICK_VERSION=6.8.9-10
   # Try with HDRI support, we don't mind if this fails currently.
   - IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
@@ -31,8 +24,6 @@ rvm:
 
 matrix:
   allow_failures:
-    - env: IMAGEMAGICK_VERSION=6.7.7-10
-    - env: IMAGEMAGICK_VERSION=6.7.9-10
     - env: IMAGEMAGICK_VERSION=latest
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Breaking changes:
 
 - drop support for Ruby < 2.3.8
+- drop support for ImageMagick < 6.8
 
 ## RMagick 2.16.0
 

--- a/README.textile
+++ b/README.textile
@@ -186,7 +186,7 @@ h4. 3) install ImageMagick and additional environment stuff
 
 <pre>
 cd /vagrant/rmagick
-export IMAGEMAGICK_VERSION=6.6.9-10 # the only known passing version as of this writing
+export IMAGEMAGICK_VERSION=6.8.9-10
 sh ./before_install_linux.sh
 </pre>
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -455,12 +455,7 @@ class Image2_UT < Test::Unit::TestCase
     assert_nothing_raised do
       @img.each_profile do |name, value|
         assert_equal('iptc', name)
-        # As of 6.3.1
-        if IM_VERSION < Gem::Version.new('6.6.4') || (IM_VERSION == Gem::Version.new('6.6.4') && IM_REVISION < Gem::Version.new('5'))
-          assert_equal("8BIM\004\004\000\000\000\000\001\340test profile", value)
-        else
-          assert_equal('test profile', value)
-        end
+        assert_equal('test profile', value)
       end
     end
   end

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -160,11 +160,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
   def test_colorspace
     assert_nothing_raised { @img.colorspace }
     assert_instance_of(Magick::ColorspaceType, @img.colorspace)
-    if IM_VERSION < Gem::Version.new('6.7.5') || (IM_VERSION == Gem::Version.new('6.7.5') && IM_REVISION < Gem::Version.new('5'))
-      assert_equal(Magick::RGBColorspace, @img.colorspace)
-    else
-      assert_equal(Magick::SRGBColorspace, @img.colorspace)
-    end
+    assert_equal(Magick::SRGBColorspace, @img.colorspace)
     img = @img.copy
     assert_nothing_raised { img.colorspace = Magick::GRAYColorspace }
     assert_equal(Magick::GRAYColorspace, img.colorspace)
@@ -394,11 +390,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
   def test_gamma
     assert_nothing_raised { @img.gamma }
     assert_instance_of(Float, @img.gamma)
-    if IM_VERSION < Gem::Version.new('6.7.5') || (IM_VERSION == Gem::Version.new('6.7.5') && IM_REVISION < Gem::Version.new('5'))
-      assert_equal(0.0, @img.gamma)
-    else
-      assert_equal(0.45454543828964233, @img.gamma)
-    end
+    assert_equal(0.45454543828964233, @img.gamma)
     assert_nothing_raised { @img.gamma = 2.0 }
     assert_equal(2.0, @img.gamma)
     assert_raise(TypeError) { @img.gamma = 'x' }
@@ -487,11 +479,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
   def test_number_colors
     assert_nothing_raised { @hat.number_colors }
-    if IM_VERSION < Gem::Version.new('6.7.5') || (IM_VERSION == Gem::Version.new('6.7.5') && IM_REVISION < Gem::Version.new('5'))
-      assert_equal(27_980, @hat.number_colors)
-    else
-      assert_equal(27_942, @hat.number_colors)
-    end
+    assert_equal(27_942, @hat.number_colors)
     assert_raise(NoMethodError) { @hat.number_colors = 2 }
   end
 
@@ -554,11 +542,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
   def test_rendering_intent
     assert_nothing_raised { @img.rendering_intent }
     assert_instance_of(Magick::RenderingIntent, @img.rendering_intent)
-    if IM_VERSION < Gem::Version.new('6.7.5') || (IM_VERSION == Gem::Version.new('6.7.5') && IM_REVISION < Gem::Version.new('5'))
-      assert_equal(Magick::UndefinedIntent, @img.rendering_intent)
-    else
-      assert_equal(Magick::PerceptualIntent, @img.rendering_intent)
-    end
+    assert_equal(Magick::PerceptualIntent, @img.rendering_intent)
     assert_nothing_raised { @img.rendering_intent = Magick::SaturationIntent }
     assert_nothing_raised { @img.rendering_intent = Magick::PerceptualIntent }
     assert_nothing_raised { @img.rendering_intent = Magick::AbsoluteIntent }
@@ -603,11 +587,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
   def test_total_colors
     assert_nothing_raised { @hat.total_colors }
-    if IM_VERSION < Gem::Version.new('6.7.5') || (IM_VERSION == Gem::Version.new('6.7.5') && IM_REVISION < Gem::Version.new('5'))
-      assert_equal(27_980, @hat.total_colors)
-    else
-      assert_equal(27_942, @hat.total_colors)
-    end
+    assert_equal(27_942, @hat.total_colors)
     assert_raise(NoMethodError) { @img.total_colors = 2 }
   end
 


### PR DESCRIPTION
The default Heroku and Ubuntu version for ImageMagick is 6.8, so we
should be good to march forward from there.