### PR TITLE
Removed zero_nans because this calls a private method called ZeroKernelNans.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -773,7 +773,6 @@ extern GravityType rm_gravity_to_enum(const char *);
 extern VALUE KernelInfo_alloc(VALUE);
 
 extern VALUE KernelInfo_initialize(VALUE, VALUE);
-extern VALUE KernelInfo_zero_nans(VALUE);
 extern VALUE KernelInfo_unity_add(VALUE, VALUE);
 extern VALUE KernelInfo_show(VALUE);
 extern VALUE KernelInfo_scale(VALUE, VALUE, VALUE);

--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -67,21 +67,6 @@ KernelInfo_initialize(VALUE self, VALUE kernel_string)
 }
 
 /**
- * Zero kerne NaNs.
- *
- * Ruby usage:
- *   - @verbatim KernelInfo#zero_nans @endverbatim
- *
- * @param self this object
- */
-VALUE
-KernelInfo_zero_nans(VALUE self)
-{
-  ZeroKernelNans((KernelInfo*)DATA_PTR(self));
-  return Qnil;
-}
-
-/**
  * Adds a given amount of the 'Unity' Convolution Kernel to the given pre-scaled and normalized Kernel.
  *
  * Ruby usage:

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -755,7 +755,6 @@ Init_RMagick2(void)
     rb_define_alloc_func(Class_KernelInfo, KernelInfo_alloc);
 
     rb_define_method(Class_KernelInfo, "initialize", KernelInfo_initialize, 1);
-    rb_define_method(Class_KernelInfo, "zero_nans", KernelInfo_zero_nans, 0);
     rb_define_method(Class_KernelInfo, "unity_add", KernelInfo_unity_add, 1);
     rb_define_method(Class_KernelInfo, "show", KernelInfo_show, 0);
     rb_define_method(Class_KernelInfo, "scale", KernelInfo_scale, 2);


### PR DESCRIPTION
This PR removes the zero_nans method from KernelInfo. This method makes a call to ZeroKernelNans which is defined in `morphology-private.h` and should not be used outside ImageMagick because it is subject to change. It looks like we also no longer use it ourselves so we might remove this in a future version of ImageMagick.