### PR TITLE
Faster build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,7 @@ os:
 sudo: required
 
 env:
-  - IMAGEMAGICK_VERSION=6.7.7-10
-  - IMAGEMAGICK_VERSION=6.7.7-10 CONFIGURE_OPTIONS=--enable-hdri
   - IMAGEMAGICK_VERSION=6.8.9-10
-  - IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 before_install:
   - source before_install_$TRAVIS_OS_NAME.sh
@@ -30,6 +27,12 @@ matrix:
   include:
     - rvm: 2.3
       env: STYLE_CHECKS=true IMAGEMAGICK_VERSION=6.8.9-10
+    - rvm: 2.6
+      env: IMAGEMAGICK_VERSION=6.7.7-10
+    - rvm: 2.6
+      env: IMAGEMAGICK_VERSION=6.7.7-10 CONFIGURE_OPTIONS=--enable-hdri
+    - rvm: 2.6
+      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 notifications:
   webhooks:

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -25,11 +25,9 @@ else
   exit 1
 fi
 
-if [ -v CONFIGURE_OPTIONS ]; then
-  CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr $CONFIGURE_OPTIONS
-else
-  CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr
-fi
+export CONFIGURE_OPTIONS="${CONFIGURE_OPTIONS} --with-magick-plus-plus=no --disable-docs"
+
+CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr ${CONFIGURE_OPTIONS}
 
 make -j
 sudo make install -j

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -25,9 +25,12 @@ else
   exit 1
 fi
 
-export CONFIGURE_OPTIONS="${CONFIGURE_OPTIONS} --with-magick-plus-plus=no --disable-docs"
+options="--with-magick-plus-plus=no --disable-docs"
+if [ -v CONFIGURE_OPTIONS ]; then
+  options="${CONFIGURE_OPTIONS} $options"
+fi
 
-CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr ${CONFIGURE_OPTIONS}
+CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr $options
 
 make -j
 sudo make install -j


### PR DESCRIPTION
This PR changes the Travis build to improve the build speed. This includes the following changes:

- The ImageMagick build now includes two extra flags that disables building Magick++ and the documentation . The latter requires a more recent version of ImageMagick but was added in advance.
- The current build checks every version of ImageMagick with every version of Ruby. In this PR this is changed to only build the recent version of ImageMagick with every Ruby version and only build the old version and hdri on one version of Ruby.