### PR TITLE
Return value instead of self in attribute writers.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -430,7 +430,7 @@ EXTERN ID rm_ID_y;                 /**< "y" */
         rb_check_frozen(self);\
         Data_Get_Struct(self, class, ptr);\
         ptr->attr = R_##type##_to_C_##type(val);\
-        return self;\
+        return val;\
     }
 
 //! define attribute accessor

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -40,7 +40,7 @@ Draw_affine_eq(VALUE self, VALUE matrix)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Export_AffineMatrix(&draw->info->affine, matrix);
-    return self;
+    return matrix;
 }
 
 
@@ -62,7 +62,7 @@ Draw_align_eq(VALUE self, VALUE align)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     VALUE_TO_ENUM(align, draw->info->align, AlignType);
-    return self;
+    return align;
 }
 
 
@@ -84,7 +84,7 @@ Draw_decorate_eq(VALUE self, VALUE decorate)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     VALUE_TO_ENUM(decorate, draw->info->decorate, DecorationType);
-    return self;
+    return decorate;
 }
 
 
@@ -107,7 +107,7 @@ Draw_density_eq(VALUE self, VALUE density)
     Data_Get_Struct(self, Draw, draw);
     magick_clone_string(&draw->info->density, StringValuePtr(density));
 
-    return self;
+    return density;
 }
 
 
@@ -130,7 +130,7 @@ Draw_encoding_eq(VALUE self, VALUE encoding)
     Data_Get_Struct(self, Draw, draw);
     magick_clone_string(&draw->info->encoding, StringValuePtr(encoding));
 
-    return self;
+    return encoding;
 }
 
 
@@ -152,7 +152,7 @@ Draw_fill_eq(VALUE self, VALUE fill)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Color_to_PixelColor(&draw->info->fill, fill);
-    return self;
+    return fill;
 }
 
 
@@ -192,7 +192,7 @@ Draw_fill_pattern_eq(VALUE self, VALUE pattern)
         draw->info->fill_pattern = rm_clone_image(image);
     }
 
-    return self;
+    return pattern;
 }
 
 
@@ -215,7 +215,7 @@ Draw_font_eq(VALUE self, VALUE font)
     Data_Get_Struct(self, Draw, draw);
     magick_clone_string(&draw->info->font, StringValuePtr(font));
 
-    return self;
+    return font;
 }
 
 
@@ -238,7 +238,7 @@ Draw_font_family_eq(VALUE self, VALUE family)
     Data_Get_Struct(self, Draw, draw);
     magick_clone_string(&draw->info->family, StringValuePtr(family));
 
-    return self;
+    return family;
 }
 
 
@@ -260,7 +260,7 @@ Draw_font_stretch_eq(VALUE self, VALUE stretch)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     VALUE_TO_ENUM(stretch, draw->info->stretch, StretchType);
-    return self;
+    return stretch;
 }
 
 
@@ -282,7 +282,7 @@ Draw_font_style_eq(VALUE self, VALUE style)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     VALUE_TO_ENUM(style, draw->info->style, StyleType);
-    return self;
+    return style;
 }
 
 
@@ -346,7 +346,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
         }
     }
 
-    return self;
+    return weight;
 }
 
 
@@ -382,7 +382,7 @@ Draw_gravity_eq(VALUE self, VALUE grav)
     Data_Get_Struct(self, Draw, draw);
     VALUE_TO_ENUM(grav, draw->info->gravity, GravityType);
 
-    return self;
+    return grav;
 }
 
 
@@ -407,7 +407,7 @@ Draw_kerning_eq(VALUE self, VALUE kerning)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->kerning = NUM2DBL(kerning);
-    return self;
+    return kerning;
 }
 
 
@@ -432,7 +432,7 @@ Draw_interline_spacing_eq(VALUE self, VALUE spacing)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->interline_spacing = NUM2DBL(spacing);
-    return self;
+    return spacing;
 }
 
 
@@ -457,7 +457,7 @@ Draw_interword_spacing_eq(VALUE self, VALUE spacing)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->interword_spacing = NUM2DBL(spacing);
-    return self;
+    return spacing;
 }
 
 
@@ -711,7 +711,7 @@ Draw_pointsize_eq(VALUE self, VALUE pointsize)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->pointsize = NUM2DBL(pointsize);
-    return self;
+    return pointsize;
 }
 
 
@@ -763,7 +763,7 @@ Draw_rotation_eq(VALUE self, VALUE deg)
         draw->info->affine.tx=current.sx*affine.tx+current.ry*affine.ty+current.tx;
     }
 
-    return self;
+    return deg;
 }
 
 
@@ -785,7 +785,7 @@ Draw_stroke_eq(VALUE self, VALUE stroke)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Color_to_PixelColor(&draw->info->stroke, stroke);
-    return self;
+    return stroke;
 }
 
 
@@ -825,7 +825,7 @@ Draw_stroke_pattern_eq(VALUE self, VALUE pattern)
         draw->info->stroke_pattern = rm_clone_image(image);
     }
 
-    return self;
+    return pattern;
 }
 
 
@@ -847,7 +847,7 @@ Draw_stroke_width_eq(VALUE self, VALUE stroke_width)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->stroke_width = NUM2DBL(stroke_width);
-    return self;
+    return stroke_width;
 }
 
 
@@ -869,7 +869,7 @@ Draw_text_antialias_eq(VALUE self, VALUE text_antialias)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     draw->info->text_antialias = (MagickBooleanType) RTEST(text_antialias);
-    return self;
+    return text_antialias;
 }
 
 
@@ -908,7 +908,7 @@ Draw_undercolor_eq(VALUE self, VALUE undercolor)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Color_to_PixelColor(&draw->info->undercolor, undercolor);
-    return self;
+    return undercolor;
 }
 
 
@@ -1820,7 +1820,7 @@ PolaroidOptions_shadow_color_eq(VALUE self, VALUE shadow)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Color_to_PixelColor(&draw->shadow_color, shadow);
-    return self;
+    return shadow;
 }
 
 
@@ -1842,7 +1842,7 @@ PolaroidOptions_border_color_eq(VALUE self, VALUE border)
     rb_check_frozen(self);
     Data_Get_Struct(self, Draw, draw);
     Color_to_PixelColor(&draw->info->border_color, border);
-    return self;
+    return border;
 }
 
 

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -30,7 +30,7 @@ static VALUE get_type_metrics(int, VALUE *, VALUE, get_type_metrics_func_t);
  *
  * @param self this object
  * @param matrix the affine matrix to set
- * @return self
+ * @return matrix
  */
 VALUE
 Draw_affine_eq(VALUE self, VALUE matrix)
@@ -52,7 +52,7 @@ Draw_affine_eq(VALUE self, VALUE matrix)
  *
  * @param self this object
  * @param align the alignment
- * @return self
+ * @return align
  */
 VALUE
 Draw_align_eq(VALUE self, VALUE align)
@@ -74,7 +74,7 @@ Draw_align_eq(VALUE self, VALUE align)
  *
  * @param self this object
  * @param decorate the decorate
- * @return self
+ * @return decorate
  */
 VALUE
 Draw_decorate_eq(VALUE self, VALUE decorate)
