### PR TITLE
[IM6.9] Fix test_montage()

### DIFF
--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -201,10 +201,6 @@ class ImageList2UT < Test::Unit::TestCase
       montage = ilist.montage { self.font = 2 }
       assert_equal(@ilist, ilist)
     end
-    assert_raise(Magick::ImageMagickError) do
-      montage = ilist.montage { self.frame = 'z' }
-      assert_equal(@ilist, ilist)
-    end
     assert_raise(TypeError) do
       montage = ilist.montage { self.matte_color = 2 }
       assert_equal(@ilist, ilist)


### PR DESCRIPTION
Whether `Montage#frame=` will be causes exception with GIF image,
it is strongly depends on ImageMagick behavior.

And seems ImageMagick behavior was changed between 6.8 and 6.9.

```
Failure: <Magick::ImageMagickError> exception expected but none was thrown.
test_montage(ImageList2UT)
/Users/watson/prj/rmagick/test/ImageList2.rb:204:in `test_montage'
     201:       montage = ilist.montage { self.font = 2 }
     202:       assert_equal(@ilist, ilist)
     203:     end
  => 204:     assert_raise(Magick::ImageMagickError) do
     205:       montage = ilist.montage { self.frame = 'z' }
     206:       assert_equal(@ilist, ilist)
     207:     end
```

I think this test is not appropriate.