### PR TITLE
Introduce ccache to build ImageMagick on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 
+cache:
+  directories:
+    - ~/.ccache
+
 os:
   - linux
 

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -1,7 +1,7 @@
 dpkg --list imagemagick
 sudo apt-get update
 sudo apt-get remove -y imagemagick
-sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev libpng12-dev libjpeg-dev libfreetype6-dev libxml2-dev
+sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev libpng12-dev libjpeg-dev libfreetype6-dev libxml2-dev ccache
 sudo apt-get build-dep -y imagemagick
 case $IMAGEMAGICK_VERSION in
     latest)
@@ -15,7 +15,8 @@ case $IMAGEMAGICK_VERSION in
         cd ImageMagick-${IMAGEMAGICK_VERSION}
     ;;
 esac
-./configure --prefix=/usr $CONFIGURE_OPTIONS
+CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr $CONFIGURE_OPTIONS
+make
 sudo make install
 cd ..
 sudo ldconfig


### PR DESCRIPTION
We build ImageMagick from source code for test at each time.
And it take a time slightly.

This patch introduce `ccache` to cache built objects in order to reduce compiling time.