### PR TITLE
switch from Test::Unit to Minitest

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
+  s.add_development_dependency 'minitest', '~> 5.12'
   s.add_development_dependency 'pry', '~> 0.12.2'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.8'
@@ -35,5 +36,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.64.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.32.0'
   s.add_development_dependency 'simplecov', '~> 0.16.1'
-  s.add_development_dependency 'test-unit', '~> 2.5'
 end

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class DrawUT < Test::Unit::TestCase
+class DrawUT < Minitest::Test
   def setup
     @draw = Magick::Draw.new
   end

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class EnumUT < Test::Unit::TestCase
+class EnumUT < Minitest::Test
   def test_new
     assert_nothing_raised { Magick::Enum.new(:foo, 42) }
     assert_nothing_raised { Magick::Enum.new('foo', 42) }
@@ -199,9 +198,10 @@ class EnumUT < Test::Unit::TestCase
     img = Magick::Image.new(20, 20)
     pixels = img.export_pixels(0, 0, 20, 20, 'RGB').pack('D*')
 
-    assert_raise_message(/UndefinedPixel/) do
+    error = assert_raise(ArgumentError) do
       img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
     end
+    assert_match(/UndefinedPixel/, error.message)
   end
 
   def test_stretch_type_name

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class GradientFillUT < Test::Unit::TestCase
+class GradientFillUT < Minitest::Test
   def test_new
     assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000'))
     assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red'))
@@ -74,7 +73,7 @@ class GradientFillUT < Test::Unit::TestCase
   end
 end
 
-class TextureFillUT < Test::Unit::TestCase
+class TextureFillUT < Minitest::Test
   def test_new
     granite = Magick::Image.read('granite:').first
     assert_instance_of(Magick::TextureFill, Magick::TextureFill.new(granite))

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class Image1_UT < Test::Unit::TestCase
+class Image1_UT < Minitest::Test
   def setup
     @img = Magick::Image.new(20, 20)
   end

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -1,10 +1,9 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
 # TODO: improve exif tests - need a benchmark image with EXIF data
 
-class Image2_UT < Test::Unit::TestCase
+class Image2_UT < Minitest::Test
   def setup
     @img = Magick::Image.new(20, 20)
   end

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -1,9 +1,8 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 require 'fileutils'
 
-class Image3_UT < Test::Unit::TestCase
+class Image3_UT < Minitest::Test
   def setup
     @img = Magick::Image.new(20, 20)
     @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class ImageList1UT < Test::Unit::TestCase
+class ImageList1UT < Minitest::Test
   def setup
     @list = Magick::ImageList.new(*FILES[0..9])
     @list2 = Magick::ImageList.new # intersection is 5..9
@@ -845,7 +844,7 @@ class ImageList1UT < Test::Unit::TestCase
     list2 = Magick::ImageList.new
     assert_raise(TypeError) { list2 <=> @list }
     assert_raise(TypeError) { @list <=> list2 }
-    assert_nothing_raised(TypeError) { list <=> list2 }
+    assert_nothing_raised { list <=> list2 }
   end
 end
 

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -1,9 +1,8 @@
 require 'fileutils'
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class ImageList2UT < Test::Unit::TestCase
+class ImageList2UT < Minitest::Test
   def setup
     @ilist = Magick::ImageList.new
   end

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -1,14 +1,13 @@
 require 'fileutils'
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
 # TODO
 #   test frozen attributes!
 #   improve test_directory
 #   improve test_montage
 
-class Image_Attributes_UT < Test::Unit::TestCase
+class Image_Attributes_UT < Minitest::Test
   def setup
     @img = Magick::Image.new(100, 100)
     gc = Magick::Draw.new

--- a/test/Import_Export.rb
+++ b/test/Import_Export.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class ImportExportUT < Test::Unit::TestCase
+class ImportExportUT < Minitest::Test
   def setup
     @test = Magick::Image.read(File.join(IMAGES_DIR, 'Flower_Hat.jpg')).first
   end

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class InfoUT < Test::Unit::TestCase
+class InfoUT < Minitest::Test
   def setup
     @info = Magick::Image::Info.new
   end
@@ -379,7 +378,7 @@ class InfoUT < Test::Unit::TestCase
     assert_nothing_raised { @info.stroke_width = 5.25 }
     assert_equal(5.25, @info.stroke_width)
     assert_nothing_raised { @info.stroke_width = nil }
-    assert_equal(nil, @info.stroke_width)
+    assert_nil(@info.stroke_width)
     assert_raise(TypeError) { @info.stroke_width = 'xxx' }
   end
 

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -1,9 +1,8 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class KernelInfoUT < Test::Unit::TestCase
-  setup do
+class KernelInfoUT < Minitest::Test
+  def setup
     @kernel = Magick::KernelInfo.new('Octagon')
   end
 

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -1,6 +1,5 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
 module Magick
   def self._tmpnam_
