### PR TITLE
Use valid type to get rid of warning message

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1692,7 +1692,7 @@ Init_RMagick2(void)
 static void
 test_Magick_version(void)
 {
-    unsigned long version_number;
+    size_t version_number;
     const char *version_str;
     int x, n;
     ID bypass = rb_intern("RMAGICK_BYPASS_VERSION_TEST");


### PR DESCRIPTION
This patch will remove following warning message in compiling.

```
rmmain.c: In function 'test_Magick_version':
rmmain.c:1705:36: warning: passing argument 1 of 'GetMagickVersion' from incompatible pointer type [-Wincompatible-pointer-types]
     version_str = GetMagickVersion(&version_number);
```