### PR TITLE
Deprecated the use of an unnamed argument for the opacity value of Image#transparent

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -124,6 +124,7 @@ typedef DistortImageMethod DistortMethod;
 typedef FilterTypes FilterType;
 typedef InterpolatePixelMethod PixelInterpolateMethod;
 typedef ImageLayerMethod LayerMethod;
+#define TransparentAlpha 0
 
 //! Montage
 typedef struct
@@ -1182,6 +1183,7 @@ extern Image *rm_clone_image(Image *);
 extern MagickBooleanType rm_progress_monitor(const char *, const MagickOffsetType, const MagickSizeType, void *);
 extern VALUE  rm_exif_by_entry(Image *);
 extern VALUE  rm_exif_by_number(Image *);
+extern Quantum rm_get_named_alpha_value(VALUE, const char *, const char *);
 extern void   rm_get_optional_arguments(VALUE);
 extern void   rm_fatal_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_error_handler(const ExceptionType, const char *, const char *);

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1183,7 +1183,7 @@ extern Image *rm_clone_image(Image *);
 extern MagickBooleanType rm_progress_monitor(const char *, const MagickOffsetType, const MagickSizeType, void *);
 extern VALUE  rm_exif_by_entry(Image *);
 extern VALUE  rm_exif_by_number(Image *);
-extern Quantum rm_get_named_alpha_value(VALUE, const char *, const char *);
+extern Quantum rm_get_named_alpha_value(VALUE, const char *);
 extern void   rm_get_optional_arguments(VALUE);
 extern void   rm_fatal_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_error_handler(const ExceptionType, const char *, const char *);

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1183,7 +1183,6 @@ extern Image *rm_clone_image(Image *);
 extern MagickBooleanType rm_progress_monitor(const char *, const MagickOffsetType, const MagickSizeType, void *);
 extern VALUE  rm_exif_by_entry(Image *);
 extern VALUE  rm_exif_by_number(Image *);
