### PR TITLE
Use methods instead.

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -149,10 +149,10 @@ MagickInfo_to_format(const MagickInfo *magick_info)
 {
     char mode[4];
 
-    mode[0] = magick_info->blob_support ? '*': ' ';
-    mode[1] = magick_info->decoder ? 'r' : '-';
-    mode[2] = magick_info->encoder ? 'w' : '-';
-    mode[3] = magick_info->encoder && magick_info->adjoin ? '+' : '-';
+    mode[0] = GetMagickBlobSupport(magick_info) ? '*': ' ';
+    mode[1] = GetImageDecoder(magick_info) ? 'r' : '-';
+    mode[2] = GetImageEncoder(magick_info) ? 'w' : '-';
+    mode[3] = GetMagickAdjoin(magick_info) ? '+' : '-';
 
     return rb_str_new(mode, sizeof(mode));
 }


### PR DESCRIPTION
It is better to use the methods here instead, these methods are also available in ImageMagick 7 and that will make it easier to port.

And I also don't understand why there is a check for `magick_info->encoder` before `magick_info->adjoin)`. Even if there is only a decoder it can still support multi-image files.