@@ -96,7 +96,7 @@ Draw_decorate_eq(VALUE self, VALUE decorate)
  *
  * @param self this object
  * @param density the density
- * @return self
+ * @return density
  */
 VALUE
 Draw_density_eq(VALUE self, VALUE density)
@@ -119,7 +119,7 @@ Draw_density_eq(VALUE self, VALUE density)
  *
  * @param self this object
  * @param encoding the encoding
- * @return self
+ * @return encoding
  */
 VALUE
 Draw_encoding_eq(VALUE self, VALUE encoding)
@@ -142,7 +142,7 @@ Draw_encoding_eq(VALUE self, VALUE encoding)
  *
  * @param self this object
  * @param fill the fill
- * @return self
+ * @return fill
  */
 VALUE
 Draw_fill_eq(VALUE self, VALUE fill)
@@ -164,7 +164,7 @@ Draw_fill_eq(VALUE self, VALUE fill)
  *
  * @param self this object
  * @param pattern the fill pattern
- * @return self
+ * @return pattern
  * @see Draw_stroke_pattern_eq
  * @see Draw_tile_eq
  */
@@ -204,7 +204,7 @@ Draw_fill_pattern_eq(VALUE self, VALUE pattern)
  *
  * @param self this object
  * @param font the font
- * @return self
+ * @return font
  */
 VALUE
 Draw_font_eq(VALUE self, VALUE font)
@@ -227,7 +227,7 @@ Draw_font_eq(VALUE self, VALUE font)
  *
  * @param self this object
  * @param family the family
- * @return self
+ * @return family
  */
 VALUE
 Draw_font_family_eq(VALUE self, VALUE family)
@@ -250,7 +250,7 @@ Draw_font_family_eq(VALUE self, VALUE family)
  *
  * @param self this object
  * @param stretch the font_stretch
- * @return self
+ * @return stretch
  */
 VALUE
 Draw_font_stretch_eq(VALUE self, VALUE stretch)
@@ -272,7 +272,7 @@ Draw_font_stretch_eq(VALUE self, VALUE stretch)
  *
  * @param self this object
  * @param style the font_style
- * @return self
+ * @return style
  */
 VALUE
 Draw_font_style_eq(VALUE self, VALUE style)
@@ -298,7 +298,7 @@ Draw_font_style_eq(VALUE self, VALUE style)
  *
  * @param self this object
  * @param weight the font_weight
- * @return self
+ * @return weight
  */
 VALUE
 Draw_font_weight_eq(VALUE self, VALUE weight)
@@ -371,7 +371,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
  *
  * @param self this object
  * @param grav the gravity
- * @return self
+ * @return grav
  */
 VALUE
 Draw_gravity_eq(VALUE self, VALUE grav)
@@ -397,7 +397,7 @@ Draw_gravity_eq(VALUE self, VALUE grav)
  *
  * @param self this object
  * @param kerning the kerning
- * @return self
+ * @return kerning
  */
 VALUE
 Draw_kerning_eq(VALUE self, VALUE kerning)
@@ -422,7 +422,7 @@ Draw_kerning_eq(VALUE self, VALUE kerning)
  *
  * @param self this object
  * @param spacing the spacing
- * @return self
+ * @return spacing
  */
 VALUE
 Draw_interline_spacing_eq(VALUE self, VALUE spacing)
@@ -447,7 +447,7 @@ Draw_interline_spacing_eq(VALUE self, VALUE spacing)
  *
  * @param self this object
  * @param spacing the spacing
- * @return self
+ * @return spacing
  */
 VALUE
 Draw_interword_spacing_eq(VALUE self, VALUE spacing)
@@ -701,7 +701,7 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
  *
  * @param self this object
  * @param pointsize the pointsize
- * @return self
+ * @return pointsize
  */
 VALUE
 Draw_pointsize_eq(VALUE self, VALUE pointsize)
@@ -728,7 +728,7 @@ Draw_pointsize_eq(VALUE self, VALUE pointsize)
  *
  * @param self this object
  * @param deg the number of degrees
- * @return self
+ * @return deg
  */
 VALUE
 Draw_rotation_eq(VALUE self, VALUE deg)
@@ -775,7 +775,7 @@ Draw_rotation_eq(VALUE self, VALUE deg)
  *
  * @param self this object
  * @param stroke the stroke
- * @return self
+ * @return stroke
  */
 VALUE
 Draw_stroke_eq(VALUE self, VALUE stroke)
@@ -797,7 +797,7 @@ Draw_stroke_eq(VALUE self, VALUE stroke)
  *
  * @param self this object
  * @param pattern the pattern
- * @return self
+ * @return pattern
  * @see Draw_fill_pattern_eq
  */
 VALUE
@@ -837,7 +837,7 @@ Draw_stroke_pattern_eq(VALUE self, VALUE pattern)
  *
  * @param self this object
  * @param stroke_width the stroke_width
- * @return self
+ * @return stroke_width
  */
 VALUE
 Draw_stroke_width_eq(VALUE self, VALUE stroke_width)
@@ -859,7 +859,7 @@ Draw_stroke_width_eq(VALUE self, VALUE stroke_width)
  *
  * @param self this object
  * @param text_antialias the text_antialias
- * @return self
+ * @return text_antialias
  */
 VALUE
 Draw_text_antialias_eq(VALUE self, VALUE text_antialias)
@@ -881,7 +881,7 @@ Draw_text_antialias_eq(VALUE self, VALUE text_antialias)
  *
  * @param self this object
  * @param image the image to tile
- * @return self
+ * @return image
  */
 VALUE
 Draw_tile_eq(VALUE self, VALUE image)
@@ -898,7 +898,7 @@ Draw_tile_eq(VALUE self, VALUE image)
  *
  * @param self this object
  * @param undercolor the undercolor
- * @return self
+ * @return undercolor
  */
 VALUE
 Draw_undercolor_eq(VALUE self, VALUE undercolor)
@@ -1810,7 +1810,7 @@ rm_polaroid_new(void)
  *
  * @param self this object
  * @param shadow the shadow color
- * @return self
+ * @return shadow
  */
 VALUE
 PolaroidOptions_shadow_color_eq(VALUE self, VALUE shadow)
@@ -1832,7 +1832,7 @@ PolaroidOptions_shadow_color_eq(VALUE self, VALUE shadow)
  *
  * @param self this object
  * @param border the border color
- * @return self
+ * @return border
  */
 VALUE
 PolaroidOptions_border_color_eq(VALUE self, VALUE border)

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1048,7 +1048,7 @@ Image_background_color_eq(VALUE self, VALUE color)
 {
     Image *image = rm_check_frozen(self);
     Color_to_PixelColor(&image->background_color, color);
-    return self;
+    return color;
 }
 
 
@@ -1145,7 +1145,7 @@ Image_bias_eq(VALUE self, VALUE pct)
     bias = rm_percentage(pct,1.0);
     image->bias = bias * QuantumRange;
 
