### PR TITLE
CI: Use preinstalled ruby in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ before_install:
 install: bundle install --path=vendor/bundle --verbose
 
 rvm:
-  - 2.3
-  - 2.4
-  - 2.5
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - 2.6
 
 matrix:


### PR DESCRIPTION
By using preinstalled ruby, we will cut a time to set up Ruby in Travis.

* Before
22.36 sec
<img width="832" alt="before" src="https://user-images.githubusercontent.com/199156/57287179-e735c200-70f1-11e9-89ac-31d32b4881f2.png">

* After
0.87 sec
<img width="841" alt="after" src="https://user-images.githubusercontent.com/199156/57287200-f1f05700-70f1-11e9-98aa-cc0537981bb5.png">

Travis pre-installed following Ruby versions.
* ruby-2.3.8
* ruby-2.4.5
* ruby-2.5.3

https://travis-ci.org/rmagick/rmagick/jobs/528851394#L154
<img width="338" alt="ruby" src="https://user-images.githubusercontent.com/199156/57287388-63300a00-70f2-11e9-8746-13220fe5e261.png">
