### PR TITLE
fix font warnings in specs

### DIFF
--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -128,7 +128,7 @@ class ImageList2UT < Test::Unit::TestCase
         self.compose = Magick::OverCompositeOp
         self.filename = 'test.png'
         self.fill = 'green'
-        self.font = 'Arial'
+        self.font = Magick.fonts.first.name
         self.frame = '20x20+4+4'
         self.frame = Magick::Geometry.new(20, 20, 4, 4)
         self.geometry = '63x60+5+5'

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -261,8 +261,9 @@ class LibDrawUT < Test::Unit::TestCase
 
   def test_font
     draw = Magick::Draw.new
-    draw.font('Arial')
-    assert_equal("font 'Arial'", draw.inspect)
+    font_name = Magick.fonts.first.name
+    draw.font(font_name)
+    assert_equal("font '#{font_name}'", draw.inspect)
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
   end


### PR DESCRIPTION
We've been seeing [warnings in our tests][1] about missing fonts. Rather
than expecting a specific font to be present across all systems, we can
select from one of the existing fonts on the system.

```
/home/circleci/repo/test/lib/internal/Draw.rb:267: warning: RMagick: unable to read font `Arial' @ warning/annotate.c/RenderType/90
```

[1]: https://circleci.com/gh/rmagick/rmagick/1415