### PR TITLE
Fix memory leak in Image#cycle_colormap

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4465,10 +4465,11 @@ Image_cycle_colormap(VALUE self, VALUE amount)
     Image *image, *new_image;
     int amt;
 
-    image = rm_check_destroyed(self);
-
-    new_image = rm_clone_image(image);
     amt = NUM2INT(amount);
+
+    image = rm_check_destroyed(self);
+    new_image = rm_clone_image(image);
+
     (void) CycleColormapImage(new_image, amt);
     // No need to check for an error
 


### PR DESCRIPTION
`rm_clone_image()` returns memory area allocated by ImageMagick API.
The area should be convert to Ruby object using `rm_image_new()`.

However, if invalid argument was given, `NUM2INT()` will raise an exception before converting then it causes memory leak.

* Before

```
$ ruby test.rb
Process: 89039: RSS = 153 MB
```

* After

```
$ ruby test.rb
Process: 90212: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

10000.times do |i|
  begin
    image.cycle_colormap('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```