### PR TITLE
[IM6.9][IM6.7] Fix test_image_type()

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -428,7 +428,6 @@ class Image_Attributes_UT < Test::Unit::TestCase
   def test_image_type
     assert_nothing_raised { @img.image_type }
     assert_instance_of(Magick::ImageType, @img.image_type)
-    assert_equal(Magick::GrayscaleMatteType, @img.image_type)
   end
 
   def test_interlace_type


### PR DESCRIPTION
We use `GetImageType()` in ImageMagick API to retrieve image type.
The API uses `IsGrayImage()` to detect GrayscaleMatteType.

```
  if (IsGrayImage(image,exception) != MagickFalse)
    {
      if (image->matte != MagickFalse)
        return(GrayscaleMatteType);
      return(GrayscaleType);
    }
```
https://github.com/ImageMagick/ImageMagick6/blob/27b1c74979ac473a430e266ff6c4b645664bc805/magick/attribute.c#L771-L776

We have known that the API have breaking change.
https://github.com/rmagick/rmagick/blob/1c5aed2fd15f2aa5f6ae0227e8c9b7437d11d92d/ext/RMagick/rmimage.c#L7156-L7163

So, I think test_image_type() should not test distinct value.