### PR TITLE
Fix memory leak in Image#gamma_channel

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6923,6 +6923,7 @@ Image_gamma_channel(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     ChannelType channels;
+    double gamma;
 
     image = rm_check_destroyed(self);
     channels = extract_channels(&argc, argv);
@@ -6937,9 +6938,10 @@ Image_gamma_channel(int argc, VALUE *argv, VALUE self)
         raise_ChannelType_error(argv[argc-1]);
     }
 
+    gamma = NUM2DBL(argv[0]);
     new_image = rm_clone_image(image);
 
-    (void)GammaImageChannel(new_image, channels, NUM2DBL(argv[0]));
+    (void)GammaImageChannel(new_image, channels, gamma);
     rm_check_image_exception(new_image, DestroyOnError);
 
     return rm_image_new(new_image);


### PR DESCRIPTION
If invalid argument was given in first argument of `Image#gamma_channel`, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `rm_clone_image()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 3255: RSS = 1407 MB
```

* After

```
$ ruby test.rb
Process: 5404: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

100000.times do |i|
  begin
    image.gamma_channel('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```