### PR TITLE
Remove unused stdint.h

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -45,9 +45,7 @@ module RMagick
     end
 
     def configure_headers
-      # headers = %w{assert.h ctype.h errno.h float.h limits.h math.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h time.h}
       @headers = %w[assert.h ctype.h stdio.h stdlib.h math.h time.h]
-      headers << 'stdint.h' if have_header('stdint.h') # defines uint64_t
       headers << 'sys/types.h' if have_header('sys/types.h')
 
       if have_header('magick/MagickCore.h')

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -19,9 +19,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <ctype.h>
-#if defined(HAVE_STDINT_H)
-#include <stdint.h>
-#endif
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>


### PR DESCRIPTION
int8_t, uint8_t,… etc are declared in stdint.h
However, seems RMagick does not there types or macro defined in stdint.h.

By removing headers checking, it will reduce a time generating Makefile slightly.