### PR TITLE
Fix memory leak in Info#{caption=, comment=, label=}

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -64,7 +64,7 @@ set_option(VALUE self, const char *key, VALUE string)
 
     if (NIL_P(string))
     {
-        (void) RemoveImageOption(info, key);
+        (void) DeleteImageOption(info, key);
     }
     else
     {


### PR DESCRIPTION
The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 75876: RSS = 61 MB
```

* After

```
$ ruby test.rb
Process: 76977: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.caption = "foobarbaz"
  info.caption = nil

  info.comment = "foobarbaz"
  info.comment = nil

  info.label = "foobarbaz"
  info.label = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```