### PR TITLE
Fix memory leak in Info#{attenuate=, stroke_width=}

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -179,7 +179,7 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
 
     if (NIL_P(value))
     {
-        (void) RemoveImageOption(info, option);
+        (void) DeleteImageOption(info, option);
     }
     else
     {
@@ -194,7 +194,6 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
             len = sprintf(buff, "%-10.2f", d);
         }
         memset(buff+len, '\0', sizeof(buff)-len);
-        (void) RemoveImageOption(info, option);
         (void) SetImageOption(info, option, buff);
     }
 


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 83360: RSS = 76 MB
```

* After

```
$ ruby test.rb
Process: 84430: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.attenuate = 1.0
  info.attenuate = 1.0
  info.attenuate = nil

  info.stroke_width = 1.0
  info.stroke_width = 1.0
  info.stroke_width = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```