### PR TITLE
Fix memory leak in Magick.init_formats

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -188,6 +188,7 @@ Magick_init_formats(VALUE class)
                             , rb_str_new2(magick_info[x]->name)
                             , MagickInfo_to_format((const MagickInfo *)magick_info[x]));
     }
+    magick_free((void *)magick_info);
     RB_GC_GUARD(formats);
     return formats;
 }


### PR DESCRIPTION
`GetMagickInfoList()` API returns allocated memory area which need to release in RMagick.

* Before

```
$ ruby init_formats.rb
Process: 69864: RSS = 226 MB
```

* After

```
$ ruby init_formats.rb
Process: 71149: RSS = 20 MB
```

* Test code

```ruby
require 'rmagick'

100000.times do
  Magick.init_formats
end

rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```