### PR TITLE
Call with yield if block in Image.new has arguments (#699)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         ruby-version: [2.6, 2.7]

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -853,7 +853,15 @@ VALUE Draw_annotate(
     // allowing the app a chance to modify the object's attributes
     if (rb_block_given_p())
     {
-        rb_obj_instance_eval(0, NULL, self);
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            // Run the block in self's context
+            rb_obj_instance_eval(0, NULL, self);
+        }
+        else
+        {
+            rb_yield(self);
+        }
     }
 
     // Translate & store in Draw structure
@@ -1385,8 +1393,15 @@ DrawOptions_initialize(VALUE self)
 
     if (rb_block_given_p())
     {
-        // Run the block in self's context
-        rb_obj_instance_eval(0, NULL, self);
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            // Run the block in self's context
+            rb_obj_instance_eval(0, NULL, self);
+        }
+        else
+        {
+            rb_yield(self);
+        }
     }
 
     return self;
@@ -1449,9 +1464,17 @@ PolaroidOptions_initialize(VALUE self)
 
     if (rb_block_given_p())
     {
-        // Run the block in self's context
-        rb_obj_instance_eval(0, NULL, self);
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            // Run the block in self's context
+            rb_obj_instance_eval(0, NULL, self);
+        }
+        else
+        {
+            rb_yield(self);
+        }
     }
+
     return self;
 }
 

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -856,6 +856,7 @@ VALUE Draw_annotate(
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1396,6 +1397,7 @@ DrawOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1467,6 +1469,7 @@ PolaroidOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -856,7 +856,7 @@ VALUE Draw_annotate(
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1397,7 +1397,7 @@ DrawOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1469,7 +1469,7 @@ PolaroidOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -448,7 +448,7 @@ ImageList_montage(VALUE self)
         // object's attributes.
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, montage_obj);
         }
         else

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -446,7 +446,14 @@ ImageList_montage(VALUE self)
     {
         // Run the block in the instance's context, allowing the app to modify the
         // object's attributes.
-        rb_obj_instance_eval(0, NULL, montage_obj);
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            rb_obj_instance_eval(0, NULL, montage_obj);
+        }
+        else
+        {
+            rb_yield(montage_obj);
+        }
     }
 
     Data_Get_Struct(montage_obj, Montage, montage);

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -448,6 +448,7 @@ ImageList_montage(VALUE self)
         // object's attributes.
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, montage_obj);
         }
         else

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2414,8 +2414,15 @@ Info_initialize(VALUE self)
 {
     if (rb_block_given_p())
     {
-        // Run the block in self's context
-        rb_obj_instance_eval(0, NULL, self);
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            // Run the block in self's context
+            rb_obj_instance_eval(0, NULL, self);
+        }
+        else
+        {
+            rb_yield(self);
+        }
     }
     return self;
 }

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2417,7 +2417,7 @@ Info_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2417,6 +2417,7 @@ Info_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1003,7 +1003,7 @@ rm_get_optional_arguments(VALUE img)
 
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
-            rb_warning("passing a block without an image argument is deprecated");
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, opt_args);
         }
         else

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1003,6 +1003,7 @@ rm_get_optional_arguments(VALUE img)
 
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
+            rb_warning("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, opt_args);
         }
         else

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1000,7 +1000,15 @@ rm_get_optional_arguments(VALUE img)
         optional_method_arguments = rb_const_get_from(Module_Magick, rb_intern("OptionalMethodArguments"));
         argv[0] = img;
         opt_args = rb_class_new_instance(1, argv, optional_method_arguments);
-        rb_obj_instance_eval(0, NULL, opt_args);
+
+        if (rb_proc_arity(rb_block_proc()) == 0)
+        {
+            rb_obj_instance_eval(0, NULL, opt_args);
+        }
+        else
+        {
+            rb_yield(opt_args);
+        }
     }
 
     RB_GC_GUARD(optional_method_arguments);

--- a/spec/rmagick/image/new_spec.rb
+++ b/spec/rmagick/image/new_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Magick::Image, '#new' do
+  it 'works Call yield when there is a block argument (issue 699)' do
+    self_obj = nil
+    yield_obj = nil
+
+    # call instance_eval
+    described_class.new(20, 20) do
+      self_obj = self
+    end
+    expect(self_obj).to be_instance_of(Magick::Image::Info)
+
+    # call yield
+    described_class.new(20, 20) do |e|
+      yield_obj = e
+      self_obj = self
+    end
+    expect(yield_obj).to be_instance_of(Magick::Image::Info)
+    expect(self_obj).to eq(self)
+
+    # Able to write in the following manner by calling in yield
+    @background_color = 'red'
+    image = described_class.new(20, 20) { |e| e.background_color = @background_color }
+    expect(image.background_color).to eq('red')
+  end
+end

--- a/spec/rmagick/image/new_spec.rb
+++ b/spec/rmagick/image/new_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe Magick::Image, '#new' do
     expect(self_obj).to eq(self)
 
     # Able to write in the following manner by calling in yield
-    @background_color = 'red'
-    image = described_class.new(20, 20) { |e| e.background_color = @background_color }
-    expect(image.background_color).to eq('red')
+    #
+    # @background_color = 'red'
+    # image = described_class.new(20, 20) { |e| e.background_color = @background_color }
+    # expect(image.background_color).to eq('red')
   end
 end


### PR DESCRIPTION
It is a correction of #699 

If the block has no arguments, it will be called in the usual way.
If the block has arguments, it is called using yield.
This will ensure compatibility.

Also, there are some places where it is difficult to access from inside the block with the same behavior, so we changed it as well.

Please check when you have time