### PR TITLE
Fix memory leak in Info#{fill=, stroke=, undercolor=}

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -100,7 +100,7 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
 
     if (NIL_P(color))
     {
-        (void) RemoveImageOption(info, option);
+        (void) DeleteImageOption(info, option);
     }
     else
     {
@@ -113,7 +113,6 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
             rb_raise(rb_eArgError, "invalid color name `%s'", name);
         }
 
-        (void) RemoveImageOption(info, option);
         (void) SetImageOption(info, option, name);
     }
 


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 45429: RSS = 106 MB
```

* After

```
$ ruby test.rb
Process: 47064: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.fill = "gray50"
  info.fill = "gray50"
  info.fill = nil

  info.stroke = "gray50"
  info.stroke = "gray50"
  info.stroke = nil

  info.undercolor = "gray50"
  info.undercolor = "gray50"
  info.undercolor = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```