### PR TITLE
Remove unnecessary header including to get rid of warning message

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -21,7 +21,6 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <math.h>
-#include <time.h>
 #if defined(HAVE_SYS_TYPES_H)
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
This patch will get rid of following warning message in compiling.

```
compiling ../../../../ext/RMagick/rmagick.c
In file included from /home/travis/.rvm/rubies/ruby-2.3.8/include/ruby-2.3.0/ruby/ruby.h:1988:0,
                 from /home/travis/.rvm/rubies/ruby-2.3.8/include/ruby-2.3.0/ruby.h:33,
                 from ../../../../ext/RMagick/rmagick.h:28,
                 from ../../../../ext/RMagick/rmagick.c:13:
/home/travis/.rvm/rubies/ruby-2.3.8/include/ruby-2.3.0/ruby/intern.h:923:29: warning: ‘struct timespec’ declared inside parameter list
 void rb_timespec_now(struct timespec *);
```