### PR TITLE
CI: try removing update from before install script

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -1,7 +1,5 @@
 set -euo pipefail
 
-sudo apt-get update
-
 # remove all existing imagemagick related packages
 sudo apt-get autoremove -y imagemagick* libmagick* --purge
 


### PR DESCRIPTION
We see a lot of random failures that seem to happen when updating
packages, so maybe we can do without that part. It'll also speed up the
build some.