### PR TITLE
Fix SEGV in Image#recolor

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1265,6 +1265,7 @@ extern VALUE  rm_no_freeze(VALUE);
 extern int    rm_strcasecmp(const char *, const char *);
 extern int    rm_strncasecmp(const char *, const char *, size_t);
 extern void   rm_check_ary_len(VALUE, long);
+extern VALUE  rm_check_ary_type(VALUE ary);
 extern Image *rm_check_destroyed(VALUE);
 extern Image *rm_check_frozen(VALUE);
 extern VALUE  rm_to_s(VALUE);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10949,6 +10949,8 @@ Image_recolor(VALUE self, VALUE color_matrix)
 #endif
 
     image = rm_check_destroyed(self);
+    color_matrix = rm_check_ary_type(color_matrix);
+
     exception = AcquireExceptionInfo();
 
     // Allocate color matrix from Ruby's memory

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -229,6 +229,27 @@ rm_check_ary_len(VALUE ary, long len)
 
 
 /**
+ * Raise exception if ary argument was invalid type
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param ary the array
+ * @return the array that is converted type of argument object if needed
+ * @throw TypeError
+ */
+VALUE
+rm_check_ary_type(VALUE ary)
+{
+    VALUE checked = rb_check_array_type(ary);
+    if (NIL_P(checked))
+    {
+        rb_raise(rb_eTypeError, "wrong argument type %"PRIsVALUE" was given. (must respond to :to_ary)", rb_obj_class(ary));
+    }
+    return checked;
+}
+
+
+/**
  * Raise an error if the image has been destroyed.
  *
  * No Ruby usage (internal function)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -161,6 +161,10 @@ class Image3_UT < Test::Unit::TestCase
     assert_raise(TypeError) { @img.random_threshold_channel('20%', 2) }
   end
 
+  def test_recolor
+    assert_raise(TypeError) { @img.recolor('x') }
+  end
+
   def test_reduce_noise
     assert_nothing_raised do
       res = @img.reduce_noise(0)


### PR DESCRIPTION
If invalid argument which is not `Array` object was given in `Image#recolor`,
`RARRAY_LEN()` in https://github.com/rmagick/rmagick/blob/b72b52fc9f676be1b594f28232a6a79d90c88250/ext/RMagick/rmimage.c#L10955 causes SEGV.

* Result

```
$ ruby test.rb
test.rb:4: [BUG] Segmentation fault at 0x0000000000000000
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0012 e:000011 CFUNC  :recolor
c:0002 p:0032 s:0007 E:002628 EVAL   test.rb:4 [FINISH]
c:0001 p:0000 s:0003 E:0015e0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:4:in `<main>'
test.rb:4:in `recolor'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000000 rbx: 0x0000000000000000 rcx: 0x0000000000000000
 rdx: 0x0000000000000000 rdi: 0x0000000000000000 rsi: 0x0000000000000000
 rbp: 0x00007ffee3389180 rsp: 0x00007ffee3389150  r8: 0x0000000000000001
  r9: 0x1800000000000000 r10: 0x00007fd6e5674200 r11: 0x000000010c879a10
 r12: 0x0000000000000000 r13: 0x0000000000000000 r14: 0x0000000000000000
 r15: 0x0000000000000000 rip: 0x000000010c879aae rfl: 0x0000000000010206

-- C level backtrace information -------------------------------------------
0   ruby                                0x000000010cb1d919 rb_print_backtrace + 25
1   ruby                                0x000000010cb1da28 rb_vm_bugreport + 136
2   ruby                                0x000000010c90c902 rb_bug_context + 450
3   ruby                                0x000000010ca60768 sigsegv + 88
4   libsystem_platform.dylib            0x00007fff6e333b5d _sigtramp + 29
5   ruby                                0x000000010c879aae rb_ary_entry + 158
6   RMagick2.bundle                     0x000000010cf3125a Image_recolor + 106
7   ruby                                0x000000010cb1237a call_cfunc_1 + 42
8   ruby                                0x000000010cb07c0d vm_call_cfunc_with_frame + 605
9   ruby                                0x000000010cb0331d vm_call_cfunc + 173
10  ruby                                0x000000010cb027fe vm_call_method_each_type + 190
11  ruby                                0x000000010cb02594 vm_call_method + 148
12  ruby                                0x000000010cb024f5 vm_call_general + 53
13  ruby                                0x000000010caee16e vm_exec_core + 8974
14  ruby                                0x000000010cafded6 vm_exec + 182
15  ruby                                0x000000010cafec5b rb_iseq_eval_main + 43
16  ruby                                0x000000010c917988 ruby_exec_internal + 232
17  ruby                                0x000000010c917891 ruby_exec_node + 33
18  ruby                                0x000000010c917850 ruby_run_node + 64
19  ruby                                0x000000010c87626f main + 95
...
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
image.recolor('x')
```