### PR TITLE
Get rid of compiler warning

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -304,17 +304,17 @@ VALUE
 Draw_font_weight_eq(VALUE self, VALUE weight)
 {
     Draw *draw;
-    WeightType w;
+    size_t w;
 
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
 
     if (FIXNUM_P(weight))
     {
-        w = (WeightType) FIX2INT(weight);
+        w = FIX2INT(weight);
         if (w < 100 || w > 900)
         {
-            rb_raise(rb_eArgError, "invalid font weight (%d given)", w);
+            rb_raise(rb_eArgError, "invalid font weight (%ld given)", w);
         }
         draw->info->weight = w;
     }


### PR DESCRIPTION
This patch will use expected type for variable to get rid of following compiler warning.

```
rmdraw.c:315:15: warning: result of comparison of constant 100 with expression of type 'WeightType' is always true
      [-Wtautological-constant-out-of-range-compare]
        if (w < 100 || w > 900)
            ~ ^ ~~~
rmdraw.c:315:26: warning: result of comparison of constant 900 with expression of type 'WeightType' is always false
      [-Wtautological-constant-out-of-range-compare]
        if (w < 100 || w > 900)
                       ~ ^ ~~~
2 warnings generated.
```