### PR TITLE
Draw#font_weight should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -359,10 +359,10 @@ module Magick
     # The font weight argument can be either a font weight
     # constant or [100,200,...,900]
     def font_weight(weight)
-      if FONT_WEIGHT_NAMES.key?(weight.to_i)
+      if weight.is_a?(WeightType)
         primitive "font-weight #{FONT_WEIGHT_NAMES[weight.to_i]}"
       else
-        primitive "font-weight #{weight}"
+        primitive "font-weight #{Integer(weight)}"
       end
     end
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -312,7 +312,7 @@ class LibDrawUT < Test::Unit::TestCase
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.font_weight('xxx') }
+    assert_raise(ArgumentError) { @draw.font_weight('xxx') }
   end
 
   def test_gravity


### PR DESCRIPTION
Draw#font_weight has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.font_weight('xxx')
draw.text(10, 100, 'Hello world')

draw.draw(img)
```