### PR TITLE
CI: Add “appveyor-retry” to retry download binary

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
       PATCH_VERSION: 35
 
 install:
-  - appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe
+  - appveyor-retry appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe
   - ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe /VERYSILENT /TASKS=install_Devel
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\ImageMagick-%IMAGEMAGICK_VERSION%-Q16;%PATH%
   - bundle install


### PR DESCRIPTION
Sometime, it fails to download ImageMagick installer binary on AppVeyor, like

```
Build started
git clone -q --branch=master https://github.com/rmagick/rmagick.git C:\projects\rmagick
git checkout -qf 23b133b1ff06ea43c592276c0619e9e9562f971e
Running Install scripts
appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe
Error downloading remote file: One or more errors occurred.
Inner Exception: The remote name could not be resolved: 'ftp.icm.edu.pl'
Command exited with code 2
```
https://ci.appveyor.com/project/mockdeep/rmagick/builds/23472095/job/s5jjgd03o1tkqmm1

I don't like to restart CI build by download failure.

So, this PR introduce retry command.
https://github.com/appveyor/ci/blob/master/scripts/appveyor-retry.cmd