### PR TITLE
Avoid SEGV in monitor feature for Ruby 2.5+

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8897,10 +8897,6 @@ Image_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageProgressMonitor(image, rm_progress_monitor, (void *)monitor);
     }
 
-#if defined(_WIN32)
-    rb_warn("Image#monitor= does not work on Windows");
-#endif
-
     return self;
 }
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1730,10 +1730,6 @@ Info_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageInfoProgressMonitor(info, rm_progress_monitor, (void *)monitor);
     }
 
-#if defined(_WIN32)
-    rb_warn("Info#monitor= does not work on Windows");
-#endif
-
     return self;
 }
 

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1455,9 +1455,15 @@ rm_progress_monitor(
     const MagickSizeType sp,
     void *client_data)
 {
-#if !defined(_WIN32)
     VALUE rval;
     VALUE method, offset, span;
+
+    if (ruby_stack_check())
+    {
+        // If there is not enough stack or the using stack size shows an abnormal value in Ruby,
+        // skip the callback and continue ImageMagick process.
+        return MagickTrue;
+    }
 
     tag = tag;      // defeat gcc message
 
@@ -1479,9 +1485,6 @@ rm_progress_monitor(
     RB_GC_GUARD(span);
 
     return RTEST(rval) ? MagickTrue : MagickFalse;
-#else
-    return MagickTrue;
-#endif
 }
 
 


### PR DESCRIPTION
Avoid SEGV in monitor feature for Ruby 2.5+

If you invoke the following code, `monitor` feature will causes SEGV or stack error.
Seems this problem depends on the platform.
(At least, the following code works fine on macOS)

```
require 'rmagick'

monitor = proc do |mth, q, s|
  p "#{q}, #{s}"
  true
end
img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
img.resize!(20, 20)
img.monitor = nil
```

When callback the Ruby code via `monitor`, it will cause Ruby stack breaking in Ruby VM.
To avoid SEGV, this patch will skip the callback if Ruby stack error detected.

Reverts https://github.com/rmagick/rmagick/pull/344
Related to https://github.com/rmagick/rmagick/pull/339