### PR TITLE
Fix memory leak in Image#export_pixels

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -7307,26 +7307,38 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
 
         if (stg_type == DoublePixel || stg_type == FloatPixel)
         {
-            // Get an array for double pixels. Use Ruby's memory so GC will clean up after
-            // us in case of an exception.
             fpixels = ALLOC_N(double, npixels);
             for (n = 0; n < npixels; n++)
             {
-                fpixels[n] = NUM2DBL(rb_ary_entry(pixel_ary, n));
+                VALUE element = rb_ary_entry(pixel_ary, n);
+                if (rm_check_num2dbl(element))
+                {
+                    fpixels[n] = NUM2DBL(element);
+                }
+                else
+                {
+                    xfree(fpixels);
+                    rb_raise(rb_eTypeError, "type mismatch: %s given", rb_class2name(CLASS_OF(element)));
+                }
             }
             buffer = (void *) fpixels;
             stg_type = DoublePixel;
         }
         else
         {
-            // Get array for Quantum pixels. Use Ruby's memory so GC will clean up after us
-            // in case of an exception.
             pixels = ALLOC_N(Quantum, npixels);
             for (n = 0; n < npixels; n++)
             {
-                VALUE p = rb_ary_entry(pixel_ary, n);
-                pixels[n] = NUM2QUANTUM(p);
-                RB_GC_GUARD(p);
+                VALUE element = rb_ary_entry(pixel_ary, n);
+                if (rm_check_num2dbl(element))
+                {
+                    pixels[n] = NUM2DBL(element);
+                }
+                else
+                {
+                    xfree(pixels);
+                    rb_raise(rb_eTypeError, "type mismatch: %s given", rb_class2name(CLASS_OF(element)));
+                }
             }
             buffer = (void *) pixels;
             stg_type = QuantumPixel;


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 25135: RSS = 37 MB
```

* After

```
$ ruby test.rb
Process: 26362: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
pixels = image.export_pixels(0, 0, image.columns, image.rows, 'RGB')
pixels[0] = 'x'

400000.times do |i|
  begin
    image.import_pixels(0, 0, image.columns, image.rows, 'RGB', pixels, Magick::IntegerPixel)
  rescue
  end

  begin
    image.import_pixels(0, 0, image.columns, image.rows, 'RGB', pixels, Magick::DoublePixel)
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```