### PR TITLE
Remove self assign warning message in compiling

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -179,14 +179,13 @@ MagickInfo_to_format(const MagickInfo *magick_info)
  * @see MagickInfo_to_format
  */
 VALUE
-Magick_init_formats(VALUE class)
+Magick_init_formats(VALUE class ATTRIBUTE_UNUSED)
 {
     const MagickInfo **magick_info;
     size_t number_formats, x;
     VALUE formats;
     ExceptionInfo *exception;
 
-    class = class;      // defeat "never referenced" message from icc
     formats = rb_hash_new();
 
     // IM 6.1.3 added an exception argument to GetMagickInfoList

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -52,6 +52,11 @@
 //! For quoting preprocessor symbols
 #define Q(q) Q2(q)
 
+#ifdef __GNUC__
+#define ATTRIBUTE_UNUSED  __attribute__((unused))
+#else
+#define ATTRIBUTE_UNUSED
+#endif
 
 //! Trace new image creation in bang methods
 #define UPDATE_DATA_PTR(_obj_, _new_) \

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1410,10 +1410,7 @@ get_offsets_from_gravity(GravityType gravity, Image *image, Image *mark
 static VALUE
 check_for_long_value(VALUE obj)
 {
-    long t;
-    t = NUM2LONG(obj);
-    t = t;      // placate gcc
-    return(VALUE)0;
+    return LONG2NUM(NUM2LONG(obj));
 }
 
 
@@ -2016,14 +2013,12 @@ Image_bounding_box(VALUE self)
  * @return a new image
  */
 VALUE
-Image_capture(int argc, VALUE *argv, VALUE self)
+Image_capture(int argc, VALUE *argv, VALUE self ATTRIBUTE_UNUSED)
 {
     Image *image;
     ImageInfo *image_info;
     VALUE info_obj;
     XImportInfo ximage_info;
-
-    self = self;  // Suppress "never referenced" message from icc
 
     XGetImportInfo(&ximage_info);
     switch (argc)
@@ -3096,13 +3091,11 @@ DEF_ATTR_READER(Image, columns, int)
  * @param self this object
  * @return a new image
  */
-VALUE Image_combine(int argc, VALUE *argv, VALUE self)
+VALUE Image_combine(int argc, VALUE *argv, VALUE self ATTRIBUTE_UNUSED)
 {
     ChannelType channel = 0;
     Image *image, *images = NULL, *new_image;
     ExceptionInfo *exception;
-
-    self = self;        // defeat "unreferenced argument" message
 
     switch (argc)
     {
@@ -3885,7 +3878,7 @@ Image_compress_colormap_bang(VALUE self)
  * @throw TypeError
  */
 VALUE
-Image_constitute(VALUE class, VALUE width_arg, VALUE height_arg
+Image_constitute(VALUE class ATTRIBUTE_UNUSED, VALUE width_arg, VALUE height_arg
                  , VALUE map_arg, VALUE pixels_arg)
 {
     Image *image;
@@ -3903,11 +3896,9 @@ Image_constitute(VALUE class, VALUE width_arg, VALUE height_arg
     VALUE pixel_class;
     StorageType stg_type;
 
-    class = class;  // Suppress "never referenced" message from icc
-
-            // rb_Array converts objects that are not Arrays to Arrays if possible,
-            // and raises TypeError if it can't.
-            pixels_arg = rb_Array(pixels_arg);
+    // rb_Array converts objects that are not Arrays to Arrays if possible,
+    // and raises TypeError if it can't.
+    pixels_arg = rb_Array(pixels_arg);
 
     width = NUM2ULONG(width_arg);
     height = NUM2ULONG(height_arg);
@@ -5369,7 +5360,7 @@ Image_distortion_channel(int argc, VALUE *argv, VALUE self)
  * @return a string representing the dumped image
  */
 VALUE
-Image__dump(VALUE self, VALUE depth)
+Image__dump(VALUE self, VALUE depth ATTRIBUTE_UNUSED)
 {
     Image *image;
     ImageInfo *info;
@@ -5378,8 +5369,6 @@ Image__dump(VALUE self, VALUE depth)
     DumpedImage mi;
     VALUE str;
     ExceptionInfo *exception;
-
-    depth = depth;  // Suppress "never referenced" message from icc
 
     image = rm_check_destroyed(self);
 
@@ -6697,7 +6686,7 @@ Image_frame(int argc, VALUE *argv, VALUE self)
  * @return an array of new images
  */
 VALUE
-Image_from_blob(VALUE class, VALUE blob_arg)
+Image_from_blob(VALUE class ATTRIBUTE_UNUSED, VALUE blob_arg)
 {
     Image *images;
     Info *info;
@@ -6705,9 +6694,6 @@ Image_from_blob(VALUE class, VALUE blob_arg)
     ExceptionInfo *exception;
     void *blob;
     long length;
-
-    class = class;          // defeat gcc message
-            blob_arg = blob_arg;    // defeat gcc message
 
     blob = (void *) rm_str2cstr(blob_arg, &length);
 
@@ -8170,7 +8156,7 @@ Image_liquid_rescale(int argc, VALUE *argv, VALUE self)
  * @see Image__dump
  */
 VALUE
-Image__load(VALUE class, VALUE str)
+Image__load(VALUE class ATTRIBUTE_UNUSED, VALUE str)
 {
     Image *image;
     ImageInfo *info;
@@ -8178,8 +8164,6 @@ Image__load(VALUE class, VALUE str)
     ExceptionInfo *exception;
     char *blob;
     long length;
-
-    class = class;  // Suppress "never referenced" message from icc
 
     blob = rm_str2cstr(str, &length);
 
@@ -10775,7 +10759,7 @@ file_arg_rescue(VALUE arg)
  * @see array_from_images
  */
 static VALUE
-rd_image(VALUE class, VALUE file, reader_t reader)
+rd_image(VALUE class ATTRIBUTE_UNUSED, VALUE file, reader_t reader)
 {
     char *filename;
     long filename_l;
@@ -10783,8 +10767,6 @@ rd_image(VALUE class, VALUE file, reader_t reader)
     VALUE info_obj;
     Image *images;
     ExceptionInfo *exception;
-
-    class = class;  // defeat gcc message
 
     // Create a new Info structure for this read/ping
     info_obj = rm_info_new();
@@ -10913,7 +10895,7 @@ Image_recolor(VALUE self, VALUE color_matrix)
  * @see array_from_images
  */
 VALUE
-Image_read_inline(VALUE self, VALUE content)
+Image_read_inline(VALUE self ATTRIBUTE_UNUSED, VALUE content)
 {
     VALUE info_obj;
     Image *images;
@@ -10923,8 +10905,6 @@ Image_read_inline(VALUE self, VALUE content)
     unsigned char *blob;
     size_t blob_l;
     ExceptionInfo *exception;
-
-    self = self;    // defeat gcc message
 
     image_data = rm_str2cstr(content, &image_data_l);
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -845,9 +845,7 @@ Info_delay(VALUE self)
 static VALUE
 arg_is_integer(VALUE arg)
 {
-    int d = NUM2INT(arg);
-    d = d;      // satisfy icc
-    return arg;
+    return INT2NUM(NUM2INT(arg));
 }
 
 /**

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -540,13 +540,11 @@ Pixel_fcmp(int argc, VALUE *argv, VALUE self)
  * @see Pixel_to_color
  */
 VALUE
-Pixel_from_color(VALUE class, VALUE name)
+Pixel_from_color(VALUE class ATTRIBUTE_UNUSED, VALUE name)
 {
     PixelColor pp;
     ExceptionInfo *exception;
     MagickBooleanType okay;
-
-    class = class;      // defeat "never referenced" message from icc
 
     exception = AcquireExceptionInfo();
     okay = QueryColorCompliance(StringValuePtr(name), AllCompliance, &pp, exception);
@@ -583,15 +581,13 @@ Pixel_from_color(VALUE class, VALUE name)
  * @return a new Magick::Pixel object
  */
 VALUE
-Pixel_from_hsla(int argc, VALUE *argv, VALUE class)
+Pixel_from_hsla(int argc, VALUE *argv, VALUE class ATTRIBUTE_UNUSED)
 {
     double h, s, l, a = 1.0;
     MagickPixel pp;
     ExceptionInfo *exception;
     char name[50];
     MagickBooleanType alpha = MagickFalse;
-
-    class = class;          // defeat "unused parameter" message.
 
     switch (argc)
     {
@@ -660,12 +656,11 @@ Pixel_from_hsla(int argc, VALUE *argv, VALUE class)
  * @deprecated This method has been deprecated. Please use Pixel_from_hsla.
  */
 VALUE
-Pixel_from_HSL(VALUE class, VALUE hsl)
+Pixel_from_HSL(VALUE class ATTRIBUTE_UNUSED, VALUE hsl)
 {
     PixelColor rgb;
     double hue, saturation, luminosity;
 
-    class = class;      // defeat "never referenced" message from icc
     memset(&rgb, 0, sizeof(rgb));
 
     hsl = rb_Array(hsl);    // Ensure array

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -359,10 +359,7 @@ rm_str2cstr(VALUE str, long *len)
 static VALUE
 arg_is_number(VALUE arg)
 {
-    double d;
-    d = NUM2DBL(arg);
-    d = d;      // satisfy icc
-    return arg;
+    return DBL2NUM(NUM2DBL(arg));
 }
 
 
@@ -472,9 +469,8 @@ check_num2dbl(VALUE obj)
  * @return 0
  */
 static VALUE
-rescue_not_dbl(VALUE ignored)
+rescue_not_dbl(VALUE ignored ATTRIBUTE_UNUSED)
 {
-    ignored = ignored;      // defeat gcc message
     return INT2FIX(0);
 }
 
@@ -1490,7 +1486,7 @@ rm_clone_image(Image *image)
  */
 MagickBooleanType
 rm_progress_monitor(
-    const char *tag,
+    const char *tag ATTRIBUTE_UNUSED,
     const MagickOffsetType of,
     const MagickSizeType sp,
     void *client_data)
@@ -1508,8 +1504,6 @@ rm_progress_monitor(
         // skip the callback and continue ImageMagick process.
         return MagickTrue;
     }
-
-    tag = tag;      // defeat gcc message
 
 #if defined(HAVE_LONG_LONG)     // defined in Ruby's defines.h
     offset = rb_ll2inum(of);


### PR DESCRIPTION
This patch will remove following warning message in compiling.
```
rmagick.c:189:11: warning: explicitly assigning value of variable of type 'VALUE' (aka 'unsigned long') to itself [-Wself-assign]
    class = class;      // defeat "never referenced" message from icc
    ~~~~~ ^ ~~~~~
```

We can indicate the unused variable to compiler using compiler attributes.
https://clang.llvm.org/docs/AttributeReference.html#maybe-unused-unused

This patch will introduce macro in
https://github.com/ruby/ruby/blob/7e72ce0f734113e3e215a74b440092443e957d45/st.c#L117-L125