### PR TITLE
Fix memory leak in Info#{fill=, stroke=, undercolor=}

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -104,8 +104,8 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
     }
     else
     {
-        exception = AcquireExceptionInfo();
         name = StringValuePtr(color);
+        exception = AcquireExceptionInfo();
         okay = QueryColorDatabase(name, &pp, exception);
         (void) DestroyExceptionInfo(exception);
         if (!okay)


### PR DESCRIPTION
If the object which can't be converted to `String`, Ruby C API `StringValuePtr()` will raise the exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby fill.rb
Process: 35832: RSS = 240 MB
```

* After

```
$ ruby fill.rb
Process: 36981: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

200000.times do
  begin
    info.fill = Object.new
  rescue
  end

  begin
    info.stroke = Object.new
  rescue
  end

  begin
    info.undercolor = Object.new
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```