### PR TITLE
Require 'simplecov' before 'test/unit' to retrives valid result

### DIFF
--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -7,12 +7,12 @@ FILES = Dir[IMAGES_DIR + '/Button_*.gif'].sort
 FLOWER_HAT = IMAGES_DIR + '/Flower_Hat.jpg'
 IMAGE_WITH_PROFILE = IMAGES_DIR + '/image_with_profile.jpg'
 
+require 'simplecov'
 require 'test/unit'
 if RUBY_VERSION < '1.9'
   require 'test/unit/ui/console/testrunner'
   $LOAD_PATH.push(root_dir)
 else
-  require 'simplecov'
   $LOAD_PATH.unshift(File.join(root_dir, 'lib'))
   $LOAD_PATH.unshift(File.join(root_dir, 'test'))
 end


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/issues/588

Seems simplecov generate wrong report if it was required after 'test/unit’.

* Before
simplecov reports 33.0% covered in rmagick_internal.rb
<img width="960" alt="coverage" src="https://user-images.githubusercontent.com/199156/56863155-e87a3700-69ed-11e9-8d6e-14c615c9fbde.png">

* After
simplecov reports 74.8% covered in rmagick_internal.rb
<img width="960" alt="coverage" src="https://user-images.githubusercontent.com/199156/56867729-b8e62180-6a23-11e9-861d-5352c18f8df5.png">
