### PR TITLE
Add Draw#alpha.

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -236,6 +236,13 @@ module Magick
       primitive 'affine ' + format('%g,%g,%g,%g,%g,%g', sx, rx, ry, sy, tx, ty)
     end
 
+    # Set alpha (make transparent) in image according to the specified
+    # colorization rule
+    def alpha(x, y, method)
+      Kernel.raise ArgumentError, 'Unknown paint method' unless PAINT_METHOD_NAMES.key?(method.to_i)
+      primitive 'matte ' + format('%g,%g, %s', x, y, PAINT_METHOD_NAMES[method.to_i])
+    end
+
     # Draw an arc.
     def arc(start_x, start_y, end_x, end_y, start_degrees, end_degrees)
       primitive 'arc ' + format('%g,%g %g,%g %g,%g',

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -21,6 +21,18 @@ class LibDrawUT < Test::Unit::TestCase
     assert_raise(ArgumentError) { @draw.affine(10, 12, 15, 20, 22, 'x') }
   end
 
+  def test_alpha
+    Magick::PaintMethod.values do |method|
+      draw = Magick::Draw.new
+      draw.alpha(10, '20.5', method)
+      assert_nothing_raised { draw.draw(@img) }
+    end
+
+    assert_raise(ArgumentError) { @draw.alpha(10, '20.5', 'xxx') }
+    assert_raise(ArgumentError) { @draw.alpha('x', 10, Magick::PointMethod) }
+    assert_raise(ArgumentError) { @draw.alpha(10, 'x', Magick::PointMethod) }
+  end
+
   def test_arc
     @draw.arc(100.5, 120.5, 200, 250, 20, 370)
     assert_equal('arc 100.5,120.5 200,250 20,370', @draw.inspect)


### PR DESCRIPTION
This PR adds `Draw#alpha` that replaces `Draw#matte` in ImageMagick 7.