### PR TITLE
Fix memory leak in Image#preview

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10286,10 +10286,10 @@ Image_preview(VALUE self, VALUE preview)
     PreviewType preview_type;
     ExceptionInfo *exception;
 
-    exception = AcquireExceptionInfo();
     image = rm_check_destroyed(self);
     VALUE_TO_ENUM(preview, preview_type, PreviewType);
 
+    exception = AcquireExceptionInfo();
     new_image = PreviewImage(image, preview_type, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 


### PR DESCRIPTION
If invalid argument was given, `rm_check_destroyed()` will raise an exception.
Then, memory area allocated by `AcquireExceptionInfo()` causes memory leak.

This is detected by profiling tool when run test at https://github.com/rmagick/rmagick/blob/e758a48bfa6fb5075b3f82cdca61cca656cdc3a3/test/Preview.rb#L51.

* Before

```
$ ruby preview.rb
Process: 78085: RSS = 390 MB
```

* After

```
$ ruby preview.rb
Process: 79161: RSS = 18 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

1000000.times do
  begin
    image.preview(2)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```