### PR TITLE
Fixed setting the name of the clip path.

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -291,7 +291,7 @@ module Magick
     # (pop) graphic-context".
     def define_clip_path(name)
       push('defs')
-      push('clip-path', name)
+      push("clip-path \"#{name}\"")
       push('graphic-context')
       yield
     ensure

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -317,4 +317,25 @@ class DrawUT < Test::Unit::TestCase
       assert_instance_of(Magick::Image::DrawOptions, yield_obj)
     end
   end
+
+  def test_issue_604
+    points = [0, 0, 1, 1, 2, 2]
+
+    pr = Magick::Draw.new
+
+    pr.define_clip_path('example') do
+      pr.polygon(*points)
+    end
+
+    pr.push
+    pr.clip_path('example')
+
+    composite = Magick::Image.new(10, 10)
+    pr.composite(0, 0, 10, 10, composite)
+
+    pr.pop
+
+    canvas = Magick::Image.new(10, 10)
+    pr.draw(canvas)
+  end
 end


### PR DESCRIPTION
This PR fixes the issue reported in #604. The name of the clip-path should be between quotes. Recent version of ImageMagick are more strict about this.