### PR TITLE
Draw#pattern should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -440,7 +440,7 @@ module Magick
     # as the argument to the 'fill' or 'stroke' methods
     def pattern(name, x, y, width, height)
       push('defs')
-      push("pattern #{name} #{x} #{y} #{width} #{height}")
+      push("pattern #{name} " + format('%g %g %g %g', x, y, width, height))
       push('graphic-context')
       yield
     ensure

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -425,14 +425,14 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_pattern
-    @draw.pattern('hat', 0, 0, 20, '20') {}
-    assert_equal("push defs\npush pattern hat 0 0 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs", @draw.inspect)
+    @draw.pattern('hat', 0, 10.5, 20, '20') {}
+    assert_equal("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs", @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.pattern('hat', 'x', 0, 20, 20){} }
-    # assert_raise(ArgumentError) { @draw.pattern('hat', 0, 'x', 20, 20){} }
-    # assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 'x', 20){} }
-    # assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 20, 'x'){} }
+    assert_raise(ArgumentError) { @draw.pattern('hat', 'x', 0, 20, 20) {} }
+    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 'x', 20, 20) {} }
+    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 'x', 20) {} }
+    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 20, 'x') {} }
   end
 
   def test_point


### PR DESCRIPTION
Draw#pattern has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.pattern('hat', 'x', 0, 20, 20) {}

draw.draw(img)
```