### PR TITLE
gemspec: Remove deprecated has_rdoc=

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'rmagick'
   s.extensions = %w[ext/RMagick/extconf.rb]
-  s.has_rdoc = false
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 


### PR DESCRIPTION
Newer Ruby shows the following notice message what `has_rdoc=` method is deprecated.

```
$ ruby -v
ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin18]

$ rake build
gem build -V rmagick.gemspec
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from rmagick.gemspec:29.
  Successfully built RubyGem
  Name: rmagick
  Version: 3.0.0
  File: rmagick-3.0.0.gem
```

This PR will remove `has_rdoc=` setting because it is `Deprecated and ignored.`.
https://apidock.com/ruby/Gem/Specification/has_rdoc%3D