### PR TITLE
Replace obsoleted $defout to $stdout

### DIFF
--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -290,7 +290,7 @@ image = image.first
 
 # Give the user something to look at while we're working.
 name = File.basename(filename).sub(/\..*?$/, '')
-$defout.sync = true
+$stdout.sync = true
 printf "Creating #{name}_Histogram.miff"
 
 timer = Thread.new do


### PR DESCRIPTION
$defout has existed until Ruby 1.8.x https://github.com/ruby/ruby/blob/f48ae0d10c5b586db5748b0d4b645c7e9ff5d52e/io.c#L6075
However, it was replaced to $stdout at Ruby 1.9

Close #263