### PR TITLE
Bump ruby version on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install: bundle install --path=vendor/bundle --verbose
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.3
+  - 2.5.5
   - 2.6
 
 matrix:


### PR DESCRIPTION
We've been seeing [inconsistent builds against 2.5.3][1], so hoping
bumping the patch version will fix the issue.

[1]: https://travis-ci.org/rmagick/rmagick/jobs/583775254