### PR TITLE
Remove have_enum_values checking of VirtualPixelMethod

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -343,13 +343,6 @@ END_MSWIN
 
       have_type('long double', headers)
 
-      have_enum_values('VirtualPixelMethod', ['HorizontalTileVirtualPixelMethod', # 6.4.2-6
-                                              'VerticalTileVirtualPixelMethod', # 6.4.2-6
-                                              'HorizontalTileEdgeVirtualPixelMethod', # 6.5.0-1
-                                              'VerticalTileEdgeVirtualPixelMethod', # 6.5.0-1
-                                              'CheckerTileVirtualPixelMethod'], # 6.5.0-1
-                       headers)
-
       headers = ['ruby.h', 'ruby/io.h']
 
       have_func('rb_frame_this_func', headers)

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -1180,21 +1180,11 @@ VirtualPixelMethod_name(VirtualPixelMethod method)
         ENUM_TO_NAME(BlackVirtualPixelMethod)
         ENUM_TO_NAME(GrayVirtualPixelMethod)
         ENUM_TO_NAME(WhiteVirtualPixelMethod)
-#if defined(HAVE_ENUM_HORIZONTALTILEVIRTUALPIXELMETHOD)
         ENUM_TO_NAME(HorizontalTileVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_VERTICALTILEVIRTUALPIXELMETHOD)
         ENUM_TO_NAME(VerticalTileVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_HORIZONTALTILEEDGEVIRTUALPIXELMETHOD)
         ENUM_TO_NAME(HorizontalTileEdgeVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_VERTICALTILEEDGEVIRTUALPIXELMETHOD)
         ENUM_TO_NAME(VerticalTileEdgeVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_CHECKERTILEVIRTUALPIXELMETHOD)
         ENUM_TO_NAME(CheckerTileVirtualPixelMethod)
-#endif
     }
 
     return "UndefinedVirtualPixelMethod";

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1427,21 +1427,11 @@ Init_RMagick2(void)
         ENUMERATOR(BlackVirtualPixelMethod)
         ENUMERATOR(GrayVirtualPixelMethod)
         ENUMERATOR(WhiteVirtualPixelMethod)
-#if defined(HAVE_ENUM_HORIZONTALTILEVIRTUALPIXELMETHOD)
         ENUMERATOR(HorizontalTileVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_VERTICALTILEVIRTUALPIXELMETHOD)
         ENUMERATOR(VerticalTileVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_HORIZONTALTILEEDGEVIRTUALPIXELMETHOD)
         ENUMERATOR(HorizontalTileEdgeVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_VERTICALTILEEDGEVIRTUALPIXELMETHOD)
         ENUMERATOR(VerticalTileEdgeVirtualPixelMethod)
-#endif
-#if defined(HAVE_ENUM_CHECKERTILEVIRTUALPIXELMETHOD)
         ENUMERATOR(CheckerTileVirtualPixelMethod)
-#endif
     END_ENUM
     // WeightType constants
     DEF_ENUM(WeightType)


### PR DESCRIPTION
Now, RMagick have supported ImageMagick 6.8.9+.
So, we can use enum values which were added in older version without any check.
The sample code will make easier mantainance.

And by removing check, it reduce the time for prepare compiling.