### PR TITLE
Remove Color_to_PixelPacket.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1142,7 +1142,6 @@ extern VALUE  VirtualPixelMethod_new(VirtualPixelMethod);
 extern VALUE  ChromaticityInfo_to_s(VALUE);
 extern VALUE  ChromaticityInfo_new(ChromaticityInfo *);
 extern void   Color_to_PixelColor(PixelColor *, VALUE);
-extern void   Color_to_PixelPacket(PixelPacket *, VALUE);
 extern void   Color_to_MagickPixel(Image *, MagickPixel *, VALUE);
 extern VALUE  Color_to_s(VALUE);
 extern VALUE  Import_ColorInfo(const ColorInfo *);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9831,7 +9831,8 @@ VALUE
 Image_pixel_color(int argc, VALUE *argv, VALUE self)
 {
     Image *image;
-    PixelPacket old_color, new_color, *pixel;
+    PixelColor new_color;
+    PixelPacket old_color, *pixel;
     ExceptionInfo *exception;
     long x, y;
     unsigned int set = False;
@@ -9848,7 +9849,7 @@ Image_pixel_color(int argc, VALUE *argv, VALUE self)
             set = True;
             // Replace with new color? The arg can be either a color name or
             // a Magick::Pixel.
-            Color_to_PixelPacket(&new_color, argv[2]);
+            Color_to_PixelColor(&new_color, argv[2]);
         case 2:
             break;
         default:

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -208,38 +208,6 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
 
 
 /**
- * Convert either a String color name or a Magick::Pixel to a PixelPacket.
- *
- * No Ruby usage (internal function)
- *
- * @param pp the PixelPacket to modify
- * @param color the color name or Magick::Pixel
- */
-void
-Color_to_PixelPacket(PixelPacket *pp, VALUE color)
-{
-    Pixel *pixel;
-
-    // Allow color name or Pixel
-    if (CLASS_OF(color) == Class_Pixel)
-    {
-        memset(pp, 0, sizeof(*pp));
-        Data_Get_Struct(color, Pixel, pixel);
-        pp->red     = pixel->red;
-        pp->green   = pixel->green;
-        pp->blue    = pixel->blue;
-        pp->opacity = pixel->opacity;
-    }
-    else
-    {
-        // require 'to_str' here instead of just 'to_s'.
-        color = rb_rescue(rb_str_to_str, color, color_arg_rescue, color);
-        Color_Name_to_PixelColor(pp, color);
-    }
-}
-
-
-/**
  * Convert a color name to a PixelColor
  *
  * No Ruby usage (internal function)


### PR DESCRIPTION
The `Color_to_PixelPacket` method was preserved because I thought I would need this for the ImageMagick 7 changes but it turns out that I don't it. This PR removes that method.