### PR TITLE
Enable managed memory feature

### DIFF
--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -1,0 +1,50 @@
+# How to measure the memory usage
+
+## 1. Install gnuplot
+If you need a graph of memory usage, it can draw the graph with `gnuplot`.
+
+With `Homebrew`, you can install `gnuplot` like
+
+```
+$ brew install gnuplot
+```
+
+## 2. Retrieve two performance data `before` / `after`
+Retrieve data before applying patches.
+
+```
+$ rake build
+$ gem install pkg/rmagick-3.1.0.gem
+$ cd benchmarks/memory
+$ ruby image_new.rb > before.csv
+```
+
+Apply the patches then retrieve improved data.
+
+```
+$ rake build
+$ gem install pkg/rmagick-3.1.0.gem
+$ cd benchmarks/memory
+$ ruby image_new.rb > after.csv
+```
+
+## 3. Draw the performance graph
+Launch `gnuplot` and execute `load 'rmagick.gnuplot'` command in prompt then the performance graph will be drew.
+
+```
+$ cd benchmarks/memory
+$ gnuplot
+
+	G N U P L O T
+	Version 5.2 patchlevel 7    last modified 2019-05-29
+
+	Copyright (C) 1986-1993, 1998, 2004, 2007-2018
+	Thomas Williams, Colin Kelley and many others
+
+	gnuplot home:     http://www.gnuplot.info
+	faq, bugs, etc:   type "help FAQ"
+	immediate help:   type "help"  (plot window: hit 'h')
+
+Terminal type is now 'qt'
+gnuplot> load 'rmagick.gnuplot'
+```

--- a/benchmarks/memory/image_new.rb
+++ b/benchmarks/memory/image_new.rb
@@ -1,0 +1,8 @@
+require 'rmagick'
+
+1000.times do |i|
+  Magick::Image.new(1000, 1000)
+
+  rss = Integer(`ps -o rss= -p #{Process.pid}`) / 1024.0
+  puts "#{i},#{rss}"
+end

--- a/benchmarks/memory/rmagick.gnuplot
+++ b/benchmarks/memory/rmagick.gnuplot
@@ -1,0 +1,16 @@
+set datafile separator ","
+
+set key outside center top horizontal reverse Left samplen 2
+unset border
+set xtics scale 0
+set ytics scale 0
+set grid ytics linewidth 1 linetype -1
+
+set style line 1 lt 1 lc rgbcolor "#3465a4" lw 2.5 pt 7 ps 1
+set style line 2 lt 1 lc rgbcolor "#ff6347" lw 2.5 pt 7 ps 1
+set style line 3 lt 1 lc rgbcolor "#888a85" lw 2.5 pt 5 ps 1
+
+set xlabel "Nth loop"
+set ylabel "Memory usage (MiB)"
+
+plot "before.csv" with line linestyle 1, "after.csv" with line linestyle 2

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -314,6 +314,9 @@ END_MINGW
       if Gem::Version.new($magick_version) >= Gem::Version.new('6.8.9')
         $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9=1')
       end
+      if Gem::Version.new($magick_version) >= Gem::Version.new('6.9.0')
+        $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_6_9_0=1')
+      end
 
       create_header
     end

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -130,13 +130,13 @@ Init_RMagick2(void)
 {
     VALUE observable;
 
-    MagickCoreGenesis("RMagick", MagickFalse);
-
-    test_Magick_version();
-
     Module_Magick = rb_define_module("Magick");
 
     set_managed_memory();
+
+    MagickCoreGenesis("RMagick", MagickFalse);
+
+    test_Magick_version();
 
     /*-----------------------------------------------------------------------*/
     /* Create IDs for frequently used methods, etc.                          */

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -105,6 +105,14 @@ static void rm_free(void *ptr)
  */
 static void set_managed_memory(void)
 {
+    ID disable_mm = rb_intern("RMAGICK_DISABLE_MANAGED_MEMORY");
+
+    if (RTEST(rb_const_defined(rb_cObject, disable_mm)) && RTEST(rb_const_get(rb_cObject, disable_mm)))
+    {
+        rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
+        return;
+    }
+
     SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
     rb_define_const(Module_Magick, "MANAGED_MEMORY", Qtrue);
 }

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -103,21 +103,29 @@ static void rm_free(void *ptr)
  *
  * No Ruby usage (internal function)
  */
+static inline void managed_memory_enable(VALUE enable)
+{
+    if (enable)
+    {
+        SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
+    }
+    rb_define_const(Module_Magick, "MANAGED_MEMORY", enable);
+}
+
 static void set_managed_memory(void)
 {
     ID disable_mm = rb_intern("RMAGICK_DISABLE_MANAGED_MEMORY");
 
     if (RTEST(rb_const_defined(rb_cObject, disable_mm)) && RTEST(rb_const_get(rb_cObject, disable_mm)))
     {
-        rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
+        managed_memory_enable(Qfalse);
         return;
     }
 
 #if !defined(_WIN32)
-    SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
-    rb_define_const(Module_Magick, "MANAGED_MEMORY", Qtrue);
+    managed_memory_enable(Qtrue);
 #else
-    rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
+    managed_memory_enable(Qfalse);
 #endif
 }
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -126,6 +126,8 @@ static void set_managed_memory(void)
 #if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_9_0)
     managed_memory_enable(Qtrue);
 #else
+    // Disable managed memory feature with ImageMagick 6.8.x or below because causes crash.
+    // Refer https://ci.appveyor.com/project/mockdeep/rmagick/builds/24706171
     managed_memory_enable(Qfalse);
 #endif
 #else

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -113,8 +113,12 @@ static void set_managed_memory(void)
         return;
     }
 
