### PR TITLE
Remove have_enum_values checking of DistortImageMethod

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,14 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('DistortImageMethod', ['BarrelDistortion', # 6.4.2-5
-                                              'BarrelInverseDistortion', # 6.4.3-8
-                                              'BilinearForwardDistortion', # 6.5.1-2
-                                              'BilinearReverseDistortion', # 6.5.1-2
-                                              'DePolarDistortion', # 6.4.2-6
-                                              'PolarDistortion', # 6.4.2-6
-                                              'PolynomialDistortion', # 6.4.2-4
-                                              'ShepardsDistortion'], headers) # 6.4.2-4
       have_enum_value('DitherMethod', 'NoDitherMethod', headers) # 6.4.3
       have_enum_values('FilterTypes', ['KaiserFilter', # 6.3.6
                                        'WelshFilter', # 6.3.6-4

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1101,34 +1101,18 @@ Init_RMagick2(void)
         ENUMERATOR(AffineDistortion)
         ENUMERATOR(AffineProjectionDistortion)
         ENUMERATOR(ArcDistortion)
-#if defined(HAVE_ENUM_POLARDISTORTION)
         ENUMERATOR(PolarDistortion)
-#endif
-#if defined(HAVE_ENUM_DEPOLARDISTORTION)
         ENUMERATOR(DePolarDistortion)
-#endif
-#if defined(HAVE_ENUM_BARRELDISTORTION)
         ENUMERATOR(BarrelDistortion)
-#endif
         ENUMERATOR(BilinearDistortion)
-#if defined(HAVE_ENUM_BILINEARFORWARDDISTORTION)
         ENUMERATOR(BilinearForwardDistortion)
-#endif
-#if defined(HAVE_ENUM_BILINEARREVERSEDISTORTION)
         ENUMERATOR(BilinearReverseDistortion)
-#endif
         ENUMERATOR(PerspectiveDistortion)
         ENUMERATOR(PerspectiveProjectionDistortion)
-#if defined(HAVE_ENUM_POLYNOMIALDISTORTION)
         ENUMERATOR(PolynomialDistortion)
-#endif
         ENUMERATOR(ScaleRotateTranslateDistortion)
-#if defined(HAVE_ENUM_SHEPARDSDISTORTION)
         ENUMERATOR(ShepardsDistortion)
-#endif
-#if defined(HAVE_ENUM_BARRELINVERSEDISTORTION)
         ENUMERATOR(BarrelInverseDistortion)
-#endif
     END_ENUM
 
     DEF_ENUM(DitherMethod)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.