### PR TITLE
Add Image#fx method

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -930,6 +930,7 @@ extern VALUE Image_flop_bang(VALUE);
 extern VALUE Image_frame(int, VALUE *, VALUE);
 extern VALUE Image_from_blob(VALUE, VALUE);
 extern VALUE Image_function_channel(int, VALUE *, VALUE);
+extern VALUE Image_fx(int, VALUE *, VALUE);
 extern VALUE Image_gamma_channel(int, VALUE *, VALUE);
 extern VALUE Image_gamma_correct(int, VALUE *, VALUE);
 extern VALUE Image_gaussian_blur(int, VALUE *, VALUE);

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -359,6 +359,7 @@ ImageList_flatten_images(VALUE self)
  * @param argv array of input arguments
  * @param self this object
  * @return a new image
+ * @deprecated This method has been deprecated. Please use Image_fx.
  */
 VALUE
 ImageList_fx(int argc, VALUE *argv, VALUE self)

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -369,6 +369,7 @@ ImageList_fx(int argc, VALUE *argv, VALUE self)
     ChannelType channels;
     ExceptionInfo *exception;
 
+    rb_warning("ImageList#fx is deprecated; use Image#fx");
 
     channels = extract_channels(&argc, argv);
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6802,6 +6802,56 @@ Image_fuzz_eq(VALUE self, VALUE fuzz)
 }
 
 
+/**
+ * Apply fx on the image.
+ *
+ * Ruby usage:
+ *   - @verbatim Image#fx(expression) @endverbatim
+ *   - @verbatim Image#fx(expression, channel) @endverbatim
+ *   - @verbatim Image#fx(expression, channel, ...) @endverbatim
+ *
+ * Notes:
+ *   - Default channel is AllChannels
+ *
+ * @param argc number of input arguments
+ * @param argv array of input arguments
+ * @param self this object
+ * @return a new image
+ */
+VALUE
+Image_fx(int argc, VALUE *argv, VALUE self)
+{
+    Image *image, *new_image;
+    char *expression;
+    ChannelType channels;
+    ExceptionInfo *exception;
+
+    image = rm_check_destroyed(self);
+    channels = extract_channels(&argc, argv);
+
+    // There must be exactly 1 remaining argument.
+    if (argc == 0)
+    {
+        rb_raise(rb_eArgError, "wrong number of arguments (0 for 1 or more)");
+    }
+    else if (argc > 1)
+    {
+        raise_ChannelType_error(argv[argc-1]);
+    }
+
+    expression = StringValuePtr(argv[0]);
+
+    exception = AcquireExceptionInfo();
+    new_image = FxImageChannel(image, channels, expression, exception);
+    rm_check_exception(exception, new_image, DestroyOnError);
+    (void) DestroyExceptionInfo(exception);
+
+    rm_ensure_result(new_image);
+
+    return rm_image_new(new_image);
+}
+
+
 DEF_ATTR_ACCESSOR(Image, gamma, dbl)
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -394,6 +394,7 @@ Init_RMagick2(void)
     rb_define_method(Class_Image, "flop!", Image_flop_bang, 0);
     rb_define_method(Class_Image, "frame", Image_frame, -1);
     rb_define_method(Class_Image, "function_channel", Image_function_channel, -1);
+    rb_define_method(Class_Image, "fx", Image_fx, -1);
     rb_define_method(Class_Image, "gamma_channel", Image_gamma_channel, -1);
     rb_define_method(Class_Image, "gamma_correct", Image_gamma_correct, -1);
     rb_define_method(Class_Image, "gaussian_blur", Image_gaussian_blur, -1);

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -716,6 +716,16 @@ class Image2_UT < Test::Unit::TestCase
     assert_raise(TypeError) { @img.frame(50, 50, 25, 25, 6, 6, 2) }
   end
 
+  def test_fx
+    assert_nothing_raised { @img.fx('1/2') }
+    assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel) }
+    assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }
+    assert_raise(ArgumentError) { @img.fx }
+    assert_raise(ArgumentError) { @img.fx(Magick::BlueChannel) }
+    assert_raise(TypeError) { @img.fx(1) }
+    assert_raise(TypeError) { @img.fx('1/2', 1) }
+  end
+
   def test_gamma_channel
     assert_nothing_raised do
       res = @img.gamma_channel(0.8)


### PR DESCRIPTION
This PR fixes the issue that was reported in #508. The `FxImageChannel` method only operates on a single image. The `Image_fx` method has been added and the `ImageList_fx` has been marked as deprecated.