### PR TITLE
Remove unnecessary value check in argument of Image#gamma_correct

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6861,13 +6861,6 @@ Image_gamma_correct(int argc, VALUE *argv, VALUE self)
     {
         case 1:
             red_gamma   = NUM2DBL(argv[0]);
-
-            // Can't have all 4 gamma values == 1.0. Also, very small values
-            // cause ImageMagick to segv.
-            if (red_gamma == 1.0 || fabs(red_gamma) < 0.003)
-            {
-                rb_raise(rb_eArgError, "invalid gamma value (%f)", red_gamma);
-            }
             green_gamma = blue_gamma = red_gamma;
             break;
         case 2:

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -765,8 +765,6 @@ class Image2_UT < Test::Unit::TestCase
 
   def test_gramma_correct
     assert_raise(ArgumentError) { @img.gamma_correct }
-    # All 4 arguments can't default to 1.0
-    assert_raise(ArgumentError) { @img.gamma_correct(1.0) }
     assert_nothing_raised do
       res = @img.gamma_correct(0.8)
       assert_instance_of(Magick::Image, res)


### PR DESCRIPTION
Close #403

Maybe, the API of ancient ImageMagick might has caused SEGV if 0.0 was given as gamma value into Image#gamma_correct.

Now, seem we can call ImageMagick API without SEGV.