### PR TITLE
Changed order to fix memory leaks.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -15254,7 +15254,11 @@ xform_image(int bang, VALUE self, VALUE x, VALUE y, VALUE width, VALUE height, x
     rm_check_exception(exception, new_image, DestroyOnError);
     (void) DestroyExceptionInfo(exception);
 
-    rm_check_image_exception(image, RetainOnError);
+    if (rm_should_raise_exception(&image->exception, RetainExceptionRetention))
+    {
+        (void) DestroyImage(new_image);
+        rm_check_image_exception(image, RetainOnError);
+    }
 
     rm_ensure_result(new_image);
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -15251,10 +15251,10 @@ xform_image(int bang, VALUE self, VALUE x, VALUE y, VALUE width, VALUE height, x
     new_image = (xformer)(image, &rect, exception);
 
     // An exception can occur in either the old or the new images
-    rm_check_image_exception(image, RetainOnError);
     rm_check_exception(exception, new_image, DestroyOnError);
-
     (void) DestroyExceptionInfo(exception);
+
+    rm_check_image_exception(image, RetainOnError);
 
     rm_ensure_result(new_image);
 


### PR DESCRIPTION
The call to `rm_check_image_exception` should be moved because this could otherwise result in leaking `exception` and `new_image`. And there should be a check if `image->exception` will throw an exception and then free `new_image` before calling `rm_check_image_exception`