-extern Quantum rm_get_named_alpha_value(VALUE, const char *);
 extern void   rm_get_optional_arguments(VALUE);
 extern void   rm_fatal_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_error_handler(const ExceptionType, const char *, const char *);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13800,7 +13800,7 @@ Image_transparent(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 2:
-            alpha = rm_get_named_alpha_value(argv[1], "Image#transparent", "alpha");
+            alpha = rm_get_named_alpha_value(argv[1], "alpha");
         case 1:
             Color_to_MagickPixel(image, &color, argv[0]);
             break;

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13772,13 +13772,13 @@ Image_total_ink_density(VALUE self)
  *
  * Ruby usage:
  *   - @verbatim Image#transparent(color-name) @endverbatim
- *   - @verbatim Image#transparent(color-name, opacity) @endverbatim
+ *   - @verbatim Image#transparent(color-name, alpha) @endverbatim
  *   - @verbatim Image#transparent(pixel) @endverbatim
- *   - @verbatim Image#transparent(pixel, opacity) @endverbatim
+ *   - @verbatim Image#transparent(pixel, alpha) @endverbatim
  *
  * Notes:
- *   - Default opacity is Magick::TransparentOpacity.
- *   - Can use Magick::OpaqueOpacity or Magick::TransparentOpacity, or any
+ *   - Default alpha is Magick::TransparentAlpha.
+ *   - Can use Magick::OpaqueAlpha or Magick::TransparentAlpha, or any
  *     value >= 0 && <= QuantumRange.
  *   - Use Image#fuzz= to define the tolerance level.
  *
@@ -13792,7 +13792,7 @@ Image_transparent(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     MagickPixel color;
-    Quantum opacity = TransparentOpacity;
+    Quantum alpha = TransparentAlpha;
     MagickBooleanType okay;
 
     image = rm_check_destroyed(self);
@@ -13800,7 +13800,7 @@ Image_transparent(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 2:
-            opacity = APP2QUANTUM(argv[1]);
+            alpha = rm_get_named_alpha_value(argv[1], "Image#transparent", "alpha");
         case 1:
             Color_to_MagickPixel(image, &color, argv[0]);
             break;
@@ -13811,7 +13811,7 @@ Image_transparent(int argc, VALUE *argv, VALUE self)
 
     new_image = rm_clone_image(image);
 
-    okay = TransparentPaintImage(new_image, &color, opacity, MagickFalse);
+    okay = TransparentPaintImage(new_image, &color, QuantumRange - alpha, MagickFalse);
     rm_check_image_exception(new_image, DestroyOnError);
     if (!okay)
     {

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -41,6 +41,37 @@ static void call_trace_proc(Image *, const char *);
 static const char *BlackPointCompensationKey = "PROFILE:black-point-compensation";
 
 
+/**
+ * Checks if opacity_or_alpha is a named argument called alpha and returns the alpha value or
+ * converts the unnamed opacity value to alpha.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @opacity_or_alpha an opacity or a named alpha value
+ * @argument_name the name of the argument
+ */
+static Quantum
+get_named_alpha_value(VALUE opacity_or_alpha, const char *argument_name)
+{
+    VALUE alpha;
+
+    if (TYPE(opacity_or_alpha) != T_HASH)
+    {
+        VALUE method = rb_id2str(rb_frame_this_func());
+        rb_warning("Image#%"PRIsVALUE" requires a named argument for '%s' and now expects an alpha value instead of an opacity value.", method, argument_name);
+
+        return QuantumRange - APP2QUANTUM(opacity_or_alpha);
+    }
+
+    alpha = rb_hash_aref(opacity_or_alpha, ID2SYM(rb_intern(argument_name)));
+    if (NIL_P(alpha))
+    {
+        VALUE method = rb_id2str(rb_frame_this_func());
+        rb_raise(rb_eArgError, "Image#%"PRIsVALUE" expects a named argument called '%s' but got a different name.", method, argument_name);
+    }
+
+    return APP2QUANTUM(alpha);
+}
 
 
 /**
@@ -13800,7 +13831,7 @@ Image_transparent(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 2:
-            alpha = rm_get_named_alpha_value(argv[1], "alpha");
+            alpha = get_named_alpha_value(argv[1], "alpha");
         case 1:
             Color_to_MagickPixel(image, &color, argv[0]);
             break;

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -66,8 +66,7 @@ get_named_alpha_value(VALUE opacity_or_alpha, const char *argument_name)
     alpha = rb_hash_aref(opacity_or_alpha, ID2SYM(rb_intern(argument_name)));
     if (NIL_P(alpha))
     {
-        VALUE method = rb_id2str(rb_frame_this_func());
-        rb_raise(rb_eArgError, "Image#%"PRIsVALUE" expects a named argument called '%s' but got a different name.", method, argument_name);
+        rb_raise(rb_eArgError, "missing keyword: %s", argument_name);
     }
 
     return APP2QUANTUM(alpha);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1788,17 +1788,17 @@ rm_ensure_result(Image *image)
  * No Ruby usage (internal function)
  *
  * @opacity_or_alpha an opacity or a named alpha value
- * @method_name the name of the method
  * @argument_name the name of the argument
  */
 Quantum
-rm_get_named_alpha_value(VALUE opacity_or_alpha, const char *method_name, const char *argument_name)
+rm_get_named_alpha_value(VALUE opacity_or_alpha, const char *argument_name)
 {
     VALUE alpha;
 
     if (TYPE(opacity_or_alpha) != T_HASH)
     {
-        rb_warning("%s requires a named argument for '%s' and now expects an alpha value instead of an opacity value.", method_name, argument_name);
+        VALUE method = rb_id2str(rb_frame_this_func());
+        rb_warning("#%"PRIsVALUE" requires a named argument for '%s' and now expects an alpha value instead of an opacity value.", method, argument_name);
 
         return QuantumRange - APP2QUANTUM(opacity_or_alpha);
     }
@@ -1806,7 +1806,8 @@ rm_get_named_alpha_value(VALUE opacity_or_alpha, const char *method_name, const 
     alpha = rb_hash_aref(opacity_or_alpha, ID2SYM(rb_intern(argument_name)));
     if (NIL_P(alpha))
     {
-        rb_raise(rb_eArgError, "%s expects a named argument called '%s' but got a different name.", method_name, argument_name);
+        VALUE method = rb_id2str(rb_frame_this_func());
+        rb_raise(rb_eArgError, "#%"PRIsVALUE" expects a named argument called '%s' but got a different name.", method, argument_name);
     }
 
     return APP2QUANTUM(alpha);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1782,6 +1782,38 @@ rm_ensure_result(Image *image)
 
 
 /**
+ * Checks if opacity_or_alpha is a named argument called alpha and returns the alpha value or
+ * converts the unnamed opacity value to alpha.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @opacity_or_alpha an opacity or a named alpha value
+ * @method_name the name of the method
+ * @argument_name the name of the argument
+ */
+Quantum
+rm_get_named_alpha_value(VALUE opacity_or_alpha, const char *method_name, const char *argument_name)
+{
+    VALUE alpha;
+
+    if (TYPE(opacity_or_alpha) != T_HASH)
+    {
+        rb_warning("%s requires a named argument for '%s' and now expects an alpha value instead of an opacity value.", method_name, argument_name);
+
+        return QuantumRange - APP2QUANTUM(opacity_or_alpha);
+    }
+
+    alpha = rb_hash_aref(opacity_or_alpha, ID2SYM(rb_intern(argument_name)));
+    if (NIL_P(alpha))
+    {
+        rb_raise(rb_eArgError, "%s expects a named argument called '%s' but got a different name.", method_name, argument_name);
+    }
+
+    return APP2QUANTUM(alpha);
+}
+
+
+/**
  * Checks if an error should be raised for the exception.
  *
  * No Ruby usage (internal function)

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1782,39 +1782,6 @@ rm_ensure_result(Image *image)
 
 
 /**
- * Checks if opacity_or_alpha is a named argument called alpha and returns the alpha value or
- * converts the unnamed opacity value to alpha.
- *
- * No Ruby usage (internal function)
- *
- * @opacity_or_alpha an opacity or a named alpha value
- * @argument_name the name of the argument
- */
-Quantum
-rm_get_named_alpha_value(VALUE opacity_or_alpha, const char *argument_name)
-{
-    VALUE alpha;
-
-    if (TYPE(opacity_or_alpha) != T_HASH)
-    {
-        VALUE method = rb_id2str(rb_frame_this_func());
-        rb_warning("#%"PRIsVALUE" requires a named argument for '%s' and now expects an alpha value instead of an opacity value.", method, argument_name);
-
-        return QuantumRange - APP2QUANTUM(opacity_or_alpha);
-    }
-
-    alpha = rb_hash_aref(opacity_or_alpha, ID2SYM(rb_intern(argument_name)));
-    if (NIL_P(alpha))
-    {
-        VALUE method = rb_id2str(rb_frame_this_func());
-        rb_raise(rb_eArgError, "#%"PRIsVALUE" expects a named argument called '%s' but got a different name.", method, argument_name);
-    }
-
-    return APP2QUANTUM(alpha);
-}
-
-
-/**
  * Checks if an error should be raised for the exception.
  *
  * No Ruby usage (internal function)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -801,6 +801,8 @@ class Image3_UT < Test::Unit::TestCase
     pixel = Magick::Pixel.new
     assert_nothing_raised { @img.transparent(pixel) }
     assert_nothing_raised { @img.transparent('white', Magick::TransparentOpacity) }
+    assert_nothing_raised { @img.transparent('white', alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.transparent('white', wrong: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.transparent('white', Magick::TransparentOpacity, 2) }
     assert_nothing_raised { @img.transparent('white', Magick::QuantumRange / 2) }
     assert_raise(TypeError) { @img.transparent(2) }


### PR DESCRIPTION
To have a smooth transition from ImageMagick 6 to ImageMagick 7 some of the arguments need to change from an opacity value to an alpha value. And after a chat @mockdeep and me came up with the following idea make sure the user will know that this is happening:

Instead of only a `Quantum` value

```ruby
img.transparent('white', Magick::TransparentOpacity)
```

A named argument should be used.

```ruby
img.transparent('white', alpha: Magick::TransparentAlpha)
```

If only a value is passed in the value will be changed from opacity to alpha and a warning will be raised to inform the user that they should use a named argument and switch from opacity to alpha.

This is the only idea we had to make sure that the user knows that they should change their opacity value into an alpha value. If you have any other ideas on how to do a smooth transition here then please let us know @Watson1978.