### PR TITLE
Deprecated the combine method of the Image class.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3090,12 +3090,15 @@ DEF_ATTR_READER(Image, columns, int)
  * @param argv array of input arguments
  * @param self this object
  * @return a new image
+ * @deprecated This method has been deprecated. Please use ImageList_combine.
  */
 VALUE Image_combine(int argc, VALUE *argv, VALUE self ATTRIBUTE_UNUSED)
 {
     ChannelType channel = 0;
     Image *image, *images = NULL, *new_image;
     ExceptionInfo *exception;
+
+    rb_warning("Image#combine is deprecated; use ImageList#combine.");
 
     switch (argc)
     {


### PR DESCRIPTION
This PR deprecates the `combine` method of the `Image` class. This has been replaced with the new `combine` method in the `ImageList` class (#589).