### PR TITLE
Remove some have_func checking for older ImageMagick API

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -335,73 +335,10 @@ END_MSWIN
 
     def create_header_file
       have_func('snprintf', headers)
-      ['AcquireImage', # 6.4.1
-       'AffinityImage', # 6.4.3-6
-       'AffinityImages', # 6.4.3-6
-       'AutoGammaImageChannel', # 6.5.5-1
-       'AutoLevelImageChannel', # 6.5.5-1
-       'BlueShiftImage', # 6.5.4-3
-       'ColorMatrixImage', # 6.6.1-0
-       'ConstituteComponentTerminus', # 6.5.7-9
-       'DeskewImage', # 6.4.2-5
-       'DestroyConstitute', # 6.5.7-9(deprecated)
-       'EncipherImage', # 6.3.8-6
-       'EqualizeImageChannel', # 6.3.6-9
-       'EvaluateImages', # 6.8.6-4
-       'FloodfillPaintImage', # 6.3.7
-       'FunctionImageChannel', # 6.4.8-8
-       'GetAuthenticIndexQueue', # 6.4.5-6
-       'GetAuthenticPixels', # 6.4.5-6
-       'GetImageAlphaChannel', # 6.3.9-2
-       'GetImageChannelEntropy', # 6.9.0-0
-       'GetMagickFeatures', # 6.5.7-1
-       'GetVirtualPixels', # 6.4.5-6
-       'LevelImageColors', # 6.4.2
-       'LevelColorsImageChannel', # 6.5.6-4
-       'LevelizeImageChannel', # 6.4.2
-       'LiquidRescaleImage', # 6.3.8-2
-       'MagickLibAddendum', # 6.5.9-1
-       'OpaquePaintImageChannel', # 6.3.7-10
-       'QueueAuthenticPixels', # 6.4.5-6
-       'RemapImage', # 6.4.4-0
-       'RemapImages', # 6.4.4-0
-       'RemoveImageArtifact', # 6.3.6
-       'RotationalBlurImage', # 6.8.8-9
-       'RotationalBlurImageChannel', # 6.8.8-9
-       'SelectiveBlurImageChannel', # 6.5.0-3
-       'SetImageAlphaChannel', # 6.3.6-9
-       'SetImageArtifact', # 6.3.6
-       'SetMagickMemoryMethods', # 6.4.1
-       'SparseColorImage', # 6.3.6-?
-       'StatisticImage', # 6.6.8-6
-       'SyncAuthenticPixels', # 6.4.5-6
-       'TransformImageColorspace', # 6.5.1
-       'TransparentPaintImage', # 6.3.7-10
-       'TransparentPaintImageChroma' # 6.4.5-6
+      [
+        'GetImageChannelEntropy' # 6.9.0-0
       ].each do |func|
         have_func(func, headers)
-      end
-
-      checking_for('QueryMagickColorname() new signature') do
-        if try_compile(<<"SRC")
-#{COMMON_HEADERS}
-        #{cpp_include(headers)}
-/*top*/
-int main() {
-  MagickBooleanType okay;
-  Image *image;
-  MagickPixelPacket *color;
-  char *name;
-  ExceptionInfo *exception;
-  okay = QueryMagickColorname(image, color, SVGCompliance, name, exception);
-  return 0;
-  }
-SRC
-          $defs.push('-DHAVE_NEW_QUERYMAGICKCOLORNAME')
-          true
-        else
-          false
-        end
       end
 
       have_struct_member('Image', 'type', headers) # ???

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -133,26 +133,7 @@
         f = NULL;
 
 
-/** ImageMagick 6.5.7 replaced DestroyConstitute with
- * ConstituteComponentTerminus. Both have the same signature.
- */
-#if defined(HAVE_CONSTITUTECOMPONENTTERMINUS)
-#define DestroyConstitute(void) ConstituteComponentTerminus(void)
-#endif
-
-/** ImageMagick 6.5.9 replaced MagickLibSubversion with
- * MagickLibAddendum.
- */
-#if defined(HAVE_MAGICKLIBADDENDUM)
 #define MagickLibSubversion MagickLibAddendum
-#endif
-
-/** IM 6.4.1 replaced AllocateImage with AcquireImage.
- * Both have the same signature.
- */
-#if !defined(HAVE_ACQUIREIMAGE)
-#define AcquireImage(info) AllocateImage(info)
-#endif
 
 // ImageLayerMethod replaced MagickLayerMethod starting with 6.3.6
 #if defined(HAVE_TYPE_IMAGELAYERMETHOD)
@@ -387,9 +368,7 @@ EXTERN VALUE Class_PaintMethod;
 EXTERN VALUE Class_PreviewType;
 EXTERN VALUE Class_RenderingIntent;
 EXTERN VALUE Class_ResolutionType;
-#if defined(HAVE_SPARSECOLORIMAGE)
 EXTERN VALUE Class_SparseColorMethod;
-#endif
 EXTERN VALUE Class_SpreadMethod;
 EXTERN VALUE Class_StorageType;
 EXTERN VALUE Class_StretchType;

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -119,11 +119,9 @@ point_fill(
     double steps, distance;
     unsigned long x, y;
     MagickRealType red_step, green_step, blue_step;
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
-#endif
 
     steps = sqrt((double)((image->columns-x0)*(image->columns-x0)
                           + (image->rows-y0)*(image->rows-y0)));
@@ -136,13 +134,9 @@ point_fill(
     {
         PixelPacket *row_pixels;
 
-#if defined(HAVE_QUEUEAUTHENTICPIXELS)
         row_pixels = QueueAuthenticPixels(image, 0, (long int)y, image->columns, 1, exception);
         CHECK_EXCEPTION()
-#else
-        row_pixels = SetImagePixels(image, 0, (long int)y, image->columns, 1);
-        rm_check_image_exception(image, RetainOnError);
-#endif
+
         for (x = 0; x < image->columns; x++)
         {
             distance = sqrt((double)((x-x0)*(x-x0)+(y-y0)*(y-y0)));
@@ -152,18 +146,11 @@ point_fill(
             row_pixels[x].opacity = OpaqueOpacity;
         }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS)
         SyncAuthenticPixels(image, exception);
         CHECK_EXCEPTION()
-#else
-        SyncImagePixels(image);
-        rm_check_image_exception(image, RetainOnError);
-#endif
     }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     DestroyExceptionInfo(exception);
-#endif
 }
 
 /**
@@ -188,11 +175,9 @@ vertical_fill(
     unsigned long x, y;
     PixelPacket *master;
     MagickRealType red_step, green_step, blue_step;
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
-#endif
 
     steps = FMAX(x1, ((long)image->columns)-x1);
 
@@ -226,28 +211,16 @@ vertical_fill(
     {
         PixelPacket *row_pixels;
 
-#if defined(HAVE_QUEUEAUTHENTICPIXELS)
         row_pixels = QueueAuthenticPixels(image, 0, (long int)y, image->columns, 1, exception);
         CHECK_EXCEPTION()
-#else
-        row_pixels = SetImagePixels(image, 0, (long int)y, image->columns, 1);
-        rm_check_image_exception(image, RetainOnError);
-#endif
 
         memcpy(row_pixels, master, image->columns * sizeof(PixelPacket));
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS)
         SyncAuthenticPixels(image, exception);
         CHECK_EXCEPTION()
-#else
-        SyncImagePixels(image);
-        rm_check_image_exception(image, RetainOnError);
-#endif
     }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     DestroyExceptionInfo(exception);
-#endif
 
     xfree((void *)master);
 }
@@ -273,11 +246,9 @@ horizontal_fill(
     unsigned long x, y;
     PixelPacket *master;
     MagickRealType red_step, green_step, blue_step;
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
-#endif
 
     steps = FMAX(y1, ((long)image->rows)-y1);
 
@@ -309,26 +280,15 @@ horizontal_fill(
     {
         PixelPacket *col_pixels;
 
-#if defined(HAVE_QUEUEAUTHENTICPIXELS)
         col_pixels = QueueAuthenticPixels(image, (long int)x, 0, 1, image->rows, exception);
-#else
-        col_pixels = SetImagePixels(image, (long int)x, 0, 1, image->rows);
-        rm_check_image_exception(image, RetainOnError);
-#endif
+
         memcpy(col_pixels, master, image->rows * sizeof(PixelPacket));
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS)
         SyncAuthenticPixels(image, exception);
         CHECK_EXCEPTION()
-#else
-        SyncImagePixels(image);
-        rm_check_image_exception(image, RetainOnError);
-#endif
     }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     DestroyExceptionInfo(exception);
-#endif
 
     xfree((PixelPacket *)master);
 }
@@ -361,11 +321,9 @@ v_diagonal_fill(
     MagickRealType red_step, green_step, blue_step;
     double m, b, steps = 0.0;
     double d1, d2;
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
-#endif
 
     // Compute the equation of the line: y=mx+b
     m = ((double)(y2 - y1))/((double)(x2 - x1));
@@ -407,13 +365,9 @@ v_diagonal_fill(
     {
         PixelPacket *row_pixels;
 
-#if defined(HAVE_QUEUEAUTHENTICPIXELS)
         row_pixels = QueueAuthenticPixels(image, 0, (long int)y, image->columns, 1, exception);
         CHECK_EXCEPTION()
-#else
-        row_pixels = SetImagePixels(image, 0, (long int)y, image->columns, 1);
-        rm_check_image_exception(image, RetainOnError);
-#endif
+
         for (x = 0; x < image->columns; x++)
         {
             double distance = (double) abs((int)(y-(m * x + b)));
@@ -423,19 +377,11 @@ v_diagonal_fill(
             row_pixels[x].opacity = OpaqueOpacity;
         }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS)
         SyncAuthenticPixels(image, exception);
         CHECK_EXCEPTION()
-#else
-        SyncImagePixels(image);
-        rm_check_image_exception(image, RetainOnError);
-#endif
     }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     DestroyExceptionInfo(exception);
-#endif
-
 }
 
 /**
@@ -466,11 +412,9 @@ h_diagonal_fill(
     double m, b, steps = 0.0;
     MagickRealType red_step, green_step, blue_step;
     double d1, d2;
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
-#endif
 
     // Compute the equation of the line: y=mx+b
     m = ((double)(y2 - y1))/((double)(x2 - x1));
@@ -514,13 +458,9 @@ h_diagonal_fill(
     {
         PixelPacket *row_pixels;
 
-#if defined(HAVE_QUEUEAUTHENTICPIXELS)
         row_pixels = QueueAuthenticPixels(image, 0, (long int)y, image->columns, 1, exception);
         CHECK_EXCEPTION()
-#else
-        row_pixels = SetImagePixels(image, 0, (long int)y, image->columns, 1);
-        rm_check_image_exception(image, RetainOnError);
-#endif
+
         for (x = 0; x < image->columns; x++)
         {
             double distance = (double) abs((int)(x-((y-b)/m)));
@@ -530,18 +470,11 @@ h_diagonal_fill(
             row_pixels[x].opacity = OpaqueOpacity;
         }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS)
         SyncAuthenticPixels(image, exception);
         CHECK_EXCEPTION()
-#else
-        SyncImagePixels(image);
-        rm_check_image_exception(image, RetainOnError);
-#endif
     }
 
-#if defined(HAVE_SYNCAUTHENTICPIXELS) || defined(HAVE_QUEUEAUTHENTICPIXELS)
     DestroyExceptionInfo(exception);
-#endif
 }
 
 /**

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -135,11 +135,7 @@ ImageList_average(VALUE self)
     images = images_from_imagelist(self);
 
     exception = AcquireExceptionInfo();
-#if defined(HAVE_EVALUATEIMAGES)
     new_image = EvaluateImages(images, MeanEvaluateOperator, exception);
-#else
-    new_image = AverageImages(images, exception);
-#endif
 
     rm_split(images);
     rm_check_exception(exception, new_image, DestroyOnError);
@@ -426,10 +422,8 @@ ImageList_map(int argc, VALUE *argv, VALUE self)
     VALUE scene, new_imagelist, t;
     ExceptionInfo *exception;
 
-#if defined(HAVE_REMAPIMAGES)
     QuantizeInfo quantize_info;
     rb_warning("ImageList#map is deprecated. Use ImageList#remap instead.");
-#endif
 
     switch (argc)
     {
@@ -457,13 +451,9 @@ ImageList_map(int argc, VALUE *argv, VALUE self)
     rm_ensure_result(new_images);
 
     // Call ImageMagick
-#if defined(HAVE_REMAPIMAGES)
     GetQuantizeInfo(&quantize_info);
     quantize_info.dither = dither;
     (void) RemapImages(&quantize_info, new_images, map);
-#else
-    (void) MapImages(new_images, map, dither);
-#endif
     rm_check_image_exception(new_images, DestroyOnError);
 
     // Set @scene in new ImageList object to same value as in self.
@@ -684,12 +674,8 @@ ImageList_optimize_layers(VALUE self, VALUE method)
             OptimizeImageTransparency(new_images, exception);
             rm_check_exception(exception, new_images, DestroyOnError);
             // mogrify supports -dither here. We don't.
-#if defined(HAVE_REMAPIMAGE)
             GetQuantizeInfo(&quantize_info);
             (void) RemapImages(&quantize_info, new_images, NULL);
-#else
-            (void) MapImages(new_images, NULL, 0);
-#endif
             break;
         case OptimizePlusLayer:
             new_images = OptimizePlusImageLayers(images, exception);
@@ -1060,7 +1046,6 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
 VALUE
 ImageList_remap(int argc, VALUE *argv, VALUE self)
 {
-#if defined(HAVE_REMAPIMAGES) || defined(HAVE_AFFINITYIMAGES)
     Image *images, *remap_image = NULL;
     QuantizeInfo quantize_info;
 
@@ -1086,22 +1071,11 @@ ImageList_remap(int argc, VALUE *argv, VALUE self)
 
     images = images_from_imagelist(self);
 
-#if defined(HAVE_REMAPIMAGE)
     (void) RemapImages(&quantize_info, images, remap_image);
-#else
-    (void) AffinityImages(&quantize_info, images, remap_image);
-#endif
     rm_check_image_exception(images, RetainOnError);
     rm_split(images);
 
     return self;
-#else
-    self = self;
-    argc = argc;
-    argv = argv;
-    rm_not_implemented();
-    return(VALUE)0;
-#endif
 }
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -31,7 +31,7 @@ static void features_constant(void);
  *  Handle transferring ImageMagick memory allocations/frees to Ruby.
  *  These functions have the same signature as the equivalent C functions.
  */
-#if defined(HAVE_SETMAGICKMEMORYMETHODS)
+
 /**
  * Allocate memory.
  *
@@ -118,7 +118,6 @@ static void set_managed_memory(void)
         rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
     }
 }
-#endif
 
 
 
@@ -139,11 +138,7 @@ Init_RMagick2(void)
 
     Module_Magick = rb_define_module("Magick");
 
-#if defined(HAVE_SETMAGICKMEMORYMETHODS)
     set_managed_memory();
-#else
-    rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
-#endif
 
     /*-----------------------------------------------------------------------*/
     /* Create IDs for frequently used methods, etc.                          */
@@ -1482,7 +1477,6 @@ Init_RMagick2(void)
         ENUMERATOR(PixelsPerCentimeterResolution)
     END_ENUM
 
-#if defined(HAVE_SPARSECOLORIMAGE)
     DEF_ENUM(SparseColorMethod)
         ENUMERATOR(UndefinedColorInterpolate)
         ENUMERATOR(BarycentricColorInterpolate)
@@ -1491,7 +1485,6 @@ Init_RMagick2(void)
         ENUMERATOR(ShepardsColorInterpolate)
         ENUMERATOR(VoronoiColorInterpolate)
     END_ENUM
-#endif
 
     // SpreadMethod
     DEF_ENUM(SpreadMethod)
@@ -1817,18 +1810,8 @@ features_constant(void)
 {
     VALUE features;
 
-#if defined(HAVE_GETMAGICKFEATURES)
     // 6.5.7 - latest (7.0.0)
     features = rb_str_new2(GetMagickFeatures());
-#elif defined(MagickFeatures)
-    // 6.5.7 - latest (7.0.0)
-    features = rb_str_new2(MagickFeatures);
-#elif defined(MagickSupport)
-    // 6.5.5 - 6.5.6
-    features = rb_str_new2(MagickSupport);
-#else
-    features = rb_str_new("unknown", 7);
-#endif
 
     rb_obj_freeze(features);
     rb_define_const(Module_Magick, "Magick_features", features);

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -1032,7 +1032,6 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
 
     exception = AcquireExceptionInfo();
 
-#if defined(HAVE_NEW_QUERYMAGICKCOLORNAME)
     // Support for hex-format color names moved out of QueryMagickColorname
     // in 6.4.1-9. The 'hex' argument was removed as well.
     if (hex)
@@ -1048,9 +1047,7 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
     {
         (void) QueryMagickColorname(image, &mpp, compliance, name, exception);
     }
-#else
-    (void) QueryMagickColorname(image, &mpp, compliance, hex, name, exception);
-#endif
+
     (void) DestroyImage(image);
     CHECK_EXCEPTION()
     (void) DestroyExceptionInfo(exception);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -918,7 +918,6 @@ rm_set_property(Image *image, const char *property, const char *value)
  */
 void rm_set_user_artifact(Image *images, Info *info)
 {
-#if defined(HAVE_SETIMAGEARTIFACT)
     Image *image;
     const char *value;
 
@@ -932,10 +931,6 @@ void rm_set_user_artifact(Image *images, Info *info)
             image = GetNextImageInList(image);
         }
     }
-#else
-    images = images;
-    info = info;
-#endif
 }
 
 
@@ -974,7 +969,6 @@ rm_get_optional_arguments(VALUE img)
 }
 
 
-#if defined(HAVE_SETIMAGEARTIFACT)
 /**
  * Copy image options from the Info structure to the Image structure.
  *
@@ -1000,7 +994,6 @@ static void copy_options(Image *image, Info *info)
         }
     }
 }
-#endif
 
 
 /**
@@ -1169,9 +1162,7 @@ void rm_sync_image_options(Image *image, Info *info)
         image->units = info->units;
     }
 
-#if defined(HAVE_SETIMAGEARTIFACT)
     copy_options(image, info);
-#endif
 }
 
 


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use API added in older version without check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.
