### PR TITLE
CI: Remove ccache dir from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 cache:
   directories:
-    - ~/.ccache
     - ~/.cache/rubocop_cache
     - vendor/bundle
     - build-ImageMagick


### PR DESCRIPTION
We have added cache mechanism at https://github.com/rmagick/rmagick/pull/521
It cache the build objects without ccache.

When the huge cache will be stored/retored, it will take a time slightly.
This patch will remove cache directory of ccache from travis.yml to remove redundant cache object and it will reduce the CI running time.