### PR TITLE
Fix memory leak in Image#distort

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -5200,13 +5200,20 @@ Image_distort(int argc, VALUE *argv, VALUE self)
     }
 
     npoints = RARRAY_LEN(pts);
-    // Allocate points array from Ruby's memory. If an error occurs Ruby will
-    // be able to clean it up.
     points = ALLOC_N(double, npoints);
 
     for (n = 0; n < npoints; n++)
     {
-        points[n] = NUM2DBL(rb_ary_entry(pts, n));
+        VALUE element = rb_ary_entry(pts, n);
+        if (rm_check_num2dbl(element))
+        {
+            points[n] = NUM2DBL(element);
+        }
+        else
+        {
+            xfree(points);
+            rb_raise(rb_eTypeError, "type mismatch: %s given", rb_class2name(CLASS_OF(element)));
+        }
     }
 
     exception = AcquireExceptionInfo();


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 18748: RSS = 35 MB
```

* After

```
$ ruby test.rb
Process: 19800: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

400000.times do |i|
  begin
    image.distort(Magick::AffineProjectionDistortion, ['x', 0, 0, 1, 0, 0])
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```