### PR TITLE
Draw#opacity should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -221,6 +221,13 @@ module Magick
       end
     end
 
+    def check_opacity(opacity)
+      return if opacity.is_a?(String) && opacity['%']
+
+      value = Float(opacity)
+      Kernel.raise ArgumentError, 'opacity must be >= 0 and <= 1.0' if value < 0 || value > 1.0
+    end
+
     public
 
     # Apply coordinate transformations to support scaling (s), rotation (r),
@@ -416,9 +423,7 @@ module Magick
     # Specify drawing fill and stroke opacities. If the value is a string
     # ending with a %, the number will be multiplied by 0.01.
     def opacity(opacity)
-      if opacity.is_a?(Numeric)
-        Kernel.raise ArgumentError, 'opacity must be >= 0 and <= 1.0' if opacity < 0 || opacity > 1.0
-      end
+      check_opacity(opacity)
       primitive "opacity #{opacity}"
     end
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -399,12 +399,13 @@ class LibDrawUT < Test::Unit::TestCase
     assert_nothing_raised { @draw.opacity(1.0) }
     assert_nothing_raised { @draw.opacity('0.0') }
     assert_nothing_raised { @draw.opacity('1.0') }
+    assert_nothing_raised { @draw.opacity('20%') }
 
     assert_raise(ArgumentError) { @draw.opacity(-0.01) }
     assert_raise(ArgumentError) { @draw.opacity(1.01) }
-    # assert_raise(ArgumentError) { @draw.opacity('-0.01') }
-    # assert_raise(ArgumentError) { @draw.opacity('1.01') }
-    # assert_raise(ArgumentError) { @draw.opacity('xxx') }
+    assert_raise(ArgumentError) { @draw.opacity('-0.01') }
+    assert_raise(ArgumentError) { @draw.opacity('1.01') }
+    assert_raise(ArgumentError) { @draw.opacity('xxx') }
   end
 
   def test_path


### PR DESCRIPTION
Draw#coopacitylor has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.opacity('xxx')
draw.fill('tomato')
draw.rectangle(10, '10', 100, 100)

draw.draw(img)
```