### PR TITLE
Deprecated the use of an unnamed argument for the opacity value of Image#black_threshold and Image#white_threshold.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1287,7 +1287,7 @@ Image_black_point_compensation_eq(VALUE self, VALUE arg)
  *   - @verbatim Image#black_threshold(red_channel) @endverbatim
  *   - @verbatim Image#black_threshold(red_channel, green_channel) @endverbatim
  *   - @verbatim Image#black_threshold(red_channel, green_channel, blue_channel) @endverbatim
- *   - @verbatim Image#black_threshold(red_channel, green_channel, blue_channel, opacity_channel) @endverbatim
+ *   - @verbatim Image#black_threshold(red_channel, green_channel, blue_channel, alpha_channel) @endverbatim
  *
  * @param argc number of input arguments
  * @param argv array of input arguments
@@ -13340,7 +13340,7 @@ static
 VALUE threshold_image(int argc, VALUE *argv, VALUE self, thresholder_t thresholder)
 {
     Image *image, *new_image;
-    double red, green, blue, opacity;
+    double red, green, blue, alpha;
     char ctarg[200];
 
     image = rm_check_destroyed(self);
@@ -13351,8 +13351,8 @@ VALUE threshold_image(int argc, VALUE *argv, VALUE self, thresholder_t threshold
             red     = NUM2DBL(argv[0]);
             green   = NUM2DBL(argv[1]);
             blue    = NUM2DBL(argv[2]);
-            opacity = NUM2DBL(argv[3]);
-            sprintf(ctarg, "%f,%f,%f,%f", red, green, blue, opacity);
+            alpha   = get_named_alpha_value(argv[3], "alpha_channel");
+            sprintf(ctarg, "%f,%f,%f,%f", red, green, blue, QuantumRange - alpha);
             break;
         case 3:
             red     = NUM2DBL(argv[0]);
@@ -14898,7 +14898,7 @@ Image_wet_floor(int argc, VALUE *argv, VALUE self)
  *   - @verbatim Image#white_threshold(red_channel) @endverbatim
  *   - @verbatim Image#white_threshold(red_channel, green_channel) @endverbatim
  *   - @verbatim Image#white_threshold(red_channel, green_channel, blue_channel) @endverbatim
- *   - @verbatim Image#white_threshold(red_channel, green_channel, blue_channel, opacity_channel) @endverbatim
+ *   - @verbatim Image#white_threshold(red_channel, green_channel, blue_channel, alpha_channel) @endverbatim
  *
  * @param argc number of input arguments
  * @param argv array of input arguments

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -322,6 +322,8 @@ class Image1_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.black_threshold(50, 50) }
     assert_nothing_raised { @img.black_threshold(50, 50, 50) }
     assert_nothing_raised { @img.black_threshold(50, 50, 50, 50) }
+    assert_nothing_raised { @img.black_threshold(50, 50, 50, alpha_channel: 50) }
+    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, wrong: 50) }
     assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, 50, 50) }
     res = @img.black_threshold(50)
     assert_instance_of(Magick::Image, res)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -1000,6 +1000,8 @@ class Image3_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.white_threshold(50, 50) }
     assert_nothing_raised { @img.white_threshold(50, 50, 50) }
     assert_nothing_raised { @img.white_threshold(50, 50, 50, 50) }
+    assert_nothing_raised { @img.white_threshold(50, 50, 50, alpha_channel: 50) }
+    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, wrong: 50) }
     assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, 50, 50) }
     res = @img.white_threshold(50)
     assert_instance_of(Magick::Image, res)


### PR DESCRIPTION
To have a smooth transition from ImageMagick 6 to ImageMagick 7 some of the arguments need to change from an opacity value to an alpha value. Instead of only a `Quantum` value a named argument should be used. If only a value is passed in the value will be changed from opacity to alpha and a warning will be raised to inform the user that they should use a named argument and switch from opacity to alpha.