### PR TITLE
Deprecate KernelInfo#zero_nans.

### DIFF
--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -73,10 +73,12 @@ KernelInfo_initialize(VALUE self, VALUE kernel_string)
  *   - @verbatim KernelInfo#zero_nans @endverbatim
  *
  * @param self this object
+ * @deprecated This method has been deprecated.
  */
 VALUE
 KernelInfo_zero_nans(VALUE self)
 {
+  rb_warning("KernelInfo#zero_nans is deprecated");
   ZeroKernelNans((KernelInfo*)DATA_PTR(self));
   return Qnil;
 }


### PR DESCRIPTION
This is a private method inside ImageMagick and should not be used. This is the first step towards removing this method.