### PR TITLE
Use CompareImageLayers instead of DeconstructImages 

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -267,7 +267,7 @@ ImageList_deconstruct(VALUE self)
 
     images = images_from_imagelist(self);
     exception = AcquireExceptionInfo();
-    new_images = DeconstructImages(images, exception);
+    new_images = CompareImageLayers(images, CompareAnyLayer, exception);
     rm_split(images);
     rm_check_exception(exception, new_images, DestroyOnError);
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
DeconstructImages  has been deprecated in ImageMagick 7. This PR changes the call to CompareImageLayers that works in both ImageMagick 6 and 7.