### PR TITLE
Deprecated the opacity property of the Pixel class.

### DIFF
--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -136,8 +136,16 @@ Pixel_alpha(VALUE self)
  *
  * @param self this object
  * @return the opacity value
+ * @deprecated This method has been deprecated. Please use Pixel_alpha.
  */
-DEF_ATTR_READER(Pixel, opacity, int)
+VALUE
+Pixel_opacity(VALUE self)
+{
+    Pixel *pixel;
+    rb_warning("Pixel#opacity is deprecated; use Pixel#opacity.");
+    Data_Get_Struct(self, Pixel, pixel);
+    return C_int_to_R_int(pixel->opacity);
+}
 
 /**
  * Set Pixel red attribute.
@@ -233,9 +241,21 @@ Pixel_alpha_eq(VALUE self, VALUE v)
  * @param self this object
  * @param v the opacity value
  * @return self
+ * @deprecated This method has been deprecated. Please use Pixel_alpha_eq.
  */
-DEF_PIXEL_CHANNEL_WRITER(opacity)
+VALUE
+Pixel_opacity_eq(VALUE self, VALUE v)
+{
+    Pixel *pixel;
 
+    rb_warning("Pixel#opacity= is deprecated; use Pixel#alpha=.");
+    rb_check_frozen(self);
+    Data_Get_Struct(self, Pixel, pixel);
+    pixel->opacity = APP2QUANTUM(v);
+    (void) rb_funcall(self, rm_ID_changed, 0);
+    (void) rb_funcall(self, rm_ID_notify_observers, 1, self);
+    return QUANTUM2NUM(pixel->opacity);
+}
 
 /*
  * Get/set Pixel CMYK attributes.


### PR DESCRIPTION
This PR deprecates the opacity property of the Pixel class. This has been replaced with the new alpha property method. (#617).