### PR TITLE
Draw#stroke_width should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -594,7 +594,7 @@ module Magick
 
     # Specify stroke (outline) width in pixels.
     def stroke_width(pixels)
-      primitive "stroke-width #{pixels}"
+      primitive 'stroke-width ' + format('%g', pixels)
     end
 
     # Draw text at position x,y. Add quotes to text that is not already quoted.

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -678,6 +678,14 @@ class LibDrawUT < Test::Unit::TestCase
     assert_raise(ArgumentError) { @draw.stroke_opacity('xxx') }
   end
 
+  def test_stroke_width
+    @draw.stroke_width(2.5)
+    assert_equal('stroke-width 2.5', @draw.inspect)
+    assert_nothing_raised { @draw.draw(@img) }
+
+    assert_raise(ArgumentError) { @draw.stroke_width('xxx') }
+  end
+
   def test_text
     draw = Magick::Draw.new
     draw.text(50, 50, 'Hello world')


### PR DESCRIPTION
Draw#stroke_width has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.stroke_width('x')

draw.draw(img)
```