### PR TITLE
Fix memory leak in Image._load

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8194,8 +8194,6 @@ Image__load(VALUE class, VALUE str)
 
     class = class;  // Suppress "never referenced" message from icc
 
-    info = CloneImageInfo(NULL);
-
     blob = rm_str2cstr(str, &length);
 
     // Must be as least as big as the 1st 4 fields in DumpedImage
@@ -8229,6 +8227,8 @@ Image__load(VALUE class, VALUE str)
     {
         rb_raise(rb_eTypeError, "image is invalid or corrupted (too short)");
     }
+
+    info = CloneImageInfo(NULL);
 
     memcpy(info->magick, ((DumpedImage *)blob)->magick, mi.len);
     info->magick[mi.len] = '\0';


### PR DESCRIPTION
If If invalid argument was given, `rm_str2cstr()` will raise exception.
Then, the memory area allocated by `rm_clone_image()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 39019: RSS = 176 MB
```

* After

```
$ ruby test.rb
Process: 40111: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

10000.times do |i|
  begin
    Magick::Image._load(Object.new)
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```