### PR TITLE
Added combine to the ImageList class.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -573,6 +573,7 @@ extern VALUE ImageList_animate(int, VALUE *, VALUE);
 extern VALUE ImageList_append(VALUE, VALUE);
 extern VALUE ImageList_average(VALUE);
 extern VALUE ImageList_coalesce(VALUE);
+extern VALUE ImageList_combine(int, VALUE *, VALUE);
 extern VALUE ImageList_composite_layers(int, VALUE *, VALUE);
 extern VALUE ImageList_deconstruct(VALUE);
 extern VALUE ImageList_display(VALUE);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -527,6 +527,7 @@ Init_RMagick2(void)
     rb_define_method(Class_ImageList, "append", ImageList_append, 1);
     rb_define_method(Class_ImageList, "average", ImageList_average, 0);
     rb_define_method(Class_ImageList, "coalesce", ImageList_coalesce, 0);
+    rb_define_method(Class_ImageList, "combine", ImageList_combine, -1);
     rb_define_method(Class_ImageList, "composite_layers", ImageList_composite_layers, -1);
     rb_define_method(Class_ImageList, "deconstruct", ImageList_deconstruct, 0);
     rb_define_method(Class_ImageList, "display", ImageList_display, 0);

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -15,6 +15,49 @@ class ImageList1UT < Test::Unit::TestCase
     @list2 << @list[9]
   end
 
+  def test_combine
+    red   = Magick::Image.new(20, 20) { self.background_color = 'red' }
+    green = Magick::Image.new(20, 20) { self.background_color = 'green' }
+    blue  = Magick::Image.new(20, 20) { self.background_color = 'blue' }
+    black = Magick::Image.new(20, 20) { self.background_color = 'black' }
+    alpha = Magick::Image.new(20, 20) { self.background_color = 'transparent' }
+
+    list = Magick::ImageList.new
+    assert_raise(ArgumentError) { list.combine }
+
+    list << red
+    assert_nothing_raised { list.combine }
+
+    res = list.combine
+    assert_instance_of(Magick::Image, res)
+
+    list << alpha
+    assert_nothing_raised { list.combine }
+
+    list.pop
+    list << green
+    list << blue
+    assert_nothing_raised { list.combine }
+
+    list << alpha
+    assert_nothing_raised { list.combine }
+
+    list.pop
+    list << black
+    assert_nothing_raised { list.combine(Magick::CMYKColorspace) }
+    assert_nothing_raised { list.combine(Magick::SRGBColorspace) }
+
+    list << alpha
+    assert_nothing_raised { list.combine(Magick::CMYKColorspace) }
+    assert_raise(ArgumentError) { list.combine(Magick::SRGBColorspace) }
+
+    list << alpha
+    assert_raise(ArgumentError) { Magick::Image.combine }
+
+    assert_raise(TypeError) { list.combine(nil) }
+    assert_raise(ArgumentError) { list.combine(Magick::SRGBColorspace, 1) }
+  end
+
   def test_composite_layers
     assert_nothing_raised { @list.composite_layers(@list2) }
     Magick::CompositeOperator.values do |op|


### PR DESCRIPTION
This PR adds the `combine` method to the `ImageList` class. This method is a replacement for the static `combine` method in the `Image` class. This is done because ImageMagick 7 needs a colorspace instead of channels. And with this new signature it is also still compatible with ImageMagick 6.

Making `combine` deprecated in the `Image` class should be a new PR after this one has been merged.