### PR TITLE
Remove have_enum_values checking of FilterTypes

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,13 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('FilterTypes', ['KaiserFilter', # 6.3.6
-                                       'WelshFilter', # 6.3.6-4
-                                       'ParzenFilter', # 6.3.6-4
-                                       'LagrangeFilter', # 6.3.7-2
-                                       'BohmanFilter', # 6.3.7-2
-                                       'BartlettFilter', # 6.3.7-2
-                                       'SentinelFilter'], headers) # 6.3.7-2
       have_enum_values('MagickEvaluateOperator', ['PowEvaluateOperator', # 6.4.1-9
                                                   'LogEvaluateOperator', # 6.4.2
                                                   'ThresholdEvaluateOperator', # 6.4.3

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -704,29 +704,15 @@ FilterTypes_name(FilterTypes type)
         ENUM_TO_NAME(LanczosFilter)
         ENUM_TO_NAME(BesselFilter)
         ENUM_TO_NAME(SincFilter)
-#if defined(HAVE_ENUM_KAISERFILTER)
         ENUM_TO_NAME(KaiserFilter)
-#endif
-#if defined(HAVE_ENUM_WELSHFILTER)
         ENUM_TO_NAME(WelshFilter)
-#endif
-#if defined(HAVE_ENUM_PARZENFILTER)
         ENUM_TO_NAME(ParzenFilter)
-#endif
-#if defined(HAVE_ENUM_LAGRANGEFILTER)
         ENUM_TO_NAME(LagrangeFilter)
-#endif
-#if defined(HAVE_ENUM_BOHMANFILTER)
         ENUM_TO_NAME(BohmanFilter)
-#endif
-#if defined(HAVE_ENUM_BARTLETTFILTER)
         ENUM_TO_NAME(BartlettFilter)
-#endif
-#if defined(HAVE_ENUM_SENTINELFILTER)
         // not a real filter name - defeat gcc warning message
         case SentinelFilter:
             break;
-#endif
     }
 
     return "UndefinedFilter";

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1146,24 +1146,12 @@ Init_RMagick2(void)
         ENUMERATOR(LanczosFilter)
         ENUMERATOR(BesselFilter)
         ENUMERATOR(SincFilter)
-#if defined(HAVE_ENUM_KAISERFILTER)
         ENUMERATOR(KaiserFilter)
-#endif
-#if defined(HAVE_ENUM_WELSHFILTER)
         ENUMERATOR(WelshFilter)
-#endif
-#if defined(HAVE_ENUM_PARZENFILTER)
         ENUMERATOR(ParzenFilter)
-#endif
-#if defined(HAVE_ENUM_LAGRANGEFILTER)
         ENUMERATOR(LagrangeFilter)
-#endif
-#if defined(HAVE_ENUM_BOHMANFILTER)
         ENUMERATOR(BohmanFilter)
-#endif
-#if defined(HAVE_ENUM_BARTLETTFILTER)
         ENUMERATOR(BartlettFilter)
-#endif
     END_ENUM
 
     // GravityType constants


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.