### PR TITLE
Deprecated the gamma_correct method of the Image class.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -6926,6 +6926,7 @@ Image_gamma_channel(int argc, VALUE *argv, VALUE self)
  * @param argv array of input arguments
  * @param self this object
  * @return a new image
+ * @deprecated This method has been deprecated. Please use Image#gamma_channel.
  */
 VALUE
 Image_gamma_correct(int argc, VALUE *argv, VALUE self)
@@ -6933,6 +6934,8 @@ Image_gamma_correct(int argc, VALUE *argv, VALUE self)
     Image *image, *new_image;
     double red_gamma, green_gamma, blue_gamma;
     char gamma_arg[50];
+
+    rb_warning("Image#gamma_correct is deprecated; use Image#gamma_channel");
 
     image = rm_check_destroyed(self);
     switch (argc)


### PR DESCRIPTION
This PR deprecates the gamma_correct method of the Image class. ImageMagick 7 has no support for this and with `gamma_channel` that is still supported the same result can be accomplished.