### PR TITLE
Draw#polyline should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -478,7 +478,7 @@ module Magick
       elsif points.length.odd?
         Kernel.raise ArgumentError, 'odd number of points specified'
       end
-      primitive 'polyline ' + points.join(',')
+      primitive 'polyline ' + points.map! { |x| format('%g', x) }.join(',')
     end
 
     # Return to the previously-saved set of whatever

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -471,13 +471,13 @@ class LibDrawUT < Test::Unit::TestCase
   end
 
   def test_polyline
-    @draw.polyline(0, '0', 16, 16)
-    assert_equal('polyline 0,0,16,16', @draw.inspect)
+    @draw.polyline(0, '0.5', 16.5, 16)
+    assert_equal('polyline 0,0.5,16.5,16', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.polyline }
     assert_raise(ArgumentError) { @draw.polyline(0) }
-    # assert_raise(ArgumentError) { @draw.polyline('x', 0, 16, 16) }
+    assert_raise(ArgumentError) { @draw.polyline('x', 0, 16, 16) }
   end
 
   def test_rectangle


### PR DESCRIPTION
Draw#polyline has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.polyline('x', 0, 16, 16)

draw.draw(img)
```