### PR TITLE
Set up PATH for Homebrew to work detecting arch flags

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -24,10 +24,18 @@ module RMagick
     def setup_paths_for_homebrew
       return unless find_executable('brew')
 
-      brew_pkg_config_path = "#{`brew --prefix imagemagick@6`.strip}/lib/pkgconfig"
+      brew_pkg_path = `brew --prefix imagemagick@6`.strip
+      brew_pkg_bin_path = "#{brew_pkg_path}/bin"
+      brew_pkg_config_path = "#{brew_pkg_path}/lib/pkgconfig"
+
       pkgconfig_paths = ENV['PKG_CONFIG_PATH'].to_s.split(':')
       if File.exist?(brew_pkg_config_path) && !pkgconfig_paths.include?(brew_pkg_config_path)
         ENV['PKG_CONFIG_PATH'] = [ENV['PKG_CONFIG_PATH'], brew_pkg_config_path].compact.join(':')
+      end
+
+      paths = ENV['PATH'].to_s.split(':')
+      if File.exist?(brew_pkg_bin_path) && !paths.include?(brew_pkg_bin_path)
+        ENV['PATH'] = [ENV['PATH'], brew_pkg_bin_path].compact.join(':')
       end
     end
 


### PR DESCRIPTION
If user installed ImageMagick 6 via Homebrew, user might not setup PATH environment variable for ImageMagick 6.

Then `which convert` will return `""` because `convert` command can't found at
https://github.com/rmagick/rmagick/blob/baec1d0cfd335541fa8c5cd3a8d73ac6ed581851/ext/RMagick/extconf.rb#L235

Finally, `file ""` will show only usage at
https://github.com/rmagick/rmagick/blob/baec1d0cfd335541fa8c5cd3a8d73ac6ed581851/ext/RMagick/extconf.rb#L236

like,
```
Usage: file [bcCdEhikLlNnprsvzZ0] [-e test] [-f namefile] [-F separator] [-m magicfiles] [-M magicfiles] file...
       file -C -m magicfiles
```

In this usecase, `set_archflags_for_osx` method does not work as expected.

This patch will fix to work this feature properly.