### PR TITLE
Bump versions

### DIFF
--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -1,6 +1,6 @@
 module Magick
-  VERSION = '2.16.0'
+  VERSION = '3.0.0'
   MIN_RUBY_VERSION = '2.3.0'
-  MIN_IM_VERSION = '6.4.9'
+  MIN_IM_VERSION = '6.8.9'
   MIN_WAND_VERSION = '6.9.0'
 end


### PR DESCRIPTION
- bump RMagick version to 3.0.0
- bump `MIN_IM_VERSION` to 6.8.9

Side note, `MIN_WAND_VERSION` was introduced in 55a2b2e (PR #255). It
looks like the `MagickWand` package was extracted in IM version 6.9.
Once we've moved our min ImageMagick version up past 6.9, we should be
able to unify the 2 constants.