### PR TITLE
Fix memory leak in Info#page=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1902,7 +1902,7 @@ Info_page_eq(VALUE self, VALUE page_arg)
         info->page = NULL;
         return self;
     }
-    magick_clone_string(&info->page, geometry);
+    info->page = geometry;
 
     RB_GC_GUARD(geom_str);
 


### PR DESCRIPTION
`GetPageGeometry()` API returns allocated memory area which need to release in RMagick.

In here, we can remove to duplicate of the string (`magick_clone_string()`) instead of release the string in `geometry`.

* Before

```
$ ruby test.rb
Process: 35116: RSS = 628 MB
```

* After

```
$ ruby test.rb
Process: 35827: RSS = 121 MB
```

* Test code

```ruby
require 'rmagick'

100000.times do
  info = Magick::Image::Info.new
  info.page = 'foobarbaz' * 100
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```