### PR TITLE
Add magick lib version

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1725,7 +1725,7 @@ test_Magick_version(void)
 
 
 /**
- * Create Version, Magick_version, and Version_long constants.
+ * Create Version, Magick_version, Magick_lib_version, and Version_long constants.
  *
  * No Ruby usage (internal function)
  */

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1734,13 +1734,18 @@ version_constants(void)
 {
     const char *mgk_version;
     VALUE str;
+    VALUE nr;
     char long_version[1000];
+    size_t lib_version;
 
-    mgk_version = GetMagickVersion(NULL);
+    mgk_version = GetMagickVersion(&lib_version);
 
     str = rb_str_new2(mgk_version);
     rb_obj_freeze(str);
     rb_define_const(Module_Magick, "Magick_version", str);
+
+    nr = rb_int_new(lib_version);
+    rb_define_const(Module_Magick, "Magick_lib_version", nr);
 
     str = rb_str_new2(Q(RMAGICK_VERSION_STRING));
     rb_obj_freeze(str);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1744,6 +1744,10 @@ version_constants(void)
     rb_obj_freeze(str);
     rb_define_const(Module_Magick, "Magick_version", str);
 
+    // Hack due to mistake in the Windows distribution of ImageMagick
+    if (lib_version == 0x6910)
+        lib_version = 0x69A;
+
     nr = rb_int_new(lib_version);
     rb_define_const(Module_Magick, "Magick_lib_version", nr);
 

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -301,7 +301,7 @@ class DrawUT < Test::Unit::TestCase
       Magick::VividLightCompositeOp,
       Magick::XorCompositeOp
     ]
-    composite_operators << Magick::HardMixCompositeOp if Magick::Magick_lib_version >= 0x689
+    composite_operators << Magick::HardMixCompositeOp if Gem::Version.new('6.8.9') <= Magick::Magick_lib_version
 
     img = Magick::Image.new(10, 10)
     assert_nothing_raised { @draw.composite(0, 0, 10, 10, img) }

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -301,7 +301,7 @@ class DrawUT < Test::Unit::TestCase
       Magick::VividLightCompositeOp,
       Magick::XorCompositeOp
     ]
-    composite_operators << Magick::HardMixCompositeOp if Gem::Version.new('6.8.9') <= Gem::Version.new(IM_VERSION)
+    composite_operators << Magick::HardMixCompositeOp if Magick::Magick_lib_version >= 0x689
 
     img = Magick::Image.new(10, 10)
     assert_nothing_raised { @draw.composite(0, 0, 10, 10, img) }

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -341,7 +341,7 @@ class Image2_UT < Test::Unit::TestCase
       elsif method == 'difference'
         other = Magick::Image.new(20, 20)
         assert_raises(Magick::DestroyedImageError) { @img.difference(other) }
-      elsif method == 'channel_entropy' && Magick::Magick_lib_version < 0x690
+      elsif method == 'channel_entropy' && Magick::Magick_lib_version < Gem::Version.new('6.9')
         assert_raises(NotImplementedError) { @img.channel_entropy }
       elsif %w[morphology morphology_channel].include?(method)
         warn "skipped testing `#destroy` against `##{method}`"

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -341,7 +341,7 @@ class Image2_UT < Test::Unit::TestCase
       elsif method == 'difference'
         other = Magick::Image.new(20, 20)
         assert_raises(Magick::DestroyedImageError) { @img.difference(other) }
-      elsif method == 'channel_entropy' && IM_VERSION < Gem::Version.new('6.9')
+      elsif method == 'channel_entropy' && Magick::Magick_lib_version < 0x690
         assert_raises(NotImplementedError) { @img.channel_entropy }
       elsif %w[morphology morphology_channel].include?(method)
         warn "skipped testing `#destroy` against `##{method}`"

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -19,12 +19,6 @@ end
 
 require 'rmagick'
 
-Magick::Magick_version =~ /ImageMagick (\d+\.\d+\.\d+)-(\d+) /
-abort 'Unable to get ImageMagick version' unless Regexp.last_match(1) && Regexp.last_match(2)
-
-IM_VERSION = Gem::Version.new(Regexp.last_match(1))
-IM_REVISION = Gem::Version.new(Regexp.last_match(2))
-
 FreezeError = if RUBY_VERSION > '2.5'
                 FrozenError
               elsif RUBY_VERSION > '1.9'


### PR DESCRIPTION
This PR adds a new constant called `Magick::Magick_lib_version` that will return the library version of the ImageMagick library. This makes it possible to do version checking without a regex in the ruby code.