### PR TITLE
Docs: update badges in README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
 h1. RMagick
 
-!https://img.shields.io/gem/v/rmagick.svg?style=flat(RubyGems)!:http://rubygems.org/gems/rmagick !https://img.shields.io/gem/dt/rmagick.svg?style=flat! !https://www.versioneye.com/ruby/rmagick/reference_badge.svg?style=flat(VersionEye)!:https://www.versioneye.com/ruby/rmagick/references !https://img.shields.io/travis/rmagick/rmagick/master.svg?style=flat(Travis CI)!:https://travis-ci.org/rmagick/rmagick !https://img.shields.io/codeclimate/github/rmagick/rmagick.svg?style=flat(Code Climate)!:https://codeclimate.com/github/rmagick/rmagick !https://badges.gitter.im/Join%20Chat.svg(Gitter)!:https://gitter.im/rmagick/rmagick?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+!https://img.shields.io/gem/v/rmagick.svg?style=flat!:http://rubygems.org/gems/rmagick !https://travis-ci.org/rmagick/rmagick.svg?branch=master!:https://travis-ci.org/rmagick/rmagick !https://ci.appveyor.com/api/projects/status/xw3usp6s1ghfimb4/branch/master?svg=true!:https://ci.appveyor.com/project/mockdeep/rmagick !https://circleci.com/gh/rmagick/rmagick.svg?style=svg!:https://circleci.com/gh/rmagick/rmagick
 
 h3. Table of Contents
 


### PR DESCRIPTION
- Remove VersionEye as it's [no longer active][1].
- Remove Gitter, as I don't think any of the core maintainers want to be
  active on there. Users are probably better off asking Stack Overflow
  questions or opening issues on the repo.
- Remove downloads badge. Doesn't seem that useful.
- Remove coverage badge. We're not monitoring coverage at the moment,
  but we can re-add it once we are.
- Add CI badges for AppVeyor and CircleCI.

Unfortunately, it looks like in `textile` format if we put them
on separate lines in the raw text each badge shows up on a separate line
on Github. When we switch it over to markdown we can put these on
different lines for easier maintenance.

[1]: https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/