### PR TITLE
[IM6.9] Fix test_iterations()

### DIFF
--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -33,7 +33,7 @@ class ImageList1UT < Test::Unit::TestCase
 
   def test_iterations
     assert_nothing_raised { @list.iterations }
-    assert_equal(1, @list.iterations)
+    assert_kind_of(Integer, @list.iterations)
     assert_nothing_raised { @list.iterations = 20 }
     assert_equal(20, @list.iterations)
     assert_raise(ArgumentError) { @list.iterations = 'x' }


### PR DESCRIPTION
test_iterations fails with ImageMagick 6.9.

```
     33:
     34:   def test_iterations
     35:     assert_nothing_raised { @list.iterations }
  => 36:     assert_equal(1, @list.iterations)
     37:     assert_nothing_raised { @list.iterations = 20 }
     38:     assert_equal(20, @list.iterations)
     39:     assert_raise(ArgumentError) { @list.iterations = 'x' }
/Users/watson/prj/rmagick/test/ImageList1.rb:36:in `test_iterations'
<1> expected but was
<0>
Failure: test_iterations(ImageList1UT)
```

The default iterations value of GIF image was set to 1 by ImageMagick `ReadGIFImage()` API with ImageMagick 6.8 when read the image via `Image#read` method.

However, the default value was removed at ImageMagick 6.9.9.
https://github.com/ImageMagick/ImageMagick6/commit/e975a5709ddcf436d9f3cf9d4f5cf52feaac053f#diff-9ca9150287325d6210601d883fb559a9