### PR TITLE
Renamed ImageLayerMethod to LayerMethod

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -121,6 +121,7 @@ typedef AlphaChannelType AlphaChannelOption;
 typedef DistortImageMethod DistortMethod;
 typedef FilterTypes FilterType;
 typedef InterpolatePixelMethod PixelInterpolateMethod;
+typedef ImageLayerMethod LayerMethod;
 
 //! Montage
 typedef struct
@@ -307,7 +308,7 @@ EXTERN VALUE Class_FilterType;
 EXTERN VALUE Class_GravityType;
 EXTERN VALUE Class_ImageType;
 EXTERN VALUE Class_InterlaceType;
-EXTERN VALUE Class_ImageLayerMethod;
+EXTERN VALUE Class_LayerMethod;
 EXTERN VALUE Class_MagickFunction;
 EXTERN VALUE Class_NoiseType;
 EXTERN VALUE Class_OrientationType;

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -616,13 +616,13 @@ VALUE
 ImageList_optimize_layers(VALUE self, VALUE method)
 {
     Image *images, *new_images, *new_images2;
-    ImageLayerMethod mthd;
+    LayerMethod mthd;
     ExceptionInfo *exception;
     QuantizeInfo quantize_info;
 
     new_images2 = NULL;     // defeat "unused variable" message
 
-    VALUE_TO_ENUM(method, mthd, ImageLayerMethod);
+    VALUE_TO_ENUM(method, mthd, LayerMethod);
     images = images_from_imagelist(self);
 
     exception = AcquireExceptionInfo();

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1245,7 +1245,7 @@ Init_RMagick2(void)
         ENUMERATOR(ArctanFunction)
     END_ENUM
 
-    DEF_ENUM(ImageLayerMethod)
+    DEF_ENUM(LayerMethod)
         ENUMERATOR(UndefinedLayer)
         ENUMERATOR(CompareAnyLayer)
         ENUMERATOR(CompareClearLayer)

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -8,6 +8,9 @@ module Magick
   FilterTypes = FilterType
   deprecate_constant 'FilterTypes'
 
+  ImageLayerMethod = LayerMethod
+  deprecate_constant 'ImageLayerMethod'
+
   InterpolatePixelMethod = PixelInterpolateMethod
   deprecate_constant 'InterpolatePixelMethod'
 end

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -279,7 +279,7 @@ class ImageList2UT < Test::Unit::TestCase
 
   def test_optimize_layers
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    Magick::ImageLayerMethod.values do |method|
+    Magick::LayerMethod.values do |method|
       next if [Magick::UndefinedLayer, Magick::CompositeLayer, Magick::TrimBoundsLayer].include?(method)
 
       assert_nothing_raised do


### PR DESCRIPTION
Renamed ImageLayerMethod to LayerMethod to prepare for ImageMagick 7 and added alias for backwards compatibility.