### PR TITLE
Fix memory leak in Info#[]=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -356,7 +356,7 @@ Info_aset(int argc, VALUE *argv, VALUE self)
 
     if (NIL_P(value))
     {
-        (void) RemoveImageOption(info, ckey);
+        (void) DeleteImageOption(info, ckey);
     }
     else
     {
@@ -364,7 +364,6 @@ Info_aset(int argc, VALUE *argv, VALUE self)
         value = rm_to_s(value);
         value_p = StringValuePtr(value);
 
-        (void) RemoveImageOption(info, ckey);
         okay = SetImageOption(info, ckey, value_p);
         if (!okay)
         {


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 85446: RSS = 45 MB
```

* After

```
$ ruby test.rb
Process: 86450: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info['test'] = 'foobarbaz'
  info['test'] = 'foobarbaz'
  info['test'] = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```