### PR TITLE
Fix memory leak in Image#roll

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11525,11 +11525,13 @@ Image_roll(VALUE self, VALUE x_offset, VALUE y_offset)
 {
     Image *image, *new_image;
     ExceptionInfo *exception;
+    ssize_t x = NUM2LONG(x_offset);
+    ssize_t y = NUM2LONG(y_offset);
 
     image = rm_check_destroyed(self);
 
     exception = AcquireExceptionInfo();
-    new_image = RollImage(image, NUM2LONG(x_offset), NUM2LONG(y_offset), exception);
+    new_image = RollImage(image, x, y, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
If invalid argument was given, `NUM2LONG()` will raise an exception.
Then, the memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 13379: RSS = 88 MB
```

* After

```
$ ruby test.rb
Process: 14490: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.roll('x', 'y')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```