### PR TITLE
Deprecated the use of an unnamed argument for the opacity value of Image#paint_transparent.

### DIFF
--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -1346,8 +1346,14 @@ class Image2_UT < Test::Unit::TestCase
     assert_instance_of(Magick::Image, res)
     assert_not_same(res, @img)
     assert_nothing_raised { @img.paint_transparent('red', Magick::TransparentOpacity) }
+    assert_nothing_raised { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }
     assert_nothing_raised { @img.paint_transparent('red', Magick::TransparentOpacity, true) }
+    assert_nothing_raised { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }
     assert_nothing_raised { @img.paint_transparent('red', Magick::TransparentOpacity, true, 50) }
+    assert_nothing_raised { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }
 
     # Too many arguments
     assert_raise(ArgumentError) { @img.paint_transparent('red', Magick::TransparentOpacity, true, 50, 50) }


### PR DESCRIPTION
To have a smooth transition from ImageMagick 6 to ImageMagick 7 some of the arguments need to change from an opacity value to an alpha value. Instead of only a Quantum value a named argument should be used. If only a value is passed in the value will be changed from opacity to alpha and a warning will be raised to inform the user that they should use a named argument and switch from opacity to alpha.