### PR TITLE
Fix unit tests

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3797,9 +3797,15 @@ Image_compression_eq(VALUE self, VALUE compression)
 VALUE
 Image_compress_colormap_bang(VALUE self)
 {
+    MagickBooleanType okay;
+
     Image *image = rm_check_frozen(self);
-    (void) CompressImageColormap(image);
+    okay = CompressImageColormap(image);
     rm_check_image_exception(image, RetainOnError);
+    if (!okay)
+    {
+        rb_warning("CompressImageColormap failed (probably DirectClass image)");
+    }
 
     return self;
 }

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -71,10 +71,10 @@ class Image2_UT < Test::Unit::TestCase
   end
 
   def test_compress_colormap!
-    # DirectClass images are converted to PseudoClass
+    # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
     assert_equal(Magick::DirectClass, @img.class_type)
     assert_nothing_raised { @img.compress_colormap! }
-    assert_equal(Magick::PseudoClass, @img.class_type)
+    # assert_equal(Magick::PseudoClass, @img.class_type)
     @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     assert_equal(Magick::PseudoClass, @img.class_type)
     assert_nothing_raised { @img.compress_colormap! }

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -35,10 +35,20 @@ class Image_Attributes_UT < Test::Unit::TestCase
     assert_equal('white', @img.background_color)
     assert_nothing_raised { @img.background_color = '#dfdfdf' }
     # assert_equal("rgb(223,223,223)", @img.background_color)
-    assert_equal('#DFDFDFDFDFDF', @img.background_color)
+    background_color = @img.background_color
+    if @img.background_color.length == 13
+      assert_equal('#DFDFDFDFDFDF', background_color)
+    else
+      assert_equal('#DFDFDFDFDFDFFFFF', background_color)
+    end
     assert_nothing_raised { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }
     # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.background_color)
-    assert_equal('#FFFF7FFF7FFF', @img.background_color)
+    background_color = @img.background_color
+    if @img.background_color.length == 13
+      assert_equal('#FFFF7FFF7FFF', background_color)
+    else
+      assert_equal('#FFFF7FFF7FFFFFFF', background_color)
+    end
     assert_raise(TypeError) { @img.background_color = 2 }
   end
 
@@ -92,12 +102,22 @@ class Image_Attributes_UT < Test::Unit::TestCase
   def test_border_color
     assert_nothing_raised { @img.border_color }
     # assert_equal("rgb(223,223,223)", @img.border_color)
-    assert_equal('#DFDFDFDFDFDF', @img.border_color)
+    border_color = @img.border_color
+    if @img.background_color.length == 13
+      assert_equal('#DFDFDFDFDFDF', border_color)
+    else
+      assert_equal('#DFDFDFDFDFDFFFFF', border_color)
+    end
     assert_nothing_raised { @img.border_color = 'red' }
     assert_equal('red', @img.border_color)
     assert_nothing_raised { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }
     # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.border_color)
-    assert_equal('#FFFF7FFF7FFF', @img.border_color)
+    border_color = @img.border_color
+    if @img.background_color.length == 13
+      assert_equal('#FFFF7FFF7FFF', border_color)
+    else
+      assert_equal('#FFFF7FFF7FFFFFFF', border_color)
+    end
     assert_raise(TypeError) { @img.border_color = 2 }
   end
 

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -36,7 +36,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.background_color = '#dfdfdf' }
     # assert_equal("rgb(223,223,223)", @img.background_color)
     background_color = @img.background_color
-    if @img.background_color.length == 13
+    if background_color.length == 13
       assert_equal('#DFDFDFDFDFDF', background_color)
     else
       assert_equal('#DFDFDFDFDFDFFFFF', background_color)
@@ -44,7 +44,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }
     # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.background_color)
     background_color = @img.background_color
-    if @img.background_color.length == 13
+    if background_color.length == 13
       assert_equal('#FFFF7FFF7FFF', background_color)
     else
       assert_equal('#FFFF7FFF7FFFFFFF', background_color)
@@ -103,7 +103,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.border_color }
     # assert_equal("rgb(223,223,223)", @img.border_color)
     border_color = @img.border_color
-    if @img.background_color.length == 13
+    if border_color.length == 13
       assert_equal('#DFDFDFDFDFDF', border_color)
     else
       assert_equal('#DFDFDFDFDFDFFFFF', border_color)
@@ -113,7 +113,7 @@ class Image_Attributes_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }
     # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.border_color)
     border_color = @img.border_color
-    if @img.background_color.length == 13
+    if border_color.length == 13
       assert_equal('#FFFF7FFF7FFF', border_color)
     else
       assert_equal('#FFFF7FFF7FFFFFFF', border_color)


### PR DESCRIPTION
This PR fixes the unit tests for newer versions of ImageMagick. 

Two tests fail because of this patch: https://github.com/ImageMagick/ImageMagick/commit/0059300b3777fa505c1856b05b2e36ee45189b24. The unit tests now checks the size of the string for when the value that is returned also contains the alpha channel.

Another test that fails is because previous version of ImageMagick would change an image from `DirectClass` to `PseudoClass` inside the `CompressImageColormap` method. This is no longer happening and that is why the assert has been disabled. And the `Image_compress_colormap_bang` method has also been changed to raise a warning when this has happened.