### PR TITLE
Use rb_frame_this_func() directly instead of THIS_FUNC() macro

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -317,8 +317,6 @@ END_MINGW
 
       headers = ['ruby.h', 'ruby/io.h']
 
-      have_func('rb_frame_this_func', headers)
-
       # Miscellaneous constants
       $defs.push("-DRUBY_VERSION_STRING=\"ruby #{RUBY_VERSION}\"")
       $defs.push("-DRMAGICK_VERSION_STRING=\"RMagick #{RMAGICK_VERS}\"")

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -315,8 +315,6 @@ END_MINGW
 
       have_type('long double', headers)
 
-      headers = ['ruby.h', 'ruby/io.h']
-
       # Miscellaneous constants
       $defs.push("-DRUBY_VERSION_STRING=\"ruby #{RUBY_VERSION}\"")
       $defs.push("-DRMAGICK_VERSION_STRING=\"RMagick #{RMAGICK_VERS}\"")

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -99,13 +99,6 @@
 #define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
 
 
-// Ruby 1.9.0 changed the name to rb_frame_this_func
-#if defined(HAVE_RB_FRAME_THIS_FUNC)
-#define THIS_FUNC() rb_frame_this_func() /**< get the Ruby function being called */
-#else
-#define THIS_FUNC() rb_frame_last_func() /**< get the Ruby function being called */
-#endif
-
 // GetReadFile doesn't exist in Ruby 1.9.0
 #if !defined(GetReadFile)
 #define GetReadFile(fptr) rb_io_stdio_file(fptr) /**< Ruby read file pointer */

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -15259,7 +15259,7 @@ static void call_trace_proc(Image *image, const char *which)
             n = sprintf(buffer, "%p", (void *)image);
             buffer[n] = '\0';
             trace_args[2] = rb_str_new2(buffer+2);      // don't use leading 0x
-            trace_args[3] = ID2SYM(THIS_FUNC());
+            trace_args[3] = ID2SYM(rb_frame_this_func());
             (void) rb_funcall2(trace, rm_ID_call, 4, (VALUE *)trace_args);
         }
     }

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -827,7 +827,7 @@ rm_not_implemented(void)
 {
 
     rb_raise(rb_eNotImpError, "the `%s' method is not supported by ImageMagick "
-            MagickLibVersionText, rb_id2name(THIS_FUNC()));
+            MagickLibVersionText, rb_id2name(rb_frame_this_func()));
 }
 
 
@@ -1512,7 +1512,7 @@ rm_progress_monitor(
     span = rb_uint2big((unsigned long)sp);
 #endif
 
-    method = rb_id2str(THIS_FUNC());
+    method = rb_id2str(rb_frame_this_func());
 
     rval = rb_funcall((VALUE)client_data, rm_ID_call, 3, method, offset, span);
 


### PR DESCRIPTION
rb_frame_this_func() was introduced at Ruby 1.9.0
Maybe, there is THIS_FUNC() definition to support Ruby 1.8.x.
However, now we don't support that.

So, now we can use rb_frame_this_func() directly.