### PR TITLE
Find the value of the virtual pixel enumeration instead of creating one.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1057,7 +1057,7 @@ extern VALUE  StretchType_new(StretchType);
 extern const char *StretchType_name(StretchType);
 extern VALUE  StyleType_new(StyleType);
 extern const char *StyleType_name(StyleType);
-extern VALUE  VirtualPixelMethod_new(VirtualPixelMethod);
+extern VALUE  VirtualPixelMethod_find(VirtualPixelMethod);
 
 
 // rmstruct.c

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -1219,43 +1219,7 @@ StyleType_new(StyleType style)
 
 
 /**
- * Return the string representation of a VirtualPixelMethod value.
- *
- * No Ruby usage (internal function)
- *
- * @param method the VirtualPixelMethod
- * @return the name
- */
-static const char *
-VirtualPixelMethod_name(VirtualPixelMethod method)
-{
-    switch (method)
-    {
-        ENUM_TO_NAME(EdgeVirtualPixelMethod)
-        ENUM_TO_NAME(MirrorVirtualPixelMethod)
-        ENUM_TO_NAME(TileVirtualPixelMethod)
-        ENUM_TO_NAME(TransparentVirtualPixelMethod)
-        ENUM_TO_NAME(BackgroundVirtualPixelMethod)
-        ENUM_TO_NAME(DitherVirtualPixelMethod)
-        ENUM_TO_NAME(RandomVirtualPixelMethod)
-        ENUM_TO_NAME(ConstantVirtualPixelMethod)
-        ENUM_TO_NAME(MaskVirtualPixelMethod)
-        ENUM_TO_NAME(BlackVirtualPixelMethod)
-        ENUM_TO_NAME(GrayVirtualPixelMethod)
-        ENUM_TO_NAME(WhiteVirtualPixelMethod)
-        ENUM_TO_NAME(HorizontalTileVirtualPixelMethod)
-        ENUM_TO_NAME(VerticalTileVirtualPixelMethod)
-        ENUM_TO_NAME(HorizontalTileEdgeVirtualPixelMethod)
-        ENUM_TO_NAME(VerticalTileEdgeVirtualPixelMethod)
-        ENUM_TO_NAME(CheckerTileVirtualPixelMethod)
-        default:
-        ENUM_TO_NAME(UndefinedVirtualPixelMethod)
-    }
-}
-
-
-/**
- * Construct a VirtualPixelMethod enum for a specified VirtualPixelMethod value.
+ * Returns a VirtualPixelMethod enum for a specified VirtualPixelMethod value.
  *
  * No Ruby usage (internal function)
  *
@@ -1263,8 +1227,7 @@ VirtualPixelMethod_name(VirtualPixelMethod method)
  * @return a new VirtualPixelMethod enumerator
  */
 VALUE
-VirtualPixelMethod_new(VirtualPixelMethod style)
+VirtualPixelMethod_find(VirtualPixelMethod style)
 {
-    const char *name = VirtualPixelMethod_name(style);
-    return rm_enum_new(Class_VirtualPixelMethod, ID2SYM(rb_intern(name)), INT2FIX(style));
+    return Enum_find(Class_VirtualPixelMethod, style);
 }

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -14534,7 +14534,7 @@ Image_virtual_pixel_method(VALUE self)
     image = rm_check_destroyed(self);
     vpm = GetImageVirtualPixelMethod(image);
     rm_check_image_exception(image, RetainOnError);
-    return VirtualPixelMethod_new(vpm);
+    return VirtualPixelMethod_find(vpm);
 }
 
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -81,4 +81,12 @@ class EnumUT < Test::Unit::TestCase
       assert_equal(op, img.compose)
     end
   end
+
+  def test_issue593_virtual_pixel_method
+    img = Magick::Image.new(1, 1)
+    Magick::VirtualPixelMethod.values do |value|
+      img.virtual_pixel_method = value
+      assert_equal(value, img.virtual_pixel_method)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the issue that was reported in #593 for the virtual pixel enumeration.