### PR TITLE
Use rb_io instead of the defines.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -95,19 +95,6 @@
 //! round to Quantum
 #define ROUND_TO_QUANTUM(value) ((Quantum) ((value) > (Quantum)QuantumRange ? QuantumRange : (value) + 0.5))
 
-
-// GetReadFile doesn't exist in Ruby 1.9.0
-#if !defined(GetReadFile)
-#define GetReadFile(fptr) rb_io_stdio_file(fptr) /**< Ruby read file pointer */
-#define GetWriteFile(fptr) rb_io_stdio_file(fptr) /**< Ruby write file pointer */
-#endif
-
-// rb_io_t replaces OpenFile in Ruby 1.9.0
-#if defined(HAVE_RB_IO_T)
-#undef OpenFile
-#define OpenFile rb_io_t /**< Ruby open file */
-#endif
-
 //! Convert a C string to a Ruby symbol. Used in marshal_dump/marshal_load methods
 #define CSTR2SYM(s) ID2SYM(rb_intern(s))
 //! Convert a C string to a Ruby String, or nil if the ptr is NULL

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -1170,7 +1170,7 @@ ImageList_write(VALUE self, VALUE file)
 
     if (TYPE(file) == T_FILE)
     {
-        OpenFile *fptr;
+        rb_io_t *fptr;
 
         // Ensure file is open - raise error if not
         GetOpenFile(file, fptr);
@@ -1178,7 +1178,7 @@ ImageList_write(VALUE self, VALUE file)
         add_format_prefix(info, fptr->pathv);
         SetImageInfoFile(info, NULL);
 #else
-        SetImageInfoFile(info, GetReadFile(fptr));
+        SetImageInfoFile(info, rb_io_stdio_file(fptr));
 #endif
     }
     else

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10683,12 +10683,12 @@ rd_image(VALUE class, VALUE file, reader_t reader)
 
     if (TYPE(file) == T_FILE)
     {
-        OpenFile *fptr;
+        rb_io_t *fptr;
 
         // Ensure file is open - raise error if not
         GetOpenFile(file, fptr);
         rb_io_check_readable(fptr);
-        SetImageInfoFile(info, GetReadFile(fptr));
+        SetImageInfoFile(info, rb_io_stdio_file(fptr));
     }
     else
     {
@@ -14863,7 +14863,7 @@ Image_write(VALUE self, VALUE file)
 
     if (TYPE(file) == T_FILE)
     {
-        OpenFile *fptr;
+        rb_io_t *fptr;
 
         // Ensure file is open - raise error if not
         GetOpenFile(file, fptr);
@@ -14873,7 +14873,7 @@ Image_write(VALUE self, VALUE file)
         strcpy(image->filename, info->filename);
         SetImageInfoFile(info, NULL);
 #else
-        SetImageInfoFile(info, GetWriteFile(fptr));
+        SetImageInfoFile(info, rb_io_stdio_file(fptr));
         memset(image->filename, 0, sizeof(image->filename));
 #endif
     }


### PR DESCRIPTION
The `rmagick.h` file has some defines that appear to be for older versions of Ruby. This PR removes the defines and replaces them with the values in the other files.