### PR TITLE
Fix memory leak in ImageList#mosaic

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -596,9 +596,9 @@ ImageList_mosaic(VALUE self)
     Image *images, *new_image;
     ExceptionInfo *exception;
 
-    exception = AcquireExceptionInfo();
     images = images_from_imagelist(self);
 
+    exception = AcquireExceptionInfo();
 #if defined(HAVE_ENUM_MOSAICLAYER)
     new_image = MergeImageLayers(images, MosaicLayer, exception);
 #else


### PR DESCRIPTION
If empty image list was given, `images_from_imagelist()` will raise exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby mosaic.rb
Process: 75028: RSS = 388 MB
```

* After

```
$ ruby mosaic.rb
Process: 76093: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new

1000000.times do
  begin
    list.mosaic()
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```