### PR TITLE
CodeQuality: remove instance variable declarations

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -22,9 +22,6 @@ require 'English'
 require 'RMagick2.so'
 
 module Magick
-  @formats = nil
-  @trace_proc = nil
-  @exit_block_set_up = nil
   IMAGEMAGICK_VERSION = Magick::Magick_version.split[1].split('-').first
 
   class << self


### PR DESCRIPTION
We don't need to declare instance variables in this way in Ruby, as
they'll be magically allocated as soon as they are referenced.