### PR TITLE
Remove have_enum_values checking of MagickEvaluateOperator

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,21 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('MagickEvaluateOperator', ['PowEvaluateOperator', # 6.4.1-9
-                                                  'LogEvaluateOperator', # 6.4.2
-                                                  'ThresholdEvaluateOperator', # 6.4.3
-                                                  'ThresholdBlackEvaluateOperator', # 6.4.3
-                                                  'ThresholdWhiteEvaluateOperator', # 6.4.3
-                                                  'GaussianNoiseEvaluateOperator', # 6.4.3
-                                                  'ImpulseNoiseEvaluateOperator', # 6.4.3
-                                                  'LaplacianNoiseEvaluateOperator', # 6.4.3
-                                                  'MultiplicativeNoiseEvaluateOperator', # 6.4.3
-                                                  'PoissonNoiseEvaluateOperator', # 6.4.3
-                                                  'UniformNoiseEvaluateOperator', # 6.4.3
-                                                  'CosineEvaluateOperator', # 6.4.8-5
-                                                  'SineEvaluateOperator', # 6.4.8-5
-                                                  'AddModulusEvaluateOperator'], # 6.4.8-5
-                       headers)
       have_enum_values('MagickFunction', ['ArcsinFunction', # 6.5.2-8
                                           'ArctanFunction', # 6.5.2-8
                                           'PolynomialFunction', # 6.4.8-8

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -240,48 +240,20 @@ typedef enum _QuantumExpressionOperator
     RShiftQuantumOperator,    /**< rshift */
     SubtractQuantumOperator,  /**< subtract */
     XorQuantumOperator,       /**< xor */
-#if defined(HAVE_ENUM_POWEVALUATEOPERATOR)
     PowQuantumOperator,       /**< pow */
-#endif
-#if defined(HAVE_ENUM_LOGEVALUATEOPERATOR)
     LogQuantumOperator,       /**< log */
-#endif
-#if defined(HAVE_ENUM_THRESHOLDEVALUATEOPERATOR)
     ThresholdQuantumOperator, /**< threshold */
-#endif
-#if defined(HAVE_ENUM_THRESHOLDBLACKEVALUATEOPERATOR)
     ThresholdBlackQuantumOperator, /**< threshold black */
-#endif
-#if defined(HAVE_ENUM_THRESHOLDWHITEEVALUATEOPERATOR)
     ThresholdWhiteQuantumOperator, /**< threshold white */
-#endif
-#if defined(HAVE_ENUM_GAUSSIANNOISEEVALUATEOPERATOR)
     GaussianNoiseQuantumOperator, /**< gaussian noise */
-#endif
-#if defined(HAVE_ENUM_IMPULSENOISEEVALUATEOPERATOR)
     ImpulseNoiseQuantumOperator, /**< impulse noise */
-#endif
-#if defined(HAVE_ENUM_LAPLACIANNOISEEVALUATEOPERATOR)
     LaplacianNoiseQuantumOperator, /**< laplacian noise */
-#endif
-#if defined(HAVE_ENUM_MULTIPLICATIVENOISEEVALUATEOPERATOR)
     MultiplicativeNoiseQuantumOperator, /**< multiplicative noise */
-#endif
-#if defined(HAVE_ENUM_POISSONNOISEEVALUATEOPERATOR)
     PoissonNoiseQuantumOperator, /**< poisson noise */
-#endif
-#if defined(HAVE_ENUM_UNIFORMNOISEEVALUATEOPERATOR)
     UniformNoiseQuantumOperator, /**< uniform noise */
-#endif
-#if defined(HAVE_ENUM_COSINEEVALUATEOPERATOR)
     CosineQuantumOperator,    /**< cosine */
-#endif
-#if defined(HAVE_ENUM_SINEEVALUATEOPERATOR)
     SineQuantumOperator,      /**< sine */
-#endif
-#if defined(HAVE_ENUM_ADDMODULUSEVALUATEOPERATOR)
     AddModulusQuantumOperator /**< add modulus */
-#endif
 } QuantumExpressionOperator ;
 
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10224,76 +10224,48 @@ Image_quantum_operator(int argc, VALUE *argv, VALUE self)
         case XorQuantumOperator:
             qop = XorEvaluateOperator;
             break;
-#if defined(HAVE_ENUM_POWEVALUATEOPERATOR)
         case PowQuantumOperator:
             qop = PowEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_LOGEVALUATEOPERATOR)
         case LogQuantumOperator:
             qop = LogEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_THRESHOLDEVALUATEOPERATOR)
         case ThresholdQuantumOperator:
             qop = ThresholdEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_THRESHOLDBLACKEVALUATEOPERATOR)
         case ThresholdBlackQuantumOperator:
             qop = ThresholdBlackEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_THRESHOLDWHITEEVALUATEOPERATOR)
         case ThresholdWhiteQuantumOperator:
             qop = ThresholdWhiteEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_GAUSSIANNOISEEVALUATEOPERATOR)
         case GaussianNoiseQuantumOperator:
             qop = GaussianNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_IMPULSENOISEEVALUATEOPERATOR)
         case ImpulseNoiseQuantumOperator:
             qop = ImpulseNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_LAPLACIANNOISEEVALUATEOPERATOR)
         case LaplacianNoiseQuantumOperator:
             qop = LaplacianNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_MULTIPLICATIVENOISEEVALUATEOPERATOR)
         case MultiplicativeNoiseQuantumOperator:
             qop = MultiplicativeNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_POISSONNOISEEVALUATEOPERATOR)
         case PoissonNoiseQuantumOperator:
             qop = PoissonNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_UNIFORMNOISEEVALUATEOPERATOR)
         case UniformNoiseQuantumOperator:
             qop = UniformNoiseEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_COSINEEVALUATEOPERATOR)
         case CosineQuantumOperator:
             qop = CosineEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_SINEEVALUATEOPERATOR)
         case SineQuantumOperator:
             qop = SineEvaluateOperator;
             break;
