### PR TITLE
Get rid of compiler warning about `image->filename`

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8306,14 +8306,7 @@ Image_marshal_dump(VALUE self)
     }
 
     ary = rb_ary_new2(2);
-    if (image->filename)
-    {
-        rb_ary_store(ary, 0, rb_str_new2(image->filename));
-    }
-    else
-    {
-        rb_ary_store(ary, 0, Qnil);
-    }
+    rb_ary_store(ary, 0, rb_str_new2(image->filename));
 
     exception = AcquireExceptionInfo();
     blob = ImageToBlob(info, image, &length, exception);


### PR DESCRIPTION
This patch will use expected type for variable to get rid of following compiler warning.

```
rmimage.c:8309:16: warning: address of array 'image->filename' will always evaluate to 'true' [-Wpointer-bool-conversion]
    if (image->filename)
    ~~  ~~~~~~~^~~~~~~~
1 warning generated.
```

`image->filename` has declared as following in ImageMagick.

```
  char
    magick[MaxTextExtent],
    unique[MaxTextExtent],
    zero[MaxTextExtent],
    filename[MaxTextExtent];
```

The address of `filename[MaxTextExtent]` always is not `NULL`.

So, this patch will remove unnecessary `if` sentence to get rid of compiler warning.