### PR TITLE
Fix memory leak in Image#map

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8364,10 +8364,11 @@ Image_map(int argc, VALUE *argv, VALUE self)
             break;
     }
 
-    new_image = rm_clone_image(image);
-
     map_obj = rm_cur_image(map_arg);
     map = rm_check_destroyed(map_obj);
+
+    new_image = rm_clone_image(image);
+
 #if defined(HAVE_REMAPIMAGE)
     GetQuantizeInfo(&quantize_info);
     quantize_info.dither=dither;


### PR DESCRIPTION
If destroyed `Image` object was given, `rm_check_destroyed()` will raise an exception.
Then, memory area allocated by `rm_clone_image()` causes memory leak.

This is detected by profiling tool when run test at https://github.com/rmagick/rmagick/blob/b72b52fc9f676be1b594f28232a6a79d90c88250/test/Image2.rb#L1015.

* Before

```
$ ruby test.rb
Process: 99463: RSS = 1407 MB
```

* After

```
$ ruby test.rb
Process: 885: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
map_obj = Magick::Image.new(5, 5)
map_obj.destroy!

100000.times do |i|
  begin
    image.map(map_obj, true)
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```