### PR TITLE
Remove have_enum_values checking of DitherMethod

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,7 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_value('DitherMethod', 'NoDitherMethod', headers) # 6.4.3
       have_enum_values('FilterTypes', ['KaiserFilter', # 6.3.6
                                        'WelshFilter', # 6.3.6-4
                                        'ParzenFilter', # 6.3.6-4

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -970,15 +970,11 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
         case 4:
             quantize_info.tree_depth = (unsigned long)NUM2INT(argv[3]);
         case 3:
-#if defined(HAVE_ENUM_NODITHERMETHOD)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
                 quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
             }
-#else
-            quantize_info.dither = (MagickBooleanType) RTEST(argv[2]);
-#endif
         case 2:
             VALUE_TO_ENUM(argv[1], quantize_info.colorspace, ColorspaceType);
         case 1:

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10345,15 +10345,11 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
         case 4:
             quantize_info.tree_depth = NUM2UINT(argv[3]);
         case 3:
-#if defined(HAVE_ENUM_NODITHERMETHOD)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
                 quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
             }
-#else
-            quantize_info.dither = (MagickBooleanType) RTEST(argv[2]);
-#endif
         case 2:
             VALUE_TO_ENUM(argv[1], quantize_info.colorspace, ColorspaceType);
         case 1:

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1117,9 +1117,7 @@ Init_RMagick2(void)
 
     DEF_ENUM(DitherMethod)
         ENUMERATOR(UndefinedDitherMethod)
-#if defined(HAVE_ENUM_NODITHERMETHOD)
         ENUMERATOR(NoDitherMethod)
-#endif
         ENUMERATOR(RiemersmaDitherMethod)
         ENUMERATOR(FloydSteinbergDitherMethod)
     END_ENUM


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.