### PR TITLE
Fix memory leak in Info#dispose=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1092,7 +1092,7 @@ Info_dispose_eq(VALUE self, VALUE disp)
 
     if (NIL_P(disp))
     {
-        (void) RemoveImageOption(info, "dispose");
+        (void) DeleteImageOption(info, "dispose");
         return self;
     }
 


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 91727: RSS = 30 MB
```

* After

```
$ ruby test.rb
Process: 92615: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.dispose = Magick::BackgroundDispose
  info.dispose = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```