### PR TITLE
Add fallback to pkg-config gem

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -312,7 +312,7 @@ END_SUMMARY
     include Singleton
 
     def initialize
-      @windows = (RUBY_PLATFORM =~ /mswin|mingw/)
+      @windows = !!(RUBY_PLATFORM =~ /mswin|mingw/)
 
       found = find_executable('pkg-config')
       @use_native_pkg_config = !!found

--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
+  s.add_runtime_dependency 'pkg-config', '~> 1.3'
+
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'


### PR DESCRIPTION
RMagick strongly depends on `pkg-config` command to install.
If user's environment lost `pkg-config` command, install error will be occurred as following.

```
$ ruby extconf.rb
checking for brew... yes
checking for clang... yes
checking for pkg-config... no
Can't install RMagick 3.0.0. Can't find pkg-config in /Users/s-fujita/.rbenv/versions/2.3.8/bin:/Users/s-fujita/.rbenv/libexec:/Users/s-fujita/.rbenv/plugins/ruby-build/bin:/Users/s-fujita/.rbenv/plugins/rbenv-update/bin:/Users/s-fujita/.rbenv/shims:/Users/s-fujita/.rbenv/bin:/Users/s-fujita/.pyenv/plugins/pyenv-virtualenv/shims:/Users/s-fujita/.pyenv/shims:/Users/s-fujita/.rbenv/shims:/Users/s-fujita/bin:/Users/s-fujita/.rbenv/bin:/Users/s-fujita/.pyenv/bin:/Users/s-fujita/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/s-fujita/n/bin

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/Users/s-fujita/.rbenv/versions/2.3.8/bin/$(RUBY_BASE_NAME)
```

If user install ImageMagick 6 using Homebrew, it does not install `pkg-config` as dependency. So, the install error will be occurred easily.

```
$ brew install imagemagick@6
==> Downloading https://homebrew.bintray.com/bottles/imagemagick@6-6.9.10-27.mojave.bottle.tar.gz
Already downloaded: /Users/s-fujita/Library/Caches/Homebrew/downloads/5729ffbe1a484b447327cf0fd3972b7d2ac5884d82d0c96f197a069bc3e6b3d3--imagemagick@6-6.9.10-27.mojave.bottle.tar.gz
==> Pouring imagemagick@6-6.9.10-27.mojave.bottle.tar.gz
==> Caveats
imagemagick@6 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

If you need to have imagemagick@6 first in your PATH run:
  echo 'export PATH="/usr/local/opt/imagemagick@6/bin:$PATH"' >> ~/.zshrc

For compilers to find imagemagick@6 you may need to set:
  export LDFLAGS="-L/usr/local/opt/imagemagick@6/lib"
  export CPPFLAGS="-I/usr/local/opt/imagemagick@6/include"

==> Summary
🍺  /usr/local/Cellar/imagemagick@6/6.9.10-27: 1,525 files, 24.3MB
```

To make installation more robust, this patch will add fallback to pkg-config gem.