### PR TITLE
Fix Image#thumbnail to keep image aspect ratio like ImageMagick

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13442,6 +13442,8 @@ thumbnail(int bang, int argc, VALUE *argv, VALUE self)
     Image *image, *new_image;
     unsigned long columns, rows;
     double scale_arg, drows, dcols;
+    char image_geometry[MaxTextExtent];
+    RectangleInfo geometry;
     ExceptionInfo *exception;
 
     Data_Get_Struct(self, Image, image);
@@ -13476,8 +13478,13 @@ thumbnail(int bang, int argc, VALUE *argv, VALUE self)
             break;
     }
 
+    snprintf(image_geometry, sizeof(image_geometry), "%ldx%ld", columns, rows);
+
     exception = AcquireExceptionInfo();
-    new_image = ThumbnailImage(image, columns, rows, exception);
+    (void) ParseRegionGeometry(image, image_geometry, &geometry, exception);
+    rm_check_exception(exception, image, RetainOnError);
+
+    new_image = ThumbnailImage(image, geometry.width, geometry.height, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
 
     (void) DestroyExceptionInfo(exception);

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -742,6 +742,15 @@ class Image3_UT < Test::Unit::TestCase
     assert_raise(ArgumentError) { @img.thumbnail(25, 25, 25) }
     assert_raise(TypeError) { @img.thumbnail('x') }
     assert_raise(TypeError) { @img.thumbnail(10, 'x') }
+
+    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+    new_img = girl.thumbnail(200, 200)
+    assert_equal(160, new_img.columns)
+    assert_equal(200, new_img.rows)
+
+    new_img = girl.thumbnail(2)
+    assert_equal(400, new_img.columns)
+    assert_equal(500, new_img.rows)
   end
 
   def test_thumbnail!


### PR DESCRIPTION
Fix #19

This patch will fix that Image#thumbnail keeps the aspect ratio of image.

## Test code
```ruby
require 'rmagick'

image = Magick::ImageList.new('./Flower_Hat.jpg').first

img = image.thumbnail(100, 100)
img.write('thumbnail.png')
```

* Result

Before | After
-- | -- 
<img src="https://user-images.githubusercontent.com/199156/58695910-72446800-83d1-11e9-92e5-a8f7b2cace3b.png"> | <img src="https://user-images.githubusercontent.com/199156/58695929-7bcdd000-83d1-11e9-8a7d-b38f14cc4850.png">

(By ImageMagick)

```
$ convert Flower_Hat.jpg -thumbnail 100x100 test.png
```

![test](https://user-images.githubusercontent.com/199156/58695957-8f793680-83d1-11e9-9519-bcb250b2a8b4.png)


* Original Image

![Flower_Hat](https://user-images.githubusercontent.com/199156/58695968-96a04480-83d1-11e9-92ce-e39e156a58e5.jpg)