+#if !defined(_WIN32)
     SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
     rb_define_const(Module_Magick, "MANAGED_MEMORY", Qtrue);
+#else
+    rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
+#endif
 }
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -62,17 +62,7 @@ static void features_constant(void);
  */
 static void *rm_malloc(size_t size)
 {
-    void *p;
-//    int old_state;
-
-//    old_state = rb_gc_disable();
-    p = xmalloc((long)size);
-//    if (!RTEST(old_state))
-//    {
-//        rb_gc_enable();
-//    }
-
-    return p;
+    return xmalloc((long)size);
 }
 
 
@@ -89,17 +79,7 @@ static void *rm_malloc(size_t size)
  */
 static void *rm_realloc(void *ptr, size_t size)
 {
-    void *p;
-//    int old_state;
-
-//    old_state = rb_gc_disable();
-    p = xrealloc(ptr, (long)size);
-//    if (!RTEST(old_state))
-//    {
-//        rb_gc_enable();
-//    }
-
-    return p;
+    return xrealloc(ptr, (long)size);
 }
 
 
@@ -125,18 +105,8 @@ static void rm_free(void *ptr)
  */
 static void set_managed_memory(void)
 {
-    ID enable_mm = rb_intern("RMAGICK_ENABLE_MANAGED_MEMORY");
-
-    if (RTEST(rb_const_defined(rb_cObject, enable_mm)) && RTEST(rb_const_get(rb_cObject, enable_mm)))
-    {
-        rb_warning("RMagick: %s", "managed memory enabled. This is an experimental feature.");
-        SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
-        rb_define_const(Module_Magick, "MANAGED_MEMORY", Qtrue);
-    }
-    else
-    {
-        rb_define_const(Module_Magick, "MANAGED_MEMORY", Qfalse);
-    }
+    SetMagickMemoryMethods(rm_malloc, rm_realloc, rm_free);
+    rb_define_const(Module_Magick, "MANAGED_MEMORY", Qtrue);
 }
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -114,9 +114,9 @@ static inline void managed_memory_enable(VALUE enable)
 
 static void set_managed_memory(void)
 {
-    ID disable_mm = rb_intern("RMAGICK_DISABLE_MANAGED_MEMORY");
+    char *disable = getenv("RMAGICK_DISABLE_MANAGED_MEMORY");
 
-    if (RTEST(rb_const_defined(rb_cObject, disable_mm)) && RTEST(rb_const_get(rb_cObject, disable_mm)))
+    if (disable)
     {
         managed_memory_enable(Qfalse);
         return;

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -122,10 +122,15 @@ static void set_managed_memory(void)
         return;
     }
 
-#if !defined(_WIN32)
+#if defined(_WIN32)
+#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_9_0)
     managed_memory_enable(Qtrue);
 #else
     managed_memory_enable(Qfalse);
+#endif
+#else
+    // Not Windows
+    managed_memory_enable(Qtrue);
 #endif
 }
 


### PR DESCRIPTION
This patch aims to goal to get Ruby's GC to work well.

For example, Ruby indicates Magick::Image object is only 40 bytes.

```ruby
require 'rmagick'
require 'objspace'

img = Magick::Image.new(400, 400)
puts ObjectSpace.memsize_of(img) #=> 40 bytes
```

However, ImageMagick allocates a lot of memory and associates to Magick::Image object.
And Ruby doesn't know that.

Please execute the following code. 

```ruby
4000.times do
  img = Magick::Image.new(400, 400)
end
```

Ruby will recognize that 40 * 4000 = 156 KB of memory has been allocated.
It may be low value as a threshold to run GC mark/sweep.

However, in fact, RMagick has been allocating more memory (156 KB + ImageMagick allocated memory).

When Ruby knows the correct memory usage, the GC works properly, and it makes system working more stably with other gems.

To solve this problem, I think we can select a way from

1. Use Ruby allocating function (xmalloc/xrealloc/xfree) in ImageMagick.
2. Notify ImageMagick allocated memory size using `rb_gc_adjust_memory_usage()` Ruby API.

I think `1.` is easy way as solution.

### Before/After
![memory_usage](https://user-images.githubusercontent.com/199156/58804142-176a7500-864c-11e9-991f-21bac27c9a90.png)


### Test code
```ruby
1000.times do |i|
  img = Magick::Image.new(1000, 1000)
end
```

### How to disable managed memory
Set some value to `RMAGICK_DISABLE_MANAGED_MEMORY` environment variable at command line

```
$ RMAGICK_DISABLE_MANAGED_MEMORY=true ruby test.rb
```

Or set some value to `ENV['RMAGICK_DISABLE_MANAGED_MEMORY']` before `require 'rmagick'` line.

```ruby
ENV['RMAGICK_DISABLE_MANAGED_MEMORY'] = 'true'
require 'rmagick'
```