### PR TITLE
CI: Remove Ruby 2.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,12 +3,6 @@ cache:
 
 environment:
   matrix:
-    - RUBY_VERSION: 23-x64
-      IMAGEMAGICK_VERSION: 6.8.9
-      PATCH_VERSION: 10
-    - RUBY_VERSION: 23-x64
-      IMAGEMAGICK_VERSION: 6.9.10
-      PATCH_VERSION: 34
     - RUBY_VERSION: 24-x64
       IMAGEMAGICK_VERSION: 6.8.9
       PATCH_VERSION: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
 install: bundle install --path=vendor/bundle --verbose
 
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6


### PR DESCRIPTION
Ruby 2.3 reaches EOL on 2019-03-31

> Ruby 2.3
> status: security maintenance
> release date: 2015-12-25
> EOL date: scheduled for 2019-03-31

https://www.ruby-lang.org/en/downloads/branches/

However, I guess many users still use Ruby 2.3.
So, this PR just remove Ruby 2.3 from Travis/AppVeyor.