### PR TITLE
Add Image#alpha=

### DIFF
--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -16,7 +16,7 @@ regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
 mask = Image.new(regwidth, regheight) { self.background_color = 'white' }
-mask.opacity = 0.50 * TransparentOpacity
+mask.alpha = 0.50 * QuantumRange
 
 black = Image.new(shorts.columns, shorts.rows) { self.background_color = 'black' }
 pairs = ImageList.new

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -695,6 +695,7 @@ extern VALUE KernelInfo_builtin(VALUE, VALUE, VALUE);
 
 
 // rmimage.c
+ATTR_WRITER(Image, alpha)
 ATTR_ACCESSOR(Image, background_color)
 ATTR_READER(Image, base_columns)
 ATTR_READER(Image, base_filename)

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -673,6 +673,30 @@ Image_alpha_q(VALUE self)
 
 
 /**
+ * Call SetImageOpacity.
+ *
+ * Ruby usage:
+ *   - @verbatim Image#alpha= @endverbatim
+ *
+ * @param self this object
+ * @param alpha_arg the opacity
+ * @return alpha_arg
+ */
+VALUE
+Image_alpha_eq(VALUE self, VALUE alpha_arg)
+{
+    Image *image;
+    Quantum alpha;
+
+    image = rm_check_frozen(self);
+    alpha = QuantumRange - APP2QUANTUM(alpha_arg);
+    (void) SetImageOpacity(image, alpha);
+    rm_check_image_exception(image, RetainOnError);
+    return alpha_arg;
+}
+
+
+/**
  * Transform an image as dictated by the affine matrix argument.
  *
  * Ruby usage:
@@ -12031,7 +12055,7 @@ Image_opacity_eq(VALUE self, VALUE opacity_arg)
     Image *image;
     Quantum opacity;
 
-    rb_warning("Image#opacity is deprecated; use Image#alpha");
+    rb_warning("Image#opacity is deprecated; use Image#alpha=");
 
     image = rm_check_frozen(self);
     opacity = APP2QUANTUM(opacity_arg);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -219,6 +219,7 @@ Init_RMagick2(void)
     rb_define_singleton_method(Class_Image, "read_inline", Image_read_inline, 1);
     rb_define_singleton_method(Class_Image, "from_blob", Image_from_blob, 1);
 
+    DCL_ATTR_WRITER(Image, alpha)
     DCL_ATTR_ACCESSOR(Image, background_color)
     DCL_ATTR_READER(Image, base_columns)
     DCL_ATTR_READER(Image, base_filename)

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -23,6 +23,11 @@ class Image_Attributes_UT < Test::Unit::TestCase
     @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
+  def test_alpha
+    assert_nothing_raised { @img.alpha = 50 }
+    assert_raise(TypeError) { @img.alpha = 'x' }
+  end
+
   def test_background_color
     assert_nothing_raised { @img.background_color }
     assert_equal('white', @img.background_color)


### PR DESCRIPTION
`Image#opacity` has become deprecated at #669, but seems there is no replacement method.
This patch will introduce `Image#alpha=` like `Pixel#alpha=` (#617). 

I think `SetImageOpacity()` in `Image#alpha=` will change to `SetImageAlpha()` with ImageMagick 7 easily.

https://github.com/ImageMagick/ImageMagick/blob/63bf487f438e051094b92b570aff08efe7068f79/MagickCore/image.c#L2322-L2338