### PR TITLE
Add CompositeOperator_find that can be used to find the ruby value of  a CompositeOperator value.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1039,6 +1039,7 @@ extern VALUE  ClassType_new(ClassType);
 extern VALUE  ColorspaceType_new(ColorspaceType);
 extern const char *ComplianceType_name(ComplianceType *);
 extern VALUE  ComplianceType_new(ComplianceType);
+extern VALUE  CompositeOperator_find(CompositeOperator);
 extern VALUE  CompressionType_new(CompressionType);
 extern VALUE  DisposeType_new(DisposeType);
 extern VALUE  EndianType_new(EndianType);

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -543,6 +543,20 @@ ComplianceType_new(ComplianceType compliance)
 }
 
 
+/**
+ * Returns a CompositeOperator enum object for the specified value.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param op the CompositeOperator
+ * @return a new CompositeOperator enumerator
+ */
+VALUE
+CompositeOperator_find(CompositeOperator op)
+{
+    return Enum_find(Class_CompositeOperator, op);
+}
+
 
 /**
  * Return the name of a CompressionType enum as a string.

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3251,7 +3251,7 @@ VALUE
 Image_compose(VALUE self)
 {
     Image *image = rm_check_destroyed(self);
-    return Enum_find(Class_CompositeOperator, image->compose);
+    return CompositeOperator_find(image->compose);
 }
 
 
@@ -3662,7 +3662,7 @@ Image_composite_mathematics(int argc, VALUE *argv, VALUE self)
     args[1] = GravityType_new(gravity);
     args[2] = LONG2FIX(x_off);
     args[3] = LONG2FIX(y_off);
-    args[4] = Enum_find(Class_CompositeOperator, MathematicsCompositeOp);
+    args[4] = CompositeOperator_find(MathematicsCompositeOp);
 
     return composite(False, 5, args, self, DefaultChannels);
 }


### PR DESCRIPTION
This PR reintroduces an alternative for the `CompositeOperator_new` method that was removed in #587. This new method is called `CompositeOperator_find`. With this method we get type safety that we don't get with Enum_find and we only have `Enum_find(Class_CompositeOperator,` at one spot.