### PR TITLE
Fix memory leak in Image#constitute

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3901,6 +3901,7 @@ Image_constitute(VALUE class, VALUE width_arg, VALUE height_arg
         pixel = rb_ary_entry(pixels_arg, x);
         if (rb_obj_is_kind_of(pixel, pixel_class) != Qtrue)
         {
+            xfree(pixels.v);
             rb_raise(rb_eTypeError, "element %ld in pixel array is %s, expected %s"
                      , x, rb_class2name(CLASS_OF(pixel)),rb_class2name(CLASS_OF(pixel0)));
         }
@@ -3909,6 +3910,7 @@ Image_constitute(VALUE class, VALUE width_arg, VALUE height_arg
             pixels.f[x] = (float) NUM2DBL(pixel);
             if (pixels.f[x] < 0.0 || pixels.f[x] > 1.0)
             {
+                xfree(pixels.v);
                 rb_raise(rb_eArgError, "element %ld is out of range [0..1]: %f", x, pixels.f[x]);
             }
         }
@@ -3924,6 +3926,7 @@ Image_constitute(VALUE class, VALUE width_arg, VALUE height_arg
     image = AcquireImage(NULL);
     if (!image)
     {
+        xfree(pixels.v);
         rb_raise(rb_eNoMemError, "not enough memory to continue.");
     }
 


### PR DESCRIPTION
`NUM2DBL()` will raise exception if non-float value is given.
The allocated memory area using `ALLOC_N()` should be freed before raising.

* Before

```
$ ruby test.rb
Process: 6843: RSS = 186 MB
```

* After

```
$ ruby test.rb
Process: 8143: RSS = 15 MB
```

* Test code

```ruby
require 'rmagick'

image = Magick::Image.new(20, 20)
pixels = image.dispatch(0, 0, image.columns, image.rows, 'RGBA')
pixels[10] = 'x'

50000.times do |i|
  begin
    Magick::Image.constitute(image.columns, image.rows, 'RGBA', pixels)
  rescue
  end

  GC.start if i % 100 == 0
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```