### PR TITLE
Use GC.start instead of GC.stress to reduce test execution time

### DIFF
--- a/test/Info.rb
+++ b/test/Info.rb
@@ -220,20 +220,17 @@ class InfoUT < Test::Unit::TestCase
   end
 
   def test_monitor
-    GC.stress = true
-
     assert_nothing_raised { @info.monitor = -> {} }
     monitor = proc do |mth, q, s|
       assert_equal('resize!', mth)
       assert_kind_of(Integer, q)
       assert_kind_of(Integer, s)
+      GC.start
       true
     end
     img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
     img.resize!(20, 20)
     img.monitor = nil
-  ensure
-    GC.stress = false
   end
 
   def test_monochrome


### PR DESCRIPTION
I introduced `GC.stress` to test GC problems.
https://github.com/rmagick/rmagick/pull/468

However, it take a time to finish `test_monitor`.
And, seems that `GC.stress` is too much for this case.
So, this PR change to `GC.start`.

By this changing, test execution time will reduce from 60sec to 40sec.

* Before

```
$ rake
...
Finished in 60.401073433 seconds.
------------------------------------------------------------------------------------------------------------------------------
402 tests, 232622 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------
6.66 tests/s, 3851.29 assertions/s
```

* After

```
$ rake
...
Finished in 40.092390367 seconds.
------------------------------------------------------------------------------------------------------------------------------
402 tests, 232622 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------
10.03 tests/s, 5802.15 assertions/s
```