### PR TITLE
CI: set strict options for setup script

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -1,3 +1,5 @@
+set -euo pipefail
+
 sudo apt-get update
 
 # remove all existing imagemagick related packages
@@ -20,10 +22,18 @@ case $IMAGEMAGICK_VERSION in
         cd ImageMagick-${IMAGEMAGICK_VERSION}
     ;;
 esac
-CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr $CONFIGURE_OPTIONS
+
+if [ -v CONFIGURE_OPTIONS ]; then
+  CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr $CONFIGURE_OPTIONS
+else
+  CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr
+fi
+
 make
 sudo make install
 cd ..
 sudo ldconfig
 
 gem install bundler -v 1.17.3
+
+set +u


### PR DESCRIPTION
- `-e` stops the script on an error
- `-u` does not allow unassigned variables, except for conditional
  checks like `case` and `-v`. Because `CONFIGURE_OPTIONS` might not be
  set, I needed to add a check for this.
- `-o pipefail` causes pipe (`|`) expressions to return a failing status
  if any of the commands in the pipeline returns a failing status. We
  currently don't have any pipes to worry about, but we might someday.

We need to add `set +u` at the end of the file to allow unbound
variables in scripts wrapping this on CircleCI and Travis.