### PR TITLE
CI: comment out `before` block in skipped specs

### DIFF
--- a/spec/rmagick/image/read_spec.rb
+++ b/spec/rmagick/image/read_spec.rb
@@ -3,15 +3,15 @@ require 'timeout'
 RSpec.describe Magick::Image, '#read' do
   describe 'issue #200' do
     before do
-      pid = Process.spawn File.join(SUPPORT_DIR, 'issue_200', 'app.rb'), err: :close, out: :close
-      begin
-        Timeout.timeout(1) do
-          _, @status = Process.waitpid2 pid
-        end
-      rescue Timeout::Error
-        Process.kill('KILL', pid)
-        _, @status = Process.waitpid2 pid
-      end
+      # pid = Process.spawn File.join(SUPPORT_DIR, 'issue_200', 'app.rb'), err: :close, out: :close
+      # begin
+      #   Timeout.timeout(1) do
+      #     _, @status = Process.waitpid2 pid
+      #   end
+      # rescue Timeout::Error
+      #   Process.kill('KILL', pid)
+      #   _, @status = Process.waitpid2 pid
+      # end
     end
 
     it 'not hangs with nil argument' do


### PR DESCRIPTION
This test is causing the appveyor build to fail due to the way it
spawns a new process. Both tests affected are already skipped, as they
have never passed, so we can just block out the offending code for the
moment.

https://ci.appveyor.com/project/mockdeep/rmagick/builds/22143507