### PR TITLE
Fix memory leak when overwritting the view value of the Info class.

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2529,18 +2529,23 @@ VALUE
 Info_view_eq(VALUE self, VALUE view_arg)
 {
     Info *info;
-    char *view;
+    char *view = NULL;
+    long length = 0;
 
     Data_Get_Struct(self, Info, info);
 
-    if (NIL_P(view_arg) || StringValuePtr(view_arg) == NULL)
+    if (!NIL_P(view_arg))
+    {
+        view = rm_str2cstr(view_arg, &length);
+    }
+
+    if (info->view)
     {
         magick_free(info->view);
         info->view = NULL;
     }
-    else
+    if (length > 0)
     {
-        view = StringValuePtr(view_arg);
         magick_clone_string(&info->view, view);
     }
     return view_arg;

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2530,13 +2530,12 @@ Info_view_eq(VALUE self, VALUE view_arg)
 {
     Info *info;
     char *view = NULL;
-    long length = 0;
 
     Data_Get_Struct(self, Info, info);
 
     if (!NIL_P(view_arg))
     {
-        view = rm_str2cstr(view_arg, &length);
+        view = StringValuePtr(view_arg);
     }
 
     if (info->view)
@@ -2544,7 +2543,7 @@ Info_view_eq(VALUE self, VALUE view_arg)
         magick_free(info->view);
         info->view = NULL;
     }
-    if (length > 0)
+    if (view)
     {
         magick_clone_string(&info->view, view);
     }

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -436,5 +436,7 @@ class InfoUT < Test::Unit::TestCase
     assert_equal('string', @info.view)
     assert_nothing_raised { @info.view = nil }
     assert_nil(@info.view)
+    assert_nothing_raised { @info.view = '' }
+    assert_equal('', @info.view)
   end
 end


### PR DESCRIPTION
The view value of the Info class should be freed before it is overwritten to prevent a memory leak and this PR fixes that.