### PR TITLE
Fix stack-buffer-overflow in Draw#annotate

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -945,7 +945,7 @@ VALUE Draw_annotate(
     unsigned long width, height;
     long x, y;
     AffineMatrix keep;
-    char geometry_str[50];
+    char geometry_str[100];
 
     // Save the affine matrix in case it is modified by
     // Draw#rotation=

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -193,6 +193,16 @@ class DrawUT < Test::Unit::TestCase
     assert_raise(NoMethodError) { @draw.annotate('x', 0, 0, 0, 20, 'Hello world') }
   end
 
+  def test_annotate_stack_buffer_overflow
+    assert_nothing_raised do
+      if 1.size == 8
+        # 64-bit environment can use larger value for Integer and it can causes stack buffer overflow.
+        img = Magick::Image.new(10, 10)
+        @draw.annotate(img, 2**63, 2**63, 2**62, 2**62, 'Hello world')
+      end
+    end
+  end
+
   def test_dup
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     @draw.taint


### PR DESCRIPTION
A buffer to generate geometry string is too small in edge case.

## Environment
* OS : Ubuntu 19.04
* Compiler : gcc 8.3

## Test code
```
require 'rmagick'

img = Magick::Image.new(100, 100)
draw = Magick::Draw.new
draw.annotate(img, 2**63, 2**63, 2**62, 2**62, 'Hello world')
```

## Result
```
$ rake build
$ CFLAGS='-g -O0 -fno-omit-frame-pointer -fsanitize=address -static-libasan' gem i pkg/rmagick-3.1.0.gem
$ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.5 LSAN_OPTIONS="detect_leaks=0" ruby test.rb
=================================================================
==15907==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc73906d42 at pc 0x7f542c9bc415 bp 0x7ffc73906af0 sp 0x7ffc73906280
WRITE of size 80 at 0x7ffc73906d42 thread T0
    #0 0x7f542c9bc414 in vsprintf (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x9d414)
    #1 0x7f542c9bc8c6 in sprintf (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x9d8c6)
    #2 0x7f5427298b50 in Draw_annotate /home/watson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rmagick-3.1.0/ext/RMagick/rmdraw.c:987
    #3 0x56490bf4d4b7 in call_cfunc_6 /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm_insnhelper.c:1785
    #4 0x56490bf5258a in vm_call_cfunc_with_frame /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm_insnhelper.c:1908
    #5 0x56490bf5258a in vm_call_cfunc /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm_insnhelper.c:1924
    #6 0x56490bf5cd03 in vm_call_method /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm_insnhelper.c:2397
    #7 0x56490bf5cd03 in vm_call_method /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm_insnhelper.c:2364
    #8 0x56490bf67158 in vm_exec_core /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/insns.def:765
    #9 0x56490bf5bbe6 in rb_vm_exec /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/vm.c:1894
    #10 0x56490bdbc7a2 in ruby_exec_internal /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/eval.c:262
    #11 0x56490bdc096b in ruby_exec_node /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/eval.c:326
    #12 0x56490bdc096b in ruby_run_node /tmp/ruby-build.20190529225611.5130/ruby-2.6.3/eval.c:318
    #13 0x56490bdbc44a in main main.c:42
    #14 0x7f542c575b6a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26b6a)
    #15 0x56490bdbc499 in _start (/home/watson/.rbenv/versions/2.6.3/bin/ruby+0x27499)

Address 0x7ffc73906d42 is located in stack of thread T0 at offset 242 in frame
    #0 0x7f5427298737 in Draw_annotate /home/watson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rmagick-3.1.0/ext/RMagick/rmdraw.c:942

  This frame has 3 object(s):
    [32, 40) 'text'
    [96, 144) 'keep'
    [192, 242) 'geometry_str' <== Memory access at offset 242 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x9d414) in vsprintf
Shadow bytes around the buggy address:
  0x10000e718d50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718d60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718d70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718d80: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f2
  0x10000e718d90: f2 f2 f2 f2 f2 f2 00 00 00 00 00 00 f2 f2 f2 f2
=>0x10000e718da0: f2 f2 00 00 00 00 00 00[02]f2 00 00 00 00 00 00
  0x10000e718db0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000e718df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==15907==ABORTING
```