### PR TITLE
Remove have_enum_values checking of ImageLayerMethod

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,10 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('ImageLayerMethod', ['FlattenLayer', # 6.3.6-2
-                                            'MergeLayer', # 6.3.6
-                                            'MosaicLayer', # 6.3.6-2
-                                            'TrimBoundsLayer'], headers) # 6.4.3-8
       have_enum_values('VirtualPixelMethod', ['HorizontalTileVirtualPixelMethod', # 6.4.2-6
                                               'VerticalTileVirtualPixelMethod', # 6.4.2-6
                                               'HorizontalTileEdgeVirtualPixelMethod', # 6.5.0-1

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -979,18 +979,10 @@ LAYERMETHODTYPE_NAME(LAYERMETHODTYPE method)
         ENUM_TO_NAME(RemoveDupsLayer)
         ENUM_TO_NAME(RemoveZeroLayer)
         ENUM_TO_NAME(CompositeLayer)
-#if defined(HAVE_ENUM_MERGELAYER)
         ENUM_TO_NAME(MergeLayer)
-#endif
-#if defined(HAVE_ENUM_MOSAICLAYER)
         ENUM_TO_NAME(MosaicLayer)
-#endif
-#if defined(HAVE_ENUM_FLATTENLAYER)
         ENUM_TO_NAME(FlattenLayer)
-#endif
-#if defined(HAVE_ENUM_TRIMBOUNDSLAYER)
         ENUM_TO_NAME(TrimBoundsLayer)
-#endif
     }
 
     return "UndefinedLayer";

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -332,11 +332,7 @@ ImageList_flatten_images(VALUE self)
     images = images_from_imagelist(self);
     exception = AcquireExceptionInfo();
 
-#if defined(HAVE_ENUM_FLATTENLAYER)
     new_image = MergeImageLayers(images, FlattenLayer, exception);
-#else
-    new_image = FlattenImages(images, exception);
-#endif
 
     rm_split(images);
     rm_check_exception(exception, new_image, DestroyOnError);
@@ -592,11 +588,7 @@ ImageList_mosaic(VALUE self)
     images = images_from_imagelist(self);
 
     exception = AcquireExceptionInfo();
-#if defined(HAVE_ENUM_MOSAICLAYER)
     new_image = MergeImageLayers(images, MosaicLayer, exception);
-#else
-    new_image = MosaicImages(images, exception);
-#endif
 
     rm_split(images);
     rm_check_exception(exception, new_image, DestroyOnError);
@@ -684,26 +676,18 @@ ImageList_optimize_layers(VALUE self, VALUE method)
         case CompareOverlayLayer:
             new_images = CompareImageLayers(images, mthd, exception);
             break;
-#if defined(HAVE_ENUM_MOSAICLAYER)
         case MosaicLayer:
             new_images = MergeImageLayers(images, mthd, exception);
             break;
-#endif
-#if defined(HAVE_ENUM_FLATTENLAYER)
         case FlattenLayer:
             new_images = MergeImageLayers(images, mthd, exception);
             break;
-#endif
-#if defined(HAVE_ENUM_MERGELAYER)
         case MergeLayer:
             new_images = MergeImageLayers(images, mthd, exception);
             break;
-#endif
-#if defined(HAVE_ENUM_TRIMBOUNDSLAYER)
         case TrimBoundsLayer:
             new_images = MergeImageLayers(images, mthd, exception);
             break;
-#endif
         default:
             rm_split(images);
             (void) DestroyExceptionInfo(exception);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1228,24 +1228,14 @@ Init_RMagick2(void)
         ENUMERATOR(CoalesceLayer)
         ENUMERATOR(DisposeLayer)
         ENUMERATOR(OptimizeTransLayer)
-#if defined(HAVE_ENUM_OPTIMIZEIMAGELAYER)
         ENUMERATOR(OptimizeImageLayer)
-#endif
         ENUMERATOR(RemoveDupsLayer)
         ENUMERATOR(RemoveZeroLayer)
         ENUMERATOR(CompositeLayer)
-#if defined(HAVE_ENUM_MERGELAYER)
         ENUMERATOR(MergeLayer)
-#endif
-#if defined(HAVE_ENUM_MOSAICLAYER)
         ENUMERATOR(MosaicLayer)
-#endif
-#if defined(HAVE_ENUM_FLATTENLAYER)
         ENUMERATOR(FlattenLayer)
-#endif
-#if defined(HAVE_ENUM_TRIMBOUNDSLAYER)
         ENUMERATOR(TrimBoundsLayer)
-#endif
     END_ENUM
 
     DEF_ENUM(MetricType)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.