### PR TITLE
Use Image#alpha? instead of Image#matte in internal library

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -904,7 +904,7 @@ module Magick
     # Make the pixel at (x,y) transparent.
     def matte_point(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.matte
+      f.opacity = OpaqueOpacity unless f.alpha?
       pixel = f.pixel_color(x, y)
       pixel.opacity = TransparentOpacity
       f.pixel_color(x, y, pixel)
@@ -915,7 +915,7 @@ module Magick
     # pixel at (x, y).
     def matte_replace(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.matte
+      f.opacity = OpaqueOpacity unless f.alpha?
       target = f.pixel_color(x, y)
       f.transparent(target)
     end
@@ -924,7 +924,7 @@ module Magick
     # at (x,y) and is a neighbor.
     def matte_floodfill(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.matte
+      f.opacity = OpaqueOpacity unless f.alpha?
       target = f.pixel_color(x, y)
       f.matte_flood_fill(target, TransparentOpacity,
                          x, y, FloodfillMethod)
@@ -933,7 +933,7 @@ module Magick
     # Make transparent any neighbor pixel that is not the border color.
     def matte_fill_to_border(x, y)
       f = copy
-      f.opacity = Magick::OpaqueOpacity unless f.matte
+      f.opacity = Magick::OpaqueOpacity unless f.alpha?
       f.matte_flood_fill(border_color, TransparentOpacity,
                          x, y, FillToBorderMethod)
     end


### PR DESCRIPTION
Image#matte was marked as deprecate at https://github.com/rmagick/rmagick/commit/c00a81d377b31e0c2daf6bf80450663afd5e2dd6

This patch will get rid of following warning message.
```
$ ruby doc/ex/affine_transform.rb
/Users/watson/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/rmagick-3.1.0/lib/rmagick_internal.rb:918: warning: Image#matte is deprecated; use Image#alpha.
```