### PR TITLE
Fix SEGV in Image#write with CMYKColorspace

### DIFF
--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1027,7 +1027,7 @@ void rm_sync_image_options(Image *image, Info *info)
 
     if (info->colorspace != UndefinedColorspace)
     {
-        image->colorspace = info->colorspace;
+        SetImageColorspace(image, info->colorspace);
     }
 
     if (info->compression != UndefinedCompression)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -1075,6 +1075,16 @@ class Image3_UT < Test::Unit::TestCase
     img = Magick::Image.read('test.webp')
     assert_equal('WEBP', img.first.format)
     FileUtils.rm('test.webp') rescue nil # Avoid failure on AppVeyor
+
+    f = File.new('test.0', 'w')
+    Magick::Image.new(100, 100).write(f) do
+      self.format = 'JPEG'
+      self.colorspace = Magick::CMYKColorspace
+    end
+    f.close
+    img = Magick::Image.read('test.0')
+    assert_equal('JPEG', img.first.format)
+    FileUtils.rm('test.0')
   end
 end
 


### PR DESCRIPTION
Fix #36

Setting `image->colorspace` is not sufficient and the unitialized property causes a SEGV.
This patch will use ImageMagick API instead to fix SEGV inside ImageMagick.

(Refer [SetImageColorspace()](https://github.com/ImageMagick/ImageMagick6/blob/8ed8ee76dd5fcfc3d182cf00c5696508425176b4/magick/colorspace.c#L1189) API)