### PR TITLE
Dissolve on ImageMagick 6.9

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1630,8 +1630,10 @@ special_composite(Image *image, Image *overlay, double image_pct, double overlay
     blend_geometry(geometry, sizeof(geometry), image_pct, overlay_pct);
     (void) CloneString(&overlay->geometry, geometry);
     (void) SetImageArtifact(overlay,"compose:args", geometry);
-
+    
     new_image = rm_clone_image(image);
+    (void) SetImageArtifact(new_image,"compose:args", geometry); // 6.9 appears to get this info from canvas (dest) image
+    
     (void) CompositeImage(new_image, op, overlay, x_off, y_off);
 
     rm_check_image_exception(new_image, DestroyOnError);
@@ -5293,7 +5295,7 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
 
     composite_image =  special_composite(image, overlay, src_percent, dst_percent
                                          , x_offset, y_offset, DissolveCompositeOp);
-
+    
     RB_GC_GUARD(composite_image);
     RB_GC_GUARD(ovly);
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1630,10 +1630,10 @@ special_composite(Image *image, Image *overlay, double image_pct, double overlay
     blend_geometry(geometry, sizeof(geometry), image_pct, overlay_pct);
     (void) CloneString(&overlay->geometry, geometry);
     (void) SetImageArtifact(overlay,"compose:args", geometry);
-    
+
     new_image = rm_clone_image(image);
     (void) SetImageArtifact(new_image,"compose:args", geometry); // 6.9 appears to get this info from canvas (dest) image
-    
+
     (void) CompositeImage(new_image, op, overlay, x_off, y_off);
 
     rm_check_image_exception(new_image, DestroyOnError);
@@ -5295,7 +5295,7 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
 
     composite_image =  special_composite(image, overlay, src_percent, dst_percent
                                          , x_offset, y_offset, DissolveCompositeOp);
-    
+
     RB_GC_GUARD(composite_image);
     RB_GC_GUARD(ovly);
 

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe Magick::Image, '#dissolve' do
+  let(:img1) { Magick::Image.new(100, 100) { self.background_color = 'transparent' } }
+  let(:img2) { Magick::Image.new(100, 100) { self.background_color = 'green' } }
+  
+  it 'raises an error given invalid arguments' do
+    expect { img1.dissolve }.to raise_error(ArgumentError)
+    expect { img1.dissolve(img2, 'x') }.to raise_error(ArgumentError)
+    expect { img1.dissolve(img2, 0.50, 'x') }.to raise_error(ArgumentError)
+    expect { img1.dissolve(img2, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
+    expect { img1.dissolve(img2, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
+  end
+  
+  
+  context 'when given 2 arguments' do
+    it 'works when alpha is float 0.0 to 1.0' do
+      dissolved = img1.dissolve(img2, 0.50)
+      expect(dissolved).to be_instance_of(Magick::Image)
+      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
+      dissolved = img1.dissolve(img2, 0.20)
+      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.15, 0.25)
+    end
+    it 'works when alpha is string percentage' do
+      dissolved = img1.dissolve(img2, '50%')
+      expect(dissolved).to be_instance_of(Magick::Image)
+      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
+      dissolved = img1.dissolve(img2, '20%')
+      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.15, 0.25)
+    end
+  end
+  
+  context 'when given gravity' do
+    # generate an image to use with gravity
+    wk = Magick::Image.new(40, 40) { self.background_color = 'transparent' }
+    d = Magick::Draw.new
+    d.stroke('none').fill('blue')
+    d.circle(wk.columns/2,wk.rows/2, 4,wk.rows/2)
+    d.draw(wk)
+    
+    it 'works on colored background' do
+      # generate an image to use with gravity
+      dissolved = img2.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
+      expect(dissolved).to be_instance_of(Magick::Image)
+      expect(dissolved.pixel_color(10,10)).to eq(img2.pixel_color(10,10))
+      expect(dissolved.pixel_color(50,50).blue.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
+      expect(dissolved.pixel_color(50,50).green.to_f).to be_between(0, img2.pixel_color(2,2).green).exclusive
+    end
+  end
+  
+  # still need to test with destination percentage, offsets
+
+
+  it 'raises an error when the image has been destroyed' do
+    img1.destroy!
+    expect do
+      img1.dissolve(img2, 0.50)
+    end.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#dissolve' do
   let(:img1) { Magick::Image.new(100, 100) { self.background_color = 'transparent' } }
-  let(:img2) { Magick::Image.new(100, 100) { self.background_color = 'green' } }
-  
+  let(:img2) { Magick::Image.new(100, 100) { self.background_color = 'green' }       }
+
   it 'raises an error given invalid arguments' do
     expect { img1.dissolve }.to raise_error(ArgumentError)
     expect { img1.dissolve(img2, 'x') }.to raise_error(ArgumentError)
@@ -9,50 +9,46 @@ RSpec.describe Magick::Image, '#dissolve' do
     expect { img1.dissolve(img2, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
     expect { img1.dissolve(img2, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
   end
-  
-  
+
   context 'when given 2 arguments' do
     it 'works when alpha is float 0.0 to 1.0' do
       dissolved = img1.dissolve(img2, 0.50)
       expect(dissolved).to be_instance_of(Magick::Image)
-      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
+      expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.45, 0.55)
       dissolved = img1.dissolve(img2, 0.20)
-      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.15, 0.25)
+      expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.15, 0.25)
     end
     it 'works when alpha is string percentage' do
       dissolved = img1.dissolve(img2, '50%')
       expect(dissolved).to be_instance_of(Magick::Image)
-      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
+      expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.45, 0.55)
       dissolved = img1.dissolve(img2, '20%')
-      expect(dissolved.pixel_color(2,2).alpha.to_f / Magick::QuantumRange).to be_between(0.15, 0.25)
+      expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.15, 0.25)
     end
   end
-  
+
   context 'when given gravity' do
     # generate an image to use with gravity
     wk = Magick::Image.new(40, 40) { self.background_color = 'transparent' }
     d = Magick::Draw.new
     d.stroke('none').fill('blue')
-    d.circle(wk.columns/2,wk.rows/2, 4,wk.rows/2)
+    d.circle(wk.columns / 2, wk.rows / 2, 4, wk.rows / 2)
     d.draw(wk)
-    
+
     it 'works on colored background' do
       # generate an image to use with gravity
       dissolved = img2.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
       expect(dissolved).to be_instance_of(Magick::Image)
-      expect(dissolved.pixel_color(10,10)).to eq(img2.pixel_color(10,10))
-      expect(dissolved.pixel_color(50,50).blue.to_f / Magick::QuantumRange).to be_between(0.45, 0.55)
-      expect(dissolved.pixel_color(50,50).green.to_f).to be_between(0, img2.pixel_color(2,2).green).exclusive
+      expect(dissolved.pixel_color(10, 10)).to eq(img2.pixel_color(10, 10))
+      expect(Float(dissolved.pixel_color(50, 50).blue) / Magick::QuantumRange).to be_between(0.45, 0.55)
+      expect(Float(dissolved.pixel_color(50, 50).green)).to be_between(0, img2.pixel_color(2, 2).green).exclusive
     end
   end
-  
-  # still need to test with destination percentage, offsets
 
+  # still need to test with destination percentage, offsets
 
   it 'raises an error when the image has been destroyed' do
     img1.destroy!
-    expect do
-      img1.dissolve(img2, 0.50)
-    end.to raise_error(Magick::DestroyedImageError)
+    expect { img1.dissolve(img2, 0.50) }.to raise_error(Magick::DestroyedImageError)
   end
 end


### PR DESCRIPTION
ImageMagick 6.9 pulls the 'compose:args' artifact from the canvas image instead of the overlay image. The special_composite function now sets the 'compose:args' artifact in both images for 6.8 and 6.9 compatibility.

Added rspec test for Image#dissolve.