### PR TITLE
Remove have_type for long double

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -311,8 +311,6 @@ END_MINGW
         have_func(func, headers)
       end
 
-      have_type('long double', headers)
-
       # Miscellaneous constants
       $defs.push("-DRUBY_VERSION_STRING=\"ruby #{RUBY_VERSION}\"")
       $defs.push("-DRMAGICK_VERSION_STRING=\"RMagick #{RMAGICK_VERS}\"")


### PR DESCRIPTION
We don’t use long double type in RMagick.

By removing have_type(), it will reduce a time generating Makefile slightly.