### PR TITLE
Added alpha property to the pixel class.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -999,6 +999,7 @@ extern VALUE  TextureFill_fill(VALUE, VALUE);
 ATTR_ACCESSOR(Pixel, red)
 ATTR_ACCESSOR(Pixel, green)
 ATTR_ACCESSOR(Pixel, blue)
+ATTR_ACCESSOR(Pixel, alpha)
 ATTR_ACCESSOR(Pixel, opacity)
 ATTR_ACCESSOR(Pixel, cyan)
 ATTR_ACCESSOR(Pixel, magenta)

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -646,6 +646,7 @@ Init_RMagick2(void)
     DCL_ATTR_ACCESSOR(Pixel, red)
     DCL_ATTR_ACCESSOR(Pixel, green)
     DCL_ATTR_ACCESSOR(Pixel, blue)
+    DCL_ATTR_ACCESSOR(Pixel, alpha)
     DCL_ATTR_ACCESSOR(Pixel, opacity)
 
     // Define the CMYK attributes

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -111,6 +111,24 @@ DEF_ATTR_READER(Pixel, green, int)
 DEF_ATTR_READER(Pixel, blue, int)
 
 /**
+ * Get Pixel alpha attribute.
+ *
+ * Ruby usage:
+ *   - @verbatim Pixel#alpha @endverbatim
+ *
+ * @param self this object
+ * @return the alpha value
+ */
+VALUE
+Pixel_alpha(VALUE self)
+{
+    Pixel *pixel;
+    Data_Get_Struct(self, Pixel, pixel);
+    return C_int_to_R_int(QuantumRange - pixel->opacity);
+}
+
+
+/**
  * Get Pixel opacity attribute.
  *
  * Ruby usage:
@@ -171,6 +189,35 @@ DEF_PIXEL_CHANNEL_WRITER(green)
  * @return self
  */
 DEF_PIXEL_CHANNEL_WRITER(blue)
+
+/**
+ * Set Pixel alpha attribute.
+ *
+ * Ruby usage:
+ *   - @verbatim Pixel#alpha= @endverbatim
+ *
+ * Notes:
+ *   - Pixel is Observable. Setters call changed, notify_observers
+ *   - Setters return their argument values for backward compatibility to when
+ *     Pixel was a Struct class.
+ *
+ * @param self this object
+ * @param v the alpha value
+ * @return self
+ */
+VALUE
+Pixel_alpha_eq(VALUE self, VALUE v)
+{
+    Pixel *pixel;
+ 
+    rb_check_frozen(self);
+    Data_Get_Struct(self, Pixel, pixel);
+    pixel->opacity = QuantumRange - APP2QUANTUM(v);
+    (void) rb_funcall(self, rm_ID_changed, 0);
+    (void) rb_funcall(self, rm_ID_notify_observers, 1, self);
+    return QUANTUM2NUM(QuantumRange - pixel->opacity);
+}
+
 
 /**
  * Set Pixel opacity attribute.

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -33,6 +33,14 @@ class PixelUT < Test::Unit::TestCase
     assert_raise(TypeError) { @pixel.blue = 'x' }
   end
 
+  def test_alpha
+    assert_nothing_raised { @pixel.alpha = 123 }
+    assert_equal(123, @pixel.alpha)
+    assert_nothing_raised { @pixel.alpha = 255.25 }
+    assert_equal(255, @pixel.alpha)
+    assert_raise(TypeError) { @pixel.alpha = 'x' }
+  end
+
   def test_opacity
     assert_nothing_raised { @pixel.opacity = 123 }
     assert_equal(123, @pixel.opacity)


### PR DESCRIPTION
This PR adds an alpha property to prepare for ImageMagick 7. After this has been merged the `opacity` property will become deprecated and users will be informed to use `alpha` instead.