### PR TITLE
Allow empty string for authenticate

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -462,13 +462,12 @@ Info_authenticate_eq(VALUE self, VALUE passwd_arg)
 {
     Info *info;
     char *passwd = NULL;
-    long length = 0;
 
     Data_Get_Struct(self, Info, info);
 
     if (!NIL_P(passwd_arg))
     {
-        passwd = rm_str2cstr(passwd_arg, &length);
+        passwd = StringValuePtr(passwd_arg);
     }
 
     if (info->authenticate)
@@ -476,7 +475,7 @@ Info_authenticate_eq(VALUE self, VALUE passwd_arg)
         magick_free(info->authenticate);
         info->authenticate = NULL;
     }
-    if (length > 0)
+    if (passwd)
     {
         magick_clone_string(&info->authenticate, passwd);
     }

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -64,6 +64,8 @@ class InfoUT < Test::Unit::TestCase
     assert_equal('string', @info.authenticate)
     assert_nothing_raised { @info.authenticate = nil }
     assert_nil(@info.authenticate)
+    assert_nothing_raised { @info.authenticate = '' }
+    assert_equal('', @info.authenticate)
   end
 
   def test_background_color


### PR DESCRIPTION
This PR changes the setter of the authenticate property to also allow an empty string.