### PR TITLE
Refactor rm_set_magick_pixel_packet

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1212,7 +1212,6 @@ extern void   rm_get_geometry(VALUE, long *, long *, unsigned long *, unsigned l
 extern const char *rm_get_property(const Image *, const char *);
 extern MagickBooleanType rm_set_property(Image *, const char *, const char *);
 extern void   rm_set_user_artifact(Image *, Info *);
-void          rm_set_magick_pixel_packet(Pixel *, MagickPixel *);
 extern void   rm_sync_image_options(Image *, Info *);
 extern void   rm_split(Image *);
 extern void   rm_magick_error(const char *);

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -1018,6 +1018,28 @@ Pixel_to_HSL(VALUE self)
 
 
 /**
+ * Convert a Pixel to a MagickPixel.
+ *
+ * No Ruby usage (internal function)
+ *
+ * Notes:
+ *   - Same code as the private function SetMagickPixelPacket in ImageMagick.
+ *
+ * @param pixel the pixel
+ * @param pp the MagickPixel to be modified
+ */
+static void
+rm_set_magick_pixel_packet(Pixel *pixel, MagickPixel *pp)
+{
+    pp->red     = (MagickRealType) pixel->red;
+    pp->green   = (MagickRealType) pixel->green;
+    pp->blue    = (MagickRealType) pixel->blue;
+    pp->opacity = (MagickRealType) pixel->opacity;
+    pp->index   = (MagickRealType) 0.0;
+}
+
+
+/**
  * Return the color name corresponding to the pixel values.
  *
  * Ruby usage:
@@ -1148,27 +1170,5 @@ Pixel_to_s(VALUE self)
     sprintf(buff, "red=" QuantumFormat ", green=" QuantumFormat ", blue=" QuantumFormat ", opacity=" QuantumFormat
           , pixel->red, pixel->green, pixel->blue, pixel->opacity);
     return rb_str_new2(buff);
-}
-
-
-/**
- * Convert a PixelColor to a MagickPixel.
- *
- * No Ruby usage (internal function)
- *
- * Notes:
- *   - Same code as the private function SetMagickPixelPacket in ImageMagick.
- *
- * @param pixel the pixel
- * @param pp the MagickPixel to be modified
- */
-void
-rm_set_magick_pixel_packet(PixelColor *pixel, MagickPixel *pp)
-{
-    pp->red     = (MagickRealType) pixel->red;
-    pp->green   = (MagickRealType) pixel->green;
-    pp->blue    = (MagickRealType) pixel->blue;
-    pp->opacity = (MagickRealType) pixel->opacity;
-    pp->index   = (MagickRealType) 0.0;
 }
 


### PR DESCRIPTION
This PR removes rm_set_magick_pixel_packet from the header file, corrects the argument type and makes it static in rmpixel.c