### PR TITLE
Fix memory leak in Image#radial_blur_channel

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10673,6 +10673,7 @@ Image_radial_blur_channel(int argc, VALUE *argv, VALUE self)
     Image *image, *new_image;
     ExceptionInfo *exception;
     ChannelType channels;
+    double angle;
 
     image = rm_check_destroyed(self);
     channels = extract_channels(&argc, argv);
@@ -10687,12 +10688,13 @@ Image_radial_blur_channel(int argc, VALUE *argv, VALUE self)
         raise_ChannelType_error(argv[argc-1]);
     }
 
+    angle = NUM2DBL(argv[0]);
     exception = AcquireExceptionInfo();
 
 #if defined(HAVE_ROTATIONALBLURIMAGECHANNEL)
-    new_image = RotationalBlurImageChannel(image, channels, NUM2DBL(argv[0]), exception);
+    new_image = RotationalBlurImageChannel(image, channels, angle, exception);
 #else
-    new_image = RadialBlurImageChannel(image, channels, NUM2DBL(argv[0]), exception);
+    new_image = RadialBlurImageChannel(image, channels, angle, exception);
 #endif
     rm_check_exception(exception, new_image, DestroyOnError);
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 10103: RSS = 88 MB
```

* After

```
$ ruby test.rb
Process: 11834: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.radial_blur_channel('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```