### PR TITLE
Remove have_func checking for snprintf

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -303,7 +303,6 @@ END_MINGW
     end
 
     def create_header_file
-      have_func('snprintf', headers)
       [
         'GetImageChannelEntropy', # 6.9.0-0
         'SetImageGray' # 6.9.1-10

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13528,11 +13528,7 @@ Image_tint(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "opacity percentages must be non-negative.");
     }
 
-#if defined(HAVE_SNPRINTF)
     snprintf(opacity, sizeof(opacity),
-#else
-    sprintf(opacity,
-#endif
             "%g,%g,%g,%g", red_pct_opaque*100.0, green_pct_opaque*100.0
             , blue_pct_opaque*100.0, alpha_pct_opaque*100.0);
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2072,11 +2072,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Data_Get_Struct(self, Info, info);
     info->scene = NUM2ULONG(scene);
 
-#if defined(HAVE_SNPRINTF)
     (void) snprintf(buf, sizeof(buf), "%-ld", info->scene);
-#else
-    (void) sprintf(buf, "%-l", info->scene);
-#endif
     (void) SetImageOption(info, "scene", buf);
 
     return scene;

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1619,11 +1619,7 @@ format_exception(const ExceptionType severity, const char *reason, const char *d
     int len;
     memset(msg, 0, sizeof(ERROR_MSG_SIZE));
 
-#if defined(HAVE_SNPRINTF)
     len = snprintf(msg, ERROR_MSG_SIZE, "%s%s%s",
-#else
-    len = sprintf(msg, "%.500s%s%.500s",
-#endif
         GetLocaleExceptionMessage(severity, reason),
         description ? ": " : "",
         description ? GetLocaleExceptionMessage(severity, description) : "");


### PR DESCRIPTION
1. have_func checking take a time slightly.
2. C99 support `snprintf` function by default.
https://en.wikipedia.org/wiki/C99

Now, RMagick will be built with C99 by https://github.com/rmagick/rmagick/pull/634