### PR TITLE
Remove bundler version from setup script

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -34,6 +34,6 @@ sudo make install
 cd ..
 sudo ldconfig
 
-gem install bundler -v 1.17.3
+gem install bundler
 
 set +u


### PR DESCRIPTION
We should be able to use the latest version now that we've dropped
support for Ruby 2.2.