### PR TITLE
Remove redundant assignment

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9326,8 +9326,6 @@ Image_negate_channel(int argc, VALUE *argv, VALUE self)
         grayscale = RTEST(argv[0]);
     }
 
-    Data_Get_Struct(self, Image, image);
-
     new_image = rm_clone_image(image);
 
     (void) NegateImageChannel(new_image, channels, grayscale);


### PR DESCRIPTION
`Data_Get_Struct()` was already called in `rm_check_destroyed()`
https://github.com/rmagick/rmagick/blob/ac388ae931e6cf32a85d555670fb6fd1c636cf1e/ext/RMagick/rmimage.c#L9316

This patch will remove redundant assignment by `Data_Get_Struct()`.