-    return self;
+    return pct;
 }
 
 /**
@@ -1247,7 +1247,7 @@ Image_black_point_compensation_eq(VALUE self, VALUE arg)
     value = RTEST(arg) ? "true" : "false";
     (void) rm_set_property(image, BlackPointCompensationKey, value);
 
-    return self;
+    return arg;
 }
 
 
@@ -1745,7 +1745,7 @@ Image_blur_eq(VALUE self, VALUE value)
     rb_check_frozen(self);
     Data_Get_Struct(self, Image, image);
     image->blur = R_dbl_to_C_dbl(value);
-    return self;
+    return value;
 }
 
 
@@ -1961,7 +1961,7 @@ Image_border_color_eq(VALUE self, VALUE color)
 {
     Image *image = rm_check_frozen(self);
     Color_to_PixelColor(&image->border_color, color);
-    return self;
+    return color;
 }
 
 
@@ -2467,7 +2467,7 @@ Image_chromaticity_eq(VALUE self, VALUE chroma)
 {
     Image *image = rm_check_frozen(self);
     Export_ChromaticityInfo(&image->chromaticity, chroma);
-    return self;
+    return chroma;
 }
 
 
@@ -2763,7 +2763,7 @@ Image_color_profile_eq(VALUE self, VALUE profile)
     {
         (void) set_profile(self, "ICC", profile);
     }
-    return self;
+    return profile;
 }
 
 
@@ -3061,7 +3061,7 @@ Image_colorspace_eq(VALUE self, VALUE colorspace)
     VALUE_TO_ENUM(colorspace, new_cs, ColorspaceType);
     (void) TransformImageColorspace(image, new_cs);
 
-    return self;
+    return colorspace;
 }
 
 
@@ -3270,7 +3270,7 @@ Image_compose_eq(VALUE self, VALUE compose_arg)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(compose_arg, image->compose, CompositeOperator);
-    return self;
+    return compose_arg;
 }
 
 /**
@@ -3829,7 +3829,7 @@ Image_compression_eq(VALUE self, VALUE compression)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(compression, image->compression, CompressionType);
-    return self;
+    return compression;
 }
 
 /**
@@ -4562,7 +4562,7 @@ Image_density_eq(VALUE self, VALUE density_arg)
     RB_GC_GUARD(x_val);
     RB_GC_GUARD(y_val);
 
-    return self;
+    return density_arg;
 }
 
 
@@ -5147,7 +5147,7 @@ Image_dispose_eq(VALUE self, VALUE dispose)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(dispose, image->dispose, DisposeType);
-    return self;
+    return dispose;
 }
 
 
@@ -5699,7 +5699,7 @@ Image_endian_eq(VALUE self, VALUE type)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(type, image->endian, EndianType);
-    return self;
+    return type;
 }
 
 /**
@@ -6265,7 +6265,7 @@ Image_extract_info_eq(VALUE self, VALUE rect)
 {
     Image *image = rm_check_frozen(self);
     Export_RectangleInfo(&image->extract_info, rect);
-    return self;
+    return rect;
 }
 
 
@@ -6329,7 +6329,7 @@ Image_filter_eq(VALUE self, VALUE filter)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(filter, image->filter, FilterTypes);
-    return self;
+    return filter;
 }
 
 
@@ -6595,7 +6595,7 @@ Image_format_eq(VALUE self, VALUE magick)
 
 
     strncpy(image->magick, m->name, MaxTextExtent-1);
-    return self;
+    return magick;
 }
 
 
@@ -6849,7 +6849,7 @@ Image_fuzz_eq(VALUE self, VALUE fuzz)
 {
     Image *image = rm_check_frozen(self);
     image->fuzz = rm_fuzz_to_dbl(fuzz);
-    return self;
+    return fuzz;
 }
 
 
@@ -7119,9 +7119,7 @@ DEF_ATTR_READER(Image, geometry, str)
  * @return self
  */
 VALUE
-Image_geometry_eq(
-                 VALUE self,
-                 VALUE geometry)
+Image_geometry_eq(VALUE self, VALUE geometry)
 {
     Image *image;
     VALUE geom_str;
@@ -7147,7 +7145,7 @@ Image_geometry_eq(
 
     RB_GC_GUARD(geom_str);
 
-    return self;
+    return geometry;
 }
 
 
@@ -7744,7 +7742,7 @@ Image_interlace_eq(VALUE self, VALUE interlace)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(interlace, image->interlace, InterlaceType);
-    return self;
+    return interlace;
 }
 
 
@@ -7798,7 +7796,7 @@ Image_iptc_profile_eq(VALUE self, VALUE profile)
     {
         (void) set_profile(self, "iptc", profile);
     }
-    return self;
+    return profile;
 }
 
 
@@ -8717,7 +8715,7 @@ Image_matte_color_eq(VALUE self, VALUE color)
 {
     Image *image = rm_check_frozen(self);
     Color_to_PixelColor(&image->matte_color, color);
-    return self;
+    return color;
 }
 
 
@@ -9022,7 +9020,7 @@ Image_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageProgressMonitor(image, rm_progress_monitor, (void *)monitor);
     }
 
-    return self;
+    return monitor;
 }
 
 
@@ -9775,7 +9773,7 @@ Image_orientation_eq(VALUE self, VALUE orientation)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(orientation, image->orientation, OrientationType);
-    return self;
+    return orientation;
 }
 
 
@@ -9811,7 +9809,7 @@ Image_page_eq(VALUE self, VALUE rect)
 {
     Image *image = rm_check_frozen(self);
     Export_RectangleInfo(&image->page, rect);
-    return self;
+    return rect;
 }
 
 
@@ -10074,7 +10072,7 @@ Image_pixel_interpolation_method_eq(VALUE self, VALUE method)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(method, image->interpolate, InterpolatePixelMethod);
-    return self;
+    return method;
 }
 
 
@@ -11117,7 +11115,7 @@ Image_rendering_intent_eq(VALUE self, VALUE ri)
 {
     Image *image = rm_check_frozen(self);
     VALUE_TO_ENUM(ri, image->rendering_intent, RenderingIntent);
-    return self;
+    return ri;
 }
 
 
@@ -12004,7 +12002,7 @@ Image_opacity_eq(VALUE self, VALUE opacity_arg)
     opacity = APP2QUANTUM(opacity_arg);
     (void) SetImageOpacity(image, opacity);
     rm_check_image_exception(image, RetainOnError);
-    return self;
+    return opacity_arg;
 }
 
 
@@ -12986,7 +12984,7 @@ Image_class_type_eq(VALUE self, VALUE new_class_type)
     }
 
     (void) SetImageStorageClass(image, class_type);
-    return self;
+    return new_class_type;
 }
 
 
@@ -13478,7 +13476,7 @@ Image_ticks_per_second_eq(VALUE self, VALUE tps)
 {
     Image *image = rm_check_frozen(self);
     image->ticks_per_second = NUM2ULONG(tps);
-    return self;
+    return tps;
 }
 
 
@@ -13895,7 +13893,7 @@ Image_transparent_color_eq(VALUE self, VALUE color)
 {
     Image *image = rm_check_frozen(self);
     Color_to_PixelColor(&image->transparent_color, color);
-    return self;
+    return color;
 }
 
 
@@ -14289,7 +14287,7 @@ Image_units_eq(VALUE self, VALUE restype)
         image->units = units;
     }
 
-    return self;
+    return restype;
 }
 
 
