### PR TITLE
CI: add ImageMagick 6.9 to CI build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,34 @@
 environment:
   matrix:
-    - RUBY_VERSION: "23-x64"
-    - RUBY_VERSION: "24-x64"
-    - RUBY_VERSION: "25-x64"
-    - RUBY_VERSION: "26-x64"
+    - RUBY_VERSION: 23-x64
+      IMAGEMAGICK_VERSION: 6.8.9
+      PATCH_VERSION: 10
+    - RUBY_VERSION: 23-x64
+      IMAGEMAGICK_VERSION: 6.9.10
+      PATCH_VERSION: 34
+    - RUBY_VERSION: 24-x64
+      IMAGEMAGICK_VERSION: 6.8.9
+      PATCH_VERSION: 10
+    - RUBY_VERSION: 24-x64
+      IMAGEMAGICK_VERSION: 6.9.10
+      PATCH_VERSION: 34
+    - RUBY_VERSION: 25-x64
+      IMAGEMAGICK_VERSION: 6.8.9
+      PATCH_VERSION: 10
+    - RUBY_VERSION: 25-x64
+      IMAGEMAGICK_VERSION: 6.9.10
+      PATCH_VERSION: 34
+    - RUBY_VERSION: 26-x64
+      IMAGEMAGICK_VERSION: 6.8.9
+      PATCH_VERSION: 10
+    - RUBY_VERSION: 26-x64
+      IMAGEMAGICK_VERSION: 6.9.10
+      PATCH_VERSION: 35
 
 install:
-  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-6.8.9-10-Q16-x64-dll.exe
-  - ImageMagick-6.8.9-10-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
-  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-6.8.9-Q16;%PATH%
+  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe
+  - ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-%IMAGEMAGICK_VERSION%-Q16;%PATH%
   - bundle install
 
 build: off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: setup linux
           command: |
-            IMAGEMAGICK_VERSION=6.8.9-10 bash before_install_linux.sh
+            IMAGEMAGICK_VERSION=6.9.10-35 bash before_install_linux.sh
 
       - run:
           name: install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ os:
 sudo: required
 
 env:
+  - IMAGEMAGICK_VERSION=6.7.7-10
+  - IMAGEMAGICK_VERSION=6.7.7-10 CONFIGURE_OPTIONS=--enable-hdri
   - IMAGEMAGICK_VERSION=6.8.9-10
+  - IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
+  - IMAGEMAGICK_VERSION=6.9.10-35
+  - IMAGEMAGICK_VERSION=6.9.10-35 CONFIGURE_OPTIONS=--enable-hdri
 
 before_install:
   - source before_install_$TRAVIS_OS_NAME.sh
@@ -27,12 +32,6 @@ matrix:
   include:
     - rvm: 2.3
       env: STYLE_CHECKS=true IMAGEMAGICK_VERSION=6.8.9-10
-    - rvm: 2.6
-      env: IMAGEMAGICK_VERSION=6.7.7-10
-    - rvm: 2.6
-      env: IMAGEMAGICK_VERSION=6.7.7-10 CONFIGURE_OPTIONS=--enable-hdri
-    - rvm: 2.6
-      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 notifications:
   webhooks:


### PR DESCRIPTION
Also add back builds across versions of ruby. We've seen a number of odd
regressions with different combinations of Ruby and ImageMagick, so even
though it slows down the build, I think we're probably better off
testing all combinations.