@@ -26,7 +25,7 @@ class Magick::AnchorType
   end
 end
 
-class MagickUT < Test::Unit::TestCase
+class MagickUT < Minitest::Test
   def test_colors
     res = nil
     assert_nothing_raised { res = Magick.colors }

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class PixelUT < Test::Unit::TestCase
+class PixelUT < Minitest::Test
   def setup
     @pixel = Magick::Pixel.from_color('brown')
   end

--- a/test/PolaroidOptions.rb
+++ b/test/PolaroidOptions.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class PolaroidOptionsUT < Test::Unit::TestCase
+class PolaroidOptionsUT < Minitest::Test
   def setup
     @options = Magick::Image::PolaroidOptions.new
   end

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class PreviewUT < Test::Unit::TestCase
+class PreviewUT < Minitest::Test
   def test_preview
     hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     assert_nothing_raised do

--- a/test/Struct.rb
+++ b/test/Struct.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class StructUT < Test::Unit::TestCase
+class StructUT < Minitest::Test
   def test_chromaticity_to_s
     image = Magick::Image.new(10, 10)
     assert_match(/red_primary=\(x=.+,y=.+\) green_primary=\(x=.+,y=.+\) blue_primary=\(x=.+,y=.+\) white_point=\(x=.+,y=.+\)/, image.chromaticity.to_s)

--- a/test/appearance/Montage.rb
+++ b/test/appearance/Montage.rb
@@ -1,9 +1,8 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 require_relative 'appearance_assertion'
 
-class AppearanceMontageUT < Test::Unit::TestCase
+class AppearanceMontageUT < Minitest::Test
   include AppearanceAssertion
 
   def test_color

--- a/test/appearance/appearance_assertion.rb
+++ b/test/appearance/appearance_assertion.rb
@@ -1,8 +1,6 @@
-require 'test/unit'
+require 'minitest/autorun'
 
 module AppearanceAssertion
-  include Test::Unit::Assertions
-
   def assert_same_image(expected_image_path, image_object, delta: 0.01)
     path = File.expand_path(File.join(__dir__, expected_image_path))
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class LibDrawUT < Test::Unit::TestCase
+class LibDrawUT < Minitest::Test
   def setup
     @draw = Magick::Draw.new
     @img = Magick::Image.new(200, 200)

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class LibGeometryUT < Test::Unit::TestCase
+class LibGeometryUT < Minitest::Test
   def test_constants
     assert_kind_of(Magick::GeometryValue, Magick::PercentGeometry)
     assert_equal('PercentGeometry', Magick::PercentGeometry.to_s)

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -1,8 +1,7 @@
 require 'rmagick'
-require 'test/unit'
-require 'test/unit/ui/console/testrunner'
+require 'minitest/autorun'
 
-class LibMagickUT < Test::Unit::TestCase
+class LibMagickUT < Minitest::Test
   def test_formats
     assert_instance_of(Hash, Magick.formats)
     Magick.formats.each do |f, v|

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -5,7 +5,7 @@ FLOWER_HAT = IMAGES_DIR + '/Flower_Hat.jpg'
 IMAGE_WITH_PROFILE = IMAGES_DIR + '/image_with_profile.jpg'
 
 require 'simplecov'
-require 'test/unit'
+require 'minitest/autorun'
 require 'pry'
 $LOAD_PATH.unshift(File.join(root_dir, 'lib'))
 $LOAD_PATH.unshift(File.join(root_dir, 'test'))
@@ -26,6 +26,26 @@ end
 
 Dir.glob(File.join(__dir__, 'appearance/**/*.rb')) do |file|
   require file
+end
+
+module Minitest
+  module Assertions
+    def assert_nothing_raised
+      yield
+    end
+
+    def assert_block
+      assert(yield)
+    end
+
+    alias assert_nothing_thrown assert_nothing_raised
+    alias assert_raise assert_raises
+    alias assert_not_same refute_same
+    alias assert_not_equal refute_equal
+    alias assert_not_nil refute_nil
+    alias assert_true assert
+    alias assert_false refute
+  end
 end
 
 require 'Draw.rb'


### PR DESCRIPTION
This changes the existing unit test framework from `Test::Unit` to
`Minitest`. The primary reason for this is to ease the transition to
RSpec, since `Minitest` [has a spec syntax][1] not far off from that of
`RSpec`. This should allow for a faster swap in terms of test syntax,
and easier diffs as we can make simple, sweeping changes.

I added a few aliases here as Minitest has fewer assertions. Since these
will be switching to the RSpec `expect` syntax before long, I don't
think it's worth the effort to switch them at the call site now, and the
aliases help reduce the diff as well.

In subsequent commits, I plan to start adding new matcher aliases that
map to the `RSpec` syntax and changing the file structures to the
`Minitest` spec syntax. I have been refactoring the tests as I've
converted them to `RSpec`, but I think for these changes I may leave the
refactoring until the end of the transition.

[1]: https://github.com/seattlerb/minitest#specs