### PR TITLE
Save image for non-X11 environment instead of display in `examples/vignette.rb`

### DIFF
--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -74,5 +74,5 @@ end
 
 checkerboard = Image.read('pattern:checkerboard') { self.size = "#{ballerina.columns}x#{ballerina.rows}" }
 vignette = checkerboard[0].composite(ballerina, CenterGravity, OverCompositeOp)
-vignette.display
+vignette.write('vignette.png')
 exit


### PR DESCRIPTION
Fix #574