### PR TITLE
Draw#stroke_dashoffset should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -567,7 +567,7 @@ module Magick
 
     # Specify the initial offset in the dash pattern
     def stroke_dashoffset(value = 0)
-      primitive "stroke-dashoffset #{value}"
+      primitive 'stroke-dashoffset ' + format('%g', value)
     end
 
     def stroke_linecap(value)

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -609,7 +609,7 @@ class LibDrawUT < Test::Unit::TestCase
     assert_equal('stroke-dashoffset 10', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.stroke_dashoffset('x') }
+    assert_raise(ArgumentError) { @draw.stroke_dashoffset('x') }
   end
 
   def test_stroke_linecap


### PR DESCRIPTION
Draw#stroke_dashoffset has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.stroke_dashoffset('x')

draw.draw(img)
```