### PR TITLE
remove some outputs from tests

### DIFF
--- a/spec/rmagick/image/channel_entropy_spec.rb
+++ b/spec/rmagick/image/channel_entropy_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe Magick::Image, '#channel_entropy' do
 
   it 'returns a channel entropy', supported_after('6.9.0') do
     res = img.channel_entropy
-    puts "res = #{res.inspect}"
     expect(res).to eq([0.5285857222715863])
   end
 end

--- a/test/Import_Export.rb
+++ b/test/Import_Export.rb
@@ -17,13 +17,11 @@ class ImportExportUT < Test::Unit::TestCase
 
   def import(pixels, type, expected = 0.0)
     diff = import_pixels(pixels, type)
-    # puts "Type=#{type} diff=#{diff}"
     assert_in_delta(expected, diff, 0.1)
   end
 
   def fimport(pixels, type)
     diff = import_pixels(pixels, type)
-    # puts "Type=#{type} diff=#{diff}"
     assert_in_delta(0.0, diff, 50.0)
   end
 

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -9,9 +9,7 @@ class PreviewUT < Test::Unit::TestCase
       prev = hat.preview(Magick::RotatePreview)
       assert_instance_of(Magick::Image, prev)
     end
-    puts "\n"
     Magick::PreviewType.values do |type|
-      puts "testing #{type}..."
       assert_nothing_raised { hat.preview(type) }
     end
     assert_raise(TypeError) { hat.preview(2) }

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -1,5 +1,3 @@
-puts RUBY_VERSION
-puts RUBY_VERSION.class
 root_dir = File.expand_path('..', __dir__)
 IMAGES_DIR = File.join(root_dir, 'doc/ex/images')
 FILES = Dir[IMAGES_DIR + '/Button_*.gif'].sort


### PR DESCRIPTION
These create noise when running the tests that distract from test
failures and warnings.