### PR TITLE
Avoid problems related to GC in monitor feature

### DIFF
--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1475,7 +1475,7 @@ rm_progress_monitor(
     span = rb_uint2big((unsigned long)sp);
 #endif
 
-    method = rb_str_new2(rb_id2name(THIS_FUNC()));
+    method = rb_id2str(THIS_FUNC());
 
     rval = rb_funcall((VALUE)client_data, rm_ID_call, 3, method, offset, span);
 

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1458,7 +1458,11 @@ rm_progress_monitor(
     VALUE rval;
     VALUE method, offset, span;
 
-    if (ruby_stack_check())
+// Default Ruby minimum stack size
+#define RUBY_VM_THREAD_MACHINE_STACK_SIZE_MIN (  16 * 1024 * sizeof(VALUE)) /*   64 KB or  128 KB */
+
+    // Check stack length manually instead of ruby_stack_check() for old Ruby.
+    if (ruby_stack_length(NULL) > RUBY_VM_THREAD_MACHINE_STACK_SIZE_MIN)
     {
         // If there is not enough stack or the using stack size shows an abnormal value in Ruby,
         // skip the callback and continue ImageMagick process.

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -220,6 +220,8 @@ class InfoUT < Test::Unit::TestCase
   end
 
   def test_monitor
+    GC.stress = true
+
     assert_nothing_raised { @info.monitor = -> {} }
     monitor = proc do |mth, q, s|
       assert_equal('resize!', mth)
@@ -230,6 +232,8 @@ class InfoUT < Test::Unit::TestCase
     img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
     img.resize!(20, 20)
     img.monitor = nil
+  ensure
+    GC.stress = false
   end
 
   def test_monochrome


### PR DESCRIPTION
### Unnecessary String object
`rb_id2name()` will create String object and return a pointer to the internal characters.

`rb_str_new2()` will create String object that refers to that pointer.

If destroyed first String object which created by `rb_id2name()`, second String object will be broken.

To fix SEGV, get rid of unnecessary String object creating.
This patch will create only one String object.
And the object should be guard from Ruby’s GC by `RB_GC_GUARD(method);`.

### Stack length
We have to add same workaround for old Ruby with https://github.com/rmagick/rmagick/pull/462.
It seems to crash when GC is executed when Ruby stack length is an abnormal value.  We have to check stack length manually because `ruby_stack_check()` does not work  Ruby 2.4

Related to https://github.com/rmagick/rmagick/pull/467