### PR TITLE
Add macros for temporarily changing the channel mask of an image.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -12,6 +12,18 @@
 
 #include "rmagick.h"
 
+#define BEGIN_CHANNEL_MASK(image, channels) \
+  { \
+    ChannelType channel_mask=SetPixelChannelMask(image, (ChannelType)channels);
+
+#define END_CHANNEL_MASK(image) \
+    SetPixelChannelMask(image, channel_mask); \
+  }
+
+#define CHANGE_RESULT_CHANNEL_MASK(result) \
+    if (result != (Image *)NULL) \
+      SetPixelChannelMask(result, channel_mask);
+
 /** Method that effects an image */
 typedef Image *(effector_t)(const Image *, const double, const double, ExceptionInfo *);
 /** Method that flips an image */


### PR DESCRIPTION
In ImageMagick 6 there are "overloads" for methods to only work on the specified channel. Those methods are no longer available in ImageMagick 7. To only change a specific channel a mask needs to be set. This PR adds some macros to make it easier to temporary change the channel mask.