### PR TITLE
Fix memory leak in ImageList#optimize_layers

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -635,7 +635,6 @@ ImageList_optimize_layers(VALUE self, VALUE method)
 
     new_images2 = NULL;     // defeat "unused variable" message
 
-    exception = AcquireExceptionInfo();
 #if defined(HAVE_TYPE_IMAGELAYERMETHOD)
     VALUE_TO_ENUM(method, mthd, ImageLayerMethod);
 #else
@@ -643,6 +642,7 @@ ImageList_optimize_layers(VALUE self, VALUE method)
 #endif
     images = images_from_imagelist(self);
 
+    exception = AcquireExceptionInfo();
     switch (mthd)
     {
         case CoalesceLayer:


### PR DESCRIPTION
If empty image list was given, `images_from_imagelist()` will raise exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby optimize_layers.rb
Process: 16589: RSS = 388 MB
```

* After

```
$ ruby optimize_layers.rb
Process: 17735: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new

1000000.times do
  begin
    list.optimize_layers(Magick::CompareAnyLayer)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```