### PR TITLE
Fix memory leak in Info#origin=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1839,10 +1839,12 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
 
     if (IsGeometry(origin) == MagickFalse)
     {
-        rb_raise(rb_eArgError, "invalid origin geometry: %s", origin);
+        magick_free(origin);
+        rb_raise(rb_eArgError, "invalid origin geometry");
     }
 
     (void) SetImageOption(info, "origin", origin);
+    magick_free(origin);
 
     RB_GC_GUARD(origin_str);
 


### PR DESCRIPTION
`GetPageGeometry()` API returns allocated memory area.
We have to release it after used or before raising exception.

* Before

```
$ ruby test.rb
Process: 42227: RSS = 1052 MB
```

* After

```
$ ruby test.rb
Process: 42536: RSS = 65 MB
```

* Test code

```ruby
require 'rmagick'

100000.times do
  info = Magick::Image::Info.new
  begin
    # origin= will raise exception.
    info.origin = 'foobarbaz' * 100
  rescue
  end

  info.origin = '+50+20'
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```