### PR TITLE
Disable monitor feature on Windows

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9061,6 +9061,9 @@ Image_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageProgressMonitor(image, rm_progress_monitor, (void *)monitor);
     }
 
+#if defined(_WIN32)
+    rb_warn("Image#monitor= does not work on Windows");
+#endif
 
     return self;
 }

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1734,6 +1734,9 @@ Info_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageInfoProgressMonitor(info, rm_progress_monitor, (void *)monitor);
     }
 
+#if defined(_WIN32)
+    rb_warn("Info#monitor= does not work on Windows");
+#endif
 
     return self;
 }

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1445,6 +1445,7 @@ rm_progress_monitor(
     const MagickSizeType sp,
     void *client_data)
 {
+#if !defined(_WIN32)
     VALUE rval;
     VALUE method, offset, span;
 
@@ -1468,6 +1469,9 @@ rm_progress_monitor(
     RB_GC_GUARD(span);
 
     return RTEST(rval) ? MagickTrue : MagickFalse;
+#else
+    return MagickTrue;
+#endif
 }
 
 


### PR DESCRIPTION
The SEGV has been occurred with old ImageMagick (v6.8.9) on only Windows.

If you set the `Proc` object through the `#monitor=` method, the object will be called each time ImageMagick processing progresses at https://github.com/rmagick/rmagick/blob/b1828e24af5eeb1e2b3c2f3e592552950a27bb6b/ext/RMagick/rmutil.c#L1464.

The Proc object is called correctly only once and SEGV always occurs in the second call.

I guess that there is a problem in callback processing with old ImageMagick and it breaks Proc object or something...

So I will disable this method on Windows because it is hard to fix this problem.

* Test code

```
monitor = proc do |mth, q, s|
  true
end
img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
img.resize!(20, 20)
```

* Result
```
> ruby test.rb
#<Magick::Image::Info:0x0000000004c676c8>
"resize!, 0, 40"
Traceback (most recent call last):
test.rb: stack level too deep (SystemStackError)
```