### PR TITLE
Deprecated the use of an unnamed argument for the opacity value of Image#transparent_chroma.

### DIFF
--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -811,9 +811,13 @@ class Image3_UT < Test::Unit::TestCase
   def test_transparent_chroma
     assert_instance_of(Magick::Image, @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)))
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), 1.0) }
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), 1.0, true) }
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), 1.0, false) }
+    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentOpacity) }
+    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }
+    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentOpacity, true) }
+    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentOpacity, false) }
+    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }
   end
 
   def test_transpose


### PR DESCRIPTION
To have a smooth transition from ImageMagick 6 to ImageMagick 7 some of the arguments need to change from an opacity value to an alpha value. Instead of only a Quantum value a named argument should be used. If only a value is passed in the value will be changed from opacity to alpha and a warning will be raised to inform the user that they should use a named argument and switch from opacity to alpha.