### PR TITLE
Draw#point should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -451,7 +451,7 @@ module Magick
 
     # Set point to fill color.
     def point(x, y)
-      primitive "point #{x},#{y}"
+      primitive 'point ' + format('%g,%g', x, y)
     end
 
     # Specify the font size in points. Yes, the primitive is "font-size" but

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -436,12 +436,12 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_point
-    @draw.point(10, '20')
-    assert_equal('point 10,20', @draw.inspect)
+    @draw.point(10.5, '20')
+    assert_equal('point 10.5,20', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.point('x', 20) }
-    # assert_raise(ArgumentError) { @draw.point(10, 'x') }
+    assert_raise(ArgumentError) { @draw.point('x', 20) }
+    assert_raise(ArgumentError) { @draw.point(10, 'x') }
   end
 
   def test_pointsize


### PR DESCRIPTION
Draw#point has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.point(10, 'x')

draw.draw(img)
```