### PR TITLE
Enforce C99

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -113,6 +113,8 @@ module RMagick
         have_library('X11')
 
       end
+
+      $CFLAGS << ' -std=c99'
     end
 
     # Test for a specific value in an enum type


### PR DESCRIPTION
If we enforce C99, we can use c99 feature, we can use `snprintf` without checking

https://github.com/rmagick/rmagick/blob/e9ad483dc0a748cf42f59e32d612b66b942aa678/ext/RMagick/extconf.rb#L304