@@ -14558,7 +14556,7 @@ Image_virtual_pixel_method_eq(VALUE self, VALUE method)
     VALUE_TO_ENUM(method, vpm, VirtualPixelMethod);
     (void) SetImageVirtualPixelMethod(image, vpm);
     rm_check_image_exception(image, RetainOnError);
-    return self;
+    return method;
 }
 
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1041,7 +1041,7 @@ Image_background_color(VALUE self)
  *
  * @param self this object
  * @param color the color
- * @return self
+ * @return color
  */
 VALUE
 Image_background_color_eq(VALUE self, VALUE color)
@@ -1133,7 +1133,7 @@ Image_bias(VALUE self)
  *
  * @param self this object
  * @param pct the bias
- * @return self
+ * @return pct
  */
 VALUE
 Image_bias_eq(VALUE self, VALUE pct)
@@ -1234,7 +1234,7 @@ Image_black_point_compensation(VALUE self)
  *
  * @param self this object
  * @param arg the compensation
- * @return self
+ * @return arg
  */
 VALUE
 Image_black_point_compensation_eq(VALUE self, VALUE arg)
@@ -1732,7 +1732,7 @@ Image_blur(VALUE self)
  *
  * @param self this object
  * @param value the blur
- * @return self
+ * @return value
  * @deprecated This method has been deprecated.
  */
 VALUE
@@ -1954,7 +1954,7 @@ Image_border_color(VALUE self)
  *
  * @param self this object
  * @param color the color
- * @return self
+ * @return color
  */
 VALUE
 Image_border_color_eq(VALUE self, VALUE color)
@@ -2460,7 +2460,7 @@ Image_chromaticity(VALUE self)
  *
  * @param self this object
  * @param chroma the chromaticity
- * @return self
+ * @return chroma
  */
 VALUE
 Image_chromaticity_eq(VALUE self, VALUE chroma)
@@ -2753,7 +2753,7 @@ Image_color_profile(VALUE self)
  *
  * @param self this object
  * @param profile the profile to set, as a Ruby string
- * @return self
+ * @return profile
  */
 VALUE
 Image_color_profile_eq(VALUE self, VALUE profile)
@@ -3048,7 +3048,7 @@ Image_colorspace(VALUE self)
  *
  * @param self this object
  * @param colorspace the colorspace
- * @return self
+ * @return colorspace
  * @see Magick::colorSpace in Magick++'s Magick::colorSpace
  */
 VALUE
@@ -3263,7 +3263,7 @@ Image_compose(VALUE self)
  *
  * @param self this object
  * @param compose_arg the composite operator
- * @return self
+ * @return compose_arg
  */
 VALUE
 Image_compose_eq(VALUE self, VALUE compose_arg)
@@ -3822,7 +3822,7 @@ Image_compression(VALUE self)
  *
  * @param self this object
  * @param compression the compression
- * @return self
+ * @return compression
  */
 VALUE
 Image_compression_eq(VALUE self, VALUE compression)
@@ -4508,7 +4508,7 @@ Image_density(VALUE self)
  *
  * @param self this object
  * @param density_arg The density String or Geometry
- * @return self
+ * @return density_arg
  */
 VALUE
 Image_density_eq(VALUE self, VALUE density_arg)
@@ -5140,7 +5140,7 @@ Image_dispose(VALUE self)
  *
  * @param self this object
  * @param dispose the dispose
- * @return self
+ * @return dispose
  */
 VALUE
 Image_dispose_eq(VALUE self, VALUE dispose)
@@ -5692,7 +5692,7 @@ Image_endian(VALUE self)
  *
  * @param self this object
  * @param type the endian type
- * @return self
+ * @return type
  */
 VALUE
 Image_endian_eq(VALUE self, VALUE type)
@@ -6258,7 +6258,7 @@ Image_extract_info(VALUE self)
  *
  * @param self this object
  * @param rect extract_info
- * @return self
+ * @return rect
  */
 VALUE
 Image_extract_info_eq(VALUE self, VALUE rect)
@@ -6322,7 +6322,7 @@ Image_filter(VALUE self)
  *
  * @param self this object
  * @param filter the filter
- * @return self
+ * @return filter
  */
 VALUE
 Image_filter_eq(VALUE self, VALUE filter)
@@ -6568,7 +6568,7 @@ Image_format(VALUE self)
  *
  * @param self this object
  * @param magick the encoding format
- * @return self
+ * @return magick
  */
 VALUE
 Image_format_eq(VALUE self, VALUE magick)
@@ -6841,7 +6841,7 @@ DEF_ATTR_READER(Image, fuzz, dbl)
  *
  * @param self this object
  * @param fuzz the fuzz
- * @return self
+ * @return fuzz
  * @see Info_fuzz_eq
  */
 VALUE
@@ -7116,7 +7116,7 @@ DEF_ATTR_READER(Image, geometry, str)
  *
  * @param self this object
  * @param geometry the geometry
- * @return self
+ * @return geometry
  */
 VALUE
 Image_geometry_eq(VALUE self, VALUE geometry)
@@ -7735,7 +7735,7 @@ Image_interlace(VALUE self)
  *
  * @param self this object
  * @param interlace the interlace
- * @return self
+ * @return interlace
  */
 VALUE
 Image_interlace_eq(VALUE self, VALUE interlace)
@@ -7786,7 +7786,7 @@ Image_iptc_profile(VALUE self)
  *
  * @param self
  * @param profile the IPTC profile (as a string)
- * @return self
+ * @return profile
  */
 VALUE
 Image_iptc_profile_eq(VALUE self, VALUE profile)
@@ -8708,7 +8708,7 @@ Image_matte_color(VALUE self)
  *
  * @param self this object
  * @param color the matte color
- * @return self
+ * @return color
  */
 VALUE
 Image_matte_color_eq(VALUE self, VALUE color)
@@ -9004,7 +9004,7 @@ Image_modulate(int argc, VALUE *argv, VALUE self)
  *
  * @param self this object
  * @param monitor the progress monitor
- * @return self
+ * @return monitor
  */
 VALUE
 Image_monitor_eq(VALUE self, VALUE monitor)
@@ -9766,7 +9766,7 @@ Image_orientation(VALUE self)
  *
  * @param self this object
  * @param orientation the orientation
- * @return self
+ * @return orientation
  */
 VALUE
 Image_orientation_eq(VALUE self, VALUE orientation)
@@ -9802,7 +9802,7 @@ Image_page(VALUE self)
  *
  * @param self this object
  * @param rect the page rectangle
- * @return self
+ * @return rect
  */
 VALUE
 Image_page_eq(VALUE self, VALUE rect)
@@ -10063,7 +10063,7 @@ Image_pixel_interpolation_method(VALUE self)
  *
  * @param self this object
  * @param method the interpolate field
- * @return self
+ * @return method
  * @see Image_pixel_interpolation_method
  * @see Image.interpolate_pixel_color
  */
@@ -11108,7 +11108,7 @@ Image_rendering_intent(VALUE self)
  *
  * @param self this object
  * @param ri the rendering intent
- * @return self
+ * @return ri
  */
 VALUE
 Image_rendering_intent_eq(VALUE self, VALUE ri)
