### PR TITLE
Draw#scale should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -529,7 +529,7 @@ module Magick
 
     # Specify scaling to be applied to coordinate space on subsequent drawing commands.
     def scale(x, y)
-      primitive "scale #{x},#{y}"
+      primitive 'scale ' + format('%g,%g', x, y)
     end
 
     def skewx(angle)

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -519,8 +519,8 @@ class LibDrawUT < Test::Unit::TestCase
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.scale('x', 1.5) }
-    # assert_raise(ArgumentError) { @draw.scale(0.5, 'x') }
+    assert_raise(ArgumentError) { @draw.scale('x', 1.5) }
+    assert_raise(ArgumentError) { @draw.scale(0.5, 'x') }
   end
 
   def test_skewx


### PR DESCRIPTION
Draw#scale has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.scale('x', 2.0)

draw.draw(img)

```