### PR TITLE
Fix memory leak in Image#convolve

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4199,7 +4199,16 @@ Image_convolve(VALUE self, VALUE order_arg, VALUE kernel_arg)
     kernel = (double *)ALLOC_N(double, order*order);
     for (x = 0; x < order*order; x++)
     {
-        kernel[x] = NUM2DBL(rb_ary_entry(kernel_arg, (long)x));
+        VALUE element = rb_ary_entry(kernel_arg, (long)x);
+        if (rm_check_num2dbl(element))
+        {
+            kernel[x] = NUM2DBL(element);
+        }
+        else
+        {
+            xfree((void *)kernel);
+            rb_raise(rb_eTypeError, "type mismatch: %s given", rb_class2name(CLASS_OF(element)));
+        }
     }
 
     exception = AcquireExceptionInfo();


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 14895: RSS = 53 MB
```

* After

```
$ ruby test.rb
Process: 16886: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

400000.times do |i|
  begin
    image.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0])
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```