@@ -11990,7 +11990,7 @@ Image_segment(int argc, VALUE *argv, VALUE self)
  *
  * @param self this object
  * @param opacity_arg the opacity
- * @return self
+ * @return opacity_arg
  */
 VALUE
 Image_opacity_eq(VALUE self, VALUE opacity_arg)
@@ -12957,7 +12957,7 @@ Image_class_type(VALUE self)
  *
  * @param self this object
  * @param new_class_type the storage class
- * @return self
+ * @return new_class_type
  */
 VALUE
 Image_class_type_eq(VALUE self, VALUE new_class_type)
@@ -13469,7 +13469,7 @@ Image_ticks_per_second(VALUE self)
  *
  * @param self this object
  * @param tps ticks per second
- * @return self
+ * @return tps
  */
 VALUE
 Image_ticks_per_second_eq(VALUE self, VALUE tps)
@@ -13886,7 +13886,7 @@ Image_transparent_color(VALUE self)
  *
  * @param self this object
  * @param color the transparent color
- * @return self
+ * @return color
  */
 VALUE
 Image_transparent_color_eq(VALUE self, VALUE color)
@@ -14247,7 +14247,7 @@ Image_units(VALUE self)
  *
  * @param self this object
  * @param restype the resolution type
- * @return self
+ * @return restype
  */
 VALUE
 Image_units_eq(VALUE self, VALUE restype)
@@ -14544,7 +14544,7 @@ Image_virtual_pixel_method(VALUE self)
  *
  * @param self this object
  * @param method the VirtualPixelMethod
- * @return self
+ * @return method
  */
 VALUE
 Image_virtual_pixel_method_eq(VALUE self, VALUE method)

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -71,7 +71,7 @@ get_option(VALUE self, const char *key)
  * @param self this object
  * @param key the option key
  * @param string the value
- * @return self
+ * @return string
  */
 static VALUE
 set_option(VALUE self, const char *key, VALUE string)
@@ -105,7 +105,7 @@ set_option(VALUE self, const char *key, VALUE string)
  * @param self this object
  * @param option the option
  * @param color the color name
- * @return self
+ * @return color
  */
 static VALUE set_color_option(VALUE self, const char *option, VALUE color)
 {
@@ -183,7 +183,7 @@ static VALUE get_dbl_option(VALUE self, const char *option)
  * @param self this object
  * @param option the option name
  * @param value the value
- * @return self
+ * @return value
  */
 static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
 {
@@ -462,7 +462,7 @@ Info_authenticate(VALUE self)
  *
  * @param self this object
  * @param passwd the authenticating password
- * @return self
+ * @return passwd
  */
 VALUE
 Info_authenticate_eq(VALUE self, VALUE passwd)
@@ -523,7 +523,7 @@ Info_background_color(VALUE self)
  *
  * @param self this object
  * @param bc_arg the background color
- * @return self
+ * @return bc_arg
  * @throw ArgumentError
  */
 VALUE
@@ -568,7 +568,7 @@ Info_border_color(VALUE self)
  *
  * @param self this object
  * @param bc_arg the border color
- * @return self
+ * @return bc_arg
  * @throw ArgumentError
  */
 VALUE
@@ -683,7 +683,7 @@ Info_colorspace(VALUE self)
  *
  * @param self this object
  * @param colorspace the colorspace type
- * @return self
+ * @return colorspace
  * @throw ArgumentError
  */
 VALUE
@@ -724,7 +724,7 @@ Info_compression(VALUE self)
  *
  * @param self this object
  * @param type the compression type
- * @return self
+ * @return type
  * @throw ArgumentError
  */
 VALUE
@@ -861,7 +861,7 @@ arg_is_integer(VALUE arg)
  *
  * @param self this object
  * @param string the delay
- * @return self
+ * @return string
  */
 VALUE
 Info_delay_eq(VALUE self, VALUE string)
@@ -914,7 +914,7 @@ DEF_ATTR_READER(Info, density, str)
  *
  * @param self this object
  * @param density_arg the density
- * @return self
+ * @return density_arg
  * @throw ArgumentError
  */
 VALUE
@@ -966,7 +966,7 @@ DEF_ATTR_READER(Info, depth, int)
  *
  * @param self this object
  * @param depth the depth
- * @return self
+ * @return depth
  * @throw ArgumentError
  */
 VALUE
@@ -1093,7 +1093,7 @@ Info_dispose(VALUE self)
  *
  * @param self this object
  * @param disp the DisposeType enumerator
- * @return self
+ * @return disp
  */
 VALUE
 Info_dispose_eq(VALUE self, VALUE disp)
@@ -1157,7 +1157,7 @@ Info_endian(VALUE self)
  *
  * @param self this object
  * @param endian the endian (Magick::MSBEndian or Magick::LSBEndian)
- * @return self
+ * @return endian
  */
 VALUE
 Info_endian_eq(VALUE self, VALUE endian)
@@ -1201,7 +1201,7 @@ DEF_ATTR_READER(Info, extract, str)
  *
  * @param self this object
  * @param extract_arg the extract string
- * @return self
+ * @return extract_arg
  * @throw ArgumentError
  */
 VALUE
@@ -1268,7 +1268,7 @@ Info_filename(VALUE self)
  *
  * @param self this object
  * @param filename the filename
- * @return self
+ * @return filename
  * @see Image_capture
  */
 VALUE
@@ -1346,7 +1346,7 @@ DEF_ATTR_READER(Info, font, str)
  *
  * @param self this object
  * @param font_arg the font (as a String)
- * @return self
+ * @return font_arg
  */
 VALUE
 Info_font_eq(VALUE self, VALUE font_arg)
@@ -1404,7 +1404,7 @@ VALUE Info_format(VALUE self)
  *
  * @param self this object
  * @param magick the encoding format
- * @return self
+ * @return magick
  */
 VALUE
 Info_format_eq(VALUE self, VALUE magick)
@@ -1453,7 +1453,7 @@ DEF_ATTR_READER(Info, fuzz, dbl)
  *
  * @param self this object
  * @param fuzz the fuzz
- * @return self
+ * @return fuzz
  * @see Image_fuzz_eq
  */
 VALUE Info_fuzz_eq(VALUE self, VALUE fuzz)
@@ -1563,7 +1563,7 @@ VALUE Info_gravity(VALUE self)
  *
  * @param self this object
  * @param grav the gravity enumerator
- * @return self
+ * @return grav
  */
 VALUE
 Info_gravity_eq(VALUE self, VALUE grav)
@@ -1628,7 +1628,7 @@ Info_group(VALUE self)
  *
  * @param self this object
  * @param value the group
- * @return self
+ * @return value
  * @deprecated This method has been deprecated.
  */
 VALUE
@@ -1671,7 +1671,7 @@ Info_image_type(VALUE self)
  *
  * @param self this object
  * @param type the classification type
- * @return self
+ * @return type
  * @throw ArgumentError
  */
 VALUE
@@ -1710,7 +1710,7 @@ Info_interlace(VALUE self)
  *
  * @param self this object
  * @param inter the interlace type
- * @return self
+ * @return inter
  * @throw ArgumentError
  */
 VALUE
@@ -1752,7 +1752,7 @@ Info_matte_color(VALUE self)
  *
  * @param self this object
  * @param matte_arg the name of the matte as a String
- * @return self
+ * @return matte_arg
  * @throw ArgumentError
  */
 VALUE
@@ -1775,7 +1775,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
  *
  * @param self this object
  * @param monitor the monitor
- * @return self
+ * @return monitor
  * @see Image_monitor_eq
  */
 VALUE
@@ -1831,7 +1831,7 @@ Info_orientation(VALUE self)
  *
  * @param self this object
  * @param inter the orientation type as an OrientationType enum value
- * @return self
+ * @return inter
  * @throw ArgumentError
  */
 VALUE
@@ -1876,7 +1876,7 @@ Info_origin(VALUE self)
  *
  * @param self this object
  * @param origin_arg the origin geometry
- * @return self
+ * @return origin_arg
  */
 VALUE
 Info_origin_eq(VALUE self, VALUE origin_arg)
@@ -1939,7 +1939,7 @@ Info_page(VALUE self)
  *
  * @param self this object
  * @param page_arg the geometry
- * @return self
+ * @return page_arg
  */
 VALUE
 Info_page_eq(VALUE self, VALUE page_arg)
@@ -2006,7 +2006,7 @@ Info_sampling_factor(VALUE self)
  *
  * @param self this object
  * @param sampling_factor the sampling factors
- * @return self
+ * @return sampling_factor
  */
 VALUE
 Info_sampling_factor_eq(VALUE self, VALUE sampling_factor)
@@ -2063,7 +2063,7 @@ Info_scene(VALUE self)
  *
  * @param self this object
  * @param scene the scene number
- * @return self
+ * @return scene
  */
 VALUE
 Info_scene_eq(VALUE self, VALUE scene)
@@ -2105,7 +2105,7 @@ DEF_ATTR_READER(Info, server_name, str)
  *
  * @param self this object
  * @param server_arg the server name as a String
- * @return self
+ * @return server_arg
  */
 VALUE
 Info_server_name_eq(VALUE self, VALUE server_arg)
@@ -2147,7 +2147,7 @@ DEF_ATTR_READER(Info, size, str)
  *
  * @param self this object
  * @param size_arg the size
- * @return self
+ * @return size_arg
  * @throw ArgumentError
  */
 VALUE
@@ -2261,7 +2261,7 @@ Info_stroke_width_eq(VALUE self, VALUE stroke_width)
  *
  * @param self this object
  * @param texture the name of the texture image
- * @return self
+ * @return texture
  */
 VALUE
 Info_texture_eq(VALUE self, VALUE texture)
@@ -2304,7 +2304,7 @@ Info_texture_eq(VALUE self, VALUE texture)
  *
  * @param self this object
  * @param offset the offset
- * @return self
+ * @return offset
  */
 VALUE
 Info_tile_offset_eq(VALUE self, VALUE offset)
@@ -2359,7 +2359,7 @@ Info_transparent_color(VALUE self)
  *
  * @param self this object
  * @param tc_arg the transparent color as a String
- * @return self
+ * @return tc_arg
  * @throw ArgumentError
  */
 VALUE
@@ -2497,7 +2497,7 @@ Info_units(VALUE self)
  *
  * @param self this object
  * @param units the resolution type
- * @return self
+ * @return units
  * @throw ArgumentError
  */
 VALUE
@@ -2529,7 +2529,7 @@ DEF_ATTR_READER(Info, view, str)
  *
  * @param self this object
  * @param view_arg the viewing parameters
- * @return self
+ * @return view_arg
  */
 VALUE
 Info_view_eq(VALUE self, VALUE view_arg)

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -90,7 +90,7 @@ set_option(VALUE self, const char *key, VALUE string)
         value = StringValuePtr(string);
         (void) SetImageOption(info, key, value);
     }
-    return self;
+    return string;
 }
 
 
