### PR TITLE
Fix memory leak in Image#matte_flood_fill

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8826,6 +8826,7 @@ Image_matte_flood_fill(VALUE self, VALUE color, VALUE opacity, VALUE x_obj, VALU
         }
 
         (void) FloodfillPaintImage(new_image, OpacityChannel, draw_info, &target_mpp, x, y, invert);
+        (void) DestroyDrawInfo(draw_info);
     }
 #else
     (void) MatteFloodfillImage(new_image, target, op, x, y, method);


### PR DESCRIPTION
The memory area allocated by `CloneDrawInfo()` is required to release after used in this method.

* Before

```
$ ruby test.rb
Process: 93466: RSS = 92 MB
```

* After

```
$ ruby test.rb
Process: 94540: RSS = 23 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
x = 5
y = 5

100000.times do |i|
  target = image.pixel_color(x, y)
  image.matte_flood_fill(target, Magick::TransparentOpacity, x, y, Magick::FloodfillMethod)

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```