### PR TITLE
[IM6.9] Fix test_optimize_layers()

### DIFF
--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -264,7 +264,6 @@ class ImageList2UT < Test::Unit::TestCase
   def test_optimize_layers
     layer_methods = [
       Magick::CompareAnyLayer,
-      Magick::CompareClearLayer,
       Magick::CompareOverlayLayer,
       Magick::OptimizeLayer,
       Magick::OptimizePlusLayer,
@@ -282,6 +281,7 @@ class ImageList2UT < Test::Unit::TestCase
         assert_equal(2, res.length)
       end
     end
+    assert_nothing_raised { @ilist.optimize_layers(Magick::CompareClearLayer) }
     assert_raise(ArgumentError) { @ilist.optimize_layers(Magick::UndefinedLayer) }
     assert_raise(TypeError) { @ilist.optimize_layers(2) }
   end


### PR DESCRIPTION
ImageList#optimize_layers(CompareClearLayer) fails with ImageMagick 6.9.

```
/Users/watson/prj/rmagick/test/ImageList2.rb:278:in `test_optimize_layers'
     275:       Magick::RemoveZeroLayer
     276:     ]
     277:     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
  => 278:     layer_methods.each do |method|
     279:       assert_nothing_raised do
     280:         res = @ilist.optimize_layers(method)
     281:         assert_instance_of(Magick::ImageList, res)
/Users/watson/prj/rmagick/test/ImageList2.rb:278:in `each'
/Users/watson/prj/rmagick/test/ImageList2.rb:279:in `block in test_optimize_layers'
/Users/watson/prj/rmagick/test/ImageList2.rb:282:in `block (2 levels) in test_optimize_layers'
<2> expected but was
<1>
Failure: test_optimize_layers(ImageList2UT)
```

With ImageMagick 6.8, the method returns `ImageList` object which contains 2 images.
The first one is same with inputed image `Button_0.gif`. The second one is 1x1 pixels image and it looks empty.

A patch was added at ImageMagick 6.9.4 and it seems bug fix to remove empty image.
https://github.com/ImageMagick/ImageMagick6/commit/4ad256e0096c3d43d8aa33d3040a2fa05fc6025e

```c
    if ((bounds[i].x == -1) && (bounds[i].y == -1) &&
	        (bounds[i].width == 1) && (bounds[i].height == 1))
	      {
	        /*
	          An empty frame is returned from CompareImageBounds(), which means the
	          current frame is identical to the previous frame.
	        */
	        i++;
	        continue;
	      }
```

If we could remove above code from ImageMagick 6.9, the test_optimize_layers() will be passed.

So, this patch will fix test_optimize_layers() for ImageMagick 6.9.