### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.executables                 = executables
   s.require_paths << 'ext' << 'deprecated'
 
-  s.rubyforge_project = 'rmagick'
   s.extensions = %w[ext/RMagick/extconf.rb]
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.