### PR TITLE
Draw#translate should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -641,7 +641,7 @@ module Magick
     # Specify center of coordinate space to use for subsequent drawing
     # commands.
     def translate(x, y)
-      primitive "translate #{x},#{y}"
+      primitive 'translate ' + format('%g,%g', x, y)
     end
   end # class Magick::Draw
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -779,7 +779,7 @@ class LibDrawUT < Test::Unit::TestCase
     assert_equal('translate 200,300', @draw.inspect)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.translate('x', 300) }
-    # assert_raise(ArgumentError) { @draw.translate(200, 'x') }
+    assert_raise(ArgumentError) { @draw.translate('x', 300) }
+    assert_raise(ArgumentError) { @draw.translate(200, 'x') }
   end
 end


### PR DESCRIPTION
Draw#translate has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.translate('x', 300)

draw.draw(img)
```