### PR TITLE
Check the number of arguments in the methods that now require a named argument for alpha.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -67,6 +67,11 @@ get_alpha_from_opacity(VALUE opacity)
 static Quantum
 get_alpha_from_hash(VALUE hash)
 {
+    if (FIX2ULONG(rb_hash_size(hash)) != 1)
+    {
+        rb_raise(rb_eArgError, "wrong number of arguments");
+    }
+
     VALUE alpha = rb_hash_aref(hash, ID2SYM(rb_intern("alpha")));
     if (NIL_P(alpha))
     {

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -324,6 +324,7 @@ class Image1_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.black_threshold(50, 50, 50, 50) }
     assert_nothing_raised { @img.black_threshold(50, 50, 50, alpha: 50) }
     assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, wrong: 50) }
+    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }
     assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, 50, 50) }
     res = @img.black_threshold(50)
     assert_instance_of(Magick::Image, res)

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -1351,6 +1351,7 @@ class Image2_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.paint_transparent('red', Magick::TransparentOpacity, true) }
     assert_nothing_raised { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
     assert_nothing_raised { @img.paint_transparent('red', Magick::TransparentOpacity, true, 50) }
     assert_nothing_raised { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -812,6 +812,7 @@ class Image3_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.transparent('white', Magick::TransparentOpacity) }
     assert_nothing_raised { @img.transparent('white', alpha: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.transparent('white', wrong: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.transparent('white', Magick::TransparentOpacity, 2) }
     assert_nothing_raised { @img.transparent('white', Magick::QuantumRange / 2) }
     assert_raise(TypeError) { @img.transparent(2) }
@@ -827,6 +828,7 @@ class Image3_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentOpacity, false) }
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha) }
     assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }
+    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
   end
 
   def test_transpose
@@ -1015,6 +1017,7 @@ class Image3_UT < Test::Unit::TestCase
     assert_nothing_raised { @img.white_threshold(50, 50, 50, 50) }
     assert_nothing_raised { @img.white_threshold(50, 50, 50, alpha: 50) }
     assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, wrong: 50) }
+    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }
     assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, 50, 50) }
     res = @img.white_threshold(50)
     assert_instance_of(Magick::Image, res)


### PR DESCRIPTION
This PR adds extra checks to make sure that it is not allowed to add extra arguments to the methods that now require a named argument for alpha.