### PR TITLE
Draw#{skewx, skewy} should raise exception if wrong value was given

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -533,11 +533,11 @@ module Magick
     end
 
     def skewx(angle)
-      primitive "skewX #{angle}"
+      primitive 'skewX ' + format('%g', angle)
     end
 
     def skewy(angle)
-      primitive "skewY #{angle}"
+      primitive 'skewY ' + format('%g', angle)
     end
 
     # Specify the object stroke, a color name or pattern name.

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -531,7 +531,7 @@ class LibDrawUT < Test::Unit::TestCase
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.skewx('x') }
+    assert_raise(ArgumentError) { @draw.skewx('x') }
   end
 
   def test_skewy
@@ -540,7 +540,7 @@ class LibDrawUT < Test::Unit::TestCase
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.skewy('x') }
+    assert_raise(ArgumentError) { @draw.skewy('x') }
   end
 
   def test_stroke


### PR DESCRIPTION
Draw#{skewx, skewy} has been accepted any value.
If wrong value was given, it should raise an exception.

```
require 'rmagick'

img = Magick::Image.new(400, 400)
draw = Magick::Draw.new

draw.skewx('x')
# draw.skewy('y')
draw.circle(100, 100, 125, 125)
draw.rectangle(65, 150, 135, 300)

draw.draw(img)
```