### PR TITLE
Fix memory leak in Image#format=

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6618,9 +6618,9 @@ Image_format_eq(VALUE self, VALUE magick)
 
     image = rm_check_frozen(self);
 
-    exception = AcquireExceptionInfo();
-
     mgk = StringValuePtr(magick);
+
+    exception = AcquireExceptionInfo();
     m = GetMagickInfo(mgk, exception);
     CHECK_EXCEPTION()
 


### PR DESCRIPTION
If the object which can't be converted to `String`, Ruby C API `StringValuePtr()` will raise the exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 61030: RSS = 390 MB
```

* After

```
$ ruby test.rb
Process: 62316: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(10, 10)

1000000.times do
  begin
    image.format = Object.new
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```