### PR TITLE
Fix memory leak in ImageList#morph

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -568,8 +568,8 @@ ImageList_morph(VALUE self, VALUE nimages)
         rb_raise(rb_eArgError, "number of intervening images must be > 0");
     }
 
-    exception = AcquireExceptionInfo();
     images = images_from_imagelist(self);
+    exception = AcquireExceptionInfo();
     new_images = MorphImages(images, (unsigned long)number_images, exception);
     rm_split(images);
     rm_check_exception(exception, new_images, DestroyOnError);


### PR DESCRIPTION
If empty image list was given, `images_from_imagelist()` will raise exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby morph.rb
Process: 14433: RSS = 388 MB
```

* After

```
$ ruby morph.rb
Process: 15567: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new

1000000.times do
  begin
    list.morph(1)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```