### PR TITLE
Add DistortImageMethod enum values

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1113,6 +1113,10 @@ Init_RMagick2(void)
         ENUMERATOR(ScaleRotateTranslateDistortion)
         ENUMERATOR(ShepardsDistortion)
         ENUMERATOR(BarrelInverseDistortion)
+        ENUMERATOR(Cylinder2PlaneDistortion)
+        ENUMERATOR(Plane2CylinderDistortion)
+        ENUMERATOR(ResizeDistortion)
+        ENUMERATOR(SentinelDistortion)
     END_ENUM
 
     DEF_ENUM(DitherMethod)


### PR DESCRIPTION
Add some enum values of DistortImageMethod declared in ImageMagick 6.8.9.