### PR TITLE
Use QueryColorCompliance instead of QueryColorDatabase.

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1771,9 +1771,9 @@ PolaroidOptions_initialize(VALUE self)
     Data_Get_Struct(self, Draw, draw);
 
     exception = AcquireExceptionInfo();
-    (void) QueryColorDatabase("gray75", &draw->shadow_color, exception);
+    (void) QueryColorCompliance("gray75", AllCompliance, &draw->shadow_color, exception);
     CHECK_EXCEPTION()
-    (void) QueryColorDatabase("#dfdfdf", &draw->info->border_color, exception);
+    (void) QueryColorCompliance("#dfdfdf", AllCompliance, &draw->info->border_color, exception);
     CHECK_EXCEPTION()
     DestroyExceptionInfo(exception);
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -81,7 +81,7 @@ set_option(VALUE self, const char *key, VALUE string)
  * No Ruby usage (internal function)
  *
  * Notes:
- *   - Call QueryColorDatabase to validate color name.
+ *   - Call QueryColorCompliance to validate color name.
  *
  * @param self this object
  * @param option the option
@@ -106,7 +106,7 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
     {
         name = StringValuePtr(color);
         exception = AcquireExceptionInfo();
-        okay = QueryColorDatabase(name, &pp, exception);
+        okay = QueryColorCompliance(name, AllCompliance, &pp, exception);
         (void) DestroyExceptionInfo(exception);
         if (!okay)
         {

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -221,7 +221,7 @@ Color_Name_to_PixelPacket(PixelPacket *color, VALUE name_arg)
 
     exception = AcquireExceptionInfo();
     name = StringValuePtr(name_arg);
-    okay = QueryColorDatabase(name, color, exception);
+    okay = QueryColorCompliance(name, AllCompliance, color, exception);
     (void) DestroyExceptionInfo(exception);
     if (!okay)
     {
@@ -455,7 +455,7 @@ Pixel_from_color(VALUE class, VALUE name)
     class = class;      // defeat "never referenced" message from icc
 
     exception = AcquireExceptionInfo();
-    okay = QueryColorDatabase(StringValuePtr(name), &pp, exception);
+    okay = QueryColorCompliance(StringValuePtr(name), AllCompliance, &pp, exception);
     CHECK_EXCEPTION()
     (void) DestroyExceptionInfo(exception);
 


### PR DESCRIPTION
QueryColorDatabase will no longer be available in ImageMagick 7 so it will be better to use QueryColorCompliance instead.