### PR TITLE
Renamed AlphaChannelType to AlphaChannelOption

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -117,6 +117,7 @@ typedef ImageInfo Info; /**< Make type name match class name */
 typedef PixelPacket Pixel; /**< Make type name match class name */
 typedef MagickPixelPacket MagickPixel;
 typedef PixelPacket PixelColor;
+typedef AlphaChannelType AlphaChannelOption;
 
 //! Montage
 typedef struct
@@ -286,7 +287,7 @@ EXTERN VALUE Class_QuantumExpressionOperator;
 // Enum classes
 EXTERN VALUE Class_Enum;
 EXTERN VALUE Class_AlignType;
-EXTERN VALUE Class_AlphaChannelType;
+EXTERN VALUE Class_AlphaChannelOption;
 EXTERN VALUE Class_AnchorType;
 EXTERN VALUE Class_ChannelType;
 EXTERN VALUE Class_ClassType;

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -573,7 +573,7 @@ VALUE
 Image_alpha(int argc, VALUE *argv, VALUE self)
 {
     Image *image;
-    AlphaChannelType alpha;
+    AlphaChannelOption alpha;
 
 
     // For backward compatibility, make alpha() act like alpha?
@@ -588,7 +588,7 @@ Image_alpha(int argc, VALUE *argv, VALUE self)
 
 
     image = rm_check_frozen(self);
-    VALUE_TO_ENUM(argv[0], alpha, AlphaChannelType);
+    VALUE_TO_ENUM(argv[0], alpha, AlphaChannelOption);
 
     (void) SetImageAlphaChannel(image, alpha);
     rm_check_image_exception(image, RetainOnError);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -45,7 +45,9 @@ static void features_constant(void);
    rb_define_const(Module_Magick, #name, _enum);
 
 //! define alias for ImageMagick 6
-#define ENUM_ALIAS(name) rb_define_const(Module_Magick, #name, _cls);
+#define ENUM_DEPRECATED_ALIAS(name)\
+    rb_define_const(Module_Magick, #name, _cls); \
+    rb_funcall(Module_Magick, rb_intern("deprecate_constant"), 1, ID2SYM(rb_intern(#name)));
 
 //! end of an enumerator
 #define END_ENUM }
@@ -914,7 +916,7 @@ Init_RMagick2(void)
         ENUMERATOR(AssociateAlphaChannel)
         ENUMERATOR(DisassociateAlphaChannel)
 #endif
-        ENUM_ALIAS(AlphaChannelType)
+        ENUM_DEPRECATED_ALIAS(AlphaChannelType)
     END_ENUM
 
     // AnchorType constants (for Draw#text_anchor - these are not defined by ImageMagick)

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -44,11 +44,6 @@ static void features_constant(void);
    _enum = rm_enum_new(_cls, ID2SYM(rb_intern(#name)), INT2NUM(val));\
    rb_define_const(Module_Magick, #name, _enum);
 
-//! define alias for ImageMagick 6
-#define ENUM_DEPRECATED_ALIAS(name)\
-    rb_define_const(Module_Magick, #name, _cls); \
-    rb_funcall(Module_Magick, rb_intern("deprecate_constant"), 1, ID2SYM(rb_intern(#name)));
-
 //! end of an enumerator
 #define END_ENUM }
 
@@ -916,7 +911,6 @@ Init_RMagick2(void)
         ENUMERATOR(AssociateAlphaChannel)
         ENUMERATOR(DisassociateAlphaChannel)
 #endif
-        ENUM_DEPRECATED_ALIAS(AlphaChannelType)
     END_ENUM
 
     // AnchorType constants (for Draw#text_anchor - these are not defined by ImageMagick)

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -44,6 +44,9 @@ static void features_constant(void);
    _enum = rm_enum_new(_cls, ID2SYM(rb_intern(#name)), INT2NUM(val));\
    rb_define_const(Module_Magick, #name, _enum);
 
+//! define alias for ImageMagick 6
+#define ENUM_ALIAS(name) rb_define_const(Module_Magick, #name, _cls);
+
 //! end of an enumerator
 #define END_ENUM }
 
@@ -892,8 +895,8 @@ Init_RMagick2(void)
         ENUMERATOR(RightAlign)
     END_ENUM
 
-    // AlphaChannelType constants
-    DEF_ENUM(AlphaChannelType)
+    // AlphaChannelOption constants
+    DEF_ENUM(AlphaChannelOption)
         ENUMERATOR(UndefinedAlphaChannel)
         ENUMERATOR(ActivateAlphaChannel)
         ENUMERATOR(DeactivateAlphaChannel)
@@ -911,6 +914,7 @@ Init_RMagick2(void)
         ENUMERATOR(AssociateAlphaChannel)
         ENUMERATOR(DisassociateAlphaChannel)
 #endif
+        ENUM_ALIAS(AlphaChannelType)
     END_ENUM
 
     // AnchorType constants (for Draw#text_anchor - these are not defined by ImageMagick)

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -1,0 +1,4 @@
+module Magick
+  AlphaChannelType = AlphaChannelOption
+  deprecate_constant 'AlphaChannelType'
+end

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -20,6 +20,7 @@ end
 
 require 'English'
 require 'RMagick2.so'
+require 'obsolete.rb'
 
 module Magick
   @formats = nil


### PR DESCRIPTION
Renamed AlphaChannelType to AlphaChannelOption to prepare for ImageMagick 7 and added alias for backwards compatibility. 

I tried to put in a warning so we could deprecate it and remove it when a major bump is done but I could not figure out how to do that. I tried to use `rb_define_module_function` and do a warning in the method and return `rb_const_get(Module_Magick, rb_intern("AlphaChannelOption"))` but that does not work. It looks like only lowercase names can be used. Maybe you have some idea how to do this @Watson1978 and maybe you know how to do this in Ruby @mockdeep?