### PR TITLE
Draw#stroke_opacity should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -586,8 +586,9 @@ module Magick
 
     # Specify opacity of stroke drawing color
     #  (use "xx%" to indicate percentage)
-    def stroke_opacity(value)
-      primitive "stroke-opacity #{value}"
+    def stroke_opacity(opacity)
+      check_opacity(opacity)
+      primitive "stroke-opacity #{opacity}"
     end
 
     # Specify stroke (outline) width in pixels.

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -651,11 +651,21 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_stroke_opacity
-    @draw.stroke_opacity(10)
-    assert_equal('stroke-opacity 10', @draw.inspect)
+    @draw.stroke_opacity(0.8)
+    assert_equal('stroke-opacity 0.8', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.stroke_opacity('foo') }
+    assert_nothing_raised { @draw.stroke_opacity(0.0) }
+    assert_nothing_raised { @draw.stroke_opacity(1.0) }
+    assert_nothing_raised { @draw.stroke_opacity('0.0') }
+    assert_nothing_raised { @draw.stroke_opacity('1.0') }
+    assert_nothing_raised { @draw.stroke_opacity('20%') }
+
+    assert_raise(ArgumentError) { @draw.stroke_opacity(-0.01) }
+    assert_raise(ArgumentError) { @draw.stroke_opacity(1.01) }
+    assert_raise(ArgumentError) { @draw.stroke_opacity('-0.01') }
+    assert_raise(ArgumentError) { @draw.stroke_opacity('1.01') }
+    assert_raise(ArgumentError) { @draw.stroke_opacity('xxx') }
   end
 
   def test_text


### PR DESCRIPTION
Draw#stroke_opacity has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.stroke_opacity('xxx')
draw.stroke('blue')
draw.stroke_width(10)
draw.rectangle(10, '10', 100, 100)

draw.draw(img)
```