### PR TITLE
Renamed InterpolatePixelMethod to PixelInterpolateMethod

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -120,6 +120,7 @@ typedef PixelPacket PixelColor;
 typedef AlphaChannelType AlphaChannelOption;
 typedef DistortImageMethod DistortMethod;
 typedef FilterTypes FilterType;
+typedef InterpolatePixelMethod PixelInterpolateMethod;
 
 //! Montage
 typedef struct
@@ -306,12 +307,12 @@ EXTERN VALUE Class_FilterType;
 EXTERN VALUE Class_GravityType;
 EXTERN VALUE Class_ImageType;
 EXTERN VALUE Class_InterlaceType;
-EXTERN VALUE Class_InterpolatePixelMethod;
 EXTERN VALUE Class_ImageLayerMethod;
 EXTERN VALUE Class_MagickFunction;
 EXTERN VALUE Class_NoiseType;
 EXTERN VALUE Class_OrientationType;
 EXTERN VALUE Class_PaintMethod;
+EXTERN VALUE Class_PixelInterpolateMethod;
 EXTERN VALUE Class_PreviewType;
 EXTERN VALUE Class_RenderingIntent;
 EXTERN VALUE Class_ResolutionType;
@@ -1050,8 +1051,8 @@ extern VALUE  FilterType_find(FilterType);
 extern VALUE  GravityType_new(GravityType);
 extern VALUE  ImageType_new(ImageType);
 extern VALUE  InterlaceType_new(InterlaceType);
-extern VALUE  InterpolatePixelMethod_find(InterpolatePixelMethod);
 extern VALUE  OrientationType_new(OrientationType);
+extern VALUE  PixelInterpolateMethod_find(PixelInterpolateMethod);
 extern VALUE  RenderingIntent_new(RenderingIntent);
 extern VALUE  ResolutionType_new(ResolutionType);
 extern const char *StorageType_name(StorageType);

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -829,21 +829,6 @@ InterlaceType_new(InterlaceType interlace)
 
 
 /**
- * Returns a InterpolatePixelMethod enum object for the specified value.
- *
- * No Ruby usage (internal function)
- *
- * @param interpolate the InterpolatePixelMethod
- * @return a new InterpolatePixelMethod enumerator
- */
-VALUE
-InterpolatePixelMethod_find(InterpolatePixelMethod interpolate)
-{
-    return Enum_find(Class_InterpolatePixelMethod, interpolate);
-}
-
-
-/**
  * Return the name of a OrientationType enum as a string.
  *
  * No Ruby usage (internal function)
@@ -883,6 +868,21 @@ OrientationType_new(OrientationType type)
 {
     const char *name = OrientationType_name(type);
     return rm_enum_new(Class_OrientationType, ID2SYM(rb_intern(name)), INT2FIX(type));
+}
+
+
+/**
+ * Returns a PixelInterpolateMethod enum object for the specified value.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param interpolate the PixelInterpolateMethod
+ * @return a new PixelInterpolateMethod enumerator
+ */
+VALUE
+PixelInterpolateMethod_find(PixelInterpolateMethod interpolate)
+{
+    return Enum_find(Class_PixelInterpolateMethod, interpolate);
 }
 
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10051,7 +10051,7 @@ VALUE
 Image_pixel_interpolation_method(VALUE self)
 {
     Image *image = rm_check_destroyed(self);
-    return InterpolatePixelMethod_find(image->interpolate);
+    return PixelInterpolateMethod_find(image->interpolate);
 }
 
 
@@ -10071,7 +10071,7 @@ VALUE
 Image_pixel_interpolation_method_eq(VALUE self, VALUE method)
 {
     Image *image = rm_check_frozen(self);
-    VALUE_TO_ENUM(method, image->interpolate, InterpolatePixelMethod);
+    VALUE_TO_ENUM(method, image->interpolate, PixelInterpolateMethod);
     return method;
 }
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1237,23 +1237,6 @@ Init_RMagick2(void)
         ENUMERATOR(PNGInterlace)
     END_ENUM
 
