### PR TITLE
Fix memory leak in Info#define

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -770,7 +770,7 @@ Info_define(int argc, VALUE *argv, VALUE self)
     }
     (void) sprintf(ckey, "%s:%s", format, key);
 
-    (void) RemoveImageOption(info, ckey);
+    (void) DeleteImageOption(info, ckey);
     okay = SetImageOption(info, ckey, value);
     if (!okay)
     {


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 86727: RSS = 30 MB
```

* After

```
$ ruby test.rb
Process: 87881: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.define('iptc', 'test', 'foobarbaz')

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```