### PR TITLE
New version of ImageMagick

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ environment:
       IMAGEMAGICK_PATCH: "10"
 
 install:
-  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGE_MAGICK_VERSION%-%IMAGEMAGICK_PATCH%-Q16-x64-dll.exe
+  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%IMAGEMAGICK_PATCH%-Q16-x64-dll.exe
   - ImageMagick-%IMAGEMAGICK_VERSION%-%IMAGEMAGICK_PATCH%-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\%IMAGEMAGICK_VERSION%-Q16;%PATH%
   - bundle install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,9 +6,9 @@ environment:
     - RUBY_VERSION: "26-x64"
 
 install:
-  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-6.8.9-10-Q16-x64-dll.exe
-  - ImageMagick-6.8.9-10-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
-  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-6.8.9-Q16;%PATH%
+  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-6.9.10-35-Q16-x64-dll.exe
+  - ImageMagick-6.9.10-35-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-6.9.10-Q16;%PATH%
   - bundle install
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,25 @@
 environment:
   matrix:
     - RUBY_VERSION: "23-x64"
+      IMAGEMAGICK_VERSION: "6.9.10"
+      IMAGEMAGICK_PATCH: "35"
     - RUBY_VERSION: "24-x64"
+      IMAGEMAGICK_VERSION: "6.9.10"
+      IMAGEMAGICK_PATCH: "35"
     - RUBY_VERSION: "25-x64"
+      IMAGEMAGICK_VERSION: "6.9.10"
+      IMAGEMAGICK_PATCH: "35"
     - RUBY_VERSION: "26-x64"
+      IMAGEMAGICK_VERSION: "6.9.10"
+      IMAGEMAGICK_PATCH: "35"
+    - RUBY_VERSION: "26-x64"
+      IMAGEMAGICK_VERSION: "6.8.9"
+      IMAGEMAGICK_PATCH: "10"
 
 install:
-  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-6.9.10-35-Q16-x64-dll.exe
-  - ImageMagick-6.9.10-35-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
-  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-6.9.10-Q16;%PATH%
+  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGE_MAGICK_VERSION%-%IMAGEMAGICK_PATCH%-Q16-x64-dll.exe
+  - ImageMagick-%IMAGEMAGICK_VERSION%-%IMAGEMAGICK_PATCH%-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\%IMAGEMAGICK_VERSION%-Q16;%PATH%
   - bundle install
 
 build: off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: setup linux
           command: |
-            IMAGEMAGICK_VERSION=6.8.9-10 bash before_install_linux.sh
+            IMAGEMAGICK_VERSION=6.9.10-35 bash before_install_linux.sh
 
       - run:
           name: install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
     - rvm: 2.6
       env: IMAGEMAGICK_VERSION=6.7.7-10
     - rvm: 2.6
-      env: IMAGEMAGICK_VERSION=6.7.7-10 CONFIGURE_OPTIONS=--enable-hdri
-    - rvm: 2.6
       env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 sudo: required
 
 env:
-  - IMAGEMAGICK_VERSION=6.8.9-10
+  - IMAGEMAGICK_VERSION=6.9.10-35
 
 before_install:
   - source before_install_$TRAVIS_OS_NAME.sh
@@ -26,11 +26,13 @@ rvm:
 matrix:
   include:
     - rvm: 2.3
-      env: STYLE_CHECKS=true IMAGEMAGICK_VERSION=6.8.9-10
+      env: STYLE_CHECKS=true IMAGEMAGICK_VERSION=6.9.10-35
+    - rvm: 2.6
+      env: IMAGEMAGICK_VERSION=6.9.10-35 CONFIGURE_OPTIONS=--enable-hdri
+    - rvm: 2.6
+      env: IMAGEMAGICK_VERSION=6.8.9-10
     - rvm: 2.6
       env: IMAGEMAGICK_VERSION=6.7.7-10
-    - rvm: 2.6
-      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 notifications:
   webhooks:

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -16,8 +16,12 @@ if [ ! -d /usr/include/freetype ]; then
 fi
 
 if [ -v IMAGEMAGICK_VERSION ]; then
-  wget http://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
-  tar -xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+  if wget https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz; then
+    tar -xzf ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz
+  else
+    wget http://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+    tar -xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+  fi
   cd ImageMagick-${IMAGEMAGICK_VERSION}
 else
   echo "you must specify an ImageMagick version."


### PR DESCRIPTION
This PR changes the build to use ImageMagick 6.9.10-35. This also includes a change to the `before_install_linux.sh` script to try to download the file from GitHub instead of ImageMagick.