### PR TITLE
Fix memory leak in Image#composite_affine

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3523,9 +3523,10 @@ Image_composite_affine(VALUE self, VALUE source, VALUE affine_matrix)
 
     image = rm_check_destroyed(self);
     composite_image = rm_check_destroyed(source);
-    new_image = rm_clone_image(image);
 
     Export_AffineMatrix(&affine, affine_matrix);
+    new_image = rm_clone_image(image);
+
     (void) DrawAffineImage(new_image, composite_image, &affine);
     rm_check_image_exception(new_image, DestroyOnError);
 


### PR DESCRIPTION
If If invalid argument was given, `Export_AffineMatrix()` will raise exception.
Then, the memory area allocated by `rm_clone_image()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 32919: RSS = 153 MB
```

* After

```
$ ruby test.rb
Process: 34697: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

image1 = Magick::Image.new(20, 20)
image2 = Magick::Image.new(20, 20)

10000.times do |i|
  begin
    image1.composite_affine(image2, 'x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```