### PR TITLE
Refactor StyleType_name() function

### DIFF
--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -745,17 +745,14 @@ StretchType_find(StretchType stretch)
  * @return the string
  */
 const char *
-StyleType_name(StyleType style)
+StyleType_name(StyleType type)
 {
-    switch (style)
+    VALUE style = Enum_find(Class_StyleType, type);
+    if (NIL_P(style))
     {
-        ENUM_TO_NAME(NormalStyle)
-        ENUM_TO_NAME(ItalicStyle)
-        ENUM_TO_NAME(ObliqueStyle)
-        ENUM_TO_NAME(AnyStyle)
-        default:
-        ENUM_TO_NAME(UndefinedStyle)
+        return "UndefinedStyle";
     }
+    return rm_enum_to_cstr(style);
 }
 
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -215,4 +215,14 @@ class EnumUT < Test::Unit::TestCase
     font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, nil, 400, nil, 'test foundry', 'test format')
     assert_match(/stretch=UndefinedStretch/, font.to_s)
   end
+
+  def test_style_type_name
+    Magick::StyleType.values do |style|
+      font = Magick::Font.new('Arial', 'font test', 'Arial family', style, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
+      assert_match(/style=#{style.to_s}/, font.to_s)
+    end
+
+    font = Magick::Font.new('Arial', 'font test', 'Arial family', nil, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
+    assert_match(/style=UndefinedStyle/, font.to_s)
+  end
 end


### PR DESCRIPTION
If StyleType enum is added in ImageMagick, we have to inssert switch/case expression.

This patch will avoid that.