### PR TITLE
Fix memory leak in Image#undefine

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -14024,7 +14024,7 @@ Image_undefine(VALUE self, VALUE artifact)
 
     image = rm_check_frozen(self);
     key = rm_str2cstr(artifact, &key_l);
-    (void) RemoveImageArtifact(image, key);
+    (void) DeleteImageArtifact(image, key);
     return self;
 }
 


### PR DESCRIPTION
This is similar issue with https://github.com/rmagick/rmagick/pull/409

The memory leak is occurred if setting and deleting option are repeated.
Seems `RemoveImageArtifact()` will not deallocate memory area completedly for this case.

If we use `DeleteImageArtifact()` instead, we can avoid the memory leak.

* Before

```
$ ruby test.rb
Process: 99131: RSS = 30 MB
```

* After

```
$ ruby test.rb
Process: 2934: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(10, 10)

1000000.times do |i|
  image.define('deskew:auto-crop', 40)
  image.undefine('deskew:auto-crop')

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```