### PR TITLE
Deprecate KernelInfo#show.

### DIFF
--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -107,10 +107,12 @@ KernelInfo_unity_add(VALUE self, VALUE scale)
  *   - @verbatim KernelInfo#show @endverbatim
  *
  * @param self this object
+ * @deprecated This method has been deprecated.
  */
 VALUE
 KernelInfo_show(VALUE self)
 {
+  rb_warning("KernelInfo#show is deprecated");
   ShowKernelInfo((KernelInfo*)DATA_PTR(self));
   return Qnil;
 }


### PR DESCRIPTION
This method has been made private in ImageMagick 7 and I don't think anyone will/should use this in ImageMagick 6.