### PR TITLE
CI: Boost STYLE_CHECKS running time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache:
   directories:
     - ~/.ccache
+    - ~/.cache/rubocop_cache
     - vendor/bundle
     - build-ImageMagick
 
@@ -20,7 +21,7 @@ env:
   - IMAGEMAGICK_VERSION=6.9.10-40 CONFIGURE_OPTIONS=--enable-hdri
 
 before_install:
-  - source before_install_$TRAVIS_OS_NAME.sh
+  - /bin/bash before_install_$TRAVIS_OS_NAME.sh
 
 install: bundle install --path=vendor/bundle --verbose
 
@@ -33,7 +34,7 @@ rvm:
 matrix:
   include:
     - rvm: 2.3
-      env: STYLE_CHECKS=true IMAGEMAGICK_VERSION=6.8.9-10
+      env: STYLE_CHECKS=true
 
 notifications:
   webhooks:

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -1,5 +1,18 @@
 set -euox pipefail
 
+gem install bundler
+
+if [ -v STYLE_CHECKS ]; then
+  set +ux
+  exit 0
+fi
+
+if [ ! -v IMAGEMAGICK_VERSION ]; then
+  echo "you must specify an ImageMagick version."
+  echo "example: 'IMAGEMAGICK_VERSION=6.8.9-10 bash ./before_install_linux.sh'"
+  exit 1
+fi
+
 sudo apt-get update
 
 # remove all existing imagemagick related packages
@@ -9,12 +22,6 @@ sudo apt-get autoremove -y imagemagick* libmagick* --purge
 sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
   liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
   libtiff5-dev libwebp-dev vim ghostscript ccache
-
-if [ ! -v IMAGEMAGICK_VERSION ]; then
-  echo "you must specify an ImageMagick version."
-  echo "example: 'IMAGEMAGICK_VERSION=6.8.9-10 bash ./before_install_linux.sh'"
-  exit 1
-fi
 
 if [ ! -d /usr/include/freetype ]; then
   # If `/usr/include/freetype` is not existed, ImageMagick 6.7 configuration fails about Freetype.
@@ -60,7 +67,5 @@ sudo make install -j
 cd $project_dir
 
 sudo ldconfig
-
-gem install bundler
 
 set +ux


### PR DESCRIPTION
1. When run `rubocop`, it is unnecessary to install ImageMagick. This patch will remove the installation.
2. `rubocop` cache the result in `~/.cache/rubocop_cache`. This patch will set up rubocop cache directory to reduce running time.