### PR TITLE
Fix memory leak in Image#store_pixels

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13994,6 +13994,28 @@ Image_class_type_eq(VALUE self, VALUE new_class_type)
     return new_class_type;
 }
 
+static VALUE
+get_pixel_body(VALUE pixel_obj)
+{
+    Pixel *pixel;
+
+    Data_Get_Struct(pixel_obj, Pixel, pixel);
+    return (VALUE)pixel;
+}
+
+static VALUE
+get_pixel_handle_exception(ExceptionInfo *exception, VALUE exc)
+{
+    DestroyExceptionInfo(exception);
+    rb_exc_raise(exc);
+    return Qnil; /* not reachable */
+}
+
+static Pixel *
+get_pixel(VALUE pixel_obj, ExceptionInfo *exception)
+{
+    return (Pixel *)rb_rescue(get_pixel_body, pixel_obj, get_pixel_handle_exception, (VALUE)exception);
+}
 
 /**
  * Replace the pixels in the specified rectangle.
@@ -14077,7 +14099,7 @@ Image_store_pixels(VALUE self, VALUE x_arg, VALUE y_arg, VALUE cols_arg
             for (n = 0; n < size; n++)
             {
                 new_pixel = rb_ary_entry(new_pixels, n);
-                Data_Get_Struct(new_pixel, Pixel, pixel);
+                pixel = get_pixel(new_pixel, exception);
 #if defined(IMAGEMAGICK_7)
                 SetPixelRed(image,   pixel->red,   pixels);
                 SetPixelGreen(image, pixel->green, pixels);


### PR DESCRIPTION
Related to #800

If unexpected parameter was given, https://github.com/rmagick/rmagick/blob/339ad7468d5f48e3ca9c76a81f8b4df608a2b475/ext/RMagick/rmimage.c#L14080 will raise exception.

Then heap area allocated by `exception = AcquireExceptionInfo();` will causes memory leak.
https://github.com/rmagick/rmagick/blob/339ad7468d5f48e3ca9c76a81f8b4df608a2b475/ext/RMagick/rmimage.c#L14066

* Before

```
ruby store_pixel.rb
Process: 38616: RSS = 462 MB
```

* After

```
ruby store_pixel.rb
Process: 39524: RSS = 17 MB
```

* Test code

```ruby
require 'rmagick'

@img = Magick::Image.new(20, 20)
pixels = @img.get_pixels(0, 0, @img.columns, 1)

1000000.times do
  begin
    pixels[0] = 'x'
    @img.store_pixels(0, 0, @img.columns, 1, pixels)
    # => will raise exception
  rescue
  end
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```