### PR TITLE
Fix memory leak in Image#recolor

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10827,9 +10827,12 @@ Image_recolor(VALUE self, VALUE color_matrix)
     order = (unsigned long)sqrt((double)(len + 1.0));
 
     // RecolorImage sets the ExceptionInfo and returns a NULL image if an error occurs.
-    kernel_info = AcquireKernelInfo("1");
+    kernel_info = AcquireKernelInfo(NULL);
     if (kernel_info == (KernelInfo *) NULL)
-      return Qnil;
+    {
+        xfree((void *)matrix);
+        return Qnil;
+    }
     kernel_info->width = order;
     kernel_info->height = order;
     kernel_info->values = (double *) matrix;


### PR DESCRIPTION
`kernel_info = AcquireKernelInfo("1");` will allocate memory area in `kernel_info->values`.
If override the pointer in `kernel_info->values`, it does not have a chance to release the area any more.
https://github.com/rmagick/rmagick/blob/b9c48b6c8b593422c3e5cbc1d4e76b671ab2db4b/ext/RMagick/rmimage.c#L10835

To suppress memory allocation in `kernel_info->values`, this PR changes to use `AcquireKernelInfo(NULL)`.

* Before

```
$ ruby test.rb
Process: 1395: RSS = 198 MB
```

* After

```
$ ruby test.rb
Process: 1961: RSS = 72 MB
```

* Test code

```ruby
require 'rmagick'

img = Magick::Image.new(20, 20)

1000000.times do
  img.recolor([1, 1, 2, 1])
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```