### PR TITLE
Draw#polygon should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -468,7 +468,7 @@ module Magick
       elsif points.length.odd?
         Kernel.raise ArgumentError, 'odd number of points specified'
       end
-      primitive 'polygon ' + points.join(',')
+      primitive 'polygon ' + points.map! { |x| format('%g', x) }.join(',')
     end
 
     # Draw a polyline

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -461,13 +461,13 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_polygon
-    @draw.polygon(0, '0', 8, 16, 16, 0, 0, 0)
-    assert_equal('polygon 0,0,8,16,16,0,0,0', @draw.inspect)
+    @draw.polygon(0, '0.5', 8.5, 16, 16, 0, 0, 0)
+    assert_equal('polygon 0,0.5,8.5,16,16,0,0,0', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.polygon }
     assert_raise(ArgumentError) { @draw.polygon(0) }
-    # assert_raise(ArgumentError) { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }
+    assert_raise(ArgumentError) { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }
   end
 
   def test_polyline


### PR DESCRIPTION
Draw#polygon has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.polygon('x', 0, 8, 16, 16, 0, 0, 0)

draw.draw(img)
```