### PR TITLE
Fix memory leak in ImageList#map

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -446,9 +446,9 @@ ImageList_map(int argc, VALUE *argv, VALUE self)
 
 
     // Convert image array to image sequence, clone image sequence.
-    exception = AcquireExceptionInfo();
-
     images = images_from_imagelist(self);
+
+    exception = AcquireExceptionInfo();
     new_images = CloneImageList(images, exception);
     rm_split(images);
     rm_check_exception(exception, new_images, DestroyOnError);


### PR DESCRIPTION
If empty image list was given in ImageList object, `images_from_imagelist()` will raise exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby map.rb
Process: 11276: RSS = 389 MB
```

* After

```
$ ruby map.rb
Process: 12419: RSS = 17 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
list = Magick::ImageList.new

1000000.times do
  begin
    list.map(image)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```