### PR TITLE
Fix Image#quantize and ImageList#quantize could not make dither false

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -959,6 +959,10 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
                 quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
             }
+            else
+            {
+                quantize_info.dither = (MagickBooleanType) RTEST(argv[2]);
+            }
         case 2:
             VALUE_TO_ENUM(argv[1], quantize_info.colorspace, ColorspaceType);
         case 1:

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10369,6 +10369,10 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
                 quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
             }
+            else
+            {
+                quantize_info.dither = (MagickBooleanType) RTEST(argv[2]);
+            }
         case 2:
             VALUE_TO_ENUM(argv[1], quantize_info.colorspace, ColorspaceType);
         case 1:


### PR DESCRIPTION
I've found these methods does not handle Boolean value as `dither` at https://github.com/rmagick/rmagick/pull/429/files#diff-ccd418bf6a9c1db42c436f11f43012ccL980

The following code should generate the image without dither.

```
require 'rmagick'

image = Magick::Image.read('./doc/ex/images/Flower_Hat.jpg').first
image.quantize(16, Magick::RGBColorspace, false).write('test.png')
```

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/199156/54082718-678faf00-435d-11e9-957d-6f94ae2279d9.png"> | <img src="https://user-images.githubusercontent.com/199156/54082721-76766180-435d-11e9-8721-489aec7fbe15.png">

Seems the test code also assumes Boolean value.

https://github.com/rmagick/rmagick/blob/e6f26e058a7762c5b08e3a8716fc7a943a7ae95b/test/Image3.rb#L105-L106

