### PR TITLE
Add TimeResource support

### DIFF
--- a/doc/magick.html
+++ b/doc/magick.html
@@ -352,9 +352,9 @@ p Magick.formats &raquo;
       <dt>resource_type</dt>
 
       <dd>One of the symbols <code>:area</code>,
-      <code>:disk</code>, <code>:file</code>, <code>:map</code>, or
-      <code>:memory</code>. You may use a string instead of a
-      symbol.</dd>
+      <code>:disk</code>, <code>:file</code>, <code>:map</code>,
+      <code>:memory</code>, or <code>:time</code>. You may use a
+      string instead of a symbol.</dd>
 
       <dt>limit</dt>
 
@@ -367,7 +367,8 @@ p Magick.formats &raquo;
       the <span class="arg">resource_type</span> is
       <code>:area</code> the limit is the maximum width * height of
       an image in pixels that can reside in pixel cache memory. If
-      this argument is omitted the limit is not changed.</dd>
+      <code>:time</code>, the limit is measured in seconds. If this
+      argument is omitted the limit is not changed.</dd>
     </dl>
 
     <h4>Returns</h4>
@@ -378,6 +379,10 @@ p Magick.formats &raquo;
     <h4>Notes</h4>
 
     <p>This method supercedes <code>set_cache_threshold</code>.</p>
+
+    <p>Setting the <code>:time</code> limit resets the elapsed time
+    to zero in the pixel cache. Call it before any operation that
+    you need to set a time limit on.</p>
   </div>
 
   <div class="sig">

--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -259,6 +259,10 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
             {
                 res = FileResource;
             }
+            else if (id == rb_intern("time"))
+            {
+                res = TimeResource;
+            }
             else
             {
                 rb_raise(rb_eArgError, "unknown resource: `:%s'", rb_id2name(id));
@@ -290,6 +294,10 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
             else if (rm_strcasecmp("file", str) == 0)
             {
                 res = FileResource;
+            }
+            else if (rm_strcasecmp("time", str) == 0)
+            {
+                res = TimeResource;
             }
             else
             {

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -296,6 +296,13 @@ class MagickUT < Test::Unit::TestCase
     assert_equal(500, new)
     Magick.limit_resource(:file, cur)
 
+    assert_nothing_raised { cur = Magick.limit_resource(:time, 300) }
+    assert_kind_of(Integer, cur)
+    assert(cur > 300)
+    assert_nothing_raised { new = Magick.limit_resource('time') }
+    assert_equal(300, new)
+    Magick.limit_resource(:time, cur)
+
     assert_raise(ArgumentError) { Magick.limit_resource(:xxx) }
     assert_raise(ArgumentError) { Magick.limit_resource('xxx') }
     assert_raise(ArgumentError) { Magick.limit_resource('map', 3500, 2) }


### PR DESCRIPTION
This pull adds support for setting a TimeResource limit.

The limit itself is a bit tricky to use as it's evaluated between subsequent calls to GetImagePixelCache, rather than being per operation. The only way reset it is to call SetMagickResourceLimit which calls ResetPixelCacheEpoch, effectively forcing you to call Magic.limit_resource(:time, <int>) before anything you want to cap.