### PR TITLE
Draw#bezier should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -242,7 +242,7 @@ module Magick
       elsif points.length.odd?
         Kernel.raise ArgumentError, 'odd number of arguments specified'
       end
-      primitive 'bezier ' + points.join(',')
+      primitive 'bezier ' + points.map! { |x| format('%g', x) }.join(',')
     end
 
     # Draw a circle

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -1,0 +1,18 @@
+require 'rmagick'
+require 'test/unit'
+require 'test/unit/ui/console/testrunner' unless RUBY_VERSION[/^1\.9|^2/]
+
+class LibDrawUT < Test::Unit::TestCase
+  def setup
+    @draw = Magick::Draw.new
+  end
+
+  def test_bezier
+    @draw.bezier(10, '20', '20.5', 30, 40.5, 50)
+    assert_equal('bezier 10,20,20.5,30,40.5,50', @draw.inspect)
+
+    assert_raise(ArgumentError) { @draw.bezier }
+    assert_raise(ArgumentError) { @draw.bezier(1) }
+    assert_raise(ArgumentError) { @draw.bezier('x', 20, 30, 40.5) }
+  end
+end


### PR DESCRIPTION
Draw#bezier has been accepted any value.
If wrong value was given, it doesn't notice the mistakes until bezier primitive is performed by Draw#draw.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.stroke('red')
draw.bezier(20, 'x', 20, 30, 320, 330, 320, 180)

draw.draw(img)
#=> test.rb:9:in `draw': non-conforming drawing primitive definition `bezier' @ error/draw.c/RenderMVGContent/4336 (Magick::ImageMagickError)
	from test.rb:9:in `<main>'
```

Draw#bezier should check the parameter value and raise exception if wrong value was given.