### PR TITLE
Use gnu99 instead of c99 for __GNUC__.

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -113,7 +113,7 @@ module RMagick
 
       end
 
-      $CFLAGS << ' -std=c99'
+      $CFLAGS << (have_macro('__GNUC__') ? ' -std=gnu99' : ' -std=c99')
     end
 
     # Test for a specific value in an enum type


### PR DESCRIPTION
This PR uses Use `gnu99` instead of `c99` for `__GNUC__` to fix the following compiler warnings:

```
/usr/local/include/ruby-2.6.0/ruby/intern.h:928:29: warning: 'struct timespec' declared inside parameter list will not be visible outside of this definition or declaration
 void rb_timespec_now(struct timespec *);
```