### PR TITLE
Replace Fixnum to Integer

### DIFF
--- a/doc/rvg.html
+++ b/doc/rvg.html
@@ -893,7 +893,7 @@ canvas.background_position = :scaled
   <div style="margin-left: 235px; margin-top:1em">
     <p>RVG supports a subset of the unit identifiers defined by the
     SVG specification. In RVG, unit identifiers are methods in the
-    Float and Fixnum classes. The units are (for the most part)
+    Float and Integer classes. The units are (for the most part)
     defined in terms of "dots per inch," accordingly, the unit
     identifier methods are added only if the value</p>
     <pre>
@@ -911,7 +911,7 @@ canvas.background_position = :scaled
 </pre>
 
     <p>If the dpi is defined, the following methods are added to
-    <code>Float</code> and <code>Fixnum</code></p>
+    <code>Float</code> and <code>Integer</code></p>
 
     <dl>
       <dt>px</dt>

--- a/doc/rvgtut.html
+++ b/doc/rvgtut.html
@@ -140,7 +140,7 @@
 
   <p><code>RVG::dpi</code> enables the use of <em>unit methods</em>
   in RVG. When you set <code>RVG::dpi</code> to a non-nil value,
-  RVG adds a number of conversion methods to the Fixnum and Float
+  RVG adds a number of conversion methods to the Integer and Float
   classes . These methods allow you to specify measurements in
   units such as inches, millimeters, and centimeters. <em>DPI</em>
   stands for "dots per inch," the image resolution. Here I set

--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -138,7 +138,7 @@ KernelInfo_scale(VALUE self, VALUE scale, VALUE flags)
   if (rb_obj_is_instance_of(flags, Class_GeometryFlags))
     VALUE_TO_ENUM(flags, geoflags, GeometryFlags);
   else
-    rb_raise(rb_eArgError, "expected Fixnum or Magick::GeometryFlags to specify flags");
+    rb_raise(rb_eArgError, "expected Integer or Magick::GeometryFlags to specify flags");
 
   ScaleKernelInfo((KernelInfo*)DATA_PTR(self), NUM2DBL(scale), geoflags);
   return Qnil;

--- a/lib/rvg/deep_equal.rb
+++ b/lib/rvg/deep_equal.rb
@@ -30,7 +30,7 @@ module Magick
               end
             else
               case itv
-              when Float, Symbol, TrueClass, FalseClass, Fixnum, NilClass
+              when Float, Symbol, TrueClass, FalseClass, Integer, NilClass
                 return false if itv != otv
               else
                 if itv.equal?(otv)

--- a/lib/rvg/misc.rb
+++ b/lib/rvg/misc.rb
@@ -14,7 +14,7 @@ module Magick
           ivars = instance_variables
           ivars.each do |ivar|
             ivalue = instance_variable_get(ivar)
-            cvalue = if ivalue.is_a?(NilClass) || ivalue.is_a?(Symbol) || ivalue.is_a?(Float) || ivalue.is_a?(Fixnum) || ivalue.is_a?(FalseClass) || ivalue.is_a?(TrueClass)
+            cvalue = if ivalue.is_a?(NilClass) || ivalue.is_a?(Symbol) || ivalue.is_a?(Float) || ivalue.is_a?(Integer) || ivalue.is_a?(FalseClass) || ivalue.is_a?(TrueClass)
                        ivalue
                      elsif ivalue.respond_to?(:deep_copy)
                        ivalue.deep_copy(h)

--- a/lib/rvg/units.rb
+++ b/lib/rvg/units.rb
@@ -2,12 +2,12 @@
 # Copyright (C) 2009 Timothy P. Hunter
 module Magick
   class RVG
-    # Define RVG.dpi and RVG.dpi=. Add conversions to Fixnum and Float classes
+    # Define RVG.dpi and RVG.dpi=. Add conversions to Integer and Float classes
     class << self
       attr_reader :dpi
       def dpi=(n)
         unless defined?(@dpi)
-          [Float, Fixnum].each do |c|
+          [Float, Integer].each do |c|
             c.class_eval <<-END_DEFS
               # the default measurement - 1px is 1 pixel
               def px

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -329,7 +329,7 @@ class Image1_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.channel_depth(Magick::GrayChannel) }
     assert_raise(TypeError) { @img.channel_depth(2) }
-    assert_instance_of(Fixnum, @img.channel_depth(Magick::RedChannel))
+    assert_kind_of(Integer, @img.channel_depth(Magick::RedChannel))
   end
 
   def test_channel_extrema

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -223,8 +223,8 @@ class InfoUT < Test::Unit::TestCase
     assert_nothing_raised { @info.monitor = -> {} }
     monitor = proc do |mth, q, s|
       assert_equal('resize!', mth)
-      assert_instance_of(Fixnum, q)
-      assert_instance_of(Fixnum, s)
+      assert_kind_of(Integer, q)
+      assert_kind_of(Integer, s)
       true
     end
     img = Magick::Image.new(2000, 2000) { self.monitor = monitor }

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -81,7 +81,7 @@ class MagickUT < Test::Unit::TestCase
       assert_instance_of(String, f.family)
       assert_instance_of(Magick::StyleType, f.style)
       assert_instance_of(Magick::StretchType, f.stretch)
-      assert_instance_of(Fixnum, f.weight)
+      assert_kind_of(Integer, f.weight)
       assert_instance_of(String, f.encoding) unless f.encoding.nil?
       assert_instance_of(String, f.foundry) unless f.foundry.nil?
       assert_instance_of(String, f.format) unless f.format.nil?


### PR DESCRIPTION
Fixnum and Bignum were unified into Integer at Ruby 2.4.
If use Fixnum in Ruby land with newer version, it shows warning message

```
warning: constant ::Fixnum is deprecated
```

It means we are not able to use Fixnum in the future.