### PR TITLE
Remove have_enum_values checking of AlphaChannelType

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,9 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('AlphaChannelType', ['CopyAlphaChannel', # 6.4.3-7
-                                            'BackgroundAlphaChannel', # 6.5.2-5
-                                            'RemoveAlphaChannel'], headers) # 6.7.5-1
       have_enum_values('CompositeOperator', ['BlurCompositeOp', # 6.5.3-7
                                              'DistortCompositeOp', # 6.5.3-10
                                              'LinearBurnCompositeOp', # 6.5.4-3

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -878,19 +878,13 @@ Init_RMagick2(void)
         ENUMERATOR(DeactivateAlphaChannel)
         ENUMERATOR(ResetAlphaChannel)  /* deprecated */
         ENUMERATOR(SetAlphaChannel)
-#if defined(HAVE_ENUM_REMOVEALPHACHANNEL)
         ENUMERATOR(RemoveAlphaChannel)
-#endif
-#if defined(HAVE_ENUM_COPYALPHACHANNEL)
         ENUMERATOR(CopyAlphaChannel)
         ENUMERATOR(ExtractAlphaChannel)
         ENUMERATOR(OpaqueAlphaChannel)
         ENUMERATOR(ShapeAlphaChannel)
         ENUMERATOR(TransparentAlphaChannel)
-#endif
-#if defined(HAVE_ENUM_BACKGROUNDALPHACHANNEL)
         ENUMERATOR(BackgroundAlphaChannel)
-#endif
     END_ENUM
 
     // AnchorType constants (for Draw#text_anchor - these are not defined by ImageMagick)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.