### PR TITLE
Fix a bug in Image#reduce_noise which might cause SEGV

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10970,11 +10970,12 @@ Image_reduce_noise(VALUE self, VALUE radius)
 {
     Image *image, *new_image;
     ExceptionInfo *exception;
+    size_t radius_size = NUM2SIZET(radius);
 
     image = rm_check_destroyed(self);
 
     exception = AcquireExceptionInfo();
-    new_image = StatisticImage(image, NonpeakStatistic, (size_t)radius, (size_t)radius, exception);
+    new_image = StatisticImage(image, NonpeakStatistic, radius_size, radius_size, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 
     (void) DestroyExceptionInfo(exception);


### PR DESCRIPTION
Fix #572

The method has passed Ruby object into ImageMagick API directly.
The Ruby object might has huge address for ImageMagick API.
So, ImageMagick API will raise following exception.

```
Caught exception: width or height exceeds limit `../doc/ex/images/model.miff[0]' @ error/cache.c/SetPixelCacheNexusPixels/5171
```

This patch will pass expected value into ImageMagick API.