### PR TITLE
Fix memory leak in Image#bilevel_channel

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1220,6 +1220,7 @@ Image_bilevel_channel(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     ChannelType channels;
+    double threshold;
 
     image = rm_check_destroyed(self);
     channels = extract_channels(&argc, argv);
@@ -1233,9 +1234,10 @@ Image_bilevel_channel(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "no threshold specified");
     }
 
+    threshold = NUM2DBL(argv[0]);
     new_image = rm_clone_image(image);
 
-    (void)BilevelImageChannel(new_image, channels, NUM2DBL(argv[0]));
+    (void)BilevelImageChannel(new_image, channels, threshold);
     rm_check_image_exception(new_image, DestroyOnError);
 
     return rm_image_new(new_image);


### PR DESCRIPTION
If invalid argument was given, `NUM2DBL()` will raise an exception.
Then, the memory area allocated by `rm_clone_image()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 23764: RSS = 2802 MB
```

* After

```
$ ruby test.rb
Process: 24929: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

200000.times do |i|
  begin
    image.bilevel_channel('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```