### PR TITLE
Remove some have_type checking for older ImageMagick API

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -341,16 +341,7 @@ END_MSWIN
         have_func(func, headers)
       end
 
-      have_type('DitherMethod', headers) # 6.4.2
-      have_type('MagickFunction', headers) # 6.4.8-8
-      have_type('ImageLayerMethod', headers) # 6.3.6 replaces MagickLayerMethod
       have_type('long double', headers)
-      # have_type("unsigned long long", headers)
-      # have_type("uint64_t", headers)
-      # have_type("__int64", headers)
-      # have_type("uintmax_t", headers)
-      # check_sizeof("unsigned long", headers)
-      # check_sizeof("Image *", headers)
 
       have_enum_values('AlphaChannelType', ['CopyAlphaChannel', # 6.4.3-7
                                             'BackgroundAlphaChannel', # 6.5.2-5

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -135,18 +135,10 @@
 
 #define MagickLibSubversion MagickLibAddendum
 
-// ImageLayerMethod replaced MagickLayerMethod starting with 6.3.6
-#if defined(HAVE_TYPE_IMAGELAYERMETHOD)
 #define LAYERMETHODTYPE ImageLayerMethod /**< layer method */
 #define CLASS_LAYERMETHODTYPE Class_ImageLayerMethod /**< layer method class */
 #define LAYERMETHODTYPE_NAME ImageLayerMethod_name /**< layer method name */
 #define LAYERMETHODTYPE_NEW  ImageLayerMethod_new /**< new layer method */
-#else
-#define LAYERMETHODTYPE MagickLayerMethod /**< layer method */
-#define CLASS_LAYERMETHODTYPE Class_MagickLayerMethod /**< layer method class */
-#define LAYERMETHODTYPE_NAME MagickLayerMethod_name /**< layer method name */
-#define LAYERMETHODTYPE_NEW  MagickLayerMethod_new /**< new layer method */
-#endif
 
 
 typedef ImageInfo Info; /**< Make type name match class name */
@@ -351,9 +343,7 @@ EXTERN VALUE Class_CompressionType;
 EXTERN VALUE Class_DecorationType;
 EXTERN VALUE Class_DisposeType;
 EXTERN VALUE Class_DistortImageMethod;
-#if defined(HAVE_TYPE_DITHERMETHOD)
 EXTERN VALUE Class_DitherMethod;
-#endif
 EXTERN VALUE Class_EndianType;
 EXTERN VALUE Class_FilterTypes;
 EXTERN VALUE Class_GravityType;

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -628,11 +628,7 @@ ImageList_optimize_layers(VALUE self, VALUE method)
 
     new_images2 = NULL;     // defeat "unused variable" message
 
-#if defined(HAVE_TYPE_IMAGELAYERMETHOD)
     VALUE_TO_ENUM(method, mthd, ImageLayerMethod);
-#else
-    VALUE_TO_ENUM(method, mthd, MagickLayerMethod);
-#endif
     images = images_from_imagelist(self);
 
     exception = AcquireExceptionInfo();
@@ -974,7 +970,7 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
         case 4:
             quantize_info.tree_depth = (unsigned long)NUM2INT(argv[3]);
         case 3:
-#if defined(HAVE_TYPE_DITHERMETHOD) && defined(HAVE_ENUM_NODITHERMETHOD)
+#if defined(HAVE_ENUM_NODITHERMETHOD)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10361,7 +10361,7 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
         case 4:
             quantize_info.tree_depth = NUM2UINT(argv[3]);
         case 3:
-#if defined(HAVE_TYPE_DITHERMETHOD) && defined(HAVE_ENUM_NODITHERMETHOD)
+#if defined(HAVE_ENUM_NODITHERMETHOD)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1168,7 +1168,6 @@ Init_RMagick2(void)
 #endif
     END_ENUM
 
-#if defined(HAVE_TYPE_DITHERMETHOD)
     DEF_ENUM(DitherMethod)
         ENUMERATOR(UndefinedDitherMethod)
 #if defined(HAVE_ENUM_NODITHERMETHOD)
@@ -1177,7 +1176,6 @@ Init_RMagick2(void)
         ENUMERATOR(RiemersmaDitherMethod)
         ENUMERATOR(FloydSteinbergDitherMethod)
     END_ENUM
-#endif
 
     DEF_ENUM(EndianType)
         ENUMERATOR(UndefinedEndian)
@@ -1279,7 +1277,6 @@ Init_RMagick2(void)
         ENUMERATOR(SplineInterpolatePixel)
     END_ENUM
 
-#if defined(HAVE_TYPE_MAGICKFUNCTION)
     DEF_ENUM(MagickFunction)
         ENUMERATOR(UndefinedFunction)
         ENUMERATOR(PolynomialFunction)
@@ -1291,13 +1288,8 @@ Init_RMagick2(void)
         ENUMERATOR(ArctanFunction)
 #endif
     END_ENUM
-#endif
 
-#if defined(HAVE_TYPE_IMAGELAYERMETHOD)
     DEF_ENUM(ImageLayerMethod)
-#else
-    DEF_ENUM(MagickLayerMethod)
-#endif
         ENUMERATOR(UndefinedLayer)
         ENUMERATOR(CompareAnyLayer)
         ENUMERATOR(CompareClearLayer)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use API added in older version without check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.