### PR TITLE
Remove have_enum_values checking of CompressionType

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,15 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('CompressionType', ['DXT1Compression', # 6.3.9-3
-                                           'DXT3Compression', # 6.3.9-3
-                                           'DXT5Compression', # 6.3.9-3
-                                           'ZipSCompression', # 6.5.5-4
-                                           'PizCompression', # 6.5.5-4
-                                           'Pxr24Compression', # 6.5.5-4
-                                           'B44Compression', # 6.5.5-4
-                                           'B44ACompression'], headers) # 6.5.5-4
-
       have_enum_values('DistortImageMethod', ['BarrelDistortion', # 6.4.2-5
                                               'BarrelInverseDistortion', # 6.4.3-8
                                               'BilinearForwardDistortion', # 6.5.1-2

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -597,39 +597,23 @@ CompressionType_name(CompressionType ct)
     {
         ENUM_TO_NAME(UndefinedCompression)
         ENUM_TO_NAME(NoCompression)
-#if defined(HAVE_ENUM_B44COMPRESSION)
         ENUM_TO_NAME(B44Compression)
-#endif
-#if defined(HAVE_ENUM_B44ACOMPRESSION)
         ENUM_TO_NAME(B44ACompression)
-#endif
         ENUM_TO_NAME(BZipCompression)
-#if defined(HAVE_ENUM_DXT1COMPRESSION)
         ENUM_TO_NAME(DXT1Compression)
-#endif
-#if defined(HAVE_ENUM_DXT3COMPRESSION)
         ENUM_TO_NAME(DXT3Compression)
-#endif
-#if defined(HAVE_ENUM_DXT5COMPRESSION)
         ENUM_TO_NAME(DXT5Compression)
-#endif
         ENUM_TO_NAME(FaxCompression)
         ENUM_TO_NAME(Group4Compression)
         ENUM_TO_NAME(JPEGCompression)
         ENUM_TO_NAME(JPEG2000Compression)
         ENUM_TO_NAME(LosslessJPEGCompression)
         ENUM_TO_NAME(LZWCompression)
-#if defined(HAVE_ENUM_PIZCOMPRESSION)
         ENUM_TO_NAME(PizCompression)
-#endif
-#if defined(HAVE_ENUM_PXR24COMPRESSION)
         ENUM_TO_NAME(Pxr24Compression)
-#endif
         ENUM_TO_NAME(RLECompression)
         ENUM_TO_NAME(ZipCompression)
-#if defined(HAVE_ENUM_ZIPSCOMPRESSION)
         ENUM_TO_NAME(ZipSCompression)
-#endif
         }
 
     return "UndefinedCompression";

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1060,39 +1060,23 @@ Init_RMagick2(void)
     DEF_ENUM(CompressionType)
         ENUMERATOR(UndefinedCompression)
         ENUMERATOR(NoCompression)
-#if defined(HAVE_ENUM_B44COMPRESSION)
         ENUMERATOR(B44Compression)
-#endif
-#if defined(HAVE_ENUM_B44ACOMPRESSION)
         ENUMERATOR(B44ACompression)
-#endif
         ENUMERATOR(BZipCompression)
-#if defined(HAVE_ENUM_DXT1COMPRESSION)
         ENUMERATOR(DXT1Compression)
-#endif
-#if defined(HAVE_ENUM_DXT3COMPRESSION)
         ENUMERATOR(DXT3Compression)
-#endif
-#if defined(HAVE_ENUM_DXT5COMPRESSION)
         ENUMERATOR(DXT5Compression)
-#endif
         ENUMERATOR(FaxCompression)
         ENUMERATOR(Group4Compression)
         ENUMERATOR(JPEGCompression)
         ENUMERATOR(JPEG2000Compression)
         ENUMERATOR(LosslessJPEGCompression)
         ENUMERATOR(LZWCompression)
-#if defined(HAVE_ENUM_PIZCOMPRESSION)
         ENUMERATOR(PizCompression)
-#endif
-#if defined(HAVE_ENUM_PXR24COMPRESSION)
         ENUMERATOR(Pxr24Compression)
-#endif
         ENUMERATOR(RLECompression)
         ENUMERATOR(ZipCompression)
-#if defined(HAVE_ENUM_ZIPSCOMPRESSION)
         ENUMERATOR(ZipSCompression)
-#endif
     END_ENUM
 
     // DecorationType constants


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.