### PR TITLE
add pry as a dev dependency

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
+  s.add_development_dependency 'pry', '~> 0.12.2'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'rmagick'
 
 root_dir = File.expand_path('..', __dir__)

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -6,6 +6,7 @@ IMAGE_WITH_PROFILE = IMAGES_DIR + '/image_with_profile.jpg'
 
 require 'simplecov'
 require 'test/unit'
+require 'pry'
 $LOAD_PATH.unshift(File.join(root_dir, 'lib'))
 $LOAD_PATH.unshift(File.join(root_dir, 'test'))
 


### PR DESCRIPTION
with this we can toss a `binding.pry` into our ruby code when we're
testing for easier debugging.