### PR TITLE
Added the new MetricType values that will be used in ImageMagick 7

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1268,18 +1268,17 @@ Init_RMagick2(void)
     END_ENUM
 
     DEF_ENUM(MetricType)
-        ENUMERATOR(UndefinedMetric)
+        ENUMERATORV(UndefinedErrorMetric, UndefinedMetric)
         ENUMERATOR(AbsoluteErrorMetric)
         ENUMERATOR(MeanAbsoluteErrorMetric)
-        ENUMERATOR(MeanErrorPerPixelMetric)
+        ENUMERATORV(MeanErrorPerPixelErrorMetric, MeanErrorPerPixelMetric)
         ENUMERATOR(MeanSquaredErrorMetric)
         ENUMERATOR(PeakAbsoluteErrorMetric)
-        ENUMERATOR(PeakSignalToNoiseRatioMetric)
+        ENUMERATORV(PeakSignalToNoiseRatioErrorMetric, PeakSignalToNoiseRatioMetric)
         ENUMERATOR(RootMeanSquaredErrorMetric)
         ENUMERATOR(NormalizedCrossCorrelationErrorMetric)
         ENUMERATOR(FuzzErrorMetric)
 #if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
-        ENUMERATOR(UndefinedErrorMetric)
         ENUMERATOR(PerceptualHashErrorMetric)
 #endif
     END_ENUM

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -29,6 +29,9 @@ module Magick
   InterpolatePixelMethod = PixelInterpolateMethod
   deprecate_constant 'InterpolatePixelMethod'
 
+  MeanErrorPerPixelMetric = MeanErrorPerPixelErrorMetric
+  deprecate_constant 'MeanErrorPerPixelMetric'
+
   MinusCompositeOp = MinusDstCompositeOp
   deprecate_constant 'MinusCompositeOp'
 
@@ -38,11 +41,17 @@ module Magick
   PaletteMatteType = PaletteAlphaType
   deprecate_constant 'PaletteMatteType'
 
+  PeakSignalToNoiseRatioMetric = PeakSignalToNoiseRatioErrorMetric
+  deprecate_constant 'PeakSignalToNoiseRatioMetric'
+
   SubtractCompositeOp = ModulusSubtractCompositeOp
   deprecate_constant 'SubtractCompositeOp'
 
   TrueColorMatteType = TrueColorAlphaType
   deprecate_constant 'TrueColorMatteType'
+
+  UndefinedMetric = UndefinedErrorMetric
+  deprecate_constant 'UndefinedMetric'
 
   deprecate_constant 'Rec601LumaColorspace'
   deprecate_constant 'Rec709LumaColorspace'

--- a/test/lib/Obsolete.rb
+++ b/test/lib/Obsolete.rb
@@ -16,10 +16,13 @@ class ObsoleteUT < Test::Unit::TestCase
     assert_nothing_raised { Magick::GrayscaleMatteType }
     assert_nothing_raised { Magick::ImageLayerMethod }
     assert_nothing_raised { Magick::InterpolatePixelMethod }
+    assert_nothing_raised { Magick::MeanErrorPerPixelMetric }
     assert_nothing_raised { Magick::MinusCompositeOp }
     assert_nothing_raised { Magick::PaletteBilevelMatteType }
+    assert_nothing_raised { Magick::PeakSignalToNoiseRatioMetric }
     assert_nothing_raised { Magick::SubtractCompositeOp }
     assert_nothing_raised { Magick::TrueColorMatteType }
+    assert_nothing_raised { Magick::UndefinedMetric }
     assert_nothing_raised { Magick::Rec601LumaColorspace }
     assert_nothing_raised { Magick::Rec709LumaColorspace }
   end


### PR DESCRIPTION
This PR adds the new MetricType values that will be used in ImageMagick 7 and adds aliases for backwards compatibility.