### PR TITLE
Fix memory leak when raise an exception in trace_proc at creating new Image

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -15525,6 +15525,23 @@ static void call_trace_proc(Image *image, const char *which)
 }
 
 
+static VALUE
+rm_trace_creation_body(VALUE img)
+{
+    Image *image = (Image *)img;
+    call_trace_proc(image, "c");
+    return Qnil;
+}
+
+static VALUE
+rm_trace_creation_handle_exception(VALUE img, VALUE exc)
+{
+    Image *image = (Image *)img;
+    DestroyImage(image);
+    rb_exc_raise(exc);
+    return Qnil; /* not reachable */
+}
+
 /**
  * Trace image creation
  *
@@ -15535,7 +15552,7 @@ static void call_trace_proc(Image *image, const char *which)
  */
 void rm_trace_creation(Image *image)
 {
-    call_trace_proc(image, "c");
+    rb_rescue(rm_trace_creation_body, (VALUE)image, rm_trace_creation_handle_exception, (VALUE)image);
 }
 
 


### PR DESCRIPTION
We can trace creating/destroying Image by setting `Proc` object via `Magick.trace_proc=` method.

If the `Proc` object raises an exception, it causes memory leak when new Image will be created.

The `Proc` object will be called by `rm_trace_creation()` and `rm_trace_creation()` works before converting ImageMagick Image object to Ruby object.

We have to release the ImageMagick object which is unmanaged by Ruby's GC.

* Before

```
$ ruby test.rb
Process: 22010: RSS = 249 MB
```

* After

```
$ ruby test.rb
Process: 23262: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
Magick.trace_proc = Proc.new { raise }

10000.times do
  begin
    image.resize(10, 10)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```