### PR TITLE
Deprecated the blur property of the Image class.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1702,8 +1702,50 @@ Image_blue_shift(int argc, VALUE *argv, VALUE self)
 }
 
 
+/**
+ * Get the blur attribute.
+ *
+ * Ruby usage:
+ *   - @verbatim Image#blur @endverbatim
+ *
+ * @param self this object
+ * @return the blur
+ * @deprecated This method has been deprecated.
+ */
+VALUE
+Image_blur(VALUE self)
+{
+    Image *image;
 
-DEF_ATTR_ACCESSOR(Image, blur, dbl)
+    rb_warning("Image#blur is deprecated");
+    (void) rm_check_destroyed(self);
+    Data_Get_Struct(self, Image, image);
+    return C_dbl_to_R_dbl(image->blur);
+}
+
+
+/**
+ * Set the blur attribute.
+ *
+ * Ruby usage:
+ *   - @verbatim Image#blur= @endverbatim
+ *
+ * @param self this object
+ * @param value the blur
+ * @return self
+ * @deprecated This method has been deprecated.
+ */
+VALUE
+Image_blur_eq(VALUE self, VALUE value)
+{
+    Image *image;
+
+    rb_warning("Image#blur= is deprecated");
+    (void) rm_check_destroyed(self);
+    rb_check_frozen(self);
+    Data_Get_Struct(self, Image, image);
+    image->blur = R_dbl_to_C_dbl(value);
+}
 
 
 /**


### PR DESCRIPTION
This PR deprecates the blur property of the Image class. This is no longer available in ImageMagick 7 and most likely not used by users of this library.