### PR TITLE
Save PNG format instead of ImageMagick miff format in example codes

### DIFF
--- a/examples/constitute.rb
+++ b/examples/constitute.rb
@@ -4,4 +4,4 @@ require 'rmagick'
 f = Magick::Image.read('../doc/ex/images/Flower_Hat.jpg').first
 pixels = f.dispatch(0, 0, f.columns, f.rows, 'RGB')
 image = Magick::Image.constitute(f.columns, f.rows, 'RGB', pixels)
-image.write('constitute.miff')
+image.write('constitute.png')

--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -38,5 +38,5 @@ montage = pairs.montage do
   self.tile = '6x3'
   self.border_width = 1
 end
-montage.write('crop_with_gravity.miff')
+montage.write('crop_with_gravity.png')
 # montage.display

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -310,8 +310,8 @@ begin
   # Write the result to a file
   montage_image.compression = RLECompression
   montage_image.matte = false
-  puts 'Writing image ./rm_demo_out.miff'
-  montage_image.write 'rm_demo_out.miff'
+  puts 'Writing image ./rm_demo_out.png'
+  montage_image.write 'rm_demo_out.png'
 
 # Uncomment the following lines to display image to screen
 # puts "Displaying image..."

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -291,7 +291,7 @@ image = image.first
 # Give the user something to look at while we're working.
 name = File.basename(filename).sub(/\..*?$/, '')
 $stdout.sync = true
-printf "Creating #{name}_Histogram.miff"
+printf "Creating #{name}_Histogram.png"
 
 timer = Thread.new do
   loop do
@@ -305,7 +305,7 @@ histogram = image.histogram(Magick::Pixel.from_color('white'), Magick::Pixel.fro
 
 # Write output file
 histogram.compression = Magick::ZipCompression
-histogram.write("./#{name}_Histogram.miff")
+histogram.write("./#{name}_Histogram.png")
 
 Thread.kill(timer)
 puts 'Done!'

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -23,6 +23,6 @@ end
 
 result = balloons.composite(legend, SouthGravity, OverCompositeOp)
 
-puts '...Writing image_opacity.miff'
-result.write 'image_opacity.miff'
+puts '...Writing image_opacity.png'
+result.write 'image_opacity.png'
 exit


### PR DESCRIPTION
It is easy to handle when saved in the general PNG format.