### PR TITLE
Deprecated the use of an unnamed argument for the opacity value of Image#matte_flood_fill.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -903,7 +903,7 @@ extern VALUE Image_map(int, VALUE *, VALUE);
 extern VALUE Image_marshal_dump(VALUE);
 extern VALUE Image_marshal_load(VALUE, VALUE);
 extern VALUE Image_mask(int, VALUE *, VALUE);
-extern VALUE Image_matte_flood_fill(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+extern VALUE Image_matte_flood_fill(int, VALUE *, VALUE);
 extern VALUE Image_median_filter(int, VALUE *, VALUE);
 extern VALUE Image_minify(VALUE);
 extern VALUE Image_minify_bang(VALUE);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -419,7 +419,7 @@ Init_RMagick2(void)
     rb_define_method(Class_Image, "marshal_dump", Image_marshal_dump, 0);
     rb_define_method(Class_Image, "marshal_load", Image_marshal_load, 1);
     rb_define_method(Class_Image, "mask", Image_mask, -1);
-    rb_define_method(Class_Image, "matte_flood_fill", Image_matte_flood_fill, 5);
+    rb_define_method(Class_Image, "matte_flood_fill", Image_matte_flood_fill, -1);
     rb_define_method(Class_Image, "median_filter", Image_median_filter, -1);
     rb_define_method(Class_Image, "minify", Image_minify, 0);
     rb_define_method(Class_Image, "minify!", Image_minify_bang, 0);

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -934,16 +934,14 @@ module Magick
       f = copy
       f.alpha(OpaqueAlphaChannel) unless f.alpha?
       target = f.pixel_color(x, y)
-      f.matte_flood_fill(target, TransparentOpacity,
-                         x, y, FloodfillMethod)
+      f.matte_flood_fill(target, x, y, FloodfillMethod, alpha: TransparentAlpha)
     end
 
     # Make transparent any neighbor pixel that is not the border color.
     def matte_fill_to_border(x, y)
       f = copy
       f.alpha(OpaqueAlphaChannel) unless f.alpha?
-      f.matte_flood_fill(border_color, TransparentOpacity,
-                         x, y, FillToBorderMethod)
+      f.matte_flood_fill(border_color, x, y, FillToBorderMethod, alpha: TransparentAlpha)
     end
 
     # Make all pixels transparent.

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -1155,10 +1155,12 @@ class Image2_UT < Test::Unit::TestCase
     Magick::PaintMethod.values do |method|
       next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
 
-      assert_raise(ArgumentError) { @img.matte_flood_fill('blue', Magick::TransparentOpacity, @img.columns, @img.rows, method) }
+      assert_raise(ArgumentError) { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }
     end
     assert_raise(ArgumentError) { @img.matte_floodfill(@img.columns + 1, @img.rows) }
     assert_raise(ArgumentError) { @img.matte_floodfill(@img.columns, @img.rows + 1) }
+    assert_nothing_raised { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }
   end
 
   def test_matte_replace


### PR DESCRIPTION
To have a smooth transition from ImageMagick 6 to ImageMagick 7 some of the arguments need to change from an opacity value to an alpha value. Instead of only a `Quantum` value a named argument should be used. If only a value is passed in the value will be changed from opacity to alpha and a warning will be raised to inform the user that they should use a named argument and switch from opacity to alpha.