### PR TITLE
Add new alpha constants to prepare for ImageMagick 7

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -463,8 +463,10 @@ EXTERN ID rm_ID_y;                 /**< "y" */
 //!  Define a Magick module constant
 #if MAGICKCORE_QUANTUM_DEPTH == 64
 #define DEF_CONST(constant) rb_define_const(Module_Magick, #constant, ULL2NUM(constant))
+#define DEF_CONSTV(constant, val) rb_define_const(Module_Magick, #constant, ULL2NUM(val))
 #else   // MAGICKCORE_QUANTUM_DEPTH == 8, 16, 32
 #define DEF_CONST(constant) rb_define_const(Module_Magick, #constant, UINT2NUM(constant))
+#define DEF_CONSTV(constant, val) rb_define_const(Module_Magick, #constant, UINT2NUM(val))
 #endif
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -863,7 +863,9 @@ Init_RMagick2(void)
     // Miscellaneous fixed-point constants
     DEF_CONST(QuantumRange);
     DEF_CONST(MAGICKCORE_QUANTUM_DEPTH);
+    DEF_CONSTV(OpaqueAlpha, QuantumRange);
     DEF_CONST(OpaqueOpacity);
+    DEF_CONSTV(TransparentAlpha, 0);
     DEF_CONST(TransparentOpacity);
 
     version_constants();

--- a/lib/obsolete.rb
+++ b/lib/obsolete.rb
@@ -57,8 +57,10 @@ module Magick
   deprecate_constant 'FlattenAlphaChannel'
   deprecate_constant 'IntegerPixel'
   deprecate_constant 'MatteChannel'
+  deprecate_constant 'OpaqueOpacity'
   deprecate_constant 'Rec601LumaColorspace'
   deprecate_constant 'Rec709LumaColorspace'
   deprecate_constant 'ResetAlphaChannel'
   deprecate_constant 'StaticGravity'
+  deprecate_constant 'TransparentOpacity'
 end

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -247,6 +247,10 @@ class MagickUT < Test::Unit::TestCase
     assert_instance_of(Hash, Magick.init_formats)
   end
 
+  def test_opaque_alpha
+    assert_equal(Magick::QuantumRange, Magick::OpaqueAlpha)
+  end
+
   def test_set_log_event_mask
     assert_nothing_raised { Magick.set_log_event_mask('Module,Coder') }
   end
@@ -297,6 +301,10 @@ class MagickUT < Test::Unit::TestCase
     assert_raise(ArgumentError) { Magick.limit_resource('xxx') }
     assert_raise(ArgumentError) { Magick.limit_resource('map', 3500, 2) }
     assert_raise(ArgumentError) { Magick.limit_resource }
+  end
+
+  def test_transparent_alpha
+    assert_equal(0, Magick::TransparentAlpha)
   end
 end
 


### PR DESCRIPTION
This PR adds new alpha constants to prepare for ImageMagick 7 and deprecates OpaqueOpacity and TransparentOpacity.