### PR TITLE
Revert "CodeQuality: remove instance variable declarations (#801…

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -22,6 +22,9 @@ require 'English'
 require 'RMagick2.so'
 
 module Magick
+  @formats = nil
+  @trace_proc = nil
+  @exit_block_set_up = nil
   IMAGEMAGICK_VERSION = Magick::Magick_version.split[1].split('-').first
 
   class << self


### PR DESCRIPTION
This reverts commit 0728ae3256ef20959e04de169f94257e8e21f019.

Removing these instance variable declarations caused Ruby to issue
warnings in the tests:

```
/home/circleci/repo/lib/rmagick_internal.rb:43: warning: instance variable @trace_proc not initialized
/home/circleci/repo/lib/rmagick_internal.rb:43: warning: instance variable @exit_block_set_up not initialized
```

Bringing them back for now. We probably want to eventually move to using
a more robust `Configuration` object at some point to hold these.