### PR TITLE
Fix memory leak in Info#undefine

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2377,9 +2377,7 @@ Info_undefine(VALUE self, VALUE format, VALUE key)
     sprintf(fkey, "%.60s:%.*s", format_p, (int)(MaxTextExtent-61), key_p);
 
     Data_Get_Struct(self, Info, info);
-    /* Depending on the IM version, RemoveImageOption returns either */
-    /* char * or MagickBooleanType. Ignore the return value.         */
-    (void) RemoveImageOption(info, fkey);
+    (void) DeleteImageOption(info, fkey);
 
     return self;
 }


### PR DESCRIPTION
This is same issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageOption()` will not deallocate memory area completedly for this case.

If we use `DeleteImageOption()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 15203: RSS = 30 MB
```

* After

```
$ ruby test.rb
Process: 16508: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

info = Magick::Image::Info.new

1000000.times do |i|
  info.define('tiff', 'bits-per-sample', 2)
  info.undefine('tiff', 'bits-per-sample')

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```