### PR TITLE
Fix memory leak in Info#delay=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -859,7 +859,7 @@ Info_delay_eq(VALUE self, VALUE string)
 
     if (NIL_P(string))
     {
-        (void) RemoveImageOption(info, "delay");
+        (void) DeleteImageOption(info, "delay");
     }
     else
     {
@@ -871,7 +871,6 @@ Info_delay_eq(VALUE self, VALUE string)
         }
         delay = NUM2INT(string);
         sprintf(dstr, "%d", delay);
-        (void) RemoveImageOption(info, "delay");
         (void) SetImageOption(info, "delay", dstr);
     }
     return self;


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 89367: RSS = 45 MB
```

* After

```
$ ruby test.rb
Process: 90734: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.delay = 42
  info.delay = 42
  info.delay = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```