### PR TITLE
Lock down development dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rmagick.gemspec
 gemspec
-
-group :development, :test do
-  gem 'simplecov', require: false
-end
-# Used by README.textile
-# gem "RedCloth"

--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
-  s.add_development_dependency 'rake-compiler'
-  s.add_development_dependency 'rspec', '~> 3'
+  s.add_development_dependency 'rake-compiler', '~> 1.0'
+  s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
-  s.add_development_dependency 'rubocop'
-
-  s.add_development_dependency 'test-unit', '~> 2'
+  s.add_development_dependency 'rubocop', '0.64.0'
+  s.add_development_dependency 'simplecov', '~> 0.16.1'
+  s.add_development_dependency 'test-unit', '~> 2.5'
 end


### PR DESCRIPTION
Because we don't check in `Gemfile.lock`, it's good to lock these down
in our `gemspec` file. This makes sure the build stays consistent if,
say, there's a major breaking release of RSpec, or once we've added
Rubocop to the build we don't want it to randomly fail every time they
add new rules.