### PR TITLE
Fix memory leak in Image#function_channel

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6717,7 +6717,16 @@ Image_function_channel(int argc, VALUE *argv, VALUE self)
 
     for (n = 0; n < nparms; n++)
     {
-        parms[n] = NUM2DBL(argv[n]);
+        VALUE element = argv[n];
+        if (rm_check_num2dbl(element))
+        {
+            parms[n] = NUM2DBL(element);
+        }
+        else
+        {
+            xfree(parms);
+            rb_raise(rb_eTypeError, "type mismatch: %s given", rb_class2name(CLASS_OF(element)));
+        }
     }
 
     exception = AcquireExceptionInfo();


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 21658: RSS = 59 MB
```

* After

```
$ ruby test.rb
Process: 22717: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

400000.times do |i|
  begin
    image.function_channel(Magick::SinusoidFunction, 'x', 1.0, 1.0, 1.0)
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```