### PR TITLE
Fix memory leak in Image#sharpen_channel

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12393,10 +12393,8 @@ Image_sharpen_channel(int argc, VALUE *argv, VALUE self)
             raise_ChannelType_error(argv[argc-1]);
     }
 
-    new_image = rm_clone_image(image);
-
     exception = AcquireExceptionInfo();
-    (void) SharpenImageChannel(new_image, channels, radius, sigma, exception);
+    new_image = SharpenImageChannel(image, channels, radius, sigma, exception);
 
     rm_check_exception(exception, new_image, DestroyOnError);
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
ImageMagick `SharpenImageChannel()` API returns new Image object.
So, the memory area allocated by `rm_clone_image(image);` causes memory leak.

* Before

```
$ ruby sharpen_channel.rb
Process: 9502: RSS = 281 MB
```

* After

```
$ ruby sharpen_channel.rb
Process: 10950: RSS = 22 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

10000.times do |i|
  image.sharpen_channel

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```

## Note

This pull request has breaking change.
Before this change, `Image#sharpen_channel` just returns cloned image.

After this, `Image#sharpen_channel` returns expected image effected by `SharpenImageChannel()` API.