### PR TITLE
Draw#fill_opacity should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -328,6 +328,7 @@ module Magick
 
     # Specify fill opacity (use "xx%" to indicate percentage)
     def fill_opacity(opacity)
+      check_opacity(opacity)
       primitive "fill-opacity #{opacity}"
     end
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -218,7 +218,17 @@ class LibDrawUT < Test::Unit::TestCase
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.fill_opacity('xxx') }
+    assert_nothing_raised { @draw.fill_opacity(0.0) }
+    assert_nothing_raised { @draw.fill_opacity(1.0) }
+    assert_nothing_raised { @draw.fill_opacity('0.0') }
+    assert_nothing_raised { @draw.fill_opacity('1.0') }
+    assert_nothing_raised { @draw.fill_opacity('20%') }
+
+    assert_raise(ArgumentError) { @draw.fill_opacity(-0.01) }
+    assert_raise(ArgumentError) { @draw.fill_opacity(1.01) }
+    assert_raise(ArgumentError) { @draw.fill_opacity('-0.01') }
+    assert_raise(ArgumentError) { @draw.fill_opacity('1.01') }
+    assert_raise(ArgumentError) { @draw.fill_opacity('xxx') }
   end
 
   def test_fill_rule


### PR DESCRIPTION
Draw#fill_opacity has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.fill_opacity('xxx')
draw.fill('blue')
draw.rectangle(10, '10', 100, 100)

draw.draw(img)
```