### PR TITLE
Fix color histogram

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2544,13 +2544,16 @@ Image_color_histogram(VALUE self)
         }
         rb_raise(rb_eNoMemError, "not enough memory to continue");
     }
-    if (exception->severity != UndefinedException)
+    if (rm_should_raise_exception(exception, DestroyExceptionRetention))
     {
         (void) RelinquishMagickMemory(histogram);
-        rm_check_exception(exception, dc_copy, DestroyOnError);
-    }
+        if (dc_copy)
+        {
+            (void) DestroyImage(dc_copy);
+        }
 
-    (void) DestroyExceptionInfo(exception);
+        rm_raise_exception(exception);
+    }
 
     hash = rb_hash_new();
     for (x = 0; x < colors; x++)

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2529,10 +2529,7 @@ Image_color_histogram(VALUE self)
     if (image->storage_class != DirectClass)
     {
         dc_copy = rm_clone_image(image);
-        (void) SyncImage(dc_copy);
-        magick_free(dc_copy->colormap);
-        dc_copy->colormap = NULL;
-        dc_copy->storage_class = DirectClass;
+        (void) SetImageStorageClass(dc_copy, DirectClass);
         image = dc_copy;
     }
 

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -434,6 +434,12 @@ class Image1_UT < Test::Unit::TestCase
       res = @img.color_histogram
       assert_instance_of(Hash, res)
     end
+    assert_nothing_raised do
+      @img.class_type = Magick::PseudoClass
+      res = @img.color_histogram
+      assert_equal(Magick::PseudoClass, @img.class_type)
+      assert_instance_of(Hash, res)
+    end
   end
 
   def test_colorize


### PR DESCRIPTION
This PR fixes some issues in the `Image_color_histogram` method:
- `SetImageStorageClass` should be used instead of a custom implementation.
- The check `exception->severity != UndefinedException` will also be true for a warning but `rm_check_exception` will not raise an exception. But `histogram` was already freed at this point and that will cause issues later in the method. This has been resolve by using `rm_should_raise_exception` instead.