### PR TITLE
Use the return value of SeparateImage in ImageMagick 7.

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2290,14 +2290,13 @@ Image_channel(VALUE self, VALUE channel_arg)
 
     VALUE_TO_ENUM(channel_arg, channel, ChannelType);
 
-    new_image = rm_clone_image(image);
-
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
-    (void) SeparateImage(new_image, channel, exception);
+    new_image = SeparateImage(image, channel, exception);
     rm_check_exception(exception, new_image, DestroyOnError);
     (void) DestroyExceptionInfo(exception);
 #else
+    new_image = rm_clone_image(image);
     (void) SeparateImageChannel(new_image, channel);
 
     rm_check_image_exception(new_image, DestroyOnError);


### PR DESCRIPTION
This PR fixes the problem report here: https://github.com/rmagick/rmagick/issues/800#issuecomment-536268649. In ImageMagick 7 the return value of `SeparateImage` should be used.