### PR TITLE
Add Draw#image

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -373,6 +373,12 @@ module Magick
       primitive "gravity #{GRAVITY_NAMES[grav.to_i]}"
     end
 
+    def image(composite, x, y, width, height, image_file_path)
+      Kernel.raise ArgumentError, 'Unknown composite' unless composite.is_a?(CompositeOperator)
+      composite_name = composite.to_s.sub!('CompositeOp', '')
+      primitive 'image ' + format('%s %g,%g %g,%g %s', composite_name, x, y, width, height, enquote(image_file_path))
+    end
+
     # IM 6.5.5-8 and later
     def interline_spacing(space)
       begin

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -328,6 +328,22 @@ class LibDrawUT < Test::Unit::TestCase
     assert_raise(ArgumentError) { @draw.gravity('xxx') }
   end
 
+  def test_image
+    Magick::CompositeOperator.values do |composite|
+      next if [Magick::CopyAlphaCompositeOp, Magick::NoCompositeOp].include?(composite)
+
+      draw = Magick::Draw.new
+      draw.image(composite, 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg")
+      assert_nothing_raised { draw.draw(@img) }
+    end
+
+    assert_raise(ArgumentError) { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
+    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 'x', 100, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
+    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 'x', 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
+    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 100, 'x', 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
+    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 100, 200, 'x', "#{IMAGES_DIR}/Flower_Hat.jpg") }
+  end
+
   def test_interline_spacing
     draw = Magick::Draw.new
     draw.interline_spacing(40.5)


### PR DESCRIPTION
This PR will add missing method about  image primitive in ImageMagick.

* Sample

```
require 'rmagick'

img = Magick::Image.new(200, 200)
draw = Magick::Draw.new

draw.rectangle(5, 0, 195, 200)
draw.image(Magick::PlusCompositeOp, 10, 0, 180, 200, 'doc/ex/images/Flower_Hat.jpg')
draw.draw(img)

img.write('sample.png')
```

* Result
![sample](https://user-images.githubusercontent.com/199156/58729100-74371700-8423-11e9-86dd-3082b75ab20c.png)
