### PR TITLE
Use SetImageGray() to fix Image#gray? with IM 6.9

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -295,7 +295,8 @@ END_MINGW
     def create_header_file
       have_func('snprintf', headers)
       [
-        'GetImageChannelEntropy' # 6.9.0-0
+        'GetImageChannelEntropy', # 6.9.0-0
+        'SetImageGray' # 6.9.1-10
       ].each do |func|
         have_func(func, headers)
       end

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -7143,7 +7143,11 @@ has_attribute(VALUE self, MagickBooleanType (attr_test)(const Image *, Exception
 VALUE
 Image_gray_q(VALUE self)
 {
+#if defined(HAVE_SETIMAGEGRAY)
+    return has_attribute(self, (MagickBooleanType (*)(const Image *, ExceptionInfo *))SetImageGray);
+#else
     return has_attribute(self, (MagickBooleanType (*)(const Image *, ExceptionInfo *))IsGrayImage);
+#endif
 }
 
 


### PR DESCRIPTION
https://github.com/rmagick/rmagick/pull/327#issuecomment-471152383

ImageMagick renamed `IsGrayImage()` to `SetImageGray()` on version 6.9.x.