### PR TITLE
Renamed DistortImageMethod to DistortMethod

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -118,6 +118,7 @@ typedef PixelPacket Pixel; /**< Make type name match class name */
 typedef MagickPixelPacket MagickPixel;
 typedef PixelPacket PixelColor;
 typedef AlphaChannelType AlphaChannelOption;
+typedef DistortImageMethod DistortMethod;
 
 //! Montage
 typedef struct
@@ -297,7 +298,7 @@ EXTERN VALUE Class_CompositeOperator;
 EXTERN VALUE Class_CompressionType;
 EXTERN VALUE Class_DecorationType;
 EXTERN VALUE Class_DisposeType;
-EXTERN VALUE Class_DistortImageMethod;
+EXTERN VALUE Class_DistortMethod;
 EXTERN VALUE Class_DitherMethod;
 EXTERN VALUE Class_EndianType;
 EXTERN VALUE Class_FilterTypes;

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -5249,7 +5249,7 @@ Image_distort(int argc, VALUE *argv, VALUE self)
     Image *image, *new_image;
     VALUE pts;
     unsigned long n, npoints;
-    DistortImageMethod distortion_method;
+    DistortMethod distortion_method;
     double *points;
     MagickBooleanType bestfit = MagickFalse;
     ExceptionInfo *exception;
@@ -5264,7 +5264,7 @@ Image_distort(int argc, VALUE *argv, VALUE self)
         case 2:
             // Ensure pts is an array
             pts = rb_Array(argv[1]);
-            VALUE_TO_ENUM(argv[0], distortion_method, DistortImageMethod);
+            VALUE_TO_ENUM(argv[0], distortion_method, DistortMethod);
             break;
         default:
             rb_raise(rb_eArgError, "wrong number of arguments (expected 2 or 3, got %d)", argc);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1118,8 +1118,8 @@ Init_RMagick2(void)
         ENUMERATOR(PreviousDispose)
     END_ENUM
 
-    // DistortImage "method" argument values
-    DEF_ENUM(DistortImageMethod)
+    // DistortMethod constants
+    DEF_ENUM(DistortMethod)
         ENUMERATOR(UndefinedDistortion)
         ENUMERATOR(AffineDistortion)
         ENUMERATOR(AffineProjectionDistortion)

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -1,4 +1,7 @@
 module Magick
   AlphaChannelType = AlphaChannelOption
   deprecate_constant 'AlphaChannelType'
+
+  DistortImageMethod = DistortMethod
+  deprecate_constant 'DistortImageMethod'
 end


### PR DESCRIPTION
Renamed DistortImageMethod to DistortMethod to prepare for ImageMagick 7 and added alias for backwards compatibility.