### PR TITLE
Fix memory leak in Image#threshold

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13384,14 +13384,15 @@ Image_texture_flood_fill(VALUE self, VALUE color_obj, VALUE texture_obj
  * @return a new image
  */
 VALUE
-Image_threshold(VALUE self, VALUE threshold)
+Image_threshold(VALUE self, VALUE threshold_obj)
 {
     Image *image, *new_image;
+    double threshold = NUM2DBL(threshold_obj);
 
     image = rm_check_destroyed(self);
     new_image = rm_clone_image(image);
 
-    (void) BilevelImageChannel(new_image, DefaultChannels, NUM2DBL(threshold));
+    (void) BilevelImageChannel(new_image, DefaultChannels, threshold);
     rm_check_image_exception(new_image, DestroyOnError);
 
     return rm_image_new(new_image);


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `rm_clone_image()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 20884: RSS = 2801 MB
```

* After

```
$ ruby test.rb
Process: 22217: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.threshold('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```