### PR TITLE
Fix memory leak in Image#sparse_color

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12551,8 +12551,18 @@ Image_sparse_color(int argc, VALUE *argv, VALUE self)
     n = 0;
     while (n < argc)
     {
-        args[x++] = NUM2DBL(argv[n++]);
-        args[x++] = NUM2DBL(argv[n++]);
+        VALUE elem1 = argv[n++];
+        VALUE elem2 = argv[n++];
+        if (rm_check_num2dbl(elem1) && rm_check_num2dbl(elem2))
+        {
+            args[x++] = NUM2DBL(elem1);
+            args[x++] = NUM2DBL(elem2);
+        }
+        else
+        {
+            xfree((void *)args);
+            rb_raise(rb_eTypeError, "type mismatch: %s and %s given", rb_class2name(CLASS_OF(elem1)), rb_class2name(CLASS_OF(elem2)));
+        }
         Color_to_MagickPixelPacket(NULL, &pp, argv[n++]);
         if (channels & RedChannel)
         {


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 2669: RSS = 76 MB
```

* After

```
$ ruby test.rb
Process: 5014: RSS = 14 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)

400000.times do |i|
  begin
    image.sparse_color(Magick::VoronoiColorInterpolate,
      'x', 10, 'red',
      10, 'y', 'blue',
      'x', 'y', 'lime',
      80, 20, 'yellow')
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```