### PR TITLE
Add ArchLinux support

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -15,19 +15,24 @@ module RMagick
     def initialize
       @stdout = $stdout.dup
 
-      setup_paths_for_homebrew
+      setup_pkg_config_path
       configure_compile_options
       assert_can_compile!
       configure_headers
     end
 
-    def setup_paths_for_homebrew
-      return unless find_executable('brew')
+    def setup_pkg_config_path
+      if find_executable('brew')
+        pkg_config_path = "#{`brew --prefix imagemagick@6`.strip}/lib/pkgconfig"
+      elsif find_executable('pacman')
+        pkg_config_path = '/usr/lib/imagemagick6/pkgconfig'
+      else
+        return
+      end
 
-      brew_pkg_config_path = "#{`brew --prefix imagemagick@6`.strip}/lib/pkgconfig"
-      pkgconfig_paths = ENV['PKG_CONFIG_PATH'].to_s.split(':')
-      if File.exist?(brew_pkg_config_path) && !pkgconfig_paths.include?(brew_pkg_config_path)
-        ENV['PKG_CONFIG_PATH'] = [ENV['PKG_CONFIG_PATH'], brew_pkg_config_path].compact.join(':')
+      pkg_config_paths = ENV['PKG_CONFIG_PATH'].to_s.split(':')
+      if File.exist?(pkg_config_path) && !pkg_config_paths.include?(pkg_config_path)
+        ENV['PKG_CONFIG_PATH'] = [ENV['PKG_CONFIG_PATH'], pkg_config_path].compact.join(':')
       end
     end
 


### PR DESCRIPTION
pacman in ArchLinux will install `pkg-config` of ImageMagick 6 into `/usr/lib/imagemagick6/pkgconfig` which can't be searched by default.

### Dockerfile
```
FROM archlinux/base:latest

RUN pacman -Syy --noconfirm pkg-config make gcc ruby libmagick6 libxml2

WORKDIR /opt/rmagick

```

### Result
```
# ls /usr/lib/imagemagick6/pkgconfig/
ImageMagick++-6.Q16HDRI.pc  ImageMagick++.pc  Magick++-6.Q16HDRI.pc    MagickCore.pc  MagickWand-6.Q16HDRI.pc  Wand-6.Q16HDRI.pc
ImageMagick-6.Q16HDRI.pc    ImageMagick.pc    MagickCore-6.Q16HDRI.pc  Magick++.pc    MagickWand.pc	       Wand.pc
```

```
# gem install rmagick-3.1.0.gem
WARNING:  You don't have /root/.gem/ruby/2.6.0/bin in your PATH,
	  gem executables will not run.
Building native extensions. This could take a while...
ERROR:  Error installing rmagick-3.1.0.gem:
	ERROR: Failed to build gem native extension.

    current directory: /root/.gem/ruby/2.6.0/gems/rmagick-3.1.0/ext/RMagick
/usr/bin/ruby -I /usr/lib/ruby/2.6.0 -r ./siteconf20190608-326-1i6hpcx.rb extconf.rb
checking for brew... no
checking for gcc... yes
checking for pkg-config... yes

ERROR: Can't install RMagick 3.1.0. Can't find ImageMagick with pkg-config

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /root/.gem/ruby/2.6.0/extensions/x86_64-linux/2.6.0/rmagick-3.1.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /root/.gem/ruby/2.6.0/gems/rmagick-3.1.0 for inspection.
Results logged to /root/.gem/ruby/2.6.0/extensions/x86_64-linux/2.6.0/rmagick-3.1.0/gem_make.out
```

This patch will fix above error on ArchLinux.