### PR TITLE
Don't allow undefined class.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12972,6 +12972,9 @@ Image_class_type_eq(VALUE self, VALUE new_class_type)
 
     VALUE_TO_ENUM(new_class_type, class_type, ClassType);
 
+    if (class_type == UndefinedClass)
+        rb_raise(rb_eArgError, "Invalid class type specified.");
+
     if (image->storage_class == PseudoClass && class_type == DirectClass)
     {
         (void) SyncImage(image);

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -9,6 +9,10 @@ class Image1_UT < Test::Unit::TestCase
     @img = Magick::Image.new(20, 20)
   end
 
+  def test_class_type
+    assert_raise(ArgumentError) { @img.class_type = Magick::UndefinedClass }
+  end
+
   def test_constitute
     pixels = @img.dispatch(0, 0, @img.columns, @img.rows, 'RGBA')
     res = Magick::Image.constitute(@img.columns, @img.rows, 'RGBA', pixels)


### PR DESCRIPTION
While adding a unit test for #594 I found an issue. The storage type of the image should not be changed to undefined.