### PR TITLE
Draw#color should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -271,7 +271,7 @@ module Magick
     # point, replace, floodfill, filltoborder,reset
     def color(x, y, method)
       Kernel.raise ArgumentError, "Unknown PaintMethod: #{method}" unless PAINT_METHOD_NAMES.key?(method.to_i)
-      primitive "color #{x},#{y},#{PAINT_METHOD_NAMES[method.to_i]}"
+      primitive 'color ' + format('%g,%g,%s', x, y, PAINT_METHOD_NAMES[method.to_i])
     end
 
     # Specify EITHER the text decoration (none, underline, overline,

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -121,8 +121,8 @@ class LibDrawUT < Test::Unit::TestCase
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.color(10, 20, 'unknown') }
-    # assert_raise(ArgumentError) { draw.color('x', 20, Magick::PointMethod) }
-    # assert_raise(ArgumentError) { draw.color(10, 'x', Magick::PointMethod) }
+    assert_raise(ArgumentError) { @draw.color('x', 20, Magick::PointMethod) }
+    assert_raise(ArgumentError) { @draw.color(10, 'x', Magick::PointMethod) }
   end
 
   def test_decorate


### PR DESCRIPTION
Draw#color has been accepted any value as (x, y) coordinates.
If wrong value was given, it doesn't notice the mistakes until the primitive is performed by Draw#draw.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.color('x', 20, Magick::PointMethod)

draw.draw(img)
#=> t.rb:8:in `draw': non-conforming drawing primitive definition `color' @ error/draw.c/RenderMVGContent/4336 (Magick::ImageMagickError)
```