-    DEF_ENUM(InterpolatePixelMethod)
-        ENUMERATOR(UndefinedInterpolatePixel)
-        ENUMERATOR(AverageInterpolatePixel)
-        ENUMERATOR(BicubicInterpolatePixel)
-        ENUMERATOR(BilinearInterpolatePixel)
-        ENUMERATOR(FilterInterpolatePixel)
-        ENUMERATOR(IntegerInterpolatePixel)
-        ENUMERATOR(MeshInterpolatePixel)
-        ENUMERATOR(NearestNeighborInterpolatePixel)
-        ENUMERATOR(SplineInterpolatePixel)
-        ENUMERATOR(Average9InterpolatePixel)
-        ENUMERATOR(Average16InterpolatePixel)
-        ENUMERATOR(BlendInterpolatePixel)
-        ENUMERATOR(BackgroundInterpolatePixel)
-        ENUMERATOR(CatromInterpolatePixel)
-    END_ENUM
-
     DEF_ENUM(MagickFunction)
         ENUMERATOR(UndefinedFunction)
         ENUMERATOR(PolynomialFunction)
@@ -1330,6 +1313,24 @@ Init_RMagick2(void)
         ENUMERATOR(FloodfillMethod)
         ENUMERATOR(FillToBorderMethod)
         ENUMERATOR(ResetMethod)
+    END_ENUM
+
+    // PixelInterpolateMethod constants
+    DEF_ENUM(PixelInterpolateMethod)
+        ENUMERATOR(UndefinedInterpolatePixel)
+        ENUMERATOR(AverageInterpolatePixel)
+        ENUMERATOR(BicubicInterpolatePixel)
+        ENUMERATOR(BilinearInterpolatePixel)
+        ENUMERATOR(FilterInterpolatePixel)
+        ENUMERATOR(IntegerInterpolatePixel)
+        ENUMERATOR(MeshInterpolatePixel)
+        ENUMERATOR(NearestNeighborInterpolatePixel)
+        ENUMERATOR(SplineInterpolatePixel)
+        ENUMERATOR(Average9InterpolatePixel)
+        ENUMERATOR(Average16InterpolatePixel)
+        ENUMERATOR(BlendInterpolatePixel)
+        ENUMERATOR(BackgroundInterpolatePixel)
+        ENUMERATOR(CatromInterpolatePixel)
     END_ENUM
 
     // PreviewType

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -7,4 +7,7 @@ module Magick
 
   FilterTypes = FilterType
   deprecate_constant 'FilterTypes'
+
+  InterpolatePixelMethod = PixelInterpolateMethod
+  deprecate_constant 'InterpolatePixelMethod'
 end

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -102,7 +102,7 @@ class EnumUT < Test::Unit::TestCase
 
   def test_issue593_pixel_interpolation_method
     img = Magick::Image.new(1, 1)
-    Magick::InterpolatePixelMethod.values do |value|
+    Magick::PixelInterpolateMethod.values do |value|
       img.pixel_interpolation_method = value
       assert_equal(value, img.pixel_interpolation_method)
     end

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -504,12 +504,12 @@ class Image_Attributes_UT < Test::Unit::TestCase
 
   def test_pixel_interpolation_method
     assert_nothing_raised { @img.pixel_interpolation_method }
-    assert_instance_of(Magick::InterpolatePixelMethod, @img.pixel_interpolation_method)
+    assert_instance_of(Magick::PixelInterpolateMethod, @img.pixel_interpolation_method)
     assert_equal(Magick::UndefinedInterpolatePixel, @img.pixel_interpolation_method)
     assert_nothing_raised { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }
     assert_equal(Magick::AverageInterpolatePixel, @img.pixel_interpolation_method)
 
-    Magick::InterpolatePixelMethod.values do |interpolate_pixel_method|
+    Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
       assert_nothing_raised { @img.pixel_interpolation_method = interpolate_pixel_method }
     end
     assert_raise(TypeError) { @img.pixel_interpolation_method = 2 }


### PR DESCRIPTION
Renamed InterpolatePixelMethod to PixelInterpolateMethod to prepare for ImageMagick 7 and added alias for backwards compatibility.