### PR TITLE
Attribute writer method should return self

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1745,6 +1745,7 @@ Image_blur_eq(VALUE self, VALUE value)
     rb_check_frozen(self);
     Data_Get_Struct(self, Image, image);
     image->blur = R_dbl_to_C_dbl(value);
+    return self;
 }
 
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1641,6 +1641,7 @@ Info_group_eq(VALUE self, VALUE value)
     rb_check_frozen(self);
     Data_Get_Struct(self, Info, info);
     info->group = R_long_to_C_long(value);
+    return self;
 }
 
 


### PR DESCRIPTION
Related to #578 and #579.

Attribute writer method should return self.

https://github.com/rmagick/rmagick/blob/f8215532d56487fe4229bccbdc3e77518fffaf60/ext/RMagick/rmagick.h#L423-L434

This patch will get rid of following warning message.

```
$ make
…

rmimage.c:1748:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
1 warning generated.
compiling rminfo.c
rminfo.c:1644:1: warning: control may reach end of non-void function [-Wreturn-type]
}
```