### PR TITLE
Fix memory leak in ImageList#quantize

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -1001,8 +1001,8 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
 
 
     // Convert image array to image sequence, clone image sequence.
-    exception = AcquireExceptionInfo();
     images = images_from_imagelist(self);
+    exception = AcquireExceptionInfo();
     new_images = CloneImageList(images, exception);
     rm_split(images);
     rm_check_exception(exception, new_images, DestroyOnError);


### PR DESCRIPTION
If empty image list was given, `images_from_imagelist()` will raise exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby quantize.rb
Process: 18666: RSS = 388 MB
```

* After

```
$ ruby quantize.rb
Process: 19794: RSS = 17 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new

1000000.times do
  begin
    list.quantize()
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```