### PR TITLE
Refactor StretchType_name() function

### DIFF
--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -710,23 +710,14 @@ StorageType_name(StorageType type)
  * @return the string
  */
 const char *
-StretchType_name(StretchType stretch)
+StretchType_name(StretchType type)
 {
-    switch (stretch)
+    VALUE stretch = Enum_find(Class_StretchType, type);
+    if (NIL_P(stretch))
     {
-        ENUM_TO_NAME(NormalStretch)
-        ENUM_TO_NAME(UltraCondensedStretch)
-        ENUM_TO_NAME(ExtraCondensedStretch)
-        ENUM_TO_NAME(CondensedStretch)
-        ENUM_TO_NAME(SemiCondensedStretch)
-        ENUM_TO_NAME(SemiExpandedStretch)
-        ENUM_TO_NAME(ExpandedStretch)
-        ENUM_TO_NAME(ExtraExpandedStretch)
-        ENUM_TO_NAME(UltraExpandedStretch)
-        ENUM_TO_NAME(AnyStretch)
-        default:
-        ENUM_TO_NAME(UndefinedStretch)
+        return "UndefinedStretch";
     }
+    return rm_enum_to_cstr(stretch);
 }
 
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -205,4 +205,14 @@ class EnumUT < Test::Unit::TestCase
       img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
     end
   end
+
+  def test_stretch_type_name
+    Magick::StretchType.values do |stretch|
+      font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, stretch, 400, nil, 'test foundry', 'test format')
+      assert_match(/stretch=#{stretch.to_s}/, font.to_s)
+    end
+
+    font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, nil, 400, nil, 'test foundry', 'test format')
+    assert_match(/stretch=UndefinedStretch/, font.to_s)
+  end
 end


### PR DESCRIPTION
If StretchType enum is added in ImageMagick, we have to inssert switch/case expression.

This patch will avoid that.