### PR TITLE
Fix memory leak in Enum#|

### DIFF
--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -83,6 +83,17 @@ rm_enum_to_cstr(VALUE enum_type)
 }
 
 /**
+ * Free Enum or Enum subclass object
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param magick_enum the enum
+ */
+static void rm_enum_free(void *magick_enum)
+{
+    xfree(magick_enum);
+}
+/**
  * Enum class alloc function.
  *
  * No Ruby usage (internal function)
@@ -96,10 +107,8 @@ Enum_alloc(VALUE class)
    MagickEnum *magick_enum;
    VALUE enumr;
 
-   enumr = Data_Make_Struct(class, MagickEnum, NULL, NULL, magick_enum);
+   enumr = Data_Make_Struct(class, MagickEnum, NULL, rm_enum_free, magick_enum);
    rb_obj_freeze(enumr);
-
-   RB_GC_GUARD(enumr);
 
    return enumr;
 }


### PR DESCRIPTION
When RMagick prepares Enum object as a constant, the objects will keep alive because there have reference.
https://github.com/rmagick/rmagick/blob/fffaf1bce49f86edc5a2671d14f803e5acf12aff/ext/RMagick/rmmain.c#L40

However, Enum objects generated by the user calling `Enum#|` might become unnecessary.
In this case, garbaged objects cause memory leaks because there is no deallocator in Enum class.

This patch will fix memory leak in `Enum#|` by adding Enum deallocator.

* Before

```
$ ruby test.rb
Process: 48440: RSS = 244 MB
```

* After

```
$ ruby test.rb
Process: 49603: RSS = 12 MB
```

* Test code

```ruby
require 'rmagick'

5000000.times do
  enum1 = Magick::Enum.new(:foo, Random.rand(2**30))
  enum2 = Magick::Enum.new(:bar, Random.rand(2**30))

  enum3 = enum1 | enum2
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```