### PR TITLE
Fix SEGV in Image#each_profile

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -5546,7 +5546,8 @@ VALUE
 Image_each_profile(VALUE self)
 {
     Image *image;
-    VALUE ary, val;
+    VALUE ary;
+    VALUE val = Qnil;
     char *name;
     const StringInfo *profile;
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -521,6 +521,8 @@ class Image2_UT < Test::Unit::TestCase
   end
 
   def test_each_profile
+    assert_nil(@img.each_profile {})
+
     @img.iptc_profile = 'test profile'
     assert_nothing_raised do
       @img.each_profile do |name, value|


### PR DESCRIPTION
If Image object doesn't have profile, Image#each_profile will cause a SEGV.

### Test code
```ruby
require 'rmagick'

img = Magick::Image.new(10, 10)

# Image#each_profile returns undefined value and it causes SEGV if use it
p img.each_profile do |name, value|
end
```

### Result
```
$ ruby test.rb
test.rb:4: [BUG] Segmentation fault at 0x0000000000000023
ruby 2.3.8p459 (2018-10-18 revision 65136) [x86_64-darwin18]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0009 e:000008 CFUNC  :p
c:0002 p:0041 s:0005 E:001048 EVAL   test.rb:4 [FINISH]
c:0001 p:0000 s:0002 E:0025a0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:4:in `<main>'
test.rb:4:in `p'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000003 rbx: 0x0000000000000000 rcx: 0x0000000000000310
 rdx: 0x00007ffeea6c7990 rdi: 0x0000000000000003 rsi: 0x0000000000000003
 rbp: 0x00007ffeea6c79b0 rsp: 0x00007ffeea6c7980  r8: 0x0000000000000001
  r9: 0x00007f97e4096608 r10: 0x00007f97e2e06440 r11: 0x00000000ffffffee
 r12: 0x0000000000000000 r13: 0x0000000000000000 r14: 0x0000000000000000
 r15: 0x0000000000000000 rip: 0x0000000105765158 rfl: 0x0000000000010202

 ...
 ```