### PR TITLE
Fix memory leak in Info#gravity=

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1562,7 +1562,7 @@ Info_gravity_eq(VALUE self, VALUE grav)
 
     if (NIL_P(grav))
     {
-        (void) RemoveImageOption(info, "gravity");
+        (void) DeleteImageOption(info, "gravity");
         return self;
     }
 


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 93913: RSS = 30 MB
```

* After

```
$ ruby test.rb
Process: 94901: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.gravity = Magick::CenterGravity
  info.gravity = nil

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```