@@ -135,7 +135,7 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
         (void) SetImageOption(info, option, name);
     }
 
-    return self;
+    return color;
 }
 
 
@@ -215,7 +215,7 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
         (void) SetImageOption(info, option, buff);
     }
 
-    return self;
+    return value;
 }
 
 
@@ -488,7 +488,7 @@ Info_authenticate_eq(VALUE self, VALUE passwd)
         magick_clone_string(&info->authenticate, passwd_p);
     }
 
-    return self;
+    return passwd;
 }
 
 
@@ -535,7 +535,7 @@ Info_background_color_eq(VALUE self, VALUE bc_arg)
     Data_Get_Struct(self, Info, info);
     Color_to_PixelColor(&info->background_color, bc_arg);
     //SetImageOption(info, "background", pixel_packet_to_hexname(&info->background_color, colorname));
-    return self;
+    return bc_arg;
 }
 
 /**
@@ -580,7 +580,7 @@ Info_border_color_eq(VALUE self, VALUE bc_arg)
     Data_Get_Struct(self, Info, info);
     Color_to_PixelColor(&info->border_color, bc_arg);
     //SetImageOption(info, "bordercolor", pixel_packet_to_hexname(&info->border_color, colorname));
-    return self;
+    return bc_arg;
 }
 
 
@@ -693,7 +693,7 @@ Info_colorspace_eq(VALUE self, VALUE colorspace)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(colorspace, info->colorspace, ColorspaceType);
-    return self;
+    return colorspace;
 }
 
 OPTION_ATTR_ACCESSOR(comment, Comment)
@@ -734,7 +734,7 @@ Info_compression_eq(VALUE self, VALUE type)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(type, info->compression, CompressionType);
-    return self;
+    return type;
 }
 
 /**
@@ -889,7 +889,7 @@ Info_delay_eq(VALUE self, VALUE string)
         sprintf(dstr, "%d", delay);
         (void) SetImageOption(info, "delay", dstr);
     }
-    return self;
+    return string;
 }
 
 /**
@@ -944,7 +944,7 @@ Info_density_eq(VALUE self, VALUE density_arg)
 
     RB_GC_GUARD(density);
 
-    return self;
+    return density_arg;
 }
 
 /**
@@ -996,7 +996,7 @@ Info_depth_eq(VALUE self, VALUE depth)
     }
 
     info->depth = d;
-    return self;
+    return depth;
 }
 
 /** A dispose option */
@@ -1124,7 +1124,7 @@ Info_dispose_eq(VALUE self, VALUE disp)
     }
 
     (void) SetImageOption(info, "dispose", option);
-    return self;
+    return disp;
 }
 
 DEF_ATTR_ACCESSOR(Info, dither, bool)
@@ -1172,7 +1172,7 @@ Info_endian_eq(VALUE self, VALUE endian)
 
     Data_Get_Struct(self, Info, info);
     info->endian = type;
-    return self;
+    return endian;
 }
 
 
@@ -1231,7 +1231,7 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
 
     RB_GC_GUARD(extract);
 
-    return self;
+    return extract_arg;
 }
 
 
@@ -1290,7 +1290,7 @@ Info_filename_eq(VALUE self, VALUE filename)
         fname = StringValuePtr(filename);
         strncpy(info->filename, fname, MaxTextExtent);
     }
-    return self;
+    return filename;
 }
 
 
@@ -1365,7 +1365,7 @@ Info_font_eq(VALUE self, VALUE font_arg)
         font = StringValuePtr(font_arg);
         magick_clone_string(&info->font, font);
     }
