### PR TITLE
Fix memory leak in ImageList#optimize_layers with not supported layer method

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -665,6 +665,7 @@ ImageList_optimize_layers(VALUE self, VALUE method)
             break;
         case CompositeLayer:
             rm_split(images);
+            (void) DestroyExceptionInfo(exception);
             rb_raise(rb_eNotImpError, "Magick::CompositeLayer is not supported. Use the composite_layers method instead.");
             break;
             // In 6.3.4-ish, OptimizeImageLayer replaced OptimizeLayer
@@ -720,6 +721,7 @@ ImageList_optimize_layers(VALUE self, VALUE method)
 #endif
         default:
             rm_split(images);
+            (void) DestroyExceptionInfo(exception);
             rb_raise(rb_eArgError, "undefined layer method");
             break;
     }


### PR DESCRIPTION


We have to release memory area allocated by `AcquireExceptionInfo()` before raising exception.

* Before

```
$ ruby test.rb
Process: 67533: RSS = 389 MB
```

* After

```
$ ruby test.rb
Process: 66292: RSS = 17 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new
list.read('./doc/ex/images/Button_0.gif', './doc/ex/images/Button_1.gif')

1000000.times do
  begin
    list.optimize_layers(Magick::UndefinedLayer)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```