### PR TITLE
Fix SEGV in ImageList methods with invalid image list

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -861,6 +861,10 @@ static long
 imagelist_length(VALUE imagelist)
 {
     VALUE images = rb_iv_get(imagelist, "@images");
+    if (!RB_TYPE_P(images, T_ARRAY))
+    {
+        rb_raise(Class_ImageMagickError, "@images is not of type Array");
+    }
 
     RB_GC_GUARD(images);
 

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -241,6 +241,12 @@ class ImageList2UT < Test::Unit::TestCase
     end
   end
 
+  def test_mosaic_with_invalid_imagelist
+    list = @ilist.copy
+    list.instance_variable_set("@images", nil)
+    assert_raise(Magick::ImageMagickError) { list.mosaic }
+  end
+
   def test_new_image
     assert_nothing_raised do
       @ilist.new_image(20, 20)


### PR DESCRIPTION
`ImageList` object has actual image list in instance variable `@images` and we can easily override the value to `@images` using `Object#instance_variable_set` method.

If you set invalid value to `@images`, RMagick causes SEGV at https://github.com/rmagick/rmagick/blob/e2c9919470555cc712a0d7d9a5d1b91079f6425b/ext/RMagick/rmilist.c#L867

This patch will check `@images` whether it has `Array` object.

* Result

```
$ ruby test.rb
test.rb:8: [BUG] Segmentation fault at 0x0000000000000003
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0011 e:000010 CFUNC  :mosaic
c:0002 p:0050 s:0007 E:000808 EVAL   test.rb:8 [FINISH]
c:0001 p:0000 s:0003 E:0014d0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:8:in `<main>'
test.rb:8:in `mosaic'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000003 rbx: 0x0000000000000000 rcx: 0x0000000000000000
 rdx: 0x00007faa03ed5b10 rdi: 0x0000000000000003 rsi: 0x00007ffeec5a00f0
 rbp: 0x00007ffeec5a00c0 rsp: 0x00007ffeec5a00c0  r8: 0x0000000000000000
  r9: 0x0000000000000000 r10: 0x00007faa03ec1ba0 r11: 0x00007ffde8bf1918
 r12: 0x0000000000000000 r13: 0x0000000000000000 r14: 0x0000000000000000
 r15: 0x0000000000000000 rip: 0x0000000103cd72dc rfl: 0x0000000000010206

-- C level backtrace information -------------------------------------------
0   ruby                                0x0000000103906919 rb_print_backtrace + 25
1   ruby                                0x0000000103906a28 rb_vm_bugreport + 136
2   ruby                                0x00000001036f5902 rb_bug_context + 450
3   ruby                                0x0000000103849768 sigsegv + 88
4   libsystem_platform.dylib            0x00007fff7e8fbb5d _sigtramp + 29
5   RMagick2.bundle                     0x0000000103cd72dc rb_array_len + 12
6   RMagick2.bundle                     0x0000000103cd7274 imagelist_length + 68
7   RMagick2.bundle                     0x0000000103cd7295 check_imagelist_length + 21
8   RMagick2.bundle                     0x0000000103cd519d images_from_imagelist + 29
9   RMagick2.bundle                     0x0000000103cd619e ImageList_mosaic + 30
10  ruby                                0x00000001038fb343 call_cfunc_0 + 35
11  ruby                                0x00000001038f0c0d vm_call_cfunc_with_frame + 605
12  ruby                                0x00000001038ec31d vm_call_cfunc + 173
13  ruby                                0x00000001038eb7fe vm_call_method_each_type + 190
14  ruby                                0x00000001038eb594 vm_call_method + 148
15  ruby                                0x00000001038eb4f5 vm_call_general + 53
16  ruby                                0x00000001038d716e vm_exec_core + 8974
17  ruby                                0x00000001038e6ed6 vm_exec + 182
18  ruby                                0x00000001038e7c5b rb_iseq_eval_main + 43
19  ruby                                0x0000000103700988 ruby_exec_internal + 232
20  ruby                                0x0000000103700891 ruby_exec_node + 33
21  ruby                                0x0000000103700850 ruby_run_node + 64
22  ruby                                0x000000010365f26f main + 95
```

 * Test code

```ruby
list = Magick::ImageList.new
list.read(File.expand_path('./doc/ex/images/Flower_Hat.jpg'))

list.instance_variable_set("@images", 1)
list.mosaic
```