-    return self;
+    return font_arg;
 }
 
 /**
@@ -1429,7 +1429,7 @@ Info_format_eq(VALUE self, VALUE magick)
     }
 
     strncpy(info->magick, m->name, MaxTextExtent-1);
-    return self;
+    return magick;
 }
 
 /**
@@ -1462,7 +1462,7 @@ VALUE Info_fuzz_eq(VALUE self, VALUE fuzz)
 
     Data_Get_Struct(self, Info, info);
     info->fuzz = rm_fuzz_to_dbl(fuzz);
-    return self;
+    return fuzz;
 }
 
 /** A gravity option */
@@ -1594,7 +1594,7 @@ Info_gravity_eq(VALUE self, VALUE grav)
     }
 
     (void) SetImageOption(info, "gravity", option);
-    return self;
+    return grav;
 }
 
 
@@ -1641,7 +1641,7 @@ Info_group_eq(VALUE self, VALUE value)
     rb_check_frozen(self);
     Data_Get_Struct(self, Info, info);
     info->group = R_long_to_C_long(value);
-    return self;
+    return value;
 }
 
 
@@ -1681,7 +1681,7 @@ Info_image_type_eq(VALUE self, VALUE type)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(type, info->type, ImageType);
-    return self;
+    return type;
 }
 
 /**
@@ -1720,7 +1720,7 @@ Info_interlace_eq(VALUE self, VALUE inter)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(inter, info->interlace, InterlaceType);
-    return self;
+    return inter;
 }
 
 OPTION_ATTR_ACCESSOR(label, Label)
@@ -1764,7 +1764,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
     Data_Get_Struct(self, Info, info);
     Color_to_PixelColor(&info->matte_color, matte_arg);
     //SetImageOption(info, "mattecolor", pixel_packet_to_hexname(&info->matte_color, colorname));
-    return self;
+    return matte_arg;
 }
 
 /**
@@ -1794,7 +1794,7 @@ Info_monitor_eq(VALUE self, VALUE monitor)
         (void) SetImageInfoProgressMonitor(info, rm_progress_monitor, (void *)monitor);
     }
 
-    return self;
+    return monitor;
 }
 
 
@@ -1841,7 +1841,7 @@ Info_orientation_eq(VALUE self, VALUE inter)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(inter, info->orientation, OrientationType);
-    return self;
+    return inter;
 }
 
 
@@ -1907,7 +1907,7 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
 
     RB_GC_GUARD(origin_str);
 
-    return self;
+    return origin_arg;
 }
 
 
@@ -1967,7 +1967,7 @@ Info_page_eq(VALUE self, VALUE page_arg)
 
     RB_GC_GUARD(geom_str);
 
-    return self;
+    return page_arg;
 }
 
 DEF_ATTR_ACCESSOR(Info, pointsize, dbl)
@@ -2032,7 +2032,7 @@ Info_sampling_factor_eq(VALUE self, VALUE sampling_factor)
         magick_clone_string(&info->sampling_factor, sampling_factor_p);
     }
 
-    return self;
+    return sampling_factor;
 }
 
 
@@ -2081,7 +2081,7 @@ Info_scene_eq(VALUE self, VALUE scene)
 #endif
     (void) SetImageOption(info, "scene", buf);
 
-    return self;
+    return scene;
 }
 
 
@@ -2124,7 +2124,7 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
         server = StringValuePtr(server_arg);
         magick_clone_string(&info->server_name, server);
     }
-    return self;
+    return server_arg;
 }
 
 /**
@@ -2177,7 +2177,7 @@ Info_size_eq(VALUE self, VALUE size_arg)
 
     RB_GC_GUARD(size);
 
-    return self;
+    return size_arg;
 }
 
 
@@ -2283,7 +2283,7 @@ Info_texture_eq(VALUE self, VALUE texture)
     // If argument is nil we're done
     if (texture == Qnil)
     {
-        return self;
+        return texture;
     }
 
     // Create a temp copy of the texture and store its name in the texture field
@@ -2292,7 +2292,7 @@ Info_texture_eq(VALUE self, VALUE texture)
 
     magick_clone_string(&info->texture, name);
 
-    return self;
+    return texture;
 }
 
 
@@ -2327,7 +2327,7 @@ Info_tile_offset_eq(VALUE self, VALUE offset)
 
     RB_GC_GUARD(offset_str);
 
-    return self;
+    return offset;
 }
 
 
@@ -2371,7 +2371,7 @@ Info_transparent_color_eq(VALUE self, VALUE tc_arg)
     Data_Get_Struct(self, Info, info);
     Color_to_PixelColor(&info->transparent_color, tc_arg);
     //SetImageOption(info, "transparent", pixel_packet_to_hexname(&info->transparent_color, colorname));
-    return self;
+    return tc_arg;
 }
 
 
@@ -2507,7 +2507,7 @@ Info_units_eq(VALUE self, VALUE units)
 
     Data_Get_Struct(self, Info, info);
     VALUE_TO_ENUM(units, info->units, ResolutionType);
-    return self;
+    return units;
 }
 
 /**
@@ -2549,7 +2549,7 @@ Info_view_eq(VALUE self, VALUE view_arg)
         view = StringValuePtr(view_arg);
         magick_clone_string(&info->view, view);
     }
-    return self;
+    return view_arg;
 }
 
 

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -99,7 +99,7 @@ Montage_alloc(VALUE class)
  *
  * @param self this object
  * @param color the color name
- * @return self
+ * @return color
  */
 VALUE
 Montage_background_color_eq(VALUE self, VALUE color)
@@ -120,7 +120,7 @@ Montage_background_color_eq(VALUE self, VALUE color)
  *
  * @param self this object
  * @param color the color name
- * @return self
+ * @return color
  */
 VALUE
 Montage_border_color_eq(VALUE self, VALUE color)
@@ -141,7 +141,7 @@ Montage_border_color_eq(VALUE self, VALUE color)
  *
  * @param self this object
  * @param width the width
- * @return self
+ * @return width
  */
 VALUE
 Montage_border_width_eq(VALUE self, VALUE width)
@@ -162,7 +162,7 @@ Montage_border_width_eq(VALUE self, VALUE width)
  *
  * @param self this object
  * @param compose the composition operator
- * @return self
+ * @return compose
  */
 VALUE
 Montage_compose_eq(VALUE self, VALUE compose)
@@ -183,7 +183,7 @@ Montage_compose_eq(VALUE self, VALUE compose)
  *
  * @param self this object
  * @param filename the filename
- * @return self
+ * @return filename
  */
 VALUE
 Montage_filename_eq(VALUE self, VALUE filename)
@@ -204,7 +204,7 @@ Montage_filename_eq(VALUE self, VALUE filename)
  *
  * @param self this object
  * @param color the color name
- * @return self
+ * @return color
  */
 VALUE
 Montage_fill_eq(VALUE self, VALUE color)
@@ -225,7 +225,7 @@ Montage_fill_eq(VALUE self, VALUE color)
  *
  * @param self this object
  * @param font the font name
- * @return self
+ * @return font
  */
 VALUE
 Montage_font_eq(VALUE self, VALUE font)
