### PR TITLE
 RVG: Use Pixel#alpha= and QuantumRange instead

### DIFF
--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -60,10 +60,10 @@ module Magick
     # else, combine it with the background_fill_opacity.
     def bgfill
       if @background_fill.nil?
-        color = Magick::Pixel.new(0, 0, 0, Magick::TransparentOpacity)
+        color = Magick::Pixel.new(0, 0, 0, Magick::OpaqueAlpha)
       else
         color = @background_fill
-        color.opacity = (1.0 - @background_fill_opacity) * Magick::TransparentOpacity
+        color.alpha = @background_fill_opacity * Magick::OpaqueAlpha
       end
       color
     end


### PR DESCRIPTION
Pixel#opacity= was marked as deprecated in #619 and removed in #735
TransparentOpacity was marked as deprecated in #651

You can confirm with

```
$ cd doc/ex
$ ruby InitialCoords.rb
/Users/watson/.rbenv/versions/2.7.0-preview1/lib/ruby/gems/2.7.0/gems/rmagick-3.2.0/lib/rvg/rvg.rb:66: warning: constant Magick::TransparentOpacity is deprecated
```