### PR TITLE
Find the value of the class type enumeration instead of creating one.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1035,7 +1035,7 @@ extern VALUE  Enum_type_initialize(VALUE, VALUE, VALUE);
 extern VALUE  Enum_find(VALUE class, int val);
 extern VALUE  Enum_type_each(VALUE);
 extern VALUE  rm_enum_new(VALUE, VALUE, VALUE);
-extern VALUE  ClassType_new(ClassType);
+extern VALUE  ClassType_find(ClassType);
 extern VALUE  ColorspaceType_new(ColorspaceType);
 extern const char *ComplianceType_name(ComplianceType *);
 extern VALUE  ComplianceType_new(ComplianceType);

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -394,8 +394,9 @@ Enum_find(VALUE class, int val)
     return Qnil;
 }
 
+
 /**
- * Construct a ClassType enum object for the specified value.
+ * Returns a ClassType enum object for the specified value.
  *
  * No Ruby usage (internal function)
  *
@@ -403,19 +404,9 @@ Enum_find(VALUE class, int val)
  * @return a new enumerator
  */
 VALUE
-ClassType_new(ClassType cls)
+ClassType_find(ClassType cls)
 {
-    const char *name;
-
-    switch(cls)
-    {
-        ENUM_SET_NAME(DirectClass)
-        ENUM_SET_NAME(PseudoClass)
-        default:
-        ENUM_SET_NAME(UndefinedClass)
-    }
-
-    return rm_enum_new(Class_ClassType, ID2SYM(rb_intern(name)), INT2FIX(cls));
+    return Enum_find(Class_ClassType, cls);
 }
 
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12944,7 +12944,7 @@ VALUE
 Image_class_type(VALUE self)
 {
     Image *image = rm_check_destroyed(self);
-    return ClassType_new(image->storage_class);
+    return ClassType_find(image->storage_class);
 }
 
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -82,6 +82,16 @@ class EnumUT < Test::Unit::TestCase
     end
   end
 
+  def test_issue593_classtype
+    img = Magick::Image.new(1, 1)
+    Magick::ClassType.values do |value|
+      next if value == Magick::UndefinedClass
+
+      img.class_type = value
+      assert_equal(value, img.class_type)
+    end
+  end
+
   def test_issue593_virtual_pixel_method
     img = Magick::Image.new(1, 1)
     Magick::VirtualPixelMethod.values do |value|


### PR DESCRIPTION
This PR fixes the issue that was reported in #593 for the class type enumeration.