### PR TITLE
Removed constant define.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -135,11 +135,6 @@
 
 #define MagickLibSubversion MagickLibAddendum
 
-#define LAYERMETHODTYPE ImageLayerMethod /**< layer method */
-#define CLASS_LAYERMETHODTYPE Class_ImageLayerMethod /**< layer method class */
-#define LAYERMETHODTYPE_NAME ImageLayerMethod_name /**< layer method name */
-#define LAYERMETHODTYPE_NEW  ImageLayerMethod_new /**< new layer method */
-
 
 typedef ImageInfo Info; /**< Make type name match class name */
 typedef PixelPacket Pixel; /**< Make type name match class name */
@@ -332,7 +327,7 @@ EXTERN VALUE Class_GravityType;
 EXTERN VALUE Class_ImageType;
 EXTERN VALUE Class_InterlaceType;
 EXTERN VALUE Class_InterpolatePixelMethod;
-EXTERN VALUE CLASS_LAYERMETHODTYPE;
+EXTERN VALUE Class_ImageLayerMethod;
 EXTERN VALUE Class_MagickFunction;
 EXTERN VALUE Class_NoiseType;
 EXTERN VALUE Class_OrientationType;
@@ -1200,7 +1195,7 @@ extern void   Export_TypeInfo(TypeInfo *, VALUE);
 extern VALUE  Import_TypeMetric(TypeMetric *);
 extern const char *StorageType_name(StorageType);
 extern VALUE  VirtualPixelMethod_new(VirtualPixelMethod);
-extern VALUE  LAYERMETHODTYPE_NEW(LAYERMETHODTYPE);
+extern VALUE  ImageLayerMethod_new(ImageLayerMethod);
 
 
 // rmutil.c

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -1018,15 +1018,15 @@ InterpolatePixelMethod_new(InterpolatePixelMethod interpolate)
 
 
 /**
- * Return the name of a MagickLayerMethod enum as a string.
+ * Return the name of a ImageLayerMethod enum as a string.
  *
  * No Ruby usage (internal function)
  *
- * @param method the MagickLayerMethod
+ * @param method the ImageLayerMethod
  * @return the name
  */
 static const char *
-LAYERMETHODTYPE_NAME(LAYERMETHODTYPE method)
+ImageLayerMethod_name(ImageLayerMethod method)
 {
     switch(method)
     {
@@ -1054,18 +1054,18 @@ LAYERMETHODTYPE_NAME(LAYERMETHODTYPE method)
 
 
 /**
- * Construct an MagickLayerMethod enum object for the specified value.
+ * Construct an ImageLayerMethod enum object for the specified value.
  *
  * No Ruby usage (internal function)
  *
- * @param method the MagickLayerMethod
- * @return a new MagickLayerMethod enumerator
+ * @param method the ImageLayerMethod
+ * @return a new ImageLayerMethod enumerator
  */
 VALUE
-LAYERMETHODTYPE_NEW(LAYERMETHODTYPE method)
+ImageLayerMethod_new(ImageLayerMethod method)
 {
-    const char *name = LAYERMETHODTYPE_NAME(method);
-    return rm_enum_new(CLASS_LAYERMETHODTYPE, ID2SYM(rb_intern(name)), INT2FIX(method));
+    const char *name = ImageLayerMethod_name(method);
+    return rm_enum_new(Class_ImageLayerMethod, ID2SYM(rb_intern(name)), INT2FIX(method));
 }
 
 

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -614,7 +614,7 @@ VALUE
 ImageList_optimize_layers(VALUE self, VALUE method)
 {
     Image *images, *new_images, *new_images2;
-    LAYERMETHODTYPE mthd;
+    ImageLayerMethod mthd;
     ExceptionInfo *exception;
     QuantizeInfo quantize_info;
 


### PR DESCRIPTION
This removes a define that is constant. Maybe this was another value in a really ancient version of ImageMagick but it can be removed now.