### PR TITLE
disable log event mask after test

### DIFF
--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -253,6 +253,7 @@ class MagickUT < Test::Unit::TestCase
 
   def test_set_log_event_mask
     assert_nothing_raised { Magick.set_log_event_mask('Module,Coder') }
+    Magick.set_log_event_mask('')
   end
 
   def test_set_log_format


### PR DESCRIPTION
We see a lot of output in our tests that appears to be coming from this.