### PR TITLE
Use Image#alpha instead of Image#matte= in examples

### DIFF
--- a/doc/ex/coalesce.rb
+++ b/doc/ex/coalesce.rb
@@ -19,7 +19,7 @@ cells = Magick::ImageList.new
 cells.new_image buttons.columns * 5, buttons.rows * 5 do
   self.background_color = '#000000ff' # transparent
 end
-cells.matte = true
+cells.alpha(Magick::ActivateAlphaChannel)
 
 offset = Magick::Rectangle.new(0, 0, 0, 0)
 
@@ -44,7 +44,7 @@ srand 1234
   offset.x = x * button.columns
   offset.y = y * button.rows
   button.page = offset
-  button.matte = true
+  button.alpha(Magick::ActivateAlphaChannel)
   cells << button
 end
 

--- a/doc/ex/get_pixels.rb
+++ b/doc/ex/get_pixels.rb
@@ -38,7 +38,7 @@ rows.times do |y|
 end
 
 # Composite the mono version of the image over the color version.
-grayrocks.matte = true
+grayrocks.alpha(Magick::ActivateAlphaChannel)
 combine = rocks.composite(grayrocks, Magick::CenterGravity, Magick::OverCompositeOp)
 # combine.display
 combine.write 'get_pixels.jpg'

--- a/doc/ex/implode.rb
+++ b/doc/ex/implode.rb
@@ -15,7 +15,7 @@ implosion = 0.25
 8.times do
   frames << img.implode(implosion)
   legend.annotate(frames, 0, 0, 10, 20, format('% 4.2f', implosion))
-  frames.matte = false
+  frames.alpha(Magick::DeactivateAlphaChannel)
   implosion -= 0.10
 end
 
@@ -23,7 +23,7 @@ end
   implosion += 0.10
   frames << img.implode(implosion)
   legend.annotate(frames, 0, 0, 10, 20, format('% 4.2f', implosion))
-  frames.matte = false
+  frames.alpha(Magick::DeactivateAlphaChannel)
 end
 
 frames.delay = 10

--- a/doc/ex/mask.rb
+++ b/doc/ex/mask.rb
@@ -26,7 +26,7 @@ end
 # in the mask image. Assign the mask image to the mask= attribute of the image
 # being masked.
 
-q.matte = false
+q.alpha(Magick::DeactivateAlphaChannel)
 img.mask q
 
 # Use the #level method to darken the image under the black part of the mask.

--- a/doc/ex/matte_fill_to_border.rb
+++ b/doc/ex/matte_fill_to_border.rb
@@ -6,7 +6,7 @@ img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
 bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
-bg[0].matte = false
+bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new
 gc.stroke_width(2)

--- a/doc/ex/matte_floodfill.rb
+++ b/doc/ex/matte_floodfill.rb
@@ -6,7 +6,7 @@ img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
 bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
-bg[0].matte = false
+bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new
 gc.stroke_width(2)

--- a/doc/ex/matte_replace.rb
+++ b/doc/ex/matte_replace.rb
@@ -6,7 +6,7 @@ img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
 bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
-bg[0].matte = false
+bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new
 gc.stroke_width(2)

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -261,7 +261,7 @@ begin
   puts '   wave...'
   temp = model.copy
   temp.cur_image[:Label] = 'Wave'
-  temp.matte = true
+  temp.alpha(Magick::ActivateAlphaChannel)
   temp.background_color = '#000000ff'
   example << temp.wave(25, 150)
 
@@ -309,7 +309,7 @@ begin
 
   # Write the result to a file
   montage_image.compression = RLECompression
-  montage_image.matte = false
+  montage_image.alpha(Magick::DeactivateAlphaChannel)
   puts 'Writing image ./rm_demo_out.png'
   montage_image.write 'rm_demo_out.png'
 

--- a/examples/find_similar_region.rb
+++ b/examples/find_similar_region.rb
@@ -18,7 +18,7 @@ begin
     gc.fill('none')
     gc.rectangle(res[0], res[1], res[0] + target.columns, res[1] + target.rows)
     gc.draw(img)
-    img.matte = false
+    img.alpha(Magick::DeactivateAlphaChannel)
     puts "Found similar region. Writing `find_similar_region.gif'..."
     img.write('find_similar_region.gif')
   else

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -68,7 +68,7 @@ module Magick
       blue_histogram['Label'] = 'Blue'
       int_histogram = rgb_histogram.copy
       int_histogram['Label'] = 'Intensity'
-      int_histogram.matte = true
+      int_histogram.alpha(Magick::ActivateAlphaChannel)
 
       rgb_column   = PixelColumn.new(HISTOGRAM_ROWS)
       red_column   = PixelColumn.new(HISTOGRAM_ROWS)

--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -51,8 +51,8 @@ oval = oval.blur_image(0, 20)
 # the oval remain opaque. Each gray pixel around the border of the oval has a
 # varying level of transparency depending on how dark or light it is.
 
-ballerina.matte = true  # Ensure the ballerina image's opacity channel is enabled.
-oval.matte = false      # Force the CopyOpacityCompositeOp to use pixel intensity
+ballerina.alpha(Magick::ActivateAlphaChannel)  # Ensure the ballerina image's opacity channel is enabled.
+oval.alpha(Magick::DeactivateAlphaChannel)     # Force the CopyOpacityCompositeOp to use pixel intensity
 # to determine how much transparency to add to the ballerina
 # pixels.
 


### PR DESCRIPTION
Image#matte= was marked as deprecate at https://github.com/rmagick/rmagick/commit/c00a81d377b31e0c2daf6bf80450663afd5e2dd6

This patch will get rid of warning message when run examples.