### PR TITLE
Remove some have_struct_member checking for older ImageMagick structure members

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -341,10 +341,6 @@ END_MSWIN
         have_func(func, headers)
       end
 
-      have_struct_member('Image', 'type', headers) # ???
-      have_struct_member('DrawInfo', 'kerning', headers) # 6.4.7-8
-      have_struct_member('DrawInfo', 'interline_spacing', headers) # 6.5.5-8
-      have_struct_member('DrawInfo', 'interword_spacing', headers) # 6.4.8-0
       have_type('DitherMethod', headers) # 6.4.2
       have_type('MagickFunction', headers) # 6.4.8-8
       have_type('ImageLayerMethod', headers) # 6.3.6 replaces MagickLayerMethod

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -402,19 +402,12 @@ Draw_gravity_eq(VALUE self, VALUE grav)
 VALUE
 Draw_kerning_eq(VALUE self, VALUE kerning)
 {
-#if defined(HAVE_ST_KERNING)
     Draw *draw;
 
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->kerning = NUM2DBL(kerning);
     return self;
-#else
-    rm_not_implemented();
-    return (VALUE)0;
-    self = self;
-    kerning = kerning;
-#endif
 }
 
 
@@ -434,19 +427,12 @@ Draw_kerning_eq(VALUE self, VALUE kerning)
 VALUE
 Draw_interline_spacing_eq(VALUE self, VALUE spacing)
 {
-#if defined(HAVE_ST_INTERLINE_SPACING)
     Draw *draw;
 
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->interline_spacing = NUM2DBL(spacing);
     return self;
-#else
-    rm_not_implemented();
-    return (VALUE)0;
-    self = self;
-    spacing = spacing;
-#endif
 }
 
 
@@ -466,19 +452,12 @@ Draw_interline_spacing_eq(VALUE self, VALUE spacing)
 VALUE
 Draw_interword_spacing_eq(VALUE self, VALUE spacing)
 {
-#if defined(HAVE_ST_INTERWORD_SPACING)
     Draw *draw;
 
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->interword_spacing = NUM2DBL(spacing);
     return self;
-#else
-    rm_not_implemented();
-    return (VALUE)0;
-    self = self;
-    spacing = spacing;
-#endif
 }
 
 
@@ -633,12 +612,8 @@ Draw_marshal_dump(VALUE self)
     // rb_hash_aset(ddraw, CSTR2SYM("render"), draw->info->render ? Qtrue : Qfalse); internal
     // rb_hash_aset(ddraw, CSTR2SYM("element_reference"), Qnil);     // not used yet
     // rb_hash_aset(ddraw, CSTR2SYM("debug"), draw->info->debug ? Qtrue : Qfalse);
-#if defined(HAVE_ST_KERNING)
     rb_hash_aset(ddraw, CSTR2SYM("kerning"), rb_float_new(draw->info->kerning));
-#endif
-#if defined(HAVE_ST_INTERWORD_SPACING)
     rb_hash_aset(ddraw, CSTR2SYM("interword_spacing"), rb_float_new(draw->info->interword_spacing));
-#endif
 
     // Non-DrawInfo fields
     rb_hash_aset(ddraw, CSTR2SYM("primitives"), draw->primitives);
@@ -711,12 +686,8 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
 
     draw->info->clip_units = FIX2INT(rb_hash_aref(ddraw, CSTR2SYM("clip_units")));
     draw->info->opacity = NUM2QUANTUM(rb_hash_aref(ddraw, CSTR2SYM("opacity")));
-#if defined(HAVE_ST_KERNING)
     draw->info->kerning = NUM2DBL(rb_hash_aref(ddraw, CSTR2SYM("kerning")));
-#endif
-#if defined(HAVE_ST_INTERWORD_SPACING)
     draw->info->interword_spacing = NUM2DBL(rb_hash_aref(ddraw, CSTR2SYM("interword_spacing")));
-#endif
 
     draw->primitives = rb_hash_aref(ddraw, CSTR2SYM("primitives"));
 

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1123,12 +1123,10 @@ void rm_sync_image_options(Image *image, Info *info)
         image->transparent_color = info->transparent_color;
     }
 
-#if defined(HAVE_ST_TYPE)
     if (info->type != UndefinedType)
     {
         image->type = info->type;
     }
-#endif
 
     if (info->units != UndefinedResolution)
     {


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use structure members which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.