### PR TITLE
Add some additional files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ tmp
 *.so
 *.o
 *.a
-mkmf.log
+*.log
+Makefile
+extconf.h
 build-ImageMagick/


### PR DESCRIPTION
- I've had an ubuntu logfile showing up in my git, so ignore all `.log`
  files
- `Makefile` and `extconf.h` are auto-generated based on the user's
  environment, so ignoring those as well.