### PR TITLE
Change order for convolve into an integer and check for negative values.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4250,12 +4250,18 @@ Image_convolve(VALUE self, VALUE order_arg, VALUE kernel_arg)
 {
     Image *image, *new_image;
     double *kernel;
-    unsigned int x, order;
+    unsigned int x;
+    int order;
     ExceptionInfo *exception;
 
     image = rm_check_destroyed(self);
 
-    order = NUM2UINT(order_arg);
+    order = NUM2INT(order_arg);
+
+    if (order <= 0)
+    {
+        rb_raise(rb_eArgError, "order must be non-zero and positive");
+    }
 
     kernel_arg = rb_Array(kernel_arg);
     rm_check_ary_len(kernel_arg, (long)(order*order));
@@ -4310,7 +4316,8 @@ Image_convolve_channel(int argc, VALUE *argv, VALUE self)
     Image *image, *new_image;
     double *kernel;
     VALUE ary;
-    unsigned int x, order;
+    unsigned int x;
+    int order;
     ChannelType channels;
     ExceptionInfo *exception;
 
@@ -4328,7 +4335,12 @@ Image_convolve_channel(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "wrong number of arguments (%d for 2 or more)", argc);
     }
 
-    order = NUM2UINT(argv[0]);
+    order = NUM2INT(argv[0]);
+    if (order <= 0)
+    {
+        rb_raise(rb_eArgError, "order must be non-zero and positive");
+    }
+
     ary = argv[1];
 
     rm_check_ary_len(ary, (long)(order*order));

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -192,15 +192,19 @@ class Image2_UT < Test::Unit::TestCase
       assert_not_same(@img, res)
     end
     assert_raise(ArgumentError) { @img.convolve }
+    assert_raise(ArgumentError) { @img.convolve(0) }
+    assert_raise(ArgumentError) { @img.convolve(-1) }
     assert_raise(ArgumentError) { @img.convolve(order) }
     assert_raise(IndexError) { @img.convolve(5, kernel) }
     assert_raise(IndexError) { @img.convolve(order, 'x') }
     assert_raise(TypeError) { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }
-    assert_raise(Magick::ImageMagickError) { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }
+    assert_raise(ArgumentError) { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }
   end
 
   def test_convolve_channel
     assert_raise(ArgumentError) { @img.convolve_channel }
+    assert_raise(ArgumentError) { @img.convolve_channel(0) }
+    assert_raise(ArgumentError) { @img.convolve_channel(-1) }
     assert_raise(ArgumentError) { @img.convolve_channel(3) }
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3


### PR DESCRIPTION
This PR changes the order from an unsigned integer into an integer to allow checking for negative values and report an argument error instead of trying to do an allocation.