### PR TITLE
Fix memory leak in Image#delete_profile

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4624,7 +4624,7 @@ VALUE
 Image_delete_profile(VALUE self, VALUE name)
 {
     Image *image = rm_check_frozen(self);
-    (void) ProfileImage(image, StringValuePtr(name), NULL, 0, MagickTrue);
+    (void) DeleteImageProfile(image, StringValuePtr(name));
     rm_check_image_exception(image, RetainOnError);
 
     return self;


### PR DESCRIPTION
If it used `ProfileImage()` API to remove image profile, the API causes memory leak.
Seems that we should not use `ProfileImage()` for that.

If we use `DeleteImageProfile()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 90640: RSS = 104 MB
```

* After

```
$ ruby test.rb
Process: 34697: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(10, 10)

20000.times do |i|
  image.profile!('iptc', 'foobarbaz')
  image.delete_profile('iptc')

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```