### PR TITLE
Remove have_enum_values checking of MagickFunction

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,10 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('MagickFunction', ['ArcsinFunction', # 6.5.2-8
-                                          'ArctanFunction', # 6.5.2-8
-                                          'PolynomialFunction', # 6.4.8-8
-                                          'SinusoidFunction'], headers) # 6.4.8-8
       have_enum_values('ImageLayerMethod', ['FlattenLayer', # 6.3.6-2
                                             'MergeLayer', # 6.3.6
                                             'MosaicLayer', # 6.3.6-2

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6693,23 +6693,15 @@ Image_function_channel(int argc, VALUE *argv, VALUE self)
 
     switch (function)
     {
-#if defined(HAVE_ENUM_POLYNOMIALFUNCTION)
         case PolynomialFunction:
             if (argc == 0)
             {
                 rb_raise(rb_eArgError, "PolynomialFunction requires at least one argument.");
             }
             break;
-#endif
-#if defined(HAVE_ENUM_SINUSOIDFUNCTION)
         case SinusoidFunction:
-#endif
-#if defined(HAVE_ENUM_ARCSINFUNCTION)
         case ArcsinFunction:
-#endif
-#if defined(HAVE_ENUM_ARCTANFUNCTION)
         case ArctanFunction:
-#endif
            if (argc < 1 || argc > 4)
            {
                rb_raise(rb_eArgError, "wrong number of arguments (%d for 1 to 4)", argc);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1214,12 +1214,8 @@ Init_RMagick2(void)
         ENUMERATOR(UndefinedFunction)
         ENUMERATOR(PolynomialFunction)
         ENUMERATOR(SinusoidFunction)
-#if defined(HAVE_ENUM_ARCSINFUNCTION)
         ENUMERATOR(ArcsinFunction)
-#endif
-#if defined(HAVE_ENUM_ARCTANFUNCTION)
         ENUMERATOR(ArctanFunction)
-#endif
     END_ENUM
 
     DEF_ENUM(ImageLayerMethod)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.