### PR TITLE
Fix test_font

### DIFF
--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -79,8 +79,8 @@ class MagickUT < Test::Unit::TestCase
       assert_instance_of(String, f.name)
       assert_instance_of(String, f.description) unless f.description.nil?
       assert_instance_of(String, f.family)
-      assert_instance_of(Magick::StyleType, f.style)
-      assert_instance_of(Magick::StretchType, f.stretch)
+      assert_instance_of(Magick::StyleType, f.style) unless f.style.nil?
+      assert_instance_of(Magick::StretchType, f.stretch) unless f.stretch.nil?
       assert_kind_of(Integer, f.weight)
       assert_instance_of(String, f.encoding) unless f.encoding.nil?
       assert_instance_of(String, f.foundry) unless f.foundry.nil?


### PR DESCRIPTION
Font#{style, stretch} might return nil.

```
Failure:
  <nil> expected to be instance_of?
  <Magick::StyleType> but was
  <NilClass>.
test_fonts(MagickUT)
/Users/watson/prj/rmagick/test/Magick.rb:82:in `block in test_fonts'
     79:       assert_instance_of(String, f.name)
     80:       assert_instance_of(String, f.description) unless f.description.nil?
     81:       assert_instance_of(String, f.family)
  => 82:       assert_instance_of(Magick::StyleType, f.style)
     83:       assert_instance_of(Magick::StretchType, f.stretch)
     84:       assert_kind_of(Integer, f.weight)
     85:       assert_instance_of(String, f.encoding) unless f.encoding.nil?
```

This PR will fix above error with running tests.