### PR TITLE
Draw#text should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -612,7 +612,7 @@ module Magick
         # escape existing braces, surround with braces
         text = '{' + text.gsub(/[}]/) { |b| '\\' + b } + '}'
       end
-      primitive "text #{x},#{y} #{text}"
+      primitive 'text ' + format('%g,%g %s', x, y, text)
     end
 
     # Specify text alignment relative to a given point

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -705,8 +705,8 @@ class LibDrawUT < Test::Unit::TestCase
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.text(50, 50, '') }
-    # assert_raise(ArgumentError) { @draw.text('x', 50, 'Hello world') }
-    # assert_raise(ArgumentError) { @draw.text(50, 'x', 'Hello world') }
+    assert_raise(ArgumentError) { @draw.text('x', 50, 'Hello world') }
+    assert_raise(ArgumentError) { @draw.text(50, 'x', 'Hello world') }
   end
 
   def test_text_align


### PR DESCRIPTION
Draw#text has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.text('x', 50, 'Hello world')

draw.draw(img)
```