### PR TITLE
Draw#rotate should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -518,7 +518,7 @@ module Magick
 
     # Specify coordinate space rotation. "angle" is measured in degrees
     def rotate(angle)
-      primitive "rotate #{angle}"
+      primitive 'rotate ' + format('%g', angle)
     end
 
     # Draw a rectangle with rounded corners

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -497,7 +497,7 @@ class LibDrawUT < Test::Unit::TestCase
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.rotate('x') }
+    assert_raise(ArgumentError) { @draw.rotate('x') }
   end
 
   def test_roundrectangle


### PR DESCRIPTION
Draw#rotate has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.rotate('x')

draw.draw(img)
```