### PR TITLE
Add ImageList tests

### DIFF
--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -15,12 +15,25 @@ class ImageList1UT < Test::Unit::TestCase
     @list2 << @list[9]
   end
 
+  def test_composite_layers
+    assert_nothing_raised { @list.composite_layers(@list2) }
+    Magick::CompositeOperator.values do |op|
+      assert_nothing_raised { @list.composite_layers(@list2, op) }
+    end
+
+    assert_raise(ArgumentError) { @list.composite_layers(@list2, Magick::AddCompositeOp, 42) }
+  end
+
   def test_delay
     assert_nothing_raised { @list.delay }
     assert_equal(0, @list.delay)
     assert_nothing_raised { @list.delay = 20 }
     assert_equal(20, @list.delay)
     assert_raise(ArgumentError) { @list.delay = 'x' }
+  end
+
+  def test_flatten_images
+    assert_nothing_raised { @list.flatten_images }
   end
 
   def test_ticks_per_second

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -133,6 +133,9 @@ class ImageList2UT < Test::Unit::TestCase
     map = Magick::ImageList.new('netscape:')
     img = @ilist.map(map, true)
     assert_instance_of(Magick::ImageList, img)
+
+    assert_raise(ArgumentError) { @ilist.map }
+    assert_raise(ArgumentError) { @ilist.map(map, true, 42) }
   end
 
   def test_marshal
@@ -259,27 +262,34 @@ class ImageList2UT < Test::Unit::TestCase
 
   def test_optimize_layers
     layer_methods = [
-      Magick::CompareAnyLayer,
-      Magick::CompareOverlayLayer,
-      Magick::OptimizeLayer,
-      Magick::OptimizePlusLayer,
       Magick::CoalesceLayer,
       Magick::DisposeLayer,
       Magick::OptimizeTransLayer,
       Magick::RemoveDupsLayer,
-      Magick::RemoveZeroLayer
+      Magick::RemoveZeroLayer,
+      Magick::OptimizeImageLayer,
+      Magick::OptimizeLayer,
+      Magick::OptimizePlusLayer,
+      Magick::CompareAnyLayer,
+      Magick::CompareClearLayer,
+      Magick::CompareOverlayLayer,
+      Magick::MosaicLayer,
+      Magick::FlattenLayer,
+      Magick::MergeLayer
     ]
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     layer_methods.each do |method|
       assert_nothing_raised do
         res = @ilist.optimize_layers(method)
         assert_instance_of(Magick::ImageList, res)
-        assert_equal(2, res.length)
+        assert_kind_of(Integer, res.length)
       end
     end
+
     assert_nothing_raised { @ilist.optimize_layers(Magick::CompareClearLayer) }
     assert_raise(ArgumentError) { @ilist.optimize_layers(Magick::UndefinedLayer) }
     assert_raise(TypeError) { @ilist.optimize_layers(2) }
+    assert_raise(NotImplementedError) { @ilist.optimize_layers(Magick::CompositeLayer) }
   end
 
   def test_ping
@@ -311,6 +321,9 @@ class ImageList2UT < Test::Unit::TestCase
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::NoDitherMethod) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }
+    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }
+    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }
+    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }
     assert_raise(TypeError) { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }
     assert_raise(ArgumentError) { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }
   end


### PR DESCRIPTION
This patch will improve coverage of rmilist.c

* Before
  - Line coverage : 78.3 %
  - Functions : 84.6 %

* After
  - Line coverage : 91.7 %
  - Functions : 92.3 %

Related to https://github.com/rmagick/rmagick/issues/542