### PR TITLE
Fix memory leak in Image#shear

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12455,11 +12455,13 @@ Image_shear(VALUE self, VALUE x_shear, VALUE y_shear)
 {
     Image *image, *new_image;
     ExceptionInfo *exception;
+    double x = NUM2DBL(x_shear);
+    double y = NUM2DBL(y_shear);
 
     image = rm_check_destroyed(self);
 
     exception = AcquireExceptionInfo();
-    new_image = ShearImage(image, NUM2DBL(x_shear), NUM2DBL(y_shear), exception);
+    new_image = ShearImage(image, x, y, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 15476: RSS = 88 MB
```

* After

```
$ ruby test.rb
Process: 16770: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.shear('x', 'y')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```