### PR TITLE
Fix build error on Homebrew environment

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -14,9 +14,20 @@ module RMagick
     attr_reader :headers
 
     def initialize
+      setup_paths_for_homebrew
       configure_compile_options
       assert_can_compile!
       configure_headers
+    end
+
+    def setup_paths_for_homebrew
+      return unless find_executable('brew')
+
+      brew_pkg_config_path = "#{`brew --prefix imagemagick@6`.strip}/lib/pkgconfig"
+      pkgconfig_paths = ENV['PKG_CONFIG_PATH'].to_s.split(':')
+      if File.exist?(brew_pkg_config_path) && !pkgconfig_paths.include?(brew_pkg_config_path)
+        ENV['PKG_CONFIG_PATH'] = [ENV['PKG_CONFIG_PATH'], brew_pkg_config_path].compact.join(':')
+      end
     end
 
     def configured_compile_options


### PR DESCRIPTION
If installed ImageMagick 6 using Homebrew, it will install ImageMagck where `pkg-config` command can't find the path by default.

The users have to set `PKG_CONFIG_PATH` environment variables to install RMagick.

```
$ brew install imagemagick@6

$ gem install rmagick
Building native extensions. This could take a while...
ERROR:  Error installing rmagick:
	ERROR: Failed to build gem native extension.

    current directory: /Users/watson/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rmagick-3.0.0/ext/RMagick
/Users/watson/.rbenv/versions/2.5.3/bin/ruby -r ./siteconf20190303-76249-1h2084u.rb extconf.rb
checking for clang... yes
checking for Magick-config... no
checking for pkg-config... yes
Package MagickCore was not found in the pkg-config search path.
Perhaps you should add the directory containing `MagickCore.pc'
to the PKG_CONFIG_PATH environment variable
No package 'MagickCore' found
checking for outdated ImageMagick version (<= 6.8.9)... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
...
```

This patch will set default `PKG_CONFIG_PATH` for Homebrew environemnt to install RMagick easily.