### PR TITLE
Fix memory leak in PolaroidOptions.new

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1797,6 +1797,8 @@ PolaroidOptions_initialize(VALUE self)
     (void) QueryColorDatabase("gray75", &draw->shadow_color, exception);
     CHECK_EXCEPTION()
     (void) QueryColorDatabase("#dfdfdf", &draw->info->border_color, exception);
+    CHECK_EXCEPTION()
+    DestroyExceptionInfo(exception);
 
     if (rb_block_given_p())
     {


### PR DESCRIPTION
`AcquireExceptionInfo()` returns allocated memory area which need to release in RMagick using `DestroyExceptionInfo()`.

* Before

```
$ ruby polaroid_options.rb
Process: 81296: RSS = 66 MB
```

* After

```
$ ruby polaroid_options.rb
Process: 83152: RSS = 29 MB
```

* Test code

```ruby
require 'rmagick'

100000.times do
  Magick::Image::PolaroidOptions.new
end

rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```