### PR TITLE
Add define to check for ImageMagick 6 instead of using !defined(IMAGEMAGICK_7)

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -133,6 +133,7 @@ typedef PixelPacket Pixel; /**< Make type name match class name */
     typedef InterpolatePixelMethod PixelInterpolateMethod;
     typedef ImageLayerMethod LayerMethod;
     #define TransparentAlpha 0
+    #define IMAGEMAGICK_6 1
 #endif
 
 //! Montage
@@ -1182,7 +1183,7 @@ extern void   rm_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_warning_handler(const ExceptionType, const char *, const char *);
 extern MagickBooleanType rm_should_raise_exception(ExceptionInfo *, const ExceptionRetention);
 extern void   rm_raise_exception(ExceptionInfo *);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
 extern void   rm_check_image_exception(Image *, ErrorRetention);
 #endif
 

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -189,7 +189,7 @@ vertical_fill(
     ssize_t x, y;
     MagickRealType red_step, green_step, blue_step;
     ExceptionInfo *exception;
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     PixelPacket *master;
 #endif
 
@@ -297,7 +297,7 @@ horizontal_fill(
     ssize_t x, y;
     MagickRealType red_step, green_step, blue_step;
     ExceptionInfo *exception;
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     PixelPacket *master;
 #endif
 

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -212,7 +212,7 @@ ImageList_coalesce(VALUE self)
  */
 VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
 {
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     ChannelType channel;
 #endif
     ColorspaceType colorspace, old_colorspace;
@@ -275,7 +275,7 @@ VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
 
     images = images_from_imagelist(self);
     exception = AcquireExceptionInfo();
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     old_colorspace = images->colorspace;
     SetImageColorspace(images, colorspace);
     new_image = CombineImages(images, channel, exception);
@@ -284,7 +284,7 @@ VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
 #endif
 
     rm_split(images);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     images->colorspace = old_colorspace;
 #endif
     rm_check_exception(exception, new_image, DestroyOnError);
@@ -1069,7 +1069,7 @@ ImageList_remap(int argc, VALUE *argv, VALUE self)
     if (argc > 1)
     {
         VALUE_TO_ENUM(argv[1], quantize_info.dither_method, DitherMethod);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
         quantize_info.dither = MagickTrue;
 #endif
     }
@@ -1238,7 +1238,7 @@ ImageList_write(VALUE self, VALUE file)
 
     m = GetMagickInfo(info->magick, exception);
     rm_check_exception(exception, images, RetainOnError);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     (void) DestroyExceptionInfo(exception);
 #endif
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10759,7 +10759,7 @@ Image_pixel_color(int argc, VALUE *argv, VALUE self)
 #endif
     }
 
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     exception = AcquireExceptionInfo();
 #endif
 
@@ -11281,7 +11281,7 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
                 quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
 #endif
             }
@@ -11906,7 +11906,7 @@ Image_remap(int argc, VALUE *argv, VALUE self)
     {
         case 2:
             VALUE_TO_ENUM(argv[1], quantize_info.dither_method, DitherMethod);
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
             quantize_info.dither = MagickTrue;
 #endif
             break;
@@ -11994,7 +11994,7 @@ resample(int bang, int argc, VALUE *argv, VALUE self)
 
     // Set up defaults
     filter  = image->filter;
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     blur    = image->blur;
 #endif
     x_resolution = 72.0;
@@ -12154,7 +12154,7 @@ resize(int bang, int argc, VALUE *argv, VALUE self)
 
     // Set up defaults
     filter  = image->filter;
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     blur    = image->blur;
 #endif
     rows    = image->rows;
@@ -15237,7 +15237,7 @@ VALUE Image_image_type(VALUE self)
 {
     Image *image;
     ImageType type;
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     ExceptionInfo *exception;
 #endif
 
@@ -16461,7 +16461,7 @@ xform_image(int bang, VALUE self, VALUE x, VALUE y, VALUE width, VALUE height, x
     rm_check_exception(exception, new_image, DestroyOnError);
     (void) DestroyExceptionInfo(exception);
 
-#if !defined(IMAGEMAGICK_7)
+#if defined(IMAGEMAGICK_6)
     if (rm_should_raise_exception(&image->exception, RetainExceptionRetention))
     {
         (void) DestroyImage(new_image);


### PR DESCRIPTION
This PR adds the define that was spoken about in the PR where the changes in rmimage.c for ImageMagick 7 were merged.