### PR TITLE
Use appropriate image property names

### DIFF
--- a/spec/rmagick/image/properties_spec.rb
+++ b/spec/rmagick/image/properties_spec.rb
@@ -3,25 +3,25 @@ RSpec.describe Magick::Image, '#properties' do
   let(:freeze_error) { RUBY_VERSION[/^1\.9|^2/] ? RuntimeError : TypeError }
 
   before(:each) do
-    img['a'] = 'str_1'
-    img['b'] = 'str_2'
-    img['c'] = 'str_3'
+    img['comment'] = 'str_1'
+    img['label'] = 'str_2'
+    img['jpeg:sampling-factor'] = '2x1,1x1,1x1'
   end
 
   it 'allows assignment of arbitrary properties' do
-    expect(img['a']).to eq 'str_1'
-    expect(img['b']).to eq 'str_2'
-    expect(img['c']).to eq 'str_3'
+    expect(img['comment']).to eq 'str_1'
+    expect(img['label']).to eq 'str_2'
+    expect(img['jpeg:sampling-factor']).to eq '2x1,1x1,1x1'
     expect(img['d']).to be nil
   end
 
   it 'returns a hash of assigned properties' do
-    expected_properties = { 'a' => 'str_1', 'b' => 'str_2', 'c' => 'str_3' }
+    expected_properties = { 'comment' => 'str_1', 'label' => 'str_2', 'jpeg:sampling-factor' => '2x1,1x1,1x1' }
     expect(img.properties).to eq(expected_properties)
   end
 
   it 'raises an error when trying to assign properties to a frozen image' do
     img.freeze
-    expect { img['d'] = 'str_4' }.to raise_error(freeze_error)
+    expect { img['comment'] = 'str_4' }.to raise_error(freeze_error)
   end
 end


### PR DESCRIPTION
Seems it will always raises exception since ImageMagick 7 if random string was given as property name with `Image#[]=`.

Want to use the same test code as possible with ImageMagick 6 and 7 both.

Refer to https://github.com/rmagick/rmagick/pull/469/commits/caa7ecfc8deefd1d5e566cdc05b55dd487661083