### PR TITLE
Deprecated Image#opacity.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11977,12 +11977,15 @@ Image_segment(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @param opacity_arg the opacity
  * @return opacity_arg
+ * @deprecated This method has been deprecated. Please use Image_alpha.
  */
 VALUE
 Image_opacity_eq(VALUE self, VALUE opacity_arg)
 {
     Image *image;
     Quantum opacity;
+
+    rb_warning("Image#opacity is deprecated; use Image#alpha");
 
     image = rm_check_frozen(self);
     opacity = APP2QUANTUM(opacity_arg);

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -941,7 +941,7 @@ module Magick
 
     # Make all pixels transparent.
     def matte_reset!
-      self.alpha(TransparentAlphaChannel)
+      alpha(TransparentAlphaChannel)
       self
     end
 

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -905,7 +905,7 @@ module Magick
     # Make the pixel at (x,y) transparent.
     def matte_point(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.alpha?
+      f.alpha(OpaqueAlphaChannel) unless f.alpha?
       pixel = f.pixel_color(x, y)
       pixel.opacity = TransparentOpacity
       f.pixel_color(x, y, pixel)
@@ -916,7 +916,7 @@ module Magick
     # pixel at (x, y).
     def matte_replace(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.alpha?
+      f.alpha(OpaqueAlphaChannel) unless f.alpha?
       target = f.pixel_color(x, y)
       f.transparent(target)
     end
@@ -925,7 +925,7 @@ module Magick
     # at (x,y) and is a neighbor.
     def matte_floodfill(x, y)
       f = copy
-      f.opacity = OpaqueOpacity unless f.alpha?
+      f.alpha(OpaqueAlphaChannel) unless f.alpha?
       target = f.pixel_color(x, y)
       f.matte_flood_fill(target, TransparentOpacity,
                          x, y, FloodfillMethod)
@@ -934,14 +934,14 @@ module Magick
     # Make transparent any neighbor pixel that is not the border color.
     def matte_fill_to_border(x, y)
       f = copy
-      f.opacity = Magick::OpaqueOpacity unless f.alpha?
+      f.alpha(OpaqueAlphaChannel) unless f.alpha?
       f.matte_flood_fill(border_color, TransparentOpacity,
                          x, y, FillToBorderMethod)
     end
 
     # Make all pixels transparent.
     def matte_reset!
-      self.opacity = Magick::TransparentOpacity
+      self.alpha(TransparentAlphaChannel)
       self
     end
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -1319,7 +1319,7 @@ class Image2_UT < Test::Unit::TestCase
     assert_nothing_raised do
       assert_block { @img.opaque? }
     end
-    @img.opacity = Magick::TransparentOpacity
+    @img.alpha(Magick::TransparentAlphaChannel)
     assert_block { !@img.opaque? }
   end
 


### PR DESCRIPTION
This PR deprecates the Image#opacity method and informs the user to use Image#alpha instead. And this also removes the use of this method from the code.