### PR TITLE
Use the new enumeration names in the unit tests 

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -907,7 +907,7 @@ module Magick
       f = copy
       f.opacity = OpaqueOpacity unless f.alpha?
       pixel = f.pixel_color(x, y)
-      pixel.opacity = TransparentOpacity
+      pixel.alpha = TransparentAlpha
       f.pixel_color(x, y, pixel)
       f
     end

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -223,7 +223,7 @@ class DrawUT < Test::Unit::TestCase
     assert_raise(TypeError) { @draw.composite(0, 0, 10, 10, img, Magick::CenterAlign) }
     assert_raise(NoMethodError) { @draw.composite(0, 0, 10, 10, 'image') }
     assert_raise(ArgumentError) { @draw.composite(0, 0, 10, 10) }
-    assert_raise(ArgumentError) { @draw.composite(0, 0, 10, 10, img, Magick::AddCompositeOp, 'x') }
+    assert_raise(ArgumentError) { @draw.composite(0, 0, 10, 10, img, Magick::ModulusAddCompositeOp, 'x') }
   end
 
   def test_draw

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -187,9 +187,9 @@ class Image1_UT < Test::Unit::TestCase
     assert @img.alpha?
     assert_nothing_raised { @img.alpha Magick::DeactivateAlphaChannel }
     assert !@img.alpha?
-    assert_nothing_raised { @img.alpha Magick::ResetAlphaChannel }
+    assert_nothing_raised { @img.alpha Magick::OpaqueAlphaChannel }
     assert_nothing_raised { @img.alpha Magick::SetAlphaChannel }
-    assert_raise(ArgumentError) { @img.alpha Magick::SetAlphaChannel, Magick::ResetAlphaChannel }
+    assert_raise(ArgumentError) { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }
     @img.freeze
     assert_raise(FreezeError) { @img.alpha Magick::SetAlphaChannel }
   end

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -481,7 +481,7 @@ class Image2_UT < Test::Unit::TestCase
     end
     assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioMetric) }
+    assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -64,7 +64,7 @@ class ImageList1UT < Test::Unit::TestCase
       assert_nothing_raised { @list.composite_layers(@list2, op) }
     end
 
-    assert_raise(ArgumentError) { @list.composite_layers(@list2, Magick::AddCompositeOp, 42) }
+    assert_raise(ArgumentError) { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }
   end
 
   def test_delay

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -10,7 +10,7 @@ module Magick
   end
 end
 
-class Magick::AlphaChannelType
+class Magick::AlphaChannelOption
   def self.enumerators
     @@enumerators
   end
@@ -47,7 +47,7 @@ class MagickUT < Test::Unit::TestCase
   def test_enumerators
     ary = nil
     assert_nothing_raised do
-      ary = Magick::AlphaChannelType.enumerators
+      ary = Magick::AlphaChannelOption.enumerators
     end
     assert_instance_of(Array, ary)
 


### PR DESCRIPTION
This PR changes the code to use the new enumeration names in the unit tests and refactors some of the unit tests to use a different method.