### PR TITLE
Update README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -187,7 +187,7 @@ h4. 3) install ImageMagick and additional environment stuff
 <pre>
 cd /vagrant/rmagick
 export IMAGEMAGICK_VERSION=6.8.9-10
-sh ./before_install_linux.sh
+bash ./before_install_linux.sh
 </pre>
 
 This will take just a few minutes to build ImageMagick


### PR DESCRIPTION
So now it suggests running `before_install_linux.sh` script using `bash` instead of `sh`,
as that script is not supported by `sh`.