### PR TITLE
Deprecated StaticGravity because this will be removed in ImageMagick 7.

### DIFF
--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -46,4 +46,5 @@ module Magick
 
   deprecate_constant 'Rec601LumaColorspace'
   deprecate_constant 'Rec709LumaColorspace'
+  deprecate_constant 'StaticGravity'
 end


### PR DESCRIPTION
This PR deprecates StaticGravity because this is nog longer supported in ImageMagick 7.  CenterGravity should be used instead.