### PR TITLE
3.0: loosen ruby version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Breaking changes:
 
-- drop support for Ruby < 2.3.8
+- drop support for Ruby < 2.3
 - drop support for ImageMagick < 6.8
 
 ## RMagick 2.16.0

--- a/README.textile
+++ b/README.textile
@@ -28,7 +28,7 @@ These prerequisites are required for the latest DEVELOPMENT version of RMagick. 
 
 *O/S* Linux, &#042;BSD, OS X, Windows 2000, XP, Vista, other &#042;nix-like systems.
 
-*Ruby* 2.3.8 or later. You can get Ruby from "www.ruby-lang.org":http://www.ruby-lang.org.
+*Ruby* 2.3 or later. You can get Ruby from "www.ruby-lang.org":http://www.ruby-lang.org.
 
 Ruby must be able to build C-Extensions (e.g. MRI, Rubinius, not JRuby)
 

--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -1,6 +1,6 @@
 module Magick
   VERSION = '2.16.0'
-  MIN_RUBY_VERSION = '2.3.8'
+  MIN_RUBY_VERSION = '2.3.0'
   MIN_IM_VERSION = '6.4.9'
   MIN_WAND_VERSION = '6.9.0'
 end


### PR DESCRIPTION
TravisCI uses 2.3.7 by default, and it doesn't seem necessary to enforce
a point release.