### PR TITLE
Fix memory leak in Info#format=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1401,9 +1401,9 @@ Info_format_eq(VALUE self, VALUE magick)
 
     Data_Get_Struct(self, Info, info);
 
-    exception = AcquireExceptionInfo();
-
     mgk = StringValuePtr(magick);
+
+    exception = AcquireExceptionInfo();
     m = GetMagickInfo(mgk, exception);
     CHECK_EXCEPTION()
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
If the object which can't be converted to `String`, Ruby C API `StringValuePtr()` will raise the exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby format.rb
Process: 32550: RSS = 398 MB
```

* After

```
$ ruby format.rb
Process: 34253: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do
  begin
    info.format = Object.new
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```