### PR TITLE
Check for negative dimensions in Image#constitute

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4103,10 +4103,8 @@ Image_constitute(VALUE class ATTRIBUTE_UNUSED, VALUE width_arg, VALUE height_arg
 {
     Image *new_image;
     VALUE pixel, pixel0;
-    unsigned long width, height;
-    long x, npixels;
+    long width, height, x, npixels, map_l;
     char *map;
-    long map_l;
     volatile union
     {
         double *f;
@@ -4121,17 +4119,17 @@ Image_constitute(VALUE class ATTRIBUTE_UNUSED, VALUE width_arg, VALUE height_arg
     // and raises TypeError if it can't.
     pixels_arg = rb_Array(pixels_arg);
 
-    width = NUM2ULONG(width_arg);
-    height = NUM2ULONG(height_arg);
+    width = NUM2LONG(width_arg);
+    height = NUM2LONG(height_arg);
 
-    if (width == 0 || height == 0)
+    if (width <= 0 || height <= 0)
     {
-        rb_raise(rb_eArgError, "width and height must be non-zero");
+        rb_raise(rb_eArgError, "width and height must be greater than zero");
     }
 
     map = rm_str2cstr(map_arg, &map_l);
 
-    npixels = (long)(width * height * map_l);
+    npixels = width * height * map_l;
     if (RARRAY_LEN(pixels_arg) != npixels)
     {
         rb_raise(rb_eArgError, "wrong number of array elements (%ld for %ld)"

--- a/spec/rmagick/image/constitute_spec.rb
+++ b/spec/rmagick/image/constitute_spec.rb
@@ -37,13 +37,31 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when 0 is passed for columns' do
+    expected_message = 'width and height must be greater than zero'
+
     expect { Magick::Image.constitute(0, img.rows, 'RGBA', pixels) }
-      .to raise_error(ArgumentError, 'width and height must be non-zero')
+      .to raise_error(ArgumentError, expected_message)
+  end
+
+  it 'raises an error when a negative number is passed for columns' do
+    expected_message = 'width and height must be greater than zero'
+
+    expect { Magick::Image.constitute(-3, img.rows, 'RGBA', pixels) }
+      .to raise_error(ArgumentError, expected_message)
   end
 
   it 'raises an error when 0 is passed for rows' do
+    expected_message = 'width and height must be greater than zero'
+
     expect { Magick::Image.constitute(img.columns, 0, 'RGBA', pixels) }
-      .to raise_error(ArgumentError, 'width and height must be non-zero')
+      .to raise_error(ArgumentError, expected_message)
+  end
+
+  it 'raises an error when a negative number is passed for rows' do
+    expected_message = 'width and height must be greater than zero'
+
+    expect { Magick::Image.constitute(img.columns, -3, 'RGBA', pixels) }
+      .to raise_error(ArgumentError, expected_message)
   end
 
   it 'raises an error given the wrong number of array elements' do


### PR DESCRIPTION
We can't check for negatives with `unsigned long`, but the numbers here
should really be `long` anyway, so this changes their type and removes a
cast later in the function.