### PR TITLE
Fix memory leak in Image#swirl

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13229,15 +13229,16 @@ Image_strip_bang(VALUE self)
  * @return a new image
  */
 VALUE
-Image_swirl(VALUE self, VALUE degrees)
+Image_swirl(VALUE self, VALUE degrees_obj)
 {
     Image *image, *new_image;
     ExceptionInfo *exception;
+    double degrees = NUM2DBL(degrees_obj);
 
     image = rm_check_destroyed(self);
 
     exception = AcquireExceptionInfo();
-    new_image = SwirlImage(image, NUM2DBL(degrees), exception);
+    new_image = SwirlImage(image, degrees, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `AcquireExceptionInfo()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 17408: RSS = 88 MB
```

* After

```
$ ruby test.rb
Process: 20019: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.swirl('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```