### PR TITLE
Fix SEGV in Image#profile!

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2611,6 +2611,11 @@ set_profile(VALUE self, const char *name, VALUE profile)
     exception = AcquireExceptionInfo();
     m = GetMagickInfo(name, exception);
     CHECK_EXCEPTION()
+    if (!m)
+    {
+        (void) DestroyExceptionInfo(exception);
+        rb_raise(rb_eArgError, "unknown name: %s", name);
+    }
 
     info = CloneImageInfo(NULL);
     if (!info)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -63,6 +63,8 @@ class Image3_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.profile!('icc', nil) }
     assert_nothing_raised { @img.profile!('iptc', nil) }
 
+    assert_raise(ArgumentError) { @img.profile!('test', 'foobarbaz') }
+
     @img.freeze
     assert_raise(FreezeError) { @img.profile!('icc', 'xxx') }
     assert_raise(FreezeError) { @img.profile!('*', nil) }


### PR DESCRIPTION
If unknow name was given in `Image#profile!`, it causes SEGV.
Seems `GetMagickInfo()` API returns NULL with unknow name without exception.
Then SEGV will be caused when it use returned value of `GetMagickInfo()`.

* Result

```
$ ruby test.rb
test.rb:4: [BUG] Segmentation fault at 0x0000000000000000
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0013 e:000012 CFUNC  :profile!
c:0002 p:0034 s:0007 E:000b58 EVAL   test.rb:4 [FINISH]
c:0001 p:0000 s:0003 E:0002d0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:4:in `<main>'
test.rb:4:in `profile!'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000001000 rbx: 0x0000000000000000 rcx: 0x0000000000001000
 rdx: 0x00007fe09f0ce948 rdi: 0x00000000d990b352 rsi: 0x0000000000000000
 rbp: 0x00007ffee345b1a0 rsp: 0x00007ffee345b110  r8: 0x0000000000000000
  r9: 0x0000000000000000 r10: 0x000000000000003d r11: 0x000000000000003d
 r12: 0x0000000000000000 r13: 0x0000000000000000 r14: 0x0000000000000000
 r15: 0x0000000000000000 rip: 0x000000010ccf4198 rfl: 0x0000000000010206

-- C level backtrace information -------------------------------------------
0   ruby                                0x000000010ca4b919 rb_print_backtrace + 25
1   ruby                                0x000000010ca4ba28 rb_vm_bugreport + 136
2   ruby                                0x000000010c83a902 rb_bug_context + 450
3   ruby                                0x000000010c98e768 sigsegv + 88
4   libsystem_platform.dylib            0x00007fff66920b5d _sigtramp + 29
5   RMagick2.bundle                     0x000000010ccf4198 set_profile + 168
6   RMagick2.bundle                     0x000000010cd015d6 Image_profile_bang + 86
7   ruby                                0x000000010ca403b2 call_cfunc_2 + 50
8   ruby                                0x000000010ca35c0d vm_call_cfunc_with_frame + 605
9   ruby                                0x000000010ca3131d vm_call_cfunc + 173
10  ruby                                0x000000010ca307fe vm_call_method_each_type + 190
11  ruby                                0x000000010ca30594 vm_call_method + 148
12  ruby                                0x000000010ca304f5 vm_call_general + 53
13  ruby                                0x000000010ca1c16e vm_exec_core + 8974
14  ruby                                0x000000010ca2bed6 vm_exec + 182
15  ruby                                0x000000010ca2cc5b rb_iseq_eval_main + 43
16  ruby                                0x000000010c845988 ruby_exec_internal + 232
17  ruby                                0x000000010c845891 ruby_exec_node + 33
18  ruby                                0x000000010c845850 ruby_run_node + 64
19  ruby                                0x000000010c7a426f main + 95

-- Other runtime information -----------------------------------------------
...
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(10, 10)
image.profile!('test', 'foobarbaz')
```