-#endif
-#if defined(HAVE_ENUM_ADDMODULUSEVALUATEOPERATOR)
         case AddModulusQuantumOperator:
             qop = AddModulusEvaluateOperator;
             break;
-#endif
     }
 
     exception = AcquireExceptionInfo();

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1343,48 +1343,20 @@ Init_RMagick2(void)
         ENUMERATOR(RShiftQuantumOperator)
         ENUMERATOR(SubtractQuantumOperator)
         ENUMERATOR(XorQuantumOperator)
-#if defined(HAVE_ENUM_POWEVALUATEOPERATOR)
         ENUMERATOR(PowQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_LOGEVALUATEOPERATOR)
         ENUMERATOR(LogQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_THRESHOLDEVALUATEOPERATOR)
         ENUMERATOR(ThresholdQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_THRESHOLDBLACKEVALUATEOPERATOR)
         ENUMERATOR(ThresholdBlackQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_THRESHOLDWHITEEVALUATEOPERATOR)
         ENUMERATOR(ThresholdWhiteQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_GAUSSIANNOISEEVALUATEOPERATOR)
         ENUMERATOR(GaussianNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_IMPULSENOISEEVALUATEOPERATOR)
         ENUMERATOR(ImpulseNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_LAPLACIANNOISEEVALUATEOPERATOR)
         ENUMERATOR(LaplacianNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_MULTIPLICATIVENOISEEVALUATEOPERATOR)
         ENUMERATOR(MultiplicativeNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_POISSONNOISEEVALUATEOPERATOR)
         ENUMERATOR(PoissonNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_UNIFORMNOISEEVALUATEOPERATOR)
         ENUMERATOR(UniformNoiseQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_COSINEEVALUATEOPERATOR)
         ENUMERATOR(CosineQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_SINEEVALUATEOPERATOR)
         ENUMERATOR(SineQuantumOperator)
-#endif
-#if defined(HAVE_ENUM_ADDMODULUSEVALUATEOPERATOR)
         ENUMERATOR(AddModulusQuantumOperator)
-#endif
     END_ENUM
 
     // RenderingIntent


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.