### PR TITLE
Fix memory leak in ImageList#animate

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -45,7 +45,12 @@ ImageList_animate(int argc, VALUE *argv, VALUE self)
     Image *images;
     Info *info;
     VALUE info_obj;
+    unsigned int delay;
 
+    if (argc == 1)
+    {
+        delay = NUM2UINT(argv[0]);
+    }
     if (argc > 1)
     {
         rb_raise(rb_eArgError, "wrong number of arguments (%d for 0 or 1)", argc);
@@ -60,9 +65,7 @@ ImageList_animate(int argc, VALUE *argv, VALUE self)
     if (argc == 1)
     {
         Image *img;
-        unsigned int delay;
 
-        delay = NUM2UINT(argv[0]);
         for (img = images; img; img = GetNextImageInList(img))
         {
             img->delay = delay;


### PR DESCRIPTION
If invalid argument was given, `NUM2UINT()` will raise exception.
Then, the memory area allocated by `images_from_imagelist()` causes memory leak.

* Before

```
$ ruby test.rb
Process: 31231: RSS = 177 MB
```

* After

```
$ ruby test.rb
Process: 32804: RSS = 18 MB
```

* Test code

```ruby
require 'rmagick'

list = Magick::ImageList.new('sample1.gif', 'sample2.gif')

10000.times do |i|
  begin
    list.animate('x')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```