### PR TITLE
Fix memory leak in Image#opaque

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9594,11 +9594,12 @@ Image_opaque(VALUE self, VALUE target, VALUE fill)
     MagickBooleanType okay;
 
     image = rm_check_destroyed(self);
-    new_image = rm_clone_image(image);
 
     // Allow color name or Pixel
     Color_to_MagickPixelPacket(image, &target_pp, target);
     Color_to_MagickPixelPacket(image, &fill_pp, fill);
+
+    new_image = rm_clone_image(image);
 
 #if defined(HAVE_OPAQUEPAINTIMAGECHANNEL)
     okay = OpaquePaintImageChannel(new_image, DefaultChannels, &target_pp, &fill_pp, MagickFalse);


### PR DESCRIPTION
`rm_clone_image()` returns memory area allocated by ImageMagick API.
The area should be convert to Ruby object using `rm_image_new()`.

However, if invalid argument was given, `Color_to_MagickPixelPacket()` will raise an exception before converting then it causes memory leak.

This is detected by profiling tool when run test at https://github.com/rmagick/rmagick/blob/e758a48bfa6fb5075b3f82cdca61cca656cdc3a3/test/Image2.rb#L1197.

* Before

```
$ ruby test.rb
Process: 85928: RSS = 152 MB
```

* After

```
$ ruby test.rb
Process: 86997: RSS = 16 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
red = Magick::Pixel.new(Magick::QuantumRange)

10000.times do
  begin
    image.opaque(red, 2)
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```