### PR TITLE
Fix memory leak in Image#radial_blur

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10627,18 +10627,19 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
  * @return a new image
  */
 VALUE
-Image_radial_blur(VALUE self, VALUE angle)
+Image_radial_blur(VALUE self, VALUE angle_obj)
 {
     Image *image, *new_image;
     ExceptionInfo *exception;
+    double angle = NUM2DBL(angle_obj);
 
     image = rm_check_destroyed(self);
     exception = AcquireExceptionInfo();
 
 #if defined(HAVE_ROTATIONALBLURIMAGE)
-    new_image = RotationalBlurImage(image, NUM2DBL(angle), exception);
+    new_image = RotationalBlurImage(image, angle, exception);
 #else
-    new_image = RadialBlurImage(image, NUM2DBL(angle), exception);
+    new_image = RadialBlurImage(image, angle, exception);
 #endif
     rm_check_exception(exception, new_image, DestroyOnError);
 


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 7256: RSS = 89 MB
```

* After

```
$ ruby test.rb
Process: 9312: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.radial_blur('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```