### PR TITLE
CI: Reduce apt update time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,24 @@ cache:
     - vendor/bundle
     - build-ImageMagick
 
+dist: xenial
+addons:
+  apt:
+    packages:
+      - build-essential
+      - libx11-dev
+      - libxext-dev
+      - zlib1g-dev
+      - liblcms2-dev
+      - libpng-dev
+      - libjpeg-dev
+      - libfreetype6-dev
+      - libxml2-dev
+      - libtiff5-dev
+      - libwebp-dev
+      - ghostscript
+      - ccache
+
 os:
   - linux
 

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -13,15 +13,17 @@ if [ ! -v IMAGEMAGICK_VERSION ]; then
   exit 1
 fi
 
-sudo apt-get update
-
 # remove all existing imagemagick related packages
 sudo apt-get autoremove -y imagemagick* libmagick* --purge
 
-# install build tools, ImageMagick delegates
-sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
-  liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
-  libtiff5-dev libwebp-dev vim ghostscript ccache
+if [ ! -v TRAVIS ]; then
+  sudo apt-get update
+
+  # install build tools, ImageMagick delegates
+  sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
+    liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
+    libtiff5-dev libwebp-dev vim ghostscript ccache
+fi
 
 if [ ! -d /usr/include/freetype ]; then
   # If `/usr/include/freetype` is not existed, ImageMagick 6.7 configuration fails about Freetype.


### PR DESCRIPTION
Move Trusty environment to Xenial in order to use `addons:apt:packages:` in travis.yml
https://docs.travis-ci.com/user/reference/xenial/

`sudo apt-get update` update all repository information.
But, `addons:apt:...` way just update necessary information to install library.

Seems it will reduce set up time slightly.