### PR TITLE
Draw#font_size should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -457,7 +457,7 @@ module Magick
     # Specify the font size in points. Yes, the primitive is "font-size" but
     # in other places this value is called the "pointsize". Give it both names.
     def pointsize(points)
-      primitive "font-size #{points}"
+      primitive 'font-size ' + format('%g', points)
     end
     alias font_size pointsize
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -445,11 +445,11 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_pointsize
-    @draw.pointsize(20)
-    assert_equal('font-size 20', @draw.inspect)
+    @draw.pointsize(20.5)
+    assert_equal('font-size 20.5', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.pointsize('x') }
+    assert_raise(ArgumentError) { @draw.pointsize('x') }
   end
 
   def test_font_size
@@ -457,7 +457,7 @@ class LibDrawUT < Test::Unit::TestCase
     assert_equal('font-size 20', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.font_size('x') }
+    assert_raise(ArgumentError) { @draw.font_size('x') }
   end
 
   def test_polygon


### PR DESCRIPTION
Draw#font_size has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.font_size('x')

draw.draw(img)
```