@@ -252,7 +252,7 @@ Montage_font_eq(VALUE self, VALUE font)
  *
  * @param self this object
  * @param frame_arg the frame geometry
- * @return self
+ * @return frame_arg
  */
 VALUE
 Montage_frame_eq(VALUE self, VALUE frame_arg)
@@ -278,7 +278,7 @@ Montage_frame_eq(VALUE self, VALUE frame_arg)
  *
  * @param self this object
  * @param geometry_arg the geometry
- * @return self
+ * @return geometry_arg
  */
 VALUE
 Montage_geometry_eq(VALUE self, VALUE geometry_arg)
@@ -304,7 +304,7 @@ Montage_geometry_eq(VALUE self, VALUE geometry_arg)
  *
  * @param self this object
  * @param gravity the gravity type
- * @return self
+ * @return gravity
  */
 VALUE
 Montage_gravity_eq(VALUE self, VALUE gravity)
@@ -342,7 +342,7 @@ Montage_initialize(VALUE self)
  *
  * @param self this object
  * @param color the color name
- * @return self
+ * @return color
  */
 VALUE
 Montage_matte_color_eq(VALUE self, VALUE color)
@@ -363,7 +363,7 @@ Montage_matte_color_eq(VALUE self, VALUE color)
  *
  * @param self this object
  * @param size the point size
- * @return self
+ * @return size
  */
 VALUE
 Montage_pointsize_eq(VALUE self, VALUE size)
@@ -384,7 +384,7 @@ Montage_pointsize_eq(VALUE self, VALUE size)
  *
  * @param self this object
  * @param shadow the shadow
- * @return self
+ * @return shadow
  */
 VALUE
 Montage_shadow_eq(VALUE self, VALUE shadow)
@@ -426,7 +426,7 @@ Montage_stroke_eq(VALUE self, VALUE color)
  *
  * @param self this object
  * @param texture the texture image
- * @return self
+ * @return texture
  */
 VALUE
 Montage_texture_eq(VALUE self, VALUE texture)
@@ -465,7 +465,7 @@ Montage_texture_eq(VALUE self, VALUE texture)
  *
  * @param self this object
  * @param tile_arg the tile
- * @return self
+ * @return tile_arg
  */
 VALUE
 Montage_tile_eq(VALUE self, VALUE tile_arg)
@@ -491,7 +491,7 @@ Montage_tile_eq(VALUE self, VALUE tile_arg)
  *
  * @param self this object
  * @param title the title
- * @return self
+ * @return title
  */
 VALUE
 Montage_title_eq(VALUE self, VALUE title)

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -108,7 +108,7 @@ Montage_background_color_eq(VALUE self, VALUE color)
 
     Data_Get_Struct(self, Montage, montage);
     Color_to_PixelColor(&montage->info->background_color, color);
-    return self;
+    return color;
 }
 
 
@@ -129,7 +129,7 @@ Montage_border_color_eq(VALUE self, VALUE color)
 
     Data_Get_Struct(self, Montage, montage);
     Color_to_PixelColor(&montage->info->border_color, color);
-    return self;
+    return color;
 }
 
 
@@ -150,7 +150,7 @@ Montage_border_width_eq(VALUE self, VALUE width)
 
     Data_Get_Struct(self, Montage, montage);
     montage->info->border_width = NUM2ULONG(width);
-    return self;
+    return width;
 }
 
 
@@ -171,7 +171,7 @@ Montage_compose_eq(VALUE self, VALUE compose)
 
     Data_Get_Struct(self, Montage, montage);
     VALUE_TO_ENUM(compose, montage->compose, CompositeOperator);
-    return self;
+    return compose;
 }
 
 
@@ -192,7 +192,7 @@ Montage_filename_eq(VALUE self, VALUE filename)
 
     Data_Get_Struct(self, Montage, montage);
     strncpy(montage->info->filename, StringValuePtr(filename), MaxTextExtent-1);
-    return self;
+    return filename;
 }
 
 
@@ -213,7 +213,7 @@ Montage_fill_eq(VALUE self, VALUE color)
 
     Data_Get_Struct(self, Montage, montage);
     Color_to_PixelColor(&montage->info->fill, color);
-    return self;
+    return color;
 }
 
 
@@ -235,7 +235,7 @@ Montage_font_eq(VALUE self, VALUE font)
     Data_Get_Struct(self, Montage, montage);
     magick_clone_string(&montage->info->font, StringValuePtr(font));
 
-    return self;
+    return font;
 }
 
 
@@ -266,7 +266,7 @@ Montage_frame_eq(VALUE self, VALUE frame_arg)
 
     RB_GC_GUARD(frame);
 
-    return self;
+    return frame_arg;
 }
 
 
@@ -292,7 +292,7 @@ Montage_geometry_eq(VALUE self, VALUE geometry_arg)
 
     RB_GC_GUARD(geometry);
 
-    return self;
+    return geometry_arg;
 }
 
 
@@ -313,7 +313,7 @@ Montage_gravity_eq(VALUE self, VALUE gravity)
 
     Data_Get_Struct(self, Montage, montage);
     VALUE_TO_ENUM(gravity, montage->info->gravity, GravityType);
-    return self;
+    return gravity;
 }
 
 
@@ -351,7 +351,7 @@ Montage_matte_color_eq(VALUE self, VALUE color)
 
     Data_Get_Struct(self, Montage, montage);
     Color_to_PixelColor(&montage->info->matte_color, color);
-    return self;
+    return color;
 }
 
 
@@ -372,7 +372,7 @@ Montage_pointsize_eq(VALUE self, VALUE size)
 
     Data_Get_Struct(self, Montage, montage);
     montage->info->pointsize = NUM2DBL(size);
-    return self;
+    return size;
 }
 
 
@@ -393,7 +393,7 @@ Montage_shadow_eq(VALUE self, VALUE shadow)
 
     Data_Get_Struct(self, Montage, montage);
     montage->info->shadow = (MagickBooleanType) RTEST(shadow);
-    return self;
+    return shadow;
 }
 
 
@@ -414,7 +414,7 @@ Montage_stroke_eq(VALUE self, VALUE color)
 
     Data_Get_Struct(self, Montage, montage);
     Color_to_PixelColor(&montage->info->stroke, color);
-    return self;
+    return color;
 }
 
 
@@ -453,7 +453,7 @@ Montage_texture_eq(VALUE self, VALUE texture)
     rm_write_temp_image(texture_image, temp_name);
     magick_clone_string(&montage->info->texture, temp_name);
 
-    return self;
+    return texture;
 }
 
 
@@ -479,7 +479,7 @@ Montage_tile_eq(VALUE self, VALUE tile_arg)
 
     RB_GC_GUARD(tile);
 
-    return self;
+    return tile_arg;
 }
 
 
@@ -500,7 +500,7 @@ Montage_title_eq(VALUE self, VALUE title)
 
     Data_Get_Struct(self, Montage, montage);
     magick_clone_string(&montage->info->title, StringValuePtr(title));
-    return self;
+    return title;
 }
 
 


### PR DESCRIPTION
As noticed in #585 there are attribute writers that return `self` instead of the `value` that was passed in. This PR fixes that for all the attribute writers.