### PR TITLE
Add Magick.delegates method

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -414,3 +414,53 @@ Magick_set_log_format(VALUE class, VALUE format)
     return class;
 }
 
+/**
+ * Get the ImageMagick delegate information.
+ *
+ * Ruby usage:
+ *   - @verbatim Magick.delegates @endverbatim
+ *
+ * Notes:
+ *   The returned hash contains `decode` and `encode` keys.
+ *
+ * @return a hash.
+ */
+
+VALUE
+Magick_delegates(VALUE class)
+{
+    const DelegateInfo **delegate_info;
+    ExceptionInfo *exception;
+    size_t number_delegates;
+    size_t i;
+    VALUE hash;
+    VALUE ary_decode;
+    VALUE ary_encode;
+
+    exception = AcquireExceptionInfo();
+    delegate_info = GetDelegateInfoList("*", &number_delegates, exception);
+    CHECK_EXCEPTION();
+    DestroyExceptionInfo(exception);
+
+    ary_decode = rb_ary_new();
+    ary_encode = rb_ary_new();
+
+    for (i = 0; i < number_delegates; i++) {
+        if (delegate_info[i]->decode)
+        {
+            rb_ary_push(ary_decode, rb_str_new_cstr(delegate_info[i]->decode));
+        }
+        if (delegate_info[i]->encode)
+        {
+            rb_ary_push(ary_encode, rb_str_new_cstr(delegate_info[i]->encode));
+        }
+    }
+
+    RelinquishMagickMemory((void *) delegate_info);
+
+    hash = rb_hash_new();
+    rb_hash_aset(hash, ID2SYM(rb_intern("decode")), ary_decode);
+    rb_hash_aset(hash, ID2SYM(rb_intern("encode")), ary_encode);
+
+    return hash;
+}

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -637,6 +637,7 @@ extern VALUE Magick_limit_resource(int, VALUE *, VALUE);
 extern VALUE Magick_set_cache_threshold(VALUE, VALUE);
 extern VALUE Magick_set_log_event_mask(int, VALUE *, VALUE);
 extern VALUE Magick_set_log_format(VALUE, VALUE);
+extern VALUE Magick_delegates(VALUE);
 
 // rmdraw.c
 ATTR_WRITER(Draw, affine)

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -180,6 +180,7 @@ Init_RMagick2(void)
     rb_define_module_function(Module_Magick, "set_cache_threshold", Magick_set_cache_threshold, 1);
     rb_define_module_function(Module_Magick, "set_log_event_mask", Magick_set_log_event_mask, -1);
     rb_define_module_function(Module_Magick, "set_log_format", Magick_set_log_format, 1);
+    rb_define_module_function(Module_Magick, "delegates", Magick_delegates, 0);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::Image methods                                           */

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -315,6 +315,12 @@ class MagickUT < Test::Unit::TestCase
       Magick.trace_proc = nil
     end
   end
+
+  def test_delegates
+    delegates = Magick.delegates
+    assert( delegates[:decode].include?('eps') )
+    assert( delegates[:encode].include?('eps') )
+  end
 end
 
 if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
Add the method to get the ImageMagick delegate information.
That information includes encoder and decoder supported by ImageMagick.

For example, when write a test code to save `webp` images, it is easy to know whether ImageMagick has been supported. Related to https://github.com/rmagick/rmagick/issues/60