### PR TITLE
Fix a bug that `identify.rb` example doesn't work

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -425,6 +425,10 @@ Style/EvalWithLocation:
     - 'lib/rmagick_internal.rb'
     - 'lib/rvg/units.rb'
 
+Style/FormatString:
+  Exclude:
+    - 'examples/identify.rb'
+
 # Offense count: 158
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: annotated, template, unannotated

--- a/examples/identify.rb
+++ b/examples/identify.rb
@@ -36,54 +36,54 @@ module Magick
       case color_space
       when Magick::RGBColorspace
         puts "\t\tRed:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::RedChannel)[0] / scale, channel_extrema(Magick::RedChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::RedChannel)[1] / scale, channel_extrema(Magick::RedChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::RedChannel)[0] / scale, channel_mean(Magick::RedChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::RedChannel)[1] / scale, channel_mean(Magick::RedChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::RedChannel)[0] / scale, channel_extrema(Magick::RedChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::RedChannel)[1] / scale, channel_extrema(Magick::RedChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::RedChannel)[0] / scale, channel_mean(Magick::RedChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::RedChannel)[1] / scale, channel_mean(Magick::RedChannel)[1] / Magick::QuantumRange)
         puts "\t\tGreen:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::GreenChannel)[0] / scale, channel_extrema(Magick::GreenChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::GreenChannel)[1] / scale, channel_extrema(Magick::GreenChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::GreenChannel)[0] / scale, channel_mean(Magick::GreenChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::GreenChannel)[1] / scale, channel_mean(Magick::GreenChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::GreenChannel)[0] / scale, channel_extrema(Magick::GreenChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::GreenChannel)[1] / scale, channel_extrema(Magick::GreenChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::GreenChannel)[0] / scale, channel_mean(Magick::GreenChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::GreenChannel)[1] / scale, channel_mean(Magick::GreenChannel)[1] / Magick::QuantumRange)
         puts "\t\tBlue:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::BlueChannel)[0] / scale, channel_extrema(Magick::BlueChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::BlueChannel)[1] / scale, channel_extrema(Magick::BlueChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::BlueChannel)[0] / scale, channel_mean(Magick::BlueChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::BlueChannel)[1] / scale, channel_mean(Magick::BlueChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::BlueChannel)[0] / scale, channel_extrema(Magick::BlueChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::BlueChannel)[1] / scale, channel_extrema(Magick::BlueChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::BlueChannel)[0] / scale, channel_mean(Magick::BlueChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::BlueChannel)[1] / scale, channel_mean(Magick::BlueChannel)[1] / Magick::QuantumRange)
       when Magick::CMYKColorspace
         puts "\t\tCyan:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::CyanChannel)[0] / scale, channel_extrema(Magick::CyanChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::CyanChannel)[1] / scale, channel_extrema(Magick::CyanChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::CyanChannel)[0] / scale, channel_mean(Magick::CyanChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::CyanChannel)[1] / scale, channel_mean(Magick::CyanChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::CyanChannel)[0] / scale, channel_extrema(Magick::CyanChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::CyanChannel)[1] / scale, channel_extrema(Magick::CyanChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::CyanChannel)[0] / scale, channel_mean(Magick::CyanChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::CyanChannel)[1] / scale, channel_mean(Magick::CyanChannel)[1] / Magick::QuantumRange)
         puts "\t\tMagenta:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::MagentaChannel)[0] / scale, channel_extrema(Magick::MagentaChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::MagentaChannel)[1] / scale, channel_extrema(Magick::MagentaChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::MagentaChannel)[0] / scale, channel_mean(Magick::MagentaChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::MagentaChannel)[1] / scale, channel_mean(Magick::MagentaChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::MagentaChannel)[0] / scale, channel_extrema(Magick::MagentaChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::MagentaChannel)[1] / scale, channel_extrema(Magick::MagentaChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::MagentaChannel)[0] / scale, channel_mean(Magick::MagentaChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::MagentaChannel)[1] / scale, channel_mean(Magick::MagentaChannel)[1] / Magick::QuantumRange)
         puts "\t\tYellow:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::YellowChannel)[0] / scale, channel_extrema(Magick::YellowChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::YellowChannel)[1] / scale, channel_extrema(Magick::YellowChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::YellowChannel)[0] / scale, channel_mean(Magick::YellowChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::YellowChannel)[1] / scale, channel_mean(Magick::YellowChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::YellowChannel)[0] / scale, channel_extrema(Magick::YellowChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::YellowChannel)[1] / scale, channel_extrema(Magick::YellowChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::YellowChannel)[0] / scale, channel_mean(Magick::YellowChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::YellowChannel)[1] / scale, channel_mean(Magick::YellowChannel)[1] / Magick::QuantumRange)
         puts "\t\tBlack:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::BlackChannel)[0] / scale, channel_extrema(Magick::BlackChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::BlackChannel)[1] / scale, channel_extrema(Magick::BlackChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::BlackChannel)[0] / scale, channel_mean(Magick::BlackChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::BlackChannel)[1] / scale, channel_mean(Magick::BlackChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::BlackChannel)[0] / scale, channel_extrema(Magick::BlackChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::BlackChannel)[1] / scale, channel_extrema(Magick::BlackChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::BlackChannel)[0] / scale, channel_mean(Magick::BlackChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::BlackChannel)[1] / scale, channel_mean(Magick::BlackChannel)[1] / Magick::QuantumRange)
       when Magick::GRAYColorspace
         puts "\t\tGray:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::GrayChannel)[0] / scale, channel_extrema(Magick::GrayChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::GrayChannel)[1] / scale, channel_extrema(Magick::GrayChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::GrayChannel)[0] / scale, channel_mean(Magick::GrayChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::GrayChannel)[1] / scale, channel_mean(Magick::GrayChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::GrayChannel)[0] / scale, channel_extrema(Magick::GrayChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::GrayChannel)[1] / scale, channel_extrema(Magick::GrayChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean: " + sprintf("%g (%g)\n", channel_mean(Magick::GrayChannel)[0] / scale, channel_mean(Magick::GrayChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation: " + sprintf("%g (%g)\n", channel_mean(Magick::GrayChannel)[1] / scale, channel_mean(Magick::GrayChannel)[1] / Magick::QuantumRange)
       end
       if matte
         puts "\t\tOpacity:\n"
-        puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::OpacityChannel)[0] / scale, channel_extrema(Magick::OpacityChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::OpacityChannel)[1] / scale, channel_extrema(Magick::OpacityChannel)[1] / Magick::QuantumRange)
-        puts "\t\t\tMean:" + format("%u (%g)\n", channel_mean(Magick::OpacityChannel)[0] / scale, channel_mean(Magick::OpacityChannel)[0] / Magick::QuantumRange)
-        puts "\t\t\tStandard deviation:" + format("%u (%g)\n", channel_mean(Magick::OpacityChannel)[1] / scale, channel_mean(Magick::OpacityChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMin: " + sprintf("%u (%g)\n", channel_extrema(Magick::OpacityChannel)[0] / scale, channel_extrema(Magick::OpacityChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tMax: " + sprintf("%u (%g)\n", channel_extrema(Magick::OpacityChannel)[1] / scale, channel_extrema(Magick::OpacityChannel)[1] / Magick::QuantumRange)
+        puts "\t\t\tMean:" + sprintf("%u (%g)\n", channel_mean(Magick::OpacityChannel)[0] / scale, channel_mean(Magick::OpacityChannel)[0] / Magick::QuantumRange)
+        puts "\t\t\tStandard deviation:" + sprintf("%u (%g)\n", channel_mean(Magick::OpacityChannel)[1] / scale, channel_mean(Magick::OpacityChannel)[1] / Magick::QuantumRange)
       end
       if class_type == Magick::DirectClass
         puts "\tColors: #{total_colors}\n"
@@ -101,20 +101,20 @@ module Magick
       chrom = chromaticity
       if chrom.red_primary.x != 0.0 || chrom.green_primary.x != 0.0 || chrom.blue_primary.x != 0.0 || chrom.white_point.x != 0.0
         puts "\tChromaticity:\n"
-        puts "\t\tred primary: (#{format('%g,%g', chrom.red_primary.x, chrom.red_primary.y)})\n"
-        puts "\t\tgreen primary: (#{format('%g,%g', chrom.green_primary.x, chrom.green_primary.y)})\n"
-        puts "\t\tblue primary: (#{format('%g,%g', chrom.blue_primary.x, chrom.blue_primary.y)})\n"
-        puts "\t\twhite point: (#{format('%g,%g', chrom.white_point.x, chrom.white_point.y)})\n"
+        puts "\t\tred primary: (#{sprintf('%g,%g', chrom.red_primary.x, chrom.red_primary.y)})\n"
+        puts "\t\tgreen primary: (#{sprintf('%g,%g', chrom.green_primary.x, chrom.green_primary.y)})\n"
+        puts "\t\tblue primary: (#{sprintf('%g,%g', chrom.blue_primary.x, chrom.blue_primary.y)})\n"
+        puts "\t\twhite point: (#{sprintf('%g,%g', chrom.white_point.x, chrom.white_point.y)})\n"
       end
       ex_info = extract_info
       puts "\tTile geometry: #{ex_info.width}x#{ex_info.height}+#{ex_info.x}+#{ex_info.y}\n" if ex_info.width * ex_info.height != 0.0
-      puts "\tResolution: #{format('%gx%g', x_resolution, y_resolution)}\n" if x_resolution != 0.0 && y_resolution != 0.0
+      puts "\tResolution: #{sprintf('%gx%g', x_resolution, y_resolution)}\n" if x_resolution != 0.0 && y_resolution != 0.0
       puts "\tUnits: #{units}\n"
       size = filesize
       if size >= 1_048_576
-        puts "\tFilesize: #{format('%.1f', (size / 1_048_576.0))}mb\n"
+        puts "\tFilesize: #{sprintf('%.1f', (size / 1_048_576.0))}mb\n"
       elsif size >= 1024
-        puts "\tFilesize: #{format('%.0f', (size / 1024.0))}kb\n"
+        puts "\tFilesize: #{sprintf('%.0f', (size / 1024.0))}kb\n"
       else
         puts "\tFilesize: #{size}b\n"
       end

--- a/examples/identify.rb
+++ b/examples/identify.rb
@@ -14,7 +14,7 @@ module Magick
       puts "\tEndianess: #{endian}\n"
       puts "\tColorspace: #{colorspace}\n"
       puts "\tChannelDepth:\n"
-      color_space = gray? ? Magick::GrayColorspace : colorspace
+      color_space = gray? ? Magick::GRAYColorspace : colorspace
       case color_space
       when Magick::RGBColorspace
         puts "\t\tRed: #{channel_depth(Magick::RedChannel)}-bits\n"
@@ -27,7 +27,7 @@ module Magick
         puts "\t\tYellow: #{channel_depth(Magick::YellowChannel)}-bits\n"
         puts "\t\tBlack: #{channel_depth(Magick::BlackChannel)}-bits\n"
         puts "\t\tOpacity: #{channel_depth(Magick::OpacityChannel)}-bits\n" if matte
-      when Magick::GrayColorspace
+      when Magick::GRAYColorspace
         puts "\t\tGray: #{channel_depth(Magick::GrayChannel)}-bits\n"
         puts "\t\tOpacity: #{channel_depth(Magick::OpacityChannel)}-bits\n" if matte
       end
@@ -71,7 +71,7 @@ module Magick
         puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::BlackChannel)[1] / scale, channel_extrema(Magick::BlackChannel)[1] / Magick::QuantumRange)
         puts "\t\t\tMean: " + format("%g (%g)\n", channel_mean(Magick::BlackChannel)[0] / scale, channel_mean(Magick::BlackChannel)[0] / Magick::QuantumRange)
         puts "\t\t\tStandard deviation: " + format("%g (%g)\n", channel_mean(Magick::BlackChannel)[1] / scale, channel_mean(Magick::BlackChannel)[1] / Magick::QuantumRange)
-      when Magick::GrayColorspace
+      when Magick::GRAYColorspace
         puts "\t\tGray:\n"
         puts "\t\t\tMin: " + format("%u (%g)\n", channel_extrema(Magick::GrayChannel)[0] / scale, channel_extrema(Magick::GrayChannel)[0] / Magick::QuantumRange)
         puts "\t\t\tMax: " + format("%u (%g)\n", channel_extrema(Magick::GrayChannel)[1] / scale, channel_extrema(Magick::GrayChannel)[1] / Magick::QuantumRange)


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/573

This PR will change following things.

1. Use valid constant. (GrayColorspace -> GRAYColorspace)

2. Use Kernel.sprintf instead of Kernel.format. 
Because this example adds method in `Magick::Image` using monkey patch.
However,  `Magick::Image` already `format` method as property and this example calls `Magick::Image#format`, after then raises ArugmentError exception.