### PR TITLE
Find the value of the InterpolatePixelMethod enumeration instead of creating one

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1049,7 +1049,7 @@ extern VALUE  FilterTypes_find(FilterTypes);
 extern VALUE  GravityType_new(GravityType);
 extern VALUE  ImageType_new(ImageType);
 extern VALUE  InterlaceType_new(InterlaceType);
-extern VALUE  InterpolatePixelMethod_new(InterpolatePixelMethod);
+extern VALUE  InterpolatePixelMethod_find(InterpolatePixelMethod);
 extern VALUE  OrientationType_new(OrientationType);
 extern VALUE  RenderingIntent_new(RenderingIntent);
 extern VALUE  ResolutionType_new(ResolutionType);

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -829,39 +829,7 @@ InterlaceType_new(InterlaceType interlace)
 
 
 /**
- * Return the name of a InterpolatePixelMethod enum as a string.
- *
- * No Ruby usage (internal function)
- *
- * @param interpolate the InterpolatePixelMethod
- * @return the name
- */
-static const char *
-InterpolatePixelMethod_name(InterpolatePixelMethod interpolate)
-{
-    switch(interpolate)
-    {
-        ENUM_TO_NAME(AverageInterpolatePixel)
-        ENUM_TO_NAME(BicubicInterpolatePixel)
-        ENUM_TO_NAME(BilinearInterpolatePixel)
-        ENUM_TO_NAME(FilterInterpolatePixel)
-        ENUM_TO_NAME(IntegerInterpolatePixel)
-        ENUM_TO_NAME(MeshInterpolatePixel)
-        ENUM_TO_NAME(NearestNeighborInterpolatePixel)
-        ENUM_TO_NAME(SplineInterpolatePixel)
-        ENUM_TO_NAME(Average9InterpolatePixel)
-        ENUM_TO_NAME(Average16InterpolatePixel)
-        ENUM_TO_NAME(BlendInterpolatePixel)
-        ENUM_TO_NAME(BackgroundInterpolatePixel)
-        ENUM_TO_NAME(CatromInterpolatePixel)
-        default:
-        ENUM_TO_NAME(UndefinedInterpolatePixel)
-    }
-}
-
-
-/**
- * Construct an InterpolatePixelMethod enum object for the specified value.
+ * Returns a InterpolatePixelMethod enum object for the specified value.
  *
  * No Ruby usage (internal function)
  *
@@ -869,10 +837,9 @@ InterpolatePixelMethod_name(InterpolatePixelMethod interpolate)
  * @return a new InterpolatePixelMethod enumerator
  */
 VALUE
-InterpolatePixelMethod_new(InterpolatePixelMethod interpolate)
+InterpolatePixelMethod_find(InterpolatePixelMethod interpolate)
 {
-    const char *name = InterpolatePixelMethod_name(interpolate);
-    return rm_enum_new(Class_InterpolatePixelMethod, ID2SYM(rb_intern(name)), INT2FIX(interpolate));
+    return Enum_find(Class_InterpolatePixelMethod, interpolate);
 }
 
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10051,7 +10051,7 @@ VALUE
 Image_pixel_interpolation_method(VALUE self)
 {
     Image *image = rm_check_destroyed(self);
-    return InterpolatePixelMethod_new(image->interpolate);
+    return InterpolatePixelMethod_find(image->interpolate);
 }
 
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -100,6 +100,14 @@ class EnumUT < Test::Unit::TestCase
     end
   end
 
+  def test_issue593_pixel_interpolation_method
+    img = Magick::Image.new(1, 1)
+    Magick::InterpolatePixelMethod.values do |value|
+      img.pixel_interpolation_method = value
+      assert_equal(value, img.pixel_interpolation_method)
+    end
+  end
+
   def test_issue593_virtual_pixel_method
     img = Magick::Image.new(1, 1)
     Magick::VirtualPixelMethod.values do |value|


### PR DESCRIPTION
This PR fixes the issue that was reported in #593 for the InterpolatePixelMethod enumeration.