### PR TITLE
Remove have_header for sys/types.h

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -44,8 +44,7 @@ module RMagick
     end
 
     def configure_headers
-      @headers = %w[assert.h ctype.h stdio.h stdlib.h math.h time.h]
-      headers << 'sys/types.h' if have_header('sys/types.h')
+      @headers = %w[assert.h ctype.h stdio.h stdlib.h math.h time.h sys/types.h]
 
       if have_header('magick/MagickCore.h')
         headers << 'magick/MagickCore.h'

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -21,9 +21,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <math.h>
-#if defined(HAVE_SYS_TYPES_H)
 #include <sys/types.h>
-#endif
 #include "ruby.h"
 #include "ruby/io.h"
 


### PR DESCRIPTION
Ruby core also has used `sys/types.h` without any checking.
https://github.com/ruby/ruby/blob/c3cf1ef9bbacac6ae5abc99046db173e258dc7ca/ruby.c#L25
I think `sys/types.h` will be used on almost system.

By removing `have_header` checking, it will reduce a time slightly in generating Makefile.