### PR TITLE
Draw#matte should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -418,7 +418,7 @@ module Magick
     # colorization rule
     def matte(x, y, method)
       Kernel.raise ArgumentError, 'Unknown paint method' unless PAINT_METHOD_NAMES.key?(method.to_i)
-      primitive "matte #{x},#{y} #{PAINT_METHOD_NAMES[method.to_i]}"
+      primitive 'matte ' + format('%g,%g, %s', x, y, PAINT_METHOD_NAMES[method.to_i])
     end
 
     # Specify drawing fill and stroke opacities. If the value is a string

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -398,6 +398,8 @@ class LibDrawUT < Test::Unit::TestCase
     end
 
     assert_raise(ArgumentError) { @draw.matte(10, '20.5', 'xxx') }
+    assert_raise(ArgumentError) { @draw.matte('x', 10, Magick::PointMethod) }
+    assert_raise(ArgumentError) { @draw.matte(10, 'x', Magick::PointMethod) }
   end
 
   def test_opacity


### PR DESCRIPTION
Draw#matte has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.matte(10, 'xxx', Magick::PointMethod)

draw.draw(img)
```