### PR TITLE
Should raise exception in Image.read if nil or empty string argument was given

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10899,6 +10899,11 @@ rd_image(VALUE class, VALUE file, reader_t reader)
 
         filename = rm_str2cstr(file, &filename_l);
         filename_l = min(filename_l, MaxTextExtent-1);
+        if (filename_l == 0)
+        {
+            rb_raise(rb_eArgError, "invalid path");
+        }
+
         memcpy(info->filename, filename, (size_t)filename_l);
         info->filename[filename_l] = '\0';
         SetImageInfoFile(info, NULL);

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -17,6 +17,8 @@ class Image1_UT < Test::Unit::TestCase
     assert_instance_of(Array, res)
     assert_instance_of(Magick::Image, res[0])
     assert_equal(img, res[0])
+    assert_raise(ArgumentError) { Magick::Image.read(nil) }
+    assert_raise(ArgumentError) { Magick::Image.read("") }
   end
 
   def test_spaceship


### PR DESCRIPTION
Fix #200

If nil or empty string argument was given in Image.read method, ImageMagick `ReadImage()` API does not return a response.