### PR TITLE
Replace `assert_equal` with RSpec style matcher

### DIFF
--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -266,11 +266,11 @@ class DrawUT < Minitest::Test
   end
 
   def test_inspect
-    assert_equal('(no primitives defined)', @draw.inspect)
+    expect(@draw.inspect).to eq('(no primitives defined)')
 
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     @draw.fill('yellow')
-    assert_equal("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'\nfill \"yellow\"", @draw.inspect)
+    expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'\nfill \"yellow\"")
   end
 
   def test_marshal
@@ -305,7 +305,7 @@ class DrawUT < Minitest::Test
     assert_nothing_raised do
       draw2.marshal_load(dumped)
     end
-    assert_equal(draw.inspect, draw2.inspect)
+    expect(draw2.inspect).to eq(draw.inspect)
   end
 
   def test_primitive

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -12,15 +12,15 @@ class EnumUT < Minitest::Test
 
   def test_to_s
     enum = Magick::Enum.new(:foo, 42)
-    assert_equal('foo', enum.to_s)
+    expect(enum.to_s).to eq('foo')
 
     enum = Magick::Enum.new('foo', 42)
-    assert_equal('foo', enum.to_s)
+    expect(enum.to_s).to eq('foo')
   end
 
   def test_to_i
     enum = Magick::Enum.new(:foo, 42)
-    assert_equal(42, enum.to_i)
+    expect(enum.to_i).to eq(42)
   end
 
   def test_spaceship
@@ -29,9 +29,9 @@ class EnumUT < Minitest::Test
     enum3 = Magick::Enum.new(:foo, 36)
     enum4 = Magick::Enum.new(:foo, 42)
 
-    assert_equal(-1, enum1 <=> enum2)
-    assert_equal(0, enum1 <=> enum4)
-    assert_equal(1, enum1 <=> enum3)
+    expect(enum1 <=> enum2).to eq(-1)
+    expect(enum1 <=> enum4).to eq(0)
+    expect(enum1 <=> enum3).to eq(1)
     assert_nil(enum1 <=> 'x')
   end
 
@@ -49,8 +49,8 @@ class EnumUT < Minitest::Test
     enum2 = Magick::Enum.new(:bar, 56)
 
     enum = enum1 | enum2
-    assert_equal(58, enum.to_i)
-    assert_equal('foo|bar', enum.to_s)
+    expect(enum.to_i).to eq(58)
+    expect(enum.to_s).to eq('foo|bar')
 
     assert_raise(ArgumentError) { enum1 | 'x' }
   end
@@ -58,8 +58,8 @@ class EnumUT < Minitest::Test
   def test_type_values
     assert_instance_of(Array, Magick::AlignType.values)
 
-    assert_equal('UndefinedAlign', Magick::AlignType.values[0].to_s)
-    assert_equal(0, Magick::AlignType.values[0].to_i)
+    expect(Magick::AlignType.values[0].to_s).to eq('UndefinedAlign')
+    expect(Magick::AlignType.values[0].to_i).to eq(0)
 
     Magick::AlignType.values do |enum|
       assert_kind_of(Magick::Enum, enum)
@@ -68,14 +68,14 @@ class EnumUT < Minitest::Test
   end
 
   def test_type_inspect
-    assert_equal('UndefinedAlign=0', Magick::AlignType.values[0].inspect)
+    expect(Magick::AlignType.values[0].inspect).to eq('UndefinedAlign=0')
   end
 
   def test_using_compose_does_not_cause_endless_loop
     img = Magick::Image.new(10, 10)
     Magick::CompositeOperator.values do |op|
       img.compose = op
-      assert_equal(op, img.compose)
+      expect(img.compose).to eq(op)
     end
   end
 
@@ -85,7 +85,7 @@ class EnumUT < Minitest::Test
       next if value == Magick::UndefinedClass
 
       img.class_type = value
-      assert_equal(value, img.class_type)
+      expect(img.class_type).to eq(value)
     end
   end
 
@@ -102,7 +102,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::CompressionType.values do |value|
       img.compression = value
-      assert_equal(value, img.compression)
+      expect(img.compression).to eq(value)
     end
   end
 
@@ -110,7 +110,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::DisposeType.values do |value|
       img.dispose = value
-      assert_equal(value, img.dispose)
+      expect(img.dispose).to eq(value)
     end
   end
 
@@ -118,7 +118,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::EndianType.values do |value|
       img.endian = value
-      assert_equal(value, img.endian)
+      expect(img.endian).to eq(value)
     end
   end
 
@@ -126,7 +126,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::FilterType.values do |value|
       img.filter = value
-      assert_equal(value, img.filter)
+      expect(img.filter).to eq(value)
     end
   end
 
@@ -134,7 +134,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::GravityType.values do |value|
       img.gravity = value
-      assert_equal(value, img.gravity)
+      expect(img.gravity).to eq(value)
     end
   end
 
@@ -142,7 +142,7 @@ class EnumUT < Minitest::Test
     info = Magick::Image::Info.new
     Magick::ImageType.values do |value|
       info.image_type = value
-      assert_equal(value, info.image_type)
+      expect(info.image_type).to eq(value)
     end
   end
 
@@ -150,7 +150,7 @@ class EnumUT < Minitest::Test
     info = Magick::Image::Info.new
     Magick::OrientationType.values do |value|
       info.orientation = value
-      assert_equal(value, info.orientation)
+      expect(info.orientation).to eq(value)
     end
   end
 
@@ -158,7 +158,7 @@ class EnumUT < Minitest::Test
     info = Magick::Image::Info.new
     Magick::InterlaceType.values do |value|
       info.interlace = value
-      assert_equal(value, info.interlace)
+      expect(info.interlace).to eq(value)
     end
   end
 
@@ -166,7 +166,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::PixelInterpolateMethod.values do |value|
       img.pixel_interpolation_method = value
-      assert_equal(value, img.pixel_interpolation_method)
+      expect(img.pixel_interpolation_method).to eq(value)
     end
   end
 
@@ -174,7 +174,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::RenderingIntent.values do |value|
       img.rendering_intent = value
-      assert_equal(value, img.rendering_intent)
+      expect(img.rendering_intent).to eq(value)
     end
   end
 
@@ -182,7 +182,7 @@ class EnumUT < Minitest::Test
     info = Magick::Image::Info.new
     Magick::ResolutionType.values do |value|
       info.units = value
-      assert_equal(value, info.units)
+      expect(info.units).to eq(value)
     end
   end
 
@@ -190,7 +190,7 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(1, 1)
     Magick::VirtualPixelMethod.values do |value|
       img.virtual_pixel_method = value
-      assert_equal(value, img.virtual_pixel_method)
+      expect(img.virtual_pixel_method).to eq(value)
     end
   end
 

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -20,55 +20,55 @@ class GradientFillUT < Minitest::Test
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 0, 0, 0, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 0, 0, 10, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 0, 10, 0, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 0, 10, 10, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 0, 5, 20, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(-10, 0, -10, 10, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, -10, 10, -10, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, -10, 10, -20, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
 
     assert_nothing_raised do
       gradient = Magick::GradientFill.new(0, 100, 100, 200, '#900', '#000')
       obj = gradient.fill(img)
-      assert_equal(gradient, obj)
+      expect(obj).to eq(gradient)
     end
   end
 end
@@ -85,6 +85,6 @@ class TextureFillUT < Minitest::Test
 
     img = Magick::Image.new(10, 10)
     obj = texture.fill(img)
-    assert_equal(texture, obj)
+    expect(obj).to eq(texture)
   end
 end

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -13,7 +13,7 @@ class Image1_UT < Minitest::Test
     res = Magick::Image.read_inline(encoded)
     assert_instance_of(Array, res)
     assert_instance_of(Magick::Image, res[0])
-    assert_equal(img, res[0])
+    expect(res[0]).to eq(img)
     assert_raise(ArgumentError) { Magick::Image.read(nil) }
     assert_raise(ArgumentError) { Magick::Image.read("") }
   end
@@ -26,9 +26,9 @@ class Image1_UT < Minitest::Test
     # since <=> is based on the signature, the images should
     # have the same relationship to each other as their
     # signatures have to each other.
-    assert_equal(sig0 <=> sig1, img0 <=> img1)
-    assert_equal(sig1 <=> sig0, img1 <=> img0)
-    assert_equal(img0, img0)
+    expect(img0 <=> img1).to eq(sig0 <=> sig1)
+    expect(img1 <=> img0).to eq(sig1 <=> sig0)
+    expect(img0).to eq(img0)
     assert_not_equal(img0, img1)
     assert_nil(img0 <=> nil)
   end
@@ -141,7 +141,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { img.add_profile(File.join(__dir__, 'cmyk.icm')) }
     # assert_raise(Magick::ImageMagickError) { img.add_profile(File.join(__dir__, 'srgb.icm')) }
 
-    img.each_profile { |name, _value| assert_equal('icc', name) }
+    img.each_profile { |name, _value| expect(name).to eq('icc') }
     assert_nothing_raised { img.delete_profile('icc') }
   end
 
@@ -185,8 +185,8 @@ class Image1_UT < Minitest::Test
   def test_aset
     @img['label'] = 'foobarbaz'
     @img[:comment] = 'Hello world'
-    assert_equal('foobarbaz', @img['label'])
-    assert_equal('Hello world', @img['comment'])
+    expect(@img['label']).to eq('foobarbaz')
+    expect(@img['comment']).to eq('Hello world')
     assert_nothing_raised { @img[nil] = 'foobarbaz' }
   end
 
@@ -335,7 +335,7 @@ class Image1_UT < Minitest::Test
     assert_raise(LocalJumpError) { @img.change_geometry('100x100') }
     assert_nothing_raised do
       res = @img.change_geometry('100x100') { 1 }
-      assert_equal(1, res)
+      expect(res).to eq(1)
     end
     assert_raise(ArgumentError) { @img.change_geometry([]) }
   end
@@ -371,7 +371,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised do
       res = @img.channel_extrema
       assert_instance_of(Array, res)
-      assert_equal(2, res.length)
+      expect(res.length).to eq(2)
       assert_kind_of(Integer, res[0])
       assert_kind_of(Integer, res[1])
     end
@@ -388,7 +388,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised do
       res = @img.channel_mean
       assert_instance_of(Array, res)
-      assert_equal(2, res.length)
+      expect(res.length).to eq(2)
       assert_instance_of(Float, res[0])
       assert_instance_of(Float, res[1])
     end
@@ -422,13 +422,13 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised do
       res = @img.clone
       assert_instance_of(Magick::Image, res)
-      assert_equal(res, @img)
+      expect(@img).to eq(res)
     end
     res = @img.clone
-    assert_equal(res.frozen?, @img.frozen?)
+    expect(@img.frozen?).to eq(res.frozen?)
     @img.freeze
     res = @img.clone
-    assert_equal(res.frozen?, @img.frozen?)
+    expect(@img.frozen?).to eq(res.frozen?)
   end
 
   def test_clut_channel
@@ -473,7 +473,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised do
       @img.class_type = Magick::PseudoClass
       res = @img.color_histogram
-      assert_equal(Magick::PseudoClass, @img.class_type)
+      expect(@img.class_type).to eq(Magick::PseudoClass)
       assert_instance_of(Hash, res)
     end
   end
@@ -515,9 +515,9 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised do
       old_color = pc_img.colormap(0)
       res = pc_img.colormap(0, 'red')
-      assert_equal(old_color, res)
+      expect(res).to eq(old_color)
       res = pc_img.colormap(0)
-      assert_equal('red', res)
+      expect(res).to eq('red')
     end
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { pc_img.colormap(0, pixel) }

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -127,11 +127,11 @@ class Image2_UT < Minitest::Test
 
   def test_compress_colormap!
     # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
-    assert_equal(Magick::DirectClass, @img.class_type)
+    expect(@img.class_type).to eq(Magick::DirectClass)
     assert_nothing_raised { @img.compress_colormap! }
-    # assert_equal(Magick::PseudoClass, @img.class_type)
+    # expect(@img.class_type).to eq(Magick::PseudoClass)
     @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_equal(Magick::PseudoClass, @img.class_type)
+    expect(@img.class_type).to eq(Magick::PseudoClass)
     assert_nothing_raised { @img.compress_colormap! }
   end
 
@@ -226,13 +226,13 @@ class Image2_UT < Minitest::Test
   def test_copy
     assert_nothing_raised do
       ditto = @img.copy
-      assert_equal(@img, ditto)
+      expect(ditto).to eq(@img)
     end
     ditto = @img.copy
-    assert_equal(@img.tainted?, ditto.tainted?)
+    expect(ditto.tainted?).to eq(@img.tainted?)
     @img.taint
     ditto = @img.copy
-    assert_equal(@img.tainted?, ditto.tainted?)
+    expect(ditto.tainted?).to eq(@img.tainted?)
   end
 
   def test_crop
@@ -278,7 +278,7 @@ class Image2_UT < Minitest::Test
       res = @img.cycle_colormap(5)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-      assert_equal(Magick::PseudoClass, res.class_type)
+      expect(res.class_type).to eq(Magick::PseudoClass)
     end
   end
 
@@ -290,13 +290,13 @@ class Image2_UT < Minitest::Test
     end
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_equal(@img.columns, res.columns)
-    assert_equal(@img.rows, res.rows)
+    expect(res.columns).to eq(@img.columns)
+    expect(res.rows).to eq(@img.rows)
     assert_instance_of(Magick::Image, res2)
     assert_not_same(@img, res2)
-    assert_equal(@img.columns, res2.columns)
-    assert_equal(@img.rows, res2.rows)
-    assert_equal(@img, res2)
+    expect(res2.columns).to eq(@img.columns)
+    expect(res2.rows).to eq(@img.rows)
+    expect(res2).to eq(@img)
   end
 
   def test_define
@@ -332,9 +332,9 @@ class Image2_UT < Minitest::Test
     methods = Magick::Image.instance_methods(false).sort
     methods -= %i[__display__ destroy! destroyed? inspect cur_image marshal_load]
 
-    assert_equal(false, @img.destroyed?)
+    expect(@img.destroyed?).to eq(false)
     @img.destroy!
-    assert_equal(true, @img.destroyed?)
+    expect(@img.destroyed?).to eq(true)
     assert_raises(Magick::DestroyedImageError) { @img.check_destroyed }
 
     methods.each do |method|
@@ -379,14 +379,14 @@ class Image2_UT < Minitest::Test
       name = File.basename m[0]
 
       assert(%i[c d].include?(which), "unexpected value for which: #{which}")
-      assert_equal(:destroy!, method) if which == :d
+      expect(method).to eq(:destroy!) if which == :d
 
       if which == :c
         assert(!images.key?(addr), 'duplicate image addresses')
         images[addr] = name
       else
         assert(images.key?(addr), 'destroying image that was not created')
-        assert_equal(name, images[addr])
+        expect(images[addr]).to eq(name)
       end
     end
 
@@ -407,7 +407,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised do
       res = img1.difference(img2)
       assert_instance_of(Array, res)
-      assert_equal(3, res.length)
+      expect(res.length).to eq(3)
       assert_instance_of(Float, res[0])
       assert_instance_of(Float, res[1])
       assert_instance_of(Float, res[2])
@@ -482,7 +482,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised do
       metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
       assert_instance_of(Float, metric)
-      assert_equal(0.0, metric)
+      expect(metric).to eq(0.0)
     end
     assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }
@@ -516,13 +516,13 @@ class Image2_UT < Minitest::Test
   def test_dup
     assert_nothing_raised do
       ditto = @img.dup
-      assert_equal(@img, ditto)
+      expect(ditto).to eq(@img)
     end
     ditto = @img.dup
-    assert_equal(@img.tainted?, ditto.tainted?)
+    expect(ditto.tainted?).to eq(@img.tainted?)
     @img.taint
     ditto = @img.dup
-    assert_equal(@img.tainted?, ditto.tainted?)
+    expect(ditto.tainted?).to eq(@img.tainted?)
   end
 
   def test_each_profile
@@ -531,8 +531,8 @@ class Image2_UT < Minitest::Test
     @img.iptc_profile = 'test profile'
     assert_nothing_raised do
       @img.each_profile do |name, value|
-        assert_equal('iptc', name)
-        assert_equal('test profile', value)
+        expect(name).to eq('iptc')
+        expect(value).to eq('test profile')
       end
     end
   end
@@ -601,19 +601,19 @@ class Image2_UT < Minitest::Test
     img = Magick::Image.new(200, 200)
     assert_nothing_raised { res = @img.excerpt(20, 20, 50, 100) }
     assert_not_same(img, res)
-    assert_equal(50, res.columns)
-    assert_equal(100, res.rows)
+    expect(res.columns).to eq(50)
+    expect(res.rows).to eq(100)
 
     assert_nothing_raised { img.excerpt!(20, 20, 50, 100) }
-    assert_equal(50, img.columns)
-    assert_equal(100, img.rows)
+    expect(img.columns).to eq(50)
+    expect(img.rows).to eq(100)
   end
 
   def test_export_pixels
     assert_nothing_raised do
       res = @img.export_pixels
       assert_instance_of(Array, res)
-      assert_equal(@img.columns * @img.rows * 'RGB'.length, res.length)
+      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
       res.each do |p|
         assert_kind_of(Integer, p)
       end
@@ -624,11 +624,11 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.export_pixels(0, 0, 10, 10) }
     assert_nothing_raised do
       res = @img.export_pixels(0, 0, 10, 10, 'RGBA')
-      assert_equal(10 * 10 * 'RGBA'.length, res.length)
+      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
     end
     assert_nothing_raised do
       res = @img.export_pixels(0, 0, 10, 10, 'I')
-      assert_equal(10 * 10 * 'I'.length, res.length)
+      expect(res.length).to eq(10 * 10 * 'I'.length)
     end
 
     # too many arguments
@@ -639,7 +639,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised do
       res = @img.export_pixels_to_str
       assert_instance_of(String, res)
-      assert_equal(@img.columns * @img.rows * 'RGB'.length, res.length)
+      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
     end
     assert_nothing_raised { @img.export_pixels_to_str(0) }
     assert_nothing_raised { @img.export_pixels_to_str(0, 0) }
@@ -647,32 +647,32 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10, 10) }
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
-      assert_equal(10 * 10 * 'RGBA'.length, res.length)
+      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
     end
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I')
-      assert_equal(10 * 10 * 'I'.length, res.length)
+      expect(res.length).to eq(10 * 10 * 'I'.length)
     end
 
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
-      assert_equal(10 * 10 * 1, res.length)
+      expect(res.length).to eq(10 * 10 * 1)
     end
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
-      assert_equal(10 * 10 * 2, res.length)
+      expect(res.length).to eq(10 * 10 * 2)
     end
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
-      assert_equal(10 * 10 * [1].pack('L!').length, res.length)
+      expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
     end
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
-      assert_equal(10 * 10 * 4, res.length)
+      expect(res.length).to eq(10 * 10 * 4)
     end
     assert_nothing_raised do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
-      assert_equal(10 * 10 * 8, res.length)
+      expect(res.length).to eq(10 * 10 * 8)
     end
     assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }
 
@@ -687,8 +687,8 @@ class Image2_UT < Minitest::Test
     res = @img.extent(40, 40)
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_equal(40, res.columns)
-    assert_equal(40, res.rows)
+    expect(res.columns).to eq(40)
+    expect(res.rows).to eq(40)
     assert_nothing_raised { @img.extent(40, 40, 5) }
     assert_nothing_raised { @img.extent(40, 40, 5, 5) }
     assert_raises(ArgumentError) { @img.extent(-40) }
@@ -709,26 +709,26 @@ class Image2_UT < Minitest::Test
       x, y = girl.find_similar_region(region)
       assert_not_nil(x)
       assert_not_nil(y)
-      assert_equal(10, x)
-      assert_equal(10, y)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
     end
     assert_nothing_raised do
       x, y = girl.find_similar_region(region, 0)
-      assert_equal(10, x)
-      assert_equal(10, y)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
     end
     assert_nothing_raised do
       x, y = girl.find_similar_region(region, 0, 0)
-      assert_equal(10, x)
-      assert_equal(10, y)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
     end
 
     list = Magick::ImageList.new
     list << region
     assert_nothing_raised do
       x, y = girl.find_similar_region(list, 0, 0)
-      assert_equal(10, x)
-      assert_equal(10, y)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
     end
 
     x = girl.find_similar_region(@img)
@@ -908,7 +908,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised do
       pixels = @img.get_pixels(0, 0, @img.columns, 1)
       assert_instance_of(Array, pixels)
-      assert_equal(@img.columns, pixels.length)
+      expect(pixels.length).to eq(@img.columns)
       assert_block do
         pixels.all? { |p| p.is_a? Magick::Pixel }
       end
@@ -988,11 +988,11 @@ class Image2_UT < Minitest::Test
   def test_level2
     img1 = @img.level(10, 2, 200)
     img2 = @img.level(10, 200, 2)
-    assert_equal(img2, img1)
+    expect(img1).to eq(img2)
 
     # Ensure that level2 uses new arg order
     img1 = @img.level2(10, 200, 2)
-    assert_equal(img2, img1)
+    expect(img1).to eq(img2)
 
     assert_nothing_raised { @img.level2 }
     assert_nothing_raised { @img.level2(10) }
@@ -1069,8 +1069,8 @@ class Image2_UT < Minitest::Test
   #       assert_nothing_raised do
   #         res = @img.liquid_rescale(15, 15)
   #       end
-  #       assert_equal(15, res.columns)
-  #       assert_equal(15, res.rows)
+  #       expect(res.columns).to eq(15)
+  #       expect(res.rows).to eq(15)
   #       assert_nothing_raised { @img.liquid_rescale(15, 15, 0, 0) }
   #       assert_raise(ArgumentError) { @img.liquid_rescale(15) }
   #       assert_raise(ArgumentError) { @img.liquid_rescale(15, 15, 0, 0, 0) }
@@ -1097,7 +1097,7 @@ class Image2_UT < Minitest::Test
     img2 = nil
     assert_nothing_raised { d = Marshal.dump(img) }
     assert_nothing_raised { img2 = Marshal.load(d) }
-    assert_equal(img, img2)
+    expect(img2).to eq(img)
   end
 
   def test_mask
@@ -1107,8 +1107,8 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { res = @img.mask }
     assert_not_nil(res)
     assert_not_same(cimg, res)
-    assert_equal(20, res.columns)
-    assert_equal(20, res.rows)
+    expect(res.columns).to eq(20)
+    expect(res.rows).to eq(20)
 
     assert_raise(ArgumentError) { @img.mask(cimg, 'x') }
     # mask expects an Image and calls `cur_image'
@@ -1367,22 +1367,22 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Magick::Pixel, res)
     end
     res = @img.pixel_color(0, 0)
-    assert_equal(@img.background_color, res.to_color)
+    expect(res.to_color).to eq(@img.background_color)
     res = @img.pixel_color(0, 0, 'red')
-    assert_equal('white', res.to_color)
+    expect(res.to_color).to eq('white')
     res = @img.pixel_color(0, 0)
-    assert_equal('red', res.to_color)
+    expect(res.to_color).to eq('red')
 
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     assert_nothing_raised { @img.pixel_color(0, 0, blue) }
     # If args are out-of-bounds return the background color
     img = Magick::Image.new(10, 10) { self.background_color = 'blue' }
-    assert_equal('blue', img.pixel_color(50, 50).to_color)
+    expect(img.pixel_color(50, 50).to_color).to eq('blue')
 
     assert_nothing_raised do
       @img.class_type = Magick::PseudoClass
       res = @img.pixel_color(0, 0, 'red')
-      assert_equal('blue', res.to_color)
+      expect(res.to_color).to eq('blue')
     end
   end
 

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -147,17 +147,17 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.resample(100, 100) }
 
     girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    assert_equal(240.0, girl.x_resolution)
-    assert_equal(240.0, girl.y_resolution)
+    expect(girl.x_resolution).to eq(240.0)
+    expect(girl.y_resolution).to eq(240.0)
     res = girl.resample(120, 120)
-    assert_equal(100, res.columns)
-    assert_equal(125, res.rows)
-    assert_equal(120.0, res.x_resolution)
-    assert_equal(120.0, res.y_resolution)
-    assert_equal(200, girl.columns)
-    assert_equal(250, girl.rows)
-    assert_equal(240.0, girl.x_resolution)
-    assert_equal(240.0, girl.y_resolution)
+    expect(res.columns).to eq(100)
+    expect(res.rows).to eq(125)
+    expect(res.x_resolution).to eq(120.0)
+    expect(res.y_resolution).to eq(120.0)
+    expect(girl.columns).to eq(200)
+    expect(girl.rows).to eq(250)
+    expect(girl.x_resolution).to eq(240.0)
+    expect(girl.y_resolution).to eq(240.0)
 
     Magick::FilterType.values do |filter|
       assert_nothing_raised { @img.resample(50, 50, filter) }
@@ -215,49 +215,49 @@ class Image3_UT < Minitest::Test
 
   def test_resize_to_fill_0
     changed = @img.resize_to_fill(@img.columns, @img.rows)
-    assert_equal(@img.columns, changed.columns)
-    assert_equal(@img.rows, changed.rows)
+    expect(changed.columns).to eq(@img.columns)
+    expect(changed.rows).to eq(@img.rows)
     assert_not_same(changed, @img)
   end
 
   def test_resize_to_fill_1
     @img = Magick::Image.new(200, 250)
     @img.resize_to_fill!(100, 100)
-    assert_equal(100, @img.columns)
-    assert_equal(100, @img.rows)
+    expect(@img.columns).to eq(100)
+    expect(@img.rows).to eq(100)
   end
 
   def test_resize_to_fill_2
     @img = Magick::Image.new(200, 250)
     changed = @img.resize_to_fill(300, 100)
-    assert_equal(300, changed.columns)
-    assert_equal(100, changed.rows)
+    expect(changed.columns).to eq(300)
+    expect(changed.rows).to eq(100)
   end
 
   def test_resize_to_fill_3
     @img = Magick::Image.new(200, 250)
     changed = @img.resize_to_fill(100, 300)
-    assert_equal(100, changed.columns)
-    assert_equal(300, changed.rows)
+    expect(changed.columns).to eq(100)
+    expect(changed.rows).to eq(300)
   end
 
   def test_resize_to_fill_4
     @img = Magick::Image.new(200, 250)
     changed = @img.resize_to_fill(300, 350)
-    assert_equal(300, changed.columns)
-    assert_equal(350, changed.rows)
+    expect(changed.columns).to eq(300)
+    expect(changed.rows).to eq(350)
   end
 
   def test_resize_to_fill_5
     changed = @img.resize_to_fill(20, 400)
-    assert_equal(20, changed.columns)
-    assert_equal(400, changed.rows)
+    expect(changed.columns).to eq(20)
+    expect(changed.rows).to eq(400)
   end
 
   def test_resize_to_fill_6
     changed = @img.resize_to_fill(3000, 400)
-    assert_equal(3000, changed.columns)
-    assert_equal(400, changed.rows)
+    expect(changed.columns).to eq(3000)
+    expect(changed.rows).to eq(400)
   end
 
   # Make sure the old name is still around
@@ -269,8 +269,8 @@ class Image3_UT < Minitest::Test
   # 2nd argument defaults to the same value as the 1st argument
   def test_resize_to_fill_8
     changed = @img.resize_to_fill(100)
-    assert_equal(100, changed.columns)
-    assert_equal(100, changed.rows)
+    expect(changed.columns).to eq(100)
+    expect(changed.rows).to eq(100)
   end
 
   def test_resize_to_fit
@@ -280,8 +280,8 @@ class Image3_UT < Minitest::Test
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
     assert_not_same(img, res)
-    assert_equal(40, res.columns)
-    assert_equal(50, res.rows)
+    expect(res.columns).to eq(40)
+    expect(res.rows).to eq(50)
   end
 
   def test_resize_to_fit2
@@ -289,8 +289,8 @@ class Image3_UT < Minitest::Test
     changed = img.resize_to_fit(100)
     assert_instance_of(Magick::Image, changed)
     assert_not_same(img, changed)
-    assert_equal(67, changed.columns)
-    assert_equal(100, changed.rows)
+    expect(changed.columns).to eq(67)
+    expect(changed.rows).to eq(100)
   end
 
   def test_resize_to_fit3
@@ -299,8 +299,8 @@ class Image3_UT < Minitest::Test
     img.resize_to_fit!(100)
     assert_instance_of(Magick::Image, img)
     assert_same(img, keep)
-    assert_equal(67, img.columns)
-    assert_equal(100, img.rows)
+    expect(img.columns).to eq(67)
+    expect(img.rows).to eq(100)
   end
 
   def test_roll
@@ -321,8 +321,8 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised do
       res = img.rotate(90, '>')
       assert_instance_of(Magick::Image, res)
-      assert_equal(50, res.columns)
-      assert_equal(100, res.rows)
+      expect(res.columns).to eq(50)
+      expect(res.rows).to eq(100)
     end
     assert_nothing_raised do
       res = img.rotate(90, '<')
@@ -422,7 +422,7 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { res = @img.selective_blur_channel(0, 1, '10%') }
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_equal([@img.columns, @img.rows], [res.columns, res.rows])
+    expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
 
     assert_nothing_raised { @img.selective_blur_channel(0, 1, 0.1) }
     assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }
@@ -738,12 +738,12 @@ class Image3_UT < Minitest::Test
 
     girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     new_img = girl.thumbnail(200, 200)
-    assert_equal(160, new_img.columns)
-    assert_equal(200, new_img.rows)
+    expect(new_img.columns).to eq(160)
+    expect(new_img.rows).to eq(200)
 
     new_img = girl.thumbnail(2)
-    assert_equal(400, new_img.columns)
-    assert_equal(500, new_img.rows)
+    expect(new_img.columns).to eq(400)
+    expect(new_img.rows).to eq(500)
   end
 
   def test_thumbnail!
@@ -784,14 +784,14 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { res = @img.to_blob { self.format = 'miff' } }
     assert_instance_of(String, res)
     restored = Magick::Image.from_blob(res)
-    assert_equal(@img, restored[0])
+    expect(restored[0]).to eq(@img)
   end
 
   def test_to_color
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised do
       res = @img.to_color(red)
-      assert_equal('red', res)
+      expect(res).to eq('red')
     end
   end
 
@@ -872,8 +872,8 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised do
       res = @img.unique_colors
       assert_instance_of(Magick::Image, res)
-      assert_equal(1, res.columns)
-      assert_equal(1, res.rows)
+      expect(res.columns).to eq(1)
+      expect(res.rows).to eq(1)
     end
   end
 
@@ -1019,34 +1019,34 @@ class Image3_UT < Minitest::Test
   def test_write
     @img.write('temp.gif')
     img = Magick::Image.read('temp.gif')
-    assert_equal('GIF', img.first.format)
+    expect(img.first.format).to eq('GIF')
     FileUtils.rm('temp.gif')
 
     @img.write('jpg:temp.foo')
     img = Magick::Image.read('temp.foo')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
     @img.write('temp.0') { self.format = 'JPEG' }
     img = Magick::Image.read('temp.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
 
     # JPEG has two names.
     @img.write('jpeg:temp.0') { self.format = 'JPEG' }
     img = Magick::Image.read('temp.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
 
     @img.write('jpg:temp.0') { self.format = 'JPG' }
     img = Magick::Image.read('temp.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
 
     @img.write('jpg:temp.0') { self.format = 'JPEG' }
     img = Magick::Image.read('temp.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
 
     @img.write('jpeg:temp.0') { self.format = 'JPG' }
     img = Magick::Image.read('temp.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
 
     assert_raise(RuntimeError) do
       @img.write('gif:temp.0') { self.format = 'JPEG' }
@@ -1056,12 +1056,12 @@ class Image3_UT < Minitest::Test
     @img.write(f) { self.format = 'JPEG' }
     f.close
     img = Magick::Image.read('test.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
     FileUtils.rm('test.0')
 
     @img.write('test.webp')
     img = Magick::Image.read('test.webp')
-    assert_equal('WEBP', img.first.format)
+    expect(img.first.format).to eq('WEBP')
     FileUtils.rm('test.webp') rescue nil # Avoid failure on AppVeyor
 
     f = File.new('test.0', 'w')
@@ -1071,7 +1071,7 @@ class Image3_UT < Minitest::Test
     end
     f.close
     img = Magick::Image.read('test.0')
-    assert_equal('JPEG', img.first.format)
+    expect(img.first.format).to eq('JPEG')
     FileUtils.rm('test.0')
   end
 end

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -66,9 +66,9 @@ class ImageList1UT < Minitest::Test
 
   def test_delay
     assert_nothing_raised { @list.delay }
-    assert_equal(0, @list.delay)
+    expect(@list.delay).to eq(0)
     assert_nothing_raised { @list.delay = 20 }
-    assert_equal(20, @list.delay)
+    expect(@list.delay).to eq(20)
     assert_raise(ArgumentError) { @list.delay = 'x' }
   end
 
@@ -78,9 +78,9 @@ class ImageList1UT < Minitest::Test
 
   def test_ticks_per_second
     assert_nothing_raised { @list.ticks_per_second }
-    assert_equal(100, @list.ticks_per_second)
+    expect(@list.ticks_per_second).to eq(100)
     assert_nothing_raised { @list.ticks_per_second = 1000 }
-    assert_equal(1000, @list.ticks_per_second)
+    expect(@list.ticks_per_second).to eq(1000)
     assert_raise(ArgumentError) { @list.ticks_per_second = 'x' }
   end
 
@@ -88,24 +88,24 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised { @list.iterations }
     assert_kind_of(Integer, @list.iterations)
     assert_nothing_raised { @list.iterations = 20 }
-    assert_equal(20, @list.iterations)
+    expect(@list.iterations).to eq(20)
     assert_raise(ArgumentError) { @list.iterations = 'x' }
   end
 
   # also tests #size
   def test_length
     assert_nothing_raised { @list.length }
-    assert_equal(10, @list.length)
+    expect(@list.length).to eq(10)
     assert_raise(NoMethodError) { @list.length = 2 }
   end
 
   def test_scene
     assert_nothing_raised { @list.scene }
-    assert_equal(9, @list.scene)
+    expect(@list.scene).to eq(9)
     assert_nothing_raised { @list.scene = 0 }
-    assert_equal(0, @list.scene)
+    expect(@list.scene).to eq(0)
     assert_nothing_raised { @list.scene = 1 }
-    assert_equal(1, @list.scene)
+    expect(@list.scene).to eq(1)
     assert_raise(IndexError) { @list.scene = -1 }
     assert_raise(IndexError) { @list.scene = 1000 }
     assert_raise(IndexError) { @list.scene = nil }
@@ -153,7 +153,7 @@ class ImageList1UT < Minitest::Test
       rv = @list[0] = img
       assert_same(img, rv)
       assert_same(img, @list[0])
-      assert_equal(0, @list.scene)
+      expect(@list.scene).to eq(0)
     end
 
     # replace 2 images with 1
@@ -161,9 +161,9 @@ class ImageList1UT < Minitest::Test
       img = Magick::Image.new(5, 5)
       rv = @list[1, 2] = img
       assert_same(img, rv)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(img, @list[1])
-      assert_equal(1, @list.scene)
+      expect(@list.scene).to eq(1)
     end
 
     # replace 1 image with 2
@@ -173,37 +173,37 @@ class ImageList1UT < Minitest::Test
       ary = [img, img2]
       rv = @list[3, 1] = ary
       assert_same(ary, rv)
-      assert_equal(10, @list.length)
+      expect(@list.length).to eq(10)
       assert_same(img, @list[3])
       assert_same(img2, @list[4])
-      assert_equal(4, @list.scene)
+      expect(@list.scene).to eq(4)
     end
 
     assert_nothing_raised do
       img = Magick::Image.new(5, 5)
       rv = @list[5..6] = img
       assert_same(img, rv)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(img, @list[5])
-      assert_equal(5, @list.scene)
+      expect(@list.scene).to eq(5)
     end
 
     assert_nothing_raised do
       ary = [img, img]
       rv = @list[7..8] = ary
       assert_same(ary, rv)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(img, @list[7])
       assert_same(img, @list[8])
-      assert_equal(8, @list.scene)
+      expect(@list.scene).to eq(8)
     end
 
     assert_nothing_raised do
       rv = @list[-1] = img
       assert_same(img, rv)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(img, @list[8])
-      assert_equal(8, @list.scene)
+      expect(@list.scene).to eq(8)
     end
 
     assert_raise(ArgumentError) { @list[0] = 1 }
@@ -219,8 +219,8 @@ class ImageList1UT < Minitest::Test
       assert_instance_of(Magick::ImageList, res)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
-      assert_equal(5, res.length)
-      assert_equal(2, res.scene)
+      expect(res.length).to eq(5)
+      expect(res.scene).to eq(2)
       assert_same(cur, res.cur_image)
     end
 
@@ -229,7 +229,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list & @list2
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(4, res.scene)
+      expect(res.scene).to eq(4)
     end
 
     assert_raise(ArgumentError) { @list & 2 }
@@ -256,7 +256,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list * 2
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(20, res.length)
+      expect(res.length).to eq(20)
       assert_not_same(res, @list)
       assert_same(cur, res.cur_image)
     end
@@ -270,7 +270,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list + @list2
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(15, res.length)
+      expect(res.length).to eq(15)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       assert_same(cur, res.cur_image)
@@ -285,7 +285,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list - @list2
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(5, res.length)
+      expect(res.length).to eq(5)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       assert_same(cur, res.cur_image)
@@ -297,16 +297,16 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list - @list2
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(5, res.length)
-      assert_equal(4, res.scene)
+      expect(res.length).to eq(5)
+      expect(res.scene).to eq(4)
     end
   end
 
   def test_catenate
     assert_nothing_raised do
       @list2.each { |img| @list << img }
-      assert_equal(15, @list.length)
-      assert_equal(14, @list.scene)
+      expect(@list.length).to eq(15)
+      expect(@list.scene).to eq(14)
     end
 
     assert_raise(ArgumentError) { @list << 2 }
@@ -322,15 +322,15 @@ class ImageList1UT < Minitest::Test
       assert_instance_of(Magick::ImageList, res)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
-      assert_equal(res, @list)
+      expect(@list).to eq(res)
     end
 
     # Try or'ing disjoint lists
     temp_list = Magick::ImageList.new(*FILES[10..14])
     res = @list | temp_list
     assert_instance_of(Magick::ImageList, res)
-    assert_equal(15, res.length)
-    assert_equal(7, res.scene)
+    expect(res.length).to eq(15)
+    expect(res.scene).to eq(7)
 
     assert_raise(ArgumentError) { @list | 2 }
     assert_raise(ArgumentError) { @list | [2] }
@@ -339,7 +339,7 @@ class ImageList1UT < Minitest::Test
   def test_clear
     assert_nothing_raised { @list.clear }
     assert_instance_of(Magick::ImageList, @list)
-    assert_equal(0, @list.length)
+    expect(@list.length).to eq(0)
     assert_nil(@list.scene)
   end
 
@@ -349,13 +349,13 @@ class ImageList1UT < Minitest::Test
       res = @list.collect(&:negate)
       assert_instance_of(Magick::ImageList, res)
       assert_not_same(res, @list)
-      assert_equal(scene, res.scene)
+      expect(res.scene).to eq(scene)
     end
     assert_nothing_raised do
       scene = @list.scene
       @list.collect!(&:negate)
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(scene, @list.scene)
+      expect(@list.scene).to eq(scene)
     end
   end
 
@@ -363,13 +363,13 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list.compact
       assert_not_same(res, @list)
-      assert_equal(res, @list)
+      expect(@list).to eq(res)
     end
     assert_nothing_raised do
       res = @list
       @list.compact!
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(res, @list)
+      expect(@list).to eq(res)
       assert_same(res, @list)
     end
   end
@@ -378,7 +378,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list.concat(@list2)
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(15, res.length)
+      expect(res.length).to eq(15)
       assert_same(res[14], res.cur_image)
     end
     assert_raise(ArgumentError) { @list.concat(2) }
@@ -390,7 +390,7 @@ class ImageList1UT < Minitest::Test
       cur = @list.cur_image
       img = @list[7]
       assert_same(img, @list.delete(img))
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
 
       # Try deleting the current image.
@@ -405,7 +405,7 @@ class ImageList1UT < Minitest::Test
       assert_nothing_raised do
         img = Magick::Image.read(FILES[10]).first
         res = @list.delete(img) { 1 }
-        assert_equal(1, res)
+        expect(res).to eq(1)
       end
     end
   end
@@ -425,7 +425,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       @list.delete_if { |img| File.basename(img.filename) =~ /5/ }
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
     end
 
@@ -433,7 +433,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       @list.delete_if { |img| File.basename(img.filename) =~ /7/ }
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(8, @list.length)
+      expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
     end
   end
@@ -496,7 +496,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(1, res.length)
+      expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
     end
   end
@@ -521,16 +521,16 @@ class ImageList1UT < Minitest::Test
     img2 = nil
     assert_nothing_raised { img2 = @list.last }
     assert_instance_of(Magick::Image, img2)
-    assert_equal(img2, img)
+    expect(img).to eq(img2)
     img2 = Magick::Image.new(5, 5)
     @list << img2
     ilist = nil
     assert_nothing_raised { ilist = @list.last(2) }
     assert_instance_of(Magick::ImageList, ilist)
-    assert_equal(2, ilist.length)
-    assert_equal(1, ilist.scene)
-    assert_equal(img, ilist[0])
-    assert_equal(img2, ilist[1])
+    expect(ilist.length).to eq(2)
+    expect(ilist.scene).to eq(1)
+    expect(ilist[0]).to eq(img)
+    expect(ilist[1]).to eq(img2)
   end
 
   def test___map__
@@ -561,13 +561,13 @@ class ImageList1UT < Minitest::Test
       end
     end
     assert_instance_of(Array, a)
-    assert_equal(2, a.size)
+    expect(a.size).to eq(2)
     assert_instance_of(Magick::ImageList, a[0])
     assert_instance_of(Magick::ImageList, a[1])
-    assert_equal(4, a[0].scene)
-    assert_equal(5, a[0].length)
-    assert_equal(4, a[1].scene)
-    assert_equal(5, a[1].length)
+    expect(a[0].scene).to eq(4)
+    expect(a[0].length).to eq(5)
+    expect(a[1].scene).to eq(4)
+    expect(a[1].length).to eq(5)
   end
 
   def test_pop
@@ -598,7 +598,7 @@ class ImageList1UT < Minitest::Test
     list = @list
     assert_nothing_raised do
       res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
-      assert_equal(9, res.length)
+      expect(res.length).to eq(9)
       assert_instance_of(Magick::ImageList, res)
       assert_same(cur, res.cur_image)
     end
@@ -607,7 +607,7 @@ class ImageList1UT < Minitest::Test
 
     # Omit current image from result list - result cur_image s/b last image
     res = @list.reject { |img| File.basename(img.filename) =~ /Button_7/ }
-    assert_equal(9, res.length)
+    expect(res.length).to eq(9)
     assert_same(res[-1], res.cur_image)
     assert_same(cur, @list.cur_image)
   end
@@ -618,7 +618,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       @list.reject! { |img| File.basename(img.filename) =~ /5/ }
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(9, @list.length)
+      expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
     end
 
@@ -626,7 +626,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       @list.reject! { |img| File.basename(img.filename) =~ /7/ }
       assert_instance_of(Magick::ImageList, @list)
-      assert_equal(8, @list.length)
+      expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
     end
 
@@ -639,7 +639,7 @@ class ImageList1UT < Minitest::Test
     assert_nothing_raised do
       res = @list.replace([])
       assert_same(res, @list)
-      assert_equal(0, @list.length)
+      expect(@list.length).to eq(0)
       assert_nil(@list.scene)
     end
 
@@ -647,8 +647,8 @@ class ImageList1UT < Minitest::Test
     temp = Magick::ImageList.new
     assert_nothing_raised do
       temp.replace(@list2)
-      assert_equal(5, temp.length)
-      assert_equal(4, temp.scene)
+      expect(temp.length).to eq(5)
+      expect(temp.scene).to eq(4)
     end
 
     # Try to replace with illegal values
@@ -662,8 +662,8 @@ class ImageList1UT < Minitest::Test
       cur = @list.cur_image
       res = @list.replace(@list2)
       assert_same(res, @list)
-      assert_equal(5, @list.length)
-      assert_equal(2, @list.scene)
+      expect(@list.length).to eq(5)
+      expect(@list.scene).to eq(2)
       assert_same(cur, @list.cur_image)
     end
   end
@@ -675,8 +675,8 @@ class ImageList1UT < Minitest::Test
       cur = @list2.cur_image
       res = @list2.replace(@list)
       assert_same(res, @list2)
-      assert_equal(10, @list2.length)
-      assert_equal(7, @list2.scene)
+      expect(@list2.length).to eq(10)
+      expect(@list2.scene).to eq(7)
       assert_same(cur, @list2.cur_image)
     end
   end
@@ -685,7 +685,7 @@ class ImageList1UT < Minitest::Test
     list = nil
     cur = @list.cur_image
     assert_nothing_raised { list = @list.reverse }
-    assert_equal(list.length, @list.length)
+    expect(@list.length).to eq(list.length)
     assert_same(cur, @list.cur_image)
   end
 
@@ -708,14 +708,14 @@ class ImageList1UT < Minitest::Test
     img = @list.last
     n = nil
     assert_nothing_raised { n = @list.rindex(img) }
-    assert_equal(9, n)
+    expect(n).to eq(9)
   end
 
   def test_select
     assert_nothing_raised do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(1, res.length)
+      expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
     end
   end
@@ -726,12 +726,12 @@ class ImageList1UT < Minitest::Test
       res = @list[0]
       img = @list.shift
       assert_same(res, img)
-      assert_equal(8, @list.scene)
+      expect(@list.scene).to eq(8)
     end
     res = @list[0]
     img = @list.shift
     assert_same(res, img)
-    assert_equal(7, @list.scene)
+    expect(@list.scene).to eq(7)
   end
 
   def test_slice
@@ -748,14 +748,14 @@ class ImageList1UT < Minitest::Test
       img0 = @list[0]
       img = @list.slice!(0)
       assert_same(img0, img)
-      assert_equal(9, @list.length)
-      assert_equal(6, @list.scene)
+      expect(@list.length).to eq(9)
+      expect(@list.scene).to eq(6)
     end
     cur = @list.cur_image
     img = @list.slice!(6)
     assert_same(cur, img)
-    assert_equal(8, @list.length)
-    assert_equal(7, @list.scene)
+    expect(@list.length).to eq(8)
+    expect(@list.scene).to eq(7)
     assert_nothing_raised { @list.slice!(-1) }
     assert_nothing_raised { @list.slice!(0, 1) }
     assert_nothing_raised { @list.slice!(0..2) }
@@ -772,7 +772,7 @@ class ImageList1UT < Minitest::Test
     a = nil
     assert_nothing_raised { a = @list.to_a }
     assert_instance_of(Array, a)
-    assert_equal(10, a.length)
+    expect(a.length).to eq(10)
   end
 
   def test_uniq
@@ -781,14 +781,14 @@ class ImageList1UT < Minitest::Test
     @list[1] = @list[0]
     @list.scene = 7
     list = @list.uniq
-    assert_equal(9, list.length)
-    assert_equal(6, list.scene)
-    assert_equal(7, @list.scene)
+    expect(list.length).to eq(9)
+    expect(list.scene).to eq(6)
+    expect(@list.scene).to eq(7)
     @list[6] = @list[7]
     list = @list.uniq
-    assert_equal(8, list.length)
-    assert_equal(5, list.scene)
-    assert_equal(7, @list.scene)
+    expect(list.length).to eq(8)
+    expect(list.scene).to eq(5)
+    expect(@list.scene).to eq(7)
   end
 
   def test_uniq!
@@ -802,18 +802,18 @@ class ImageList1UT < Minitest::Test
     @list.uniq!
     assert_same(list, @list)
     assert_same(cur, @list.cur_image)
-    assert_equal(6, @list.scene)
+    expect(@list.scene).to eq(6)
     @list[5] = @list[6]
     @list.uniq!
     assert_same(cur, @list.cur_image)
-    assert_equal(5, @list.scene)
+    expect(@list.scene).to eq(5)
   end
 
   def test_unshift
     img = @list[9]
     @list.scene = 7
     @list.unshift(img)
-    assert_equal(0, @list.scene)
+    expect(@list.scene).to eq(0)
     assert_raise(ArgumentError) { @list.unshift(2) }
     assert_raise(ArgumentError) { @list.unshift([1, 2]) }
   end
@@ -822,14 +822,14 @@ class ImageList1UT < Minitest::Test
     ilist = nil
     assert_nothing_raised { ilist = @list.values_at(1, 3, 5) }
     assert_instance_of(Magick::ImageList, ilist)
-    assert_equal(3, ilist.length)
-    assert_equal(2, ilist.scene)
+    expect(ilist.length).to eq(3)
+    expect(ilist.scene).to eq(2)
   end
 
   def test_spaceship
     list2 = @list.copy
-    assert_equal(@list.scene, list2.scene)
-    assert_equal(@list, list2)
+    expect(list2.scene).to eq(@list.scene)
+    expect(list2).to eq(@list)
     list2.scene = 0
     assert_not_equal(@list, list2)
     list2 = @list.copy

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -33,14 +33,14 @@ class ImageList2UT < Minitest::Test
   def test_clone
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     ilist2 = @ilist.clone
-    assert_equal(ilist2, @ilist)
-    assert_equal(@ilist.frozen?, ilist2.frozen?)
-    assert_equal(@ilist.tainted?, ilist2.tainted?)
+    expect(@ilist).to eq(ilist2)
+    expect(ilist2.frozen?).to eq(@ilist.frozen?)
+    expect(ilist2.tainted?).to eq(@ilist.tainted?)
     @ilist.taint
     @ilist.freeze
     ilist2 = @ilist.clone
-    assert_equal(@ilist.frozen?, ilist2.frozen?)
-    assert_equal(@ilist.tainted?, ilist2.tainted?)
+    expect(ilist2.frozen?).to eq(@ilist.frozen?)
+    expect(ilist2.tainted?).to eq(@ilist.tainted?)
   end
 
   def test_coalesce
@@ -48,8 +48,8 @@ class ImageList2UT < Minitest::Test
     ilist = nil
     assert_nothing_raised { ilist = @ilist.coalesce }
     assert_instance_of(Magick::ImageList, ilist)
-    assert_equal(2, ilist.length)
-    assert_equal(0, ilist.scene)
+    expect(ilist.length).to eq(2)
+    expect(ilist.scene).to eq(0)
   end
 
   def test_copy
@@ -57,9 +57,9 @@ class ImageList2UT < Minitest::Test
     @ilist.scene = 7
     ilist2 = @ilist.copy
     assert_not_same(@ilist, ilist2)
-    assert_equal(@ilist.scene, ilist2.scene)
+    expect(ilist2.scene).to eq(@ilist.scene)
     @ilist.each_with_index do |img, x|
-      assert_equal(img, ilist2[x])
+      expect(ilist2[x]).to eq(img)
     end
   end
 
@@ -68,21 +68,21 @@ class ImageList2UT < Minitest::Test
     ilist = nil
     assert_nothing_raised { ilist = @ilist.deconstruct }
     assert_instance_of(Magick::ImageList, ilist)
-    assert_equal(2, ilist.length)
-    assert_equal(0, ilist.scene)
+    expect(ilist.length).to eq(2)
+    expect(ilist.scene).to eq(0)
   end
 
   def test_dup
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     ilist2 = @ilist.dup
-    assert_equal(ilist2, @ilist)
-    assert_equal(@ilist.frozen?, ilist2.frozen?)
-    assert_equal(@ilist.tainted?, ilist2.tainted?)
+    expect(@ilist).to eq(ilist2)
+    expect(ilist2.frozen?).to eq(@ilist.frozen?)
+    expect(ilist2.tainted?).to eq(@ilist.tainted?)
     @ilist.taint
     @ilist.freeze
     ilist2 = @ilist.dup
     assert_not_equal(@ilist.frozen?, ilist2.frozen?)
-    assert_equal(@ilist.tainted?, ilist2.tainted?)
+    expect(ilist2.tainted?).to eq(@ilist.tainted?)
   end
 
   def flatten_images
@@ -98,10 +98,10 @@ class ImageList2UT < Minitest::Test
     blob = hat.read
     assert_nothing_raised { @ilist.from_blob(blob) }
     assert_instance_of(Magick::Image, @ilist[0])
-    assert_equal(0, @ilist.scene)
+    expect(@ilist.scene).to eq(0)
 
     ilist2 = Magick::ImageList.new(FLOWER_HAT)
-    assert_equal(@ilist, ilist2)
+    expect(ilist2).to eq(@ilist)
   end
 
   def test_marshal
@@ -110,7 +110,7 @@ class ImageList2UT < Minitest::Test
     ilist2 = nil
     assert_nothing_raised { d = Marshal.dump(ilist1) }
     assert_nothing_raised { ilist2 = Marshal.load(d) }
-    assert_equal(ilist1, ilist2)
+    expect(ilist2).to eq(ilist1)
   end
 
   def test_montage
@@ -145,11 +145,11 @@ class ImageList2UT < Minitest::Test
         self.title = 'sample'
       end
       assert_instance_of(Magick::ImageList, montage)
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
 
       montage_image = montage.first
-      assert_equal('blue', montage_image.background_color)
-      assert_equal('red', montage_image.border_color)
+      expect(montage_image.background_color).to eq('blue')
+      expect(montage_image.border_color).to eq('red')
     end
 
     # test illegal option arguments
@@ -157,51 +157,51 @@ class ImageList2UT < Minitest::Test
     # to tile= and geometry=
     assert_raise(TypeError) do
       montage = ilist.montage { self.background_color = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.border_color = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.border_width = [2] }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.compose = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.filename = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.fill = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.font = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.gravity = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.matte_color = 2 }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(TypeError) do
       montage = ilist.montage { self.pointsize = 'x' }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(ArgumentError) do
       montage = ilist.montage { self.stroke = 'x' }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
     assert_raise(NoMethodError) do
       montage = ilist.montage { self.texture = 'x' }
-      assert_equal(@ilist, ilist)
+      expect(ilist).to eq(@ilist)
     end
   end
 
@@ -214,8 +214,8 @@ class ImageList2UT < Minitest::Test
     assert_nothing_raised do
       res = @ilist.morph(2)
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(4, res.length)
-      assert_equal(0, res.scene)
+      expect(res.length).to eq(4)
+      expect(res.scene).to eq(0)
     end
   end
 
@@ -237,14 +237,14 @@ class ImageList2UT < Minitest::Test
     assert_nothing_raised do
       @ilist.new_image(20, 20)
     end
-    assert_equal(1, @ilist.length)
-    assert_equal(0, @ilist.scene)
+    expect(@ilist.length).to eq(1)
+    expect(@ilist.scene).to eq(0)
     @ilist.new_image(20, 20, Magick::HatchFill.new('black'))
-    assert_equal(2, @ilist.length)
-    assert_equal(1, @ilist.scene)
+    expect(@ilist.length).to eq(2)
+    expect(@ilist.scene).to eq(1)
     @ilist.new_image(20, 20) { self.background_color = 'red' }
-    assert_equal(3, @ilist.length)
-    assert_equal(2, @ilist.scene)
+    expect(@ilist.length).to eq(3)
+    expect(@ilist.scene).to eq(2)
   end
 
   def test_optimize_layers
@@ -267,14 +267,14 @@ class ImageList2UT < Minitest::Test
 
   def test_ping
     assert_nothing_raised { @ilist.ping(FLOWER_HAT) }
-    assert_equal(1, @ilist.length)
-    assert_equal(0, @ilist.scene)
+    expect(@ilist.length).to eq(1)
+    expect(@ilist.scene).to eq(0)
     assert_nothing_raised { @ilist.ping(FLOWER_HAT, FLOWER_HAT) }
-    assert_equal(3, @ilist.length)
-    assert_equal(2, @ilist.scene)
+    expect(@ilist.length).to eq(3)
+    expect(@ilist.scene).to eq(2)
     assert_nothing_raised { @ilist.ping(FLOWER_HAT) { self.background_color = 'red ' } }
-    assert_equal(4, @ilist.length)
-    assert_equal(3, @ilist.scene)
+    expect(@ilist.length).to eq(4)
+    expect(@ilist.scene).to eq(3)
   end
 
   def test_quantize
@@ -282,7 +282,7 @@ class ImageList2UT < Minitest::Test
     assert_nothing_raised do
       res = @ilist.quantize
       assert_instance_of(Magick::ImageList, res)
-      assert_equal(1, res.scene)
+      expect(res.scene).to eq(1)
     end
     assert_nothing_raised { @ilist.quantize(128) }
     assert_raise(TypeError) { @ilist.quantize('x') }
@@ -303,14 +303,14 @@ class ImageList2UT < Minitest::Test
 
   def test_read
     assert_nothing_raised { @ilist.read(FLOWER_HAT) }
-    assert_equal(1, @ilist.length)
-    assert_equal(0, @ilist.scene)
+    expect(@ilist.length).to eq(1)
+    expect(@ilist.scene).to eq(0)
     assert_nothing_raised { @ilist.read(FLOWER_HAT, FLOWER_HAT) }
-    assert_equal(3, @ilist.length)
-    assert_equal(2, @ilist.scene)
+    expect(@ilist.length).to eq(3)
+    expect(@ilist.scene).to eq(2)
     assert_nothing_raised { @ilist.read(FLOWER_HAT) { self.background_color = 'red ' } }
-    assert_equal(4, @ilist.length)
-    assert_equal(3, @ilist.scene)
+    expect(@ilist.length).to eq(4)
+    expect(@ilist.scene).to eq(3)
   end
 
   def test_remap
@@ -333,8 +333,8 @@ class ImageList2UT < Minitest::Test
     blob = nil
     assert_nothing_raised { blob = @ilist.to_blob }
     img = @ilist.from_blob(blob)
-    assert_equal(@ilist[0], img[0])
-    assert_equal(1, img.scene)
+    expect(img[0]).to eq(@ilist[0])
+    expect(img.scene).to eq(1)
   end
 
   def test_write
@@ -343,24 +343,24 @@ class ImageList2UT < Minitest::Test
       @ilist.write('temp.gif')
     end
     list = Magick::ImageList.new('temp.gif')
-    assert_equal('GIF', list.format)
+    expect(list.format).to eq('GIF')
     FileUtils.rm('temp.gif')
 
     @ilist.write('jpg:temp.foo')
     list = Magick::ImageList.new('temp.foo')
-    assert_equal('JPEG', list.format)
+    expect(list.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
     @ilist.write('temp.0') { self.format = 'JPEG' }
     list = Magick::ImageList.new('temp.0')
-    assert_equal('JPEG', list.format)
+    expect(list.format).to eq('JPEG')
     FileUtils.rm('temp.0')
 
     f = File.new('test.0', 'w')
     @ilist.write(f) { self.format = 'JPEG' }
     f.close
     list = Magick::ImageList.new('test.0')
-    assert_equal('JPEG', list.format)
+    expect(list.format).to eq('JPEG')
     FileUtils.rm('test.0')
   end
 end

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -22,47 +22,47 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_background_color
     assert_nothing_raised { @img.background_color }
-    assert_equal('white', @img.background_color)
+    expect(@img.background_color).to eq('white')
     assert_nothing_raised { @img.background_color = '#dfdfdf' }
-    # assert_equal("rgb(223,223,223)", @img.background_color)
+    # expect(@img.background_color).to eq("rgb(223,223,223)")
     background_color = @img.background_color
     if background_color.length == 13
-      assert_equal('#DFDFDFDFDFDF', background_color)
+      expect(background_color).to eq('#DFDFDFDFDFDF')
     else
-      assert_equal('#DFDFDFDFDFDFFFFF', background_color)
+      expect(background_color).to eq('#DFDFDFDFDFDFFFFF')
     end
     assert_nothing_raised { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }
-    # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.background_color)
+    # expect(@img.background_color).to eq("rgb(100%,49.9992%,49.9992%)")
     background_color = @img.background_color
     if background_color.length == 13
-      assert_equal('#FFFF7FFF7FFF', background_color)
+      expect(background_color).to eq('#FFFF7FFF7FFF')
     else
-      assert_equal('#FFFF7FFF7FFFFFFF', background_color)
+      expect(background_color).to eq('#FFFF7FFF7FFFFFFF')
     end
     assert_raise(TypeError) { @img.background_color = 2 }
   end
 
   def test_base_columns
     assert_nothing_raised { @img.base_columns }
-    assert_equal(0, @img.base_columns)
+    expect(@img.base_columns).to eq(0)
     assert_raise(NoMethodError) { @img.base_columns = 1 }
   end
 
   def test_base_filename
     assert_nothing_raised { @img.base_filename }
-    assert_equal('', @img.base_filename)
+    expect(@img.base_filename).to eq('')
     assert_raise(NoMethodError) { @img.base_filename = 'xxx' }
   end
 
   def test_base_rows
     assert_nothing_raised { @img.base_rows }
-    assert_equal(0, @img.base_rows)
+    expect(@img.base_rows).to eq(0)
     assert_raise(NoMethodError) { @img.base_rows = 1 }
   end
 
   def test_bias
     assert_nothing_raised { @img.bias }
-    assert_equal(0.0, @img.bias)
+    expect(@img.bias).to eq(0.0)
     assert_instance_of(Float, @img.bias)
 
     assert_nothing_raised { @img.bias = 0.1 }
@@ -79,27 +79,27 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.black_point_compensation = true }
     assert(@img.black_point_compensation)
     assert_nothing_raised { @img.black_point_compensation = false }
-    assert_equal(false, @img.black_point_compensation)
+    expect(@img.black_point_compensation).to eq(false)
   end
 
   def test_border_color
     assert_nothing_raised { @img.border_color }
-    # assert_equal("rgb(223,223,223)", @img.border_color)
+    # expect(@img.border_color).to eq("rgb(223,223,223)")
     border_color = @img.border_color
     if border_color.length == 13
-      assert_equal('#DFDFDFDFDFDF', border_color)
+      expect(border_color).to eq('#DFDFDFDFDFDF')
     else
-      assert_equal('#DFDFDFDFDFDFFFFF', border_color)
+      expect(border_color).to eq('#DFDFDFDFDFDFFFFF')
     end
     assert_nothing_raised { @img.border_color = 'red' }
-    assert_equal('red', @img.border_color)
+    expect(@img.border_color).to eq('red')
     assert_nothing_raised { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }
-    # assert_equal("rgb(100%,49.9992%,49.9992%)", @img.border_color)
+    # expect(@img.border_color).to eq("rgb(100%,49.9992%,49.9992%)")
     border_color = @img.border_color
     if border_color.length == 13
-      assert_equal('#FFFF7FFF7FFF', border_color)
+      expect(border_color).to eq('#FFFF7FFF7FFF')
     else
-      assert_equal('#FFFF7FFF7FFFFFFF', border_color)
+      expect(border_color).to eq('#FFFF7FFF7FFFFFFF')
     end
     assert_raise(TypeError) { @img.border_color = 2 }
   end
@@ -107,10 +107,10 @@ class Image_Attributes_UT < Minitest::Test
   def test_bounding_box
     assert_nothing_raised { @img.bounding_box }
     box = @img.bounding_box
-    assert_equal(87, box.width)
-    assert_equal(87, box.height)
-    assert_equal(7, box.x)
-    assert_equal(7, box.y)
+    expect(box.width).to eq(87)
+    expect(box.height).to eq(87)
+    expect(box.x).to eq(7)
+    expect(box.y).to eq(7)
     assert_raise(NoMethodError) { @img.bounding_box = 2 }
   end
 
@@ -118,18 +118,18 @@ class Image_Attributes_UT < Minitest::Test
     chrom = @img.chromaticity
     assert_nothing_raised { @img.chromaticity }
     assert_instance_of(Magick::Chromaticity, chrom)
-    assert_equal(0, chrom.red_primary.x)
-    assert_equal(0, chrom.red_primary.y)
-    assert_equal(0, chrom.red_primary.z)
-    assert_equal(0, chrom.green_primary.x)
-    assert_equal(0, chrom.green_primary.y)
-    assert_equal(0, chrom.green_primary.z)
-    assert_equal(0, chrom.blue_primary.x)
-    assert_equal(0, chrom.blue_primary.y)
-    assert_equal(0, chrom.blue_primary.z)
-    assert_equal(0, chrom.white_point.x)
-    assert_equal(0, chrom.white_point.y)
-    assert_equal(0, chrom.white_point.z)
+    expect(chrom.red_primary.x).to eq(0)
+    expect(chrom.red_primary.y).to eq(0)
+    expect(chrom.red_primary.z).to eq(0)
+    expect(chrom.green_primary.x).to eq(0)
+    expect(chrom.green_primary.y).to eq(0)
+    expect(chrom.green_primary.z).to eq(0)
+    expect(chrom.blue_primary.x).to eq(0)
+    expect(chrom.blue_primary.y).to eq(0)
+    expect(chrom.blue_primary.z).to eq(0)
+    expect(chrom.white_point.x).to eq(0)
+    expect(chrom.white_point.y).to eq(0)
+    expect(chrom.white_point.z).to eq(0)
     assert_nothing_raised { @img.chromaticity = chrom }
     assert_raise(TypeError) { @img.chromaticity = 2 }
   end
@@ -137,15 +137,15 @@ class Image_Attributes_UT < Minitest::Test
   def test_class_type
     assert_nothing_raised { @img.class_type }
     assert_instance_of(Magick::ClassType, @img.class_type)
-    assert_equal(Magick::DirectClass, @img.class_type)
+    expect(@img.class_type).to eq(Magick::DirectClass)
     assert_nothing_raised { @img.class_type = Magick::PseudoClass }
-    assert_equal(Magick::PseudoClass, @img.class_type)
+    expect(@img.class_type).to eq(Magick::PseudoClass)
     assert_raise(TypeError) { @img.class_type = 2 }
 
     assert_nothing_raised do
       @img.class_type = Magick::PseudoClass
       @img.class_type = Magick::DirectClass
-      assert_equal(Magick::DirectClass, @img.class_type)
+      expect(@img.class_type).to eq(Magick::DirectClass)
     end
   end
 
@@ -153,13 +153,13 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.color_profile }
     assert_nil(@img.color_profile)
     assert_nothing_raised { @img.color_profile = @p }
-    assert_equal(@p, @img.color_profile)
+    expect(@img.color_profile).to eq(@p)
     assert_raise(TypeError) { @img.color_profile = 2 }
   end
 
   def test_colors
     assert_nothing_raised { @img.colors }
-    assert_equal(0, @img.colors)
+    expect(@img.colors).to eq(0)
     img = @img.copy
     img.class_type = Magick::PseudoClass
     assert_kind_of(Integer, img.colors)
@@ -169,7 +169,7 @@ class Image_Attributes_UT < Minitest::Test
   def test_colorspace
     assert_nothing_raised { @img.colorspace }
     assert_instance_of(Magick::ColorspaceType, @img.colorspace)
-    assert_equal(Magick::SRGBColorspace, @img.colorspace)
+    expect(@img.colorspace).to eq(Magick::SRGBColorspace)
     img = @img.copy
 
     Magick::ColorspaceType.values do |colorspace|
@@ -183,17 +183,17 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_columns
     assert_nothing_raised { @img.columns }
-    assert_equal(100, @img.columns)
+    expect(@img.columns).to eq(100)
     assert_raise(NoMethodError) { @img.columns = 2 }
   end
 
   def test_compose
     assert_nothing_raised { @img.compose }
     assert_instance_of(Magick::CompositeOperator, @img.compose)
-    assert_equal(Magick::OverCompositeOp, @img.compose)
+    expect(@img.compose).to eq(Magick::OverCompositeOp)
     assert_raise(TypeError) { @img.compose = 2 }
     assert_nothing_raised { @img.compose = Magick::UndefinedCompositeOp }
-    assert_equal(Magick::UndefinedCompositeOp, @img.compose)
+    expect(@img.compose).to eq(Magick::UndefinedCompositeOp)
 
     Magick::CompositeOperator.values do |composite|
       assert_nothing_raised { @img.compose = composite }
@@ -204,9 +204,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_compression
     assert_nothing_raised { @img.compression }
     assert_instance_of(Magick::CompressionType, @img.compression)
-    assert_equal(Magick::UndefinedCompression, @img.compression)
+    expect(@img.compression).to eq(Magick::UndefinedCompression)
     assert_nothing_raised { @img.compression = Magick::BZipCompression }
-    assert_equal(Magick::BZipCompression, @img.compression)
+    expect(@img.compression).to eq(Magick::BZipCompression)
 
     Magick::CompressionType.values do |compression|
       assert_nothing_raised { @img.compression = compression }
@@ -216,9 +216,9 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_delay
     assert_nothing_raised { @img.delay }
-    assert_equal(0, @img.delay)
+    expect(@img.delay).to eq(0)
     assert_nothing_raised { @img.delay = 10 }
-    assert_equal(10, @img.delay)
+    expect(@img.delay).to eq(10)
     assert_raise(TypeError) { @img.delay = 'x' }
   end
 
@@ -232,7 +232,7 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_depth
-    assert_equal(Magick::MAGICKCORE_QUANTUM_DEPTH, @img.depth)
+    expect(@img.depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
     assert_raise(NoMethodError) { @img.depth = 2 }
   end
 
@@ -245,9 +245,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_dispose
     assert_nothing_raised { @img.dispose }
     assert_instance_of(Magick::DisposeType, @img.dispose)
-    assert_equal(Magick::UndefinedDispose, @img.dispose)
+    expect(@img.dispose).to eq(Magick::UndefinedDispose)
     assert_nothing_raised { @img.dispose = Magick::NoneDispose }
-    assert_equal(Magick::NoneDispose, @img.dispose)
+    expect(@img.dispose).to eq(Magick::NoneDispose)
 
     Magick::DisposeType.values do |dispose|
       assert_nothing_raised { @img.dispose = dispose }
@@ -258,9 +258,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_endian
     assert_nothing_raised { @img.endian }
     assert_instance_of(Magick::EndianType, @img.endian)
-    assert_equal(Magick::UndefinedEndian, @img.endian)
+    expect(@img.endian).to eq(Magick::UndefinedEndian)
     assert_nothing_raised { @img.endian = Magick::LSBEndian }
-    assert_equal(Magick::LSBEndian, @img.endian)
+    expect(@img.endian).to eq(Magick::LSBEndian)
     assert_nothing_raised { @img.endian = Magick::MSBEndian }
     assert_raise(TypeError) { @img.endian = 2 }
   end
@@ -269,31 +269,31 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.extract_info }
     assert_instance_of(Magick::Rectangle, @img.extract_info)
     ext = @img.extract_info
-    assert_equal(0, ext.x)
-    assert_equal(0, ext.y)
-    assert_equal(0, ext.width)
-    assert_equal(0, ext.height)
+    expect(ext.x).to eq(0)
+    expect(ext.y).to eq(0)
+    expect(ext.width).to eq(0)
+    expect(ext.height).to eq(0)
     ext = Magick::Rectangle.new(1, 2, 3, 4)
     assert_nothing_raised { @img.extract_info = ext }
-    assert_equal(1, ext.width)
-    assert_equal(2, ext.height)
-    assert_equal(3, ext.x)
-    assert_equal(4, ext.y)
+    expect(ext.width).to eq(1)
+    expect(ext.height).to eq(2)
+    expect(ext.x).to eq(3)
+    expect(ext.y).to eq(4)
     assert_raise(TypeError) { @img.extract_info = 2 }
   end
 
   def test_filename
     assert_nothing_raised { @img.filename }
-    assert_equal('', @img.filename)
+    expect(@img.filename).to eq('')
     assert_raises(NoMethodError) { @img.filename = 'xxx' }
   end
 
   def test_filter
     assert_nothing_raised { @img.filter }
     assert_instance_of(Magick::FilterType, @img.filter)
-    assert_equal(Magick::UndefinedFilter, @img.filter)
+    expect(@img.filter).to eq(Magick::UndefinedFilter)
     assert_nothing_raised { @img.filter = Magick::PointFilter }
-    assert_equal(Magick::PointFilter, @img.filter)
+    expect(@img.filter).to eq(Magick::PointFilter)
 
     Magick::FilterType.values do |filter|
       assert_nothing_raised { @img.filter = filter }
@@ -319,9 +319,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_fuzz
     assert_nothing_raised { @img.fuzz }
     assert_instance_of(Float, @img.fuzz)
-    assert_equal(0.0, @img.fuzz)
+    expect(@img.fuzz).to eq(0.0)
     assert_nothing_raised { @img.fuzz = 50 }
-    assert_equal(50.0, @img.fuzz)
+    expect(@img.fuzz).to eq(50.0)
     assert_nothing_raised { @img.fuzz = '50%' }
     assert_in_delta(Magick::QuantumRange * 0.50, @img.fuzz, 0.1)
     assert_raise(TypeError) { @img.fuzz = [] }
@@ -331,9 +331,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_gamma
     assert_nothing_raised { @img.gamma }
     assert_instance_of(Float, @img.gamma)
-    assert_equal(0.45454543828964233, @img.gamma)
+    expect(@img.gamma).to eq(0.45454543828964233)
     assert_nothing_raised { @img.gamma = 2.0 }
-    assert_equal(2.0, @img.gamma)
+    expect(@img.gamma).to eq(2.0)
     assert_raise(TypeError) { @img.gamma = 'x' }
   end
 
@@ -342,9 +342,9 @@ class Image_Attributes_UT < Minitest::Test
     assert_nil(@img.geometry)
     assert_nothing_raised { @img.geometry = nil }
     assert_nothing_raised { @img.geometry = '90x90' }
-    assert_equal('90x90', @img.geometry)
+    expect(@img.geometry).to eq('90x90')
     assert_nothing_raised { @img.geometry = Magick::Geometry.new(100, 80) }
-    assert_equal('100x80', @img.geometry)
+    expect(@img.geometry).to eq('100x80')
     assert_raise(TypeError) { @img.geometry = [] }
   end
 
@@ -371,9 +371,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_interlace_type
     assert_nothing_raised { @img.interlace }
     assert_instance_of(Magick::InterlaceType, @img.interlace)
-    assert_equal(Magick::NoInterlace, @img.interlace)
+    expect(@img.interlace).to eq(Magick::NoInterlace)
     assert_nothing_raised { @img.interlace = Magick::LineInterlace }
-    assert_equal(Magick::LineInterlace, @img.interlace)
+    expect(@img.interlace).to eq(Magick::LineInterlace)
 
     Magick::InterlaceType.values do |interlace|
       assert_nothing_raised { @img.interlace = interlace }
@@ -385,7 +385,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.iptc_profile }
     assert_nil(@img.iptc_profile)
     assert_nothing_raised { @img.iptc_profile = 'xxx' }
-    assert_equal('xxx', @img.iptc_profile)
+    expect(@img.iptc_profile).to eq('xxx')
     assert_raise(TypeError) { @img.iptc_profile = 2 }
   end
 
@@ -393,9 +393,9 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @hat.mean_error_per_pixel }
     assert_nothing_raised { @hat.normalized_mean_error }
     assert_nothing_raised { @hat.normalized_maximum_error }
-    assert_equal(0.0, @hat.mean_error_per_pixel)
-    assert_equal(0.0, @hat.normalized_mean_error)
-    assert_equal(0.0, @hat.normalized_maximum_error)
+    expect(@hat.mean_error_per_pixel).to eq(0.0)
+    expect(@hat.normalized_mean_error).to eq(0.0)
+    expect(@hat.normalized_maximum_error).to eq(0.0)
 
     hat = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
 
@@ -411,9 +411,9 @@ class Image_Attributes_UT < Minitest::Test
     img = @img.copy
     img.format = 'GIF'
     assert_nothing_raised { img.mime_type }
-    assert_equal('image/gif', img.mime_type)
+    expect(img.mime_type).to eq('image/gif')
     img.format = 'JPG'
-    assert_equal('image/jpeg', img.mime_type)
+    expect(img.mime_type).to eq('image/jpeg')
     assert_raise(NoMethodError) { img.mime_type = 'image/jpeg' }
   end
 
@@ -437,18 +437,18 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_offset
     assert_nothing_raised { @img.offset }
-    assert_equal(0, @img.offset)
+    expect(@img.offset).to eq(0)
     assert_nothing_raised { @img.offset = 10 }
-    assert_equal(10, @img.offset)
+    expect(@img.offset).to eq(10)
     assert_raise(TypeError) { @img.offset = 'x' }
   end
 
   def test_orientation
     assert_nothing_raised { @img.orientation }
     assert_instance_of(Magick::OrientationType, @img.orientation)
-    assert_equal(Magick::UndefinedOrientation, @img.orientation)
+    expect(@img.orientation).to eq(Magick::UndefinedOrientation)
     assert_nothing_raised { @img.orientation = Magick::TopLeftOrientation }
-    assert_equal(Magick::TopLeftOrientation, @img.orientation)
+    expect(@img.orientation).to eq(Magick::TopLeftOrientation)
 
     Magick::OrientationType.values do |orientation|
       assert_nothing_raised { @img.orientation = orientation }
@@ -459,25 +459,25 @@ class Image_Attributes_UT < Minitest::Test
   def test_page
     assert_nothing_raised { @img.page }
     page = @img.page
-    assert_equal(0, page.width)
-    assert_equal(0, page.height)
-    assert_equal(0, page.x)
-    assert_equal(0, page.y)
+    expect(page.width).to eq(0)
+    expect(page.height).to eq(0)
+    expect(page.x).to eq(0)
+    expect(page.y).to eq(0)
     page = Magick::Rectangle.new(1, 2, 3, 4)
     assert_nothing_raised { @img.page = page }
-    assert_equal(1, page.width)
-    assert_equal(2, page.height)
-    assert_equal(3, page.x)
-    assert_equal(4, page.y)
+    expect(page.width).to eq(1)
+    expect(page.height).to eq(2)
+    expect(page.x).to eq(3)
+    expect(page.y).to eq(4)
     assert_raise(TypeError) { @img.page = 2 }
   end
 
   def test_pixel_interpolation_method
     assert_nothing_raised { @img.pixel_interpolation_method }
     assert_instance_of(Magick::PixelInterpolateMethod, @img.pixel_interpolation_method)
-    assert_equal(Magick::UndefinedInterpolatePixel, @img.pixel_interpolation_method)
+    expect(@img.pixel_interpolation_method).to eq(Magick::UndefinedInterpolatePixel)
     assert_nothing_raised { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }
-    assert_equal(Magick::AverageInterpolatePixel, @img.pixel_interpolation_method)
+    expect(@img.pixel_interpolation_method).to eq(Magick::AverageInterpolatePixel)
 
     Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
       assert_nothing_raised { @img.pixel_interpolation_method = interpolate_pixel_method }
@@ -487,20 +487,20 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_quality
     assert_nothing_raised { @hat.quality }
-    assert_equal(75, @hat.quality)
+    expect(@hat.quality).to eq(75)
     assert_raise(NoMethodError) { @img.quality = 80 }
   end
 
   def test_quantum_depth
     assert_nothing_raised { @img.quantum_depth }
-    assert_equal(Magick::MAGICKCORE_QUANTUM_DEPTH, @img.quantum_depth)
+    expect(@img.quantum_depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
     assert_raise(NoMethodError) { @img.quantum_depth = 8 }
   end
 
   def test_rendering_intent
     assert_nothing_raised { @img.rendering_intent }
     assert_instance_of(Magick::RenderingIntent, @img.rendering_intent)
-    assert_equal(Magick::PerceptualIntent, @img.rendering_intent)
+    expect(@img.rendering_intent).to eq(Magick::PerceptualIntent)
 
     Magick::RenderingIntent.values do |rendering_intent|
       assert_nothing_raised { @img.rendering_intent = rendering_intent }
@@ -510,7 +510,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_rows
     assert_nothing_raised { @img.rows }
-    assert_equal(100, @img.rows)
+    expect(@img.rows).to eq(100)
     assert_raise(NoMethodError) { @img.rows = 2 }
   end
 
@@ -523,8 +523,8 @@ class Image_Attributes_UT < Minitest::Test
     FileUtils.rm('temp.gif')
 
     assert_nothing_raised { img.scene }
-    assert_equal(0, @img.scene)
-    assert_equal(1, img.scene)
+    expect(@img.scene).to eq(0)
+    expect(img.scene).to eq(1)
     assert_raise(NoMethodError) { img.scene = 2 }
   end
 
@@ -537,9 +537,9 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_ticks_per_second
     assert_nothing_raised { @img.ticks_per_second }
-    assert_equal(100, @img.ticks_per_second)
+    expect(@img.ticks_per_second).to eq(100)
     assert_nothing_raised { @img.ticks_per_second = 1000 }
-    assert_equal(1000, @img.ticks_per_second)
+    expect(@img.ticks_per_second).to eq(1000)
     assert_raise(TypeError) { @img.ticks_per_second = 'x' }
   end
 
@@ -552,9 +552,9 @@ class Image_Attributes_UT < Minitest::Test
   def test_units
     assert_nothing_raised { @img.units }
     assert_instance_of(Magick::ResolutionType, @img.units)
-    assert_equal(Magick::UndefinedResolution, @img.units)
+    expect(@img.units).to eq(Magick::UndefinedResolution)
     assert_nothing_raised { @img.units = Magick::PixelsPerInchResolution }
-    assert_equal(Magick::PixelsPerInchResolution, @img.units)
+    expect(@img.units).to eq(Magick::PixelsPerInchResolution)
 
     Magick::ResolutionType.values do |resolution|
       assert_nothing_raised { @img.units = resolution }
@@ -564,9 +564,9 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_virtual_pixel_method
     assert_nothing_raised { @img.virtual_pixel_method }
-    assert_equal(Magick::UndefinedVirtualPixelMethod, @img.virtual_pixel_method)
+    expect(@img.virtual_pixel_method).to eq(Magick::UndefinedVirtualPixelMethod)
     assert_nothing_raised { @img.virtual_pixel_method = Magick::EdgeVirtualPixelMethod }
-    assert_equal(Magick::EdgeVirtualPixelMethod, @img.virtual_pixel_method)
+    expect(@img.virtual_pixel_method).to eq(Magick::EdgeVirtualPixelMethod)
 
     Magick::VirtualPixelMethod.values do |virtual_pixel_method|
       assert_nothing_raised { @img.virtual_pixel_method = virtual_pixel_method }
@@ -577,14 +577,14 @@ class Image_Attributes_UT < Minitest::Test
   def test_x_resolution
     assert_nothing_raised { @img.x_resolution }
     assert_nothing_raised { @img.x_resolution = 90 }
-    assert_equal(90.0, @img.x_resolution)
+    expect(@img.x_resolution).to eq(90.0)
     assert_raise(TypeError) { @img.x_resolution = 'x' }
   end
 
   def test_y_resolution
     assert_nothing_raised { @img.y_resolution }
     assert_nothing_raised { @img.y_resolution = 90 }
-    assert_equal(90.0, @img.y_resolution)
+    expect(@img.y_resolution).to eq(90.0)
     assert_raise(TypeError) { @img.y_resolution = 'x' }
   end
 

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -12,18 +12,18 @@ class InfoUT < Minitest::Test
     assert_nil(@info['fill'])
 
     assert_nothing_raised { @info['fill'] = 'red' }
-    assert_equal('red', @info['fill'])
+    expect(@info['fill']).to eq('red')
 
     assert_nothing_raised { @info['fill'] = nil }
     assert_nil(@info['fill'])
 
     # 2-argument form
     assert_nothing_raised { @info['tiff', 'bits-per-sample'] = 2 }
-    assert_equal('2', @info['tiff', 'bits-per-sample'])
+    expect(@info['tiff', 'bits-per-sample']).to eq('2')
 
     # define and undefine
     assert_nothing_raised { @info.define('tiff', 'bits-per-sample', 4) }
-    assert_equal('4', @info['tiff', 'bits-per-sample'])
+    expect(@info['tiff', 'bits-per-sample']).to eq('4')
 
     assert_nothing_raised { @info.undefine('tiff', 'bits-per-sample') }
     assert_nil(@info['tiff', 'bits-per-sample'])
@@ -38,9 +38,9 @@ class InfoUT < Minitest::Test
 
   def test_aref_aset
     assert_nothing_raised { @info['tiff'] = 'xxx' }
-    assert_equal('xxx', @info['tiff'])
+    expect(@info['tiff']).to eq('xxx')
     assert_nothing_raised { @info['tiff', 'bits-per-sample'] = 'abc' }
-    assert_equal('abc', @info['tiff', 'bits-per-sample'])
+    expect(@info['tiff', 'bits-per-sample']).to eq('abc')
     assert_raise(ArgumentError) { @info['tiff', 'a', 'b'] }
     assert_raise(ArgumentError) { @info['tiff', 'a' * 10_000] }
     assert_raise(ArgumentError) { @info['tiff', 'a' * 10_000] = 'abc' }
@@ -49,43 +49,43 @@ class InfoUT < Minitest::Test
 
   def test_attenuate
     assert_nothing_raised { @info.attenuate = 10 }
-    assert_equal(10, @info.attenuate)
+    expect(@info.attenuate).to eq(10)
     assert_nothing_raised { @info.attenuate = 5.25 }
-    assert_equal(5.25, @info.attenuate)
+    expect(@info.attenuate).to eq(5.25)
     assert_nothing_raised { @info.attenuate = nil }
     assert_nil(@info.attenuate)
   end
 
   def test_authenticate
     assert_nothing_raised { @info.authenticate = 'string' }
-    assert_equal('string', @info.authenticate)
+    expect(@info.authenticate).to eq('string')
     assert_nothing_raised { @info.authenticate = nil }
     assert_nil(@info.authenticate)
     assert_nothing_raised { @info.authenticate = '' }
-    assert_equal('', @info.authenticate)
+    expect(@info.authenticate).to eq('')
   end
 
   def test_background_color
     assert_nothing_raised { @info.background_color = 'red' }
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @info.background_color = red }
-    assert_equal('red', @info.background_color)
+    expect(@info.background_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    assert_equal('red', img.background_color)
+    expect(img.background_color).to eq('red')
   end
 
   def test_border_color
     assert_nothing_raised { @info.border_color = 'red' }
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @info.border_color = red }
-    assert_equal('red', @info.border_color)
+    expect(@info.border_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.border_color = 'red' }
-    assert_equal('red', img.border_color)
+    expect(img.border_color).to eq('red')
   end
 
   def test_caption
     assert_nothing_raised { @info.caption = 'string' }
-    assert_equal('string', @info.caption)
+    expect(@info.caption).to eq('string')
     assert_nothing_raised { @info.caption = nil }
     assert_nil(@info.caption)
     assert_nothing_raised { Magick::Image.new(20, 20) { self.caption = 'string' } }
@@ -101,19 +101,19 @@ class InfoUT < Minitest::Test
   def test_colorspace
     Magick::ColorspaceType.values.each do |cs|
       assert_nothing_raised { @info.colorspace = cs }
-      assert_equal(cs, @info.colorspace)
+      expect(@info.colorspace).to eq(cs)
     end
   end
 
   def test_comment
     assert_nothing_raised { @info.comment = 'comment' }
-    assert_equal('comment', @info.comment)
+    expect(@info.comment).to eq('comment')
   end
 
   def test_compression
     Magick::CompressionType.values.each do |v|
       assert_nothing_raised { @info.compression = v }
-      assert_equal(v, @info.compression)
+      expect(@info.compression).to eq(v)
     end
   end
 
@@ -126,9 +126,9 @@ class InfoUT < Minitest::Test
 
   def test_density
     assert_nothing_raised { @info.density = '72x72' }
-    assert_equal('72x72', @info.density)
+    expect(@info.density).to eq('72x72')
     assert_nothing_raised { @info.density = Magick::Geometry.new(72, 72) }
-    assert_equal('72x72', @info.density)
+    expect(@info.density).to eq('72x72')
     assert_nothing_raised { @info.density = nil }
     assert_nil(@info.density)
     assert_raise(ArgumentError) { @info.density = 'aaa' }
@@ -136,7 +136,7 @@ class InfoUT < Minitest::Test
 
   def test_delay
     assert_nothing_raised { @info.delay = 60 }
-    assert_equal(60, @info.delay)
+    expect(@info.delay).to eq(60)
     assert_nothing_raised { @info.delay = nil }
     assert_nil(@info.delay)
     assert_raise(TypeError) { @info.delay = '60' }
@@ -144,38 +144,38 @@ class InfoUT < Minitest::Test
 
   def test_depth
     assert_nothing_raised { @info.depth = 8 }
-    assert_equal(8, @info.depth)
+    expect(@info.depth).to eq(8)
     assert_nothing_raised { @info.depth = 16 }
-    assert_equal(16, @info.depth)
+    expect(@info.depth).to eq(16)
     assert_raise(ArgumentError) { @info.depth = 32 }
   end
 
   def test_dispose
     Magick::DisposeType.values.each do |v|
       assert_nothing_raised { @info.dispose = v }
-      assert_equal(v, @info.dispose)
+      expect(@info.dispose).to eq(v)
     end
     assert_nothing_raised { @info.dispose = nil }
   end
 
   def test_dither
     assert_nothing_raised { @info.dither = true }
-    assert_equal(true, @info.dither)
+    expect(@info.dither).to eq(true)
     assert_nothing_raised { @info.dither = false }
-    assert_equal(false, @info.dither)
+    expect(@info.dither).to eq(false)
   end
 
   def test_endian
     assert_nothing_raised { @info.endian = Magick::LSBEndian }
-    assert_equal(Magick::LSBEndian, @info.endian)
+    expect(@info.endian).to eq(Magick::LSBEndian)
     assert_nothing_raised { @info.endian = nil }
   end
 
   def test_extract
     assert_nothing_raised { @info.extract = '100x100' }
-    assert_equal('100x100', @info.extract)
+    expect(@info.extract).to eq('100x100')
     assert_nothing_raised { @info.extract = Magick::Geometry.new(100, 100) }
-    assert_equal('100x100', @info.extract)
+    expect(@info.extract).to eq('100x100')
     assert_nothing_raised { @info.extract = nil }
     assert_nil(@info.extract)
     assert_raise(ArgumentError) { @info.extract = 'aaa' }
@@ -183,9 +183,9 @@ class InfoUT < Minitest::Test
 
   def test_filename
     assert_nothing_raised { @info.filename = 'string' }
-    assert_equal('string', @info.filename)
+    expect(@info.filename).to eq('string')
     assert_nothing_raised { @info.filename = nil }
-    assert_equal('', @info.filename)
+    expect(@info.filename).to eq('')
   end
 
   def test_fill
@@ -193,7 +193,7 @@ class InfoUT < Minitest::Test
     assert_nil(@info.fill)
 
     assert_nothing_raised { @info.fill = 'white' }
-    assert_equal('white', @info.fill)
+    expect(@info.fill).to eq('white')
 
     assert_nothing_raised { @info.fill = nil }
     assert_nil(@info.fill)
@@ -203,22 +203,22 @@ class InfoUT < Minitest::Test
 
   def test_font
     assert_nothing_raised { @info.font = 'Arial' }
-    assert_equal('Arial', @info.font)
+    expect(@info.font).to eq('Arial')
     assert_nothing_raised { @info.font = nil }
     assert_nil(@info.font)
   end
 
   def test_format
     assert_nothing_raised { @info.format = 'GIF' }
-    assert_equal('GIF', @info.format)
+    expect(@info.format).to eq('GIF')
     assert_raise(TypeError) { @info.format = nil }
   end
 
   def test_fuzz
     assert_nothing_raised { @info.fuzz = 50 }
-    assert_equal(50, @info.fuzz)
+    expect(@info.fuzz).to eq(50)
     assert_nothing_raised { @info.fuzz = '50%' }
-    assert_equal(Magick::QuantumRange * 0.5, @info.fuzz)
+    expect(@info.fuzz).to eq(Magick::QuantumRange * 0.5)
     assert_raise(TypeError) { @info.fuzz = nil }
     assert_raise(ArgumentError) { @info.fuzz = 'xxx' }
   end
@@ -226,7 +226,7 @@ class InfoUT < Minitest::Test
   def test_gravity
     Magick::GravityType.values.each do |v|
       assert_nothing_raised { @info.gravity = v }
-      assert_equal(v, @info.gravity)
+      expect(@info.gravity).to eq(v)
     end
     assert_nothing_raised { @info.gravity = nil }
   end
@@ -234,7 +234,7 @@ class InfoUT < Minitest::Test
   def test_image_type
     Magick::ImageType.values.each do |v|
       assert_nothing_raised { @info.image_type = v }
-      assert_equal(v, @info.image_type)
+      expect(@info.image_type).to eq(v)
     end
     assert_raise(TypeError) { @info.image_type = nil }
   end
@@ -242,14 +242,14 @@ class InfoUT < Minitest::Test
   def test_interlace
     Magick::InterlaceType.values.each do |v|
       assert_nothing_raised { @info.interlace = v }
-      assert_equal(v, @info.interlace)
+      expect(@info.interlace).to eq(v)
     end
     assert_raise(TypeError) { @info.interlace = nil }
   end
 
   def test_label
     assert_nothing_raised { @info.label = 'string' }
-    assert_equal('string', @info.label)
+    expect(@info.label).to eq('string')
     assert_nothing_raised { @info.label = nil }
     assert_nil(@info.label)
   end
@@ -258,16 +258,16 @@ class InfoUT < Minitest::Test
     assert_nothing_raised { @info.matte_color = 'red' }
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @info.matte_color = red }
-    assert_equal('red', @info.matte_color)
+    expect(@info.matte_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.matte_color = 'red' }
-    assert_equal('red', img.matte_color)
+    expect(img.matte_color).to eq('red')
     assert_raise(TypeError) { @info.matte_color = nil }
   end
 
   def test_monitor
     assert_nothing_raised { @info.monitor = -> {} }
     monitor = proc do |mth, q, s|
-      assert_equal('resize!', mth)
+      expect(mth).to eq('resize!')
       assert_kind_of(Integer, q)
       assert_kind_of(Integer, s)
       GC.start
@@ -289,7 +289,7 @@ class InfoUT < Minitest::Test
   def test_number_scenes
     assert_kind_of(Integer, @info.number_scenes)
     assert_nothing_raised { @info.number_scenes = 50 }
-    assert_equal(50, @info.number_scenes)
+    expect(@info.number_scenes).to eq(50)
     assert_raise(TypeError) { @info.number_scenes = nil }
     assert_raise(TypeError) { @info.number_scenes = 'xxx' }
   end
@@ -297,16 +297,16 @@ class InfoUT < Minitest::Test
   def test_orientation
     Magick::OrientationType.values.each do |v|
       assert_nothing_raised { @info.orientation = v }
-      assert_equal(v, @info.orientation)
+      expect(@info.orientation).to eq(v)
     end
     assert_raise(TypeError) { @info.orientation = nil }
   end
 
   def test_origin
     assert_nothing_raised { @info.origin = '+10+10' }
-    assert_equal('+10+10', @info.origin)
+    expect(@info.origin).to eq('+10+10')
     assert_nothing_raised { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }
-    assert_equal('+10+10', @info.origin)
+    expect(@info.origin).to eq('+10+10')
     assert_nothing_raised { @info.origin = nil }
     assert_nil(@info.origin)
     assert_raise(ArgumentError) { @info.origin = 'aaa' }
@@ -314,46 +314,46 @@ class InfoUT < Minitest::Test
 
   def test_page
     assert_nothing_raised { @info.page = '612x792>' }
-    assert_equal('612x792>', @info.page)
+    expect(@info.page).to eq('612x792>')
     assert_nothing_raised { @info.page = nil }
     assert_nil(@info.page)
   end
 
   def test_pointsize
     assert_nothing_raised { @info.pointsize = 12 }
-    assert_equal(12, @info.pointsize)
+    expect(@info.pointsize).to eq(12)
   end
 
   def test_quality
     assert_nothing_raised { @info.quality = 75 }
-    assert_equal(75, @info.quality)
+    expect(@info.quality).to eq(75)
   end
 
   def test_sampling_factor
     assert_nothing_raised { @info.sampling_factor = '2x1' }
-    assert_equal('2x1', @info.sampling_factor)
+    expect(@info.sampling_factor).to eq('2x1')
     assert_nothing_raised { @info.sampling_factor = nil }
     assert_nil(@info.sampling_factor)
   end
 
   def test_scene
     assert_nothing_raised { @info.scene = 123 }
-    assert_equal(123, @info.scene)
+    expect(@info.scene).to eq(123)
     assert_raise(TypeError) { @info.scene = 'xxx' }
   end
 
   def test_server_name
     assert_nothing_raised { @info.server_name = 'foo' }
-    assert_equal('foo', @info.server_name)
+    expect(@info.server_name).to eq('foo')
     assert_nothing_raised { @info.server_name = nil }
     assert_nil(@info.server_name)
   end
 
   def test_size
     assert_nothing_raised { @info.size = '200x100' }
-    assert_equal('200x100', @info.size)
+    expect(@info.size).to eq('200x100')
     assert_nothing_raised { @info.size = Magick::Geometry.new(100, 200) }
-    assert_equal('100x200', @info.size)
+    expect(@info.size).to eq('100x200')
     assert_nothing_raised { @info.size = nil }
     assert_nil(@info.size)
     assert_raise(ArgumentError) { @info.size = 'aaa' }
@@ -364,7 +364,7 @@ class InfoUT < Minitest::Test
     assert_nil(@info.stroke)
 
     assert_nothing_raised { @info.stroke = 'white' }
-    assert_equal('white', @info.stroke)
+    expect(@info.stroke).to eq('white')
 
     assert_nothing_raised { @info.stroke = nil }
     assert_nil(@info.stroke)
@@ -374,9 +374,9 @@ class InfoUT < Minitest::Test
 
   def test_stroke_width
     assert_nothing_raised { @info.stroke_width = 10 }
-    assert_equal(10, @info.stroke_width)
+    expect(@info.stroke_width).to eq(10)
     assert_nothing_raised { @info.stroke_width = 5.25 }
-    assert_equal(5.25, @info.stroke_width)
+    expect(@info.stroke_width).to eq(5.25)
     assert_nothing_raised { @info.stroke_width = nil }
     assert_nil(@info.stroke_width)
     assert_raise(TypeError) { @info.stroke_width = 'xxx' }
@@ -390,15 +390,15 @@ class InfoUT < Minitest::Test
 
   def test_tile_offset
     assert_nothing_raised { @info.tile_offset = '200x100' }
-    assert_equal('200x100', @info.tile_offset)
+    expect(@info.tile_offset).to eq('200x100')
     assert_nothing_raised { @info.tile_offset = Magick::Geometry.new(100, 200) }
-    assert_equal('100x200', @info.tile_offset)
+    expect(@info.tile_offset).to eq('100x200')
     assert_raise(ArgumentError) { @info.tile_offset = nil }
   end
 
   def test_transparent_color
     assert_nothing_raised { @info.transparent_color = 'white' }
-    assert_equal('white', @info.transparent_color)
+    expect(@info.transparent_color).to eq('white')
     assert_raise(TypeError) { @info.transparent_color = nil }
   end
 
@@ -407,7 +407,7 @@ class InfoUT < Minitest::Test
     assert_nil(@info.undercolor)
 
     assert_nothing_raised { @info.undercolor = 'white' }
-    assert_equal('white', @info.undercolor)
+    expect(@info.undercolor).to eq('white')
 
     assert_nothing_raised { @info.undercolor = nil }
     assert_nil(@info.undercolor)
@@ -418,16 +418,16 @@ class InfoUT < Minitest::Test
   def test_units
     Magick::ResolutionType.values.each do |v|
       assert_nothing_raised { @info.units = v }
-      assert_equal(v, @info.units)
+      expect(@info.units).to eq(v)
     end
   end
 
   def test_view
     assert_nothing_raised { @info.view = 'string' }
-    assert_equal('string', @info.view)
+    expect(@info.view).to eq('string')
     assert_nothing_raised { @info.view = nil }
     assert_nil(@info.view)
     assert_nothing_raised { @info.view = '' }
-    assert_equal('', @info.view)
+    expect(@info.view).to eq('')
   end
 end

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -52,13 +52,13 @@ class MagickUT < Minitest::Test
       ary = Magick::AlignType.enumerators
     end
     assert_instance_of(Array, ary)
-    assert_equal(4, ary.length)
+    expect(ary.length).to eq(4)
 
     assert_nothing_raised do
       ary = Magick::AnchorType.enumerators
     end
     assert_instance_of(Array, ary)
-    assert_equal(3, ary.length)
+    expect(ary.length).to eq(3)
   end
 
   def test_features
@@ -92,147 +92,147 @@ class MagickUT < Minitest::Test
     g2 = nil
     assert_nothing_raised { g = Magick::Geometry.new }
     assert_nothing_raised { gs = g.to_s }
-    assert_equal('', gs)
+    expect(gs).to eq('')
 
     g = Magick::Geometry.new(40)
     gs = g.to_s
-    assert_equal('40x', gs)
+    expect(gs).to eq('40x')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50)
     gs = g.to_s
-    assert_equal('40x50', gs)
+    expect(gs).to eq('40x50')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 10)
     gs = g.to_s
-    assert_equal('40x50+10+0', gs)
+    expect(gs).to eq('40x50+10+0')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 10, -15)
     gs = g.to_s
-    assert_equal('40x50+10-15', gs)
+    expect(gs).to eq('40x50+10-15')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 0, 0, Magick::AreaGeometry)
     gs = g.to_s
-    assert_equal('40x50@', gs)
+    expect(gs).to eq('40x50@')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 0, 0, Magick::AspectGeometry)
     gs = g.to_s
-    assert_equal('40x50!', gs)
+    expect(gs).to eq('40x50!')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 0, 0, Magick::LessGeometry)
     gs = g.to_s
-    assert_equal('40x50<', gs)
+    expect(gs).to eq('40x50<')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 0, 0, Magick::GreaterGeometry)
     gs = g.to_s
-    assert_equal('40x50>', gs)
+    expect(gs).to eq('40x50>')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 50, 0, 0, Magick::MinimumGeometry)
     gs = g.to_s
-    assert_equal('40x50^', gs)
+    expect(gs).to eq('40x50^')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 0, 0, 0, Magick::PercentGeometry)
     gs = g.to_s
-    assert_equal('40%', gs)
+    expect(gs).to eq('40%')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 60, 0, 0, Magick::PercentGeometry)
     gs = g.to_s
-    assert_equal('40%x60%', gs)
+    expect(gs).to eq('40%x60%')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 60, 10, 0, Magick::PercentGeometry)
     gs = g.to_s
-    assert_equal('40%x60%+10+0', gs)
+    expect(gs).to eq('40%x60%+10+0')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40, 60, 10, 20, Magick::PercentGeometry)
     gs = g.to_s
-    assert_equal('40%x60%+10+20', gs)
+    expect(gs).to eq('40%x60%+10+20')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40.5, 60.75)
     gs = g.to_s
-    assert_equal('40.50x60.75', gs)
+    expect(gs).to eq('40.50x60.75')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(40.5, 60.75, 0, 0, Magick::PercentGeometry)
     gs = g.to_s
-    assert_equal('40.50%x60.75%', gs)
+    expect(gs).to eq('40.50%x60.75%')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(0, 0, 10, 20)
     gs = g.to_s
-    assert_equal('+10+20', gs)
+    expect(gs).to eq('+10+20')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     g = Magick::Geometry.new(0, 0, 10)
     gs = g.to_s
-    assert_equal('+10+0', gs)
+    expect(gs).to eq('+10+0')
 
     assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
     gs2 = g2.to_s
-    assert_equal(gs, gs2)
+    expect(gs2).to eq(gs)
 
     # assert behavior with empty string argument
     assert_nothing_raised { g = Magick::Geometry.from_s('') }
-    assert_equal('', g.to_s)
+    expect(g.to_s).to eq('')
 
     assert_raise(ArgumentError) { Magick::Geometry.new(Magick::AreaGeometry) }
     assert_raise(ArgumentError) { Magick::Geometry.new(40, Magick::AreaGeometry) }
@@ -245,7 +245,7 @@ class MagickUT < Minitest::Test
   end
 
   def test_opaque_alpha
-    assert_equal(Magick::QuantumRange, Magick::OpaqueAlpha)
+    expect(Magick::OpaqueAlpha).to eq(Magick::QuantumRange)
   end
 
   def test_set_log_event_mask
@@ -264,35 +264,35 @@ class MagickUT < Minitest::Test
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
     assert_nothing_raised { new = Magick.limit_resource('memory') }
-    assert_equal(500, new)
+    expect(new).to eq(500)
     Magick.limit_resource(:memory, cur)
 
     assert_nothing_raised { cur = Magick.limit_resource(:map, 3500) }
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
     assert_nothing_raised { new = Magick.limit_resource('map') }
-    assert_equal(3500, new)
+    expect(new).to eq(3500)
     Magick.limit_resource(:map, cur)
 
     assert_nothing_raised { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
     assert_nothing_raised { new = Magick.limit_resource('disk') }
-    assert_equal(3_221_225_472, new)
+    expect(new).to eq(3_221_225_472)
     Magick.limit_resource(:disk, cur)
 
     assert_nothing_raised { cur = Magick.limit_resource(:file, 500) }
     assert_kind_of(Integer, cur)
     assert(cur > 512)
     assert_nothing_raised { new = Magick.limit_resource('file') }
-    assert_equal(500, new)
+    expect(new).to eq(500)
     Magick.limit_resource(:file, cur)
 
     assert_nothing_raised { cur = Magick.limit_resource(:time, 300) }
     assert_kind_of(Integer, cur)
     assert(cur > 300)
     assert_nothing_raised { new = Magick.limit_resource('time') }
-    assert_equal(300, new)
+    expect(new).to eq(300)
     Magick.limit_resource(:time, cur)
 
     assert_raise(ArgumentError) { Magick.limit_resource(:xxx) }
@@ -302,7 +302,7 @@ class MagickUT < Minitest::Test
   end
 
   def test_transparent_alpha
-    assert_equal(0, Magick::TransparentAlpha)
+    expect(Magick::TransparentAlpha).to eq(0)
   end
 end
 

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -8,65 +8,65 @@ class PixelUT < Minitest::Test
 
   def test_red
     assert_nothing_raised { @pixel.red = 123 }
-    assert_equal(123, @pixel.red)
+    expect(@pixel.red).to eq(123)
     assert_nothing_raised { @pixel.red = 255.25 }
-    assert_equal(255, @pixel.red)
+    expect(@pixel.red).to eq(255)
     assert_raise(TypeError) { @pixel.red = 'x' }
   end
 
   def test_green
     assert_nothing_raised { @pixel.green = 123 }
-    assert_equal(123, @pixel.green)
+    expect(@pixel.green).to eq(123)
     assert_nothing_raised { @pixel.green = 255.25 }
-    assert_equal(255, @pixel.green)
+    expect(@pixel.green).to eq(255)
     assert_raise(TypeError) { @pixel.green = 'x' }
   end
 
   def test_blue
     assert_nothing_raised { @pixel.blue = 123 }
-    assert_equal(123, @pixel.blue)
+    expect(@pixel.blue).to eq(123)
     assert_nothing_raised { @pixel.blue = 255.25 }
-    assert_equal(255, @pixel.blue)
+    expect(@pixel.blue).to eq(255)
     assert_raise(TypeError) { @pixel.blue = 'x' }
   end
 
   def test_alpha
     assert_nothing_raised { @pixel.alpha = 123 }
-    assert_equal(123, @pixel.alpha)
+    expect(@pixel.alpha).to eq(123)
     assert_nothing_raised { @pixel.alpha = 255.25 }
-    assert_equal(255, @pixel.alpha)
+    expect(@pixel.alpha).to eq(255)
     assert_raise(TypeError) { @pixel.alpha = 'x' }
   end
 
   def test_cyan
     assert_nothing_raised { @pixel.cyan = 123 }
-    assert_equal(123, @pixel.cyan)
+    expect(@pixel.cyan).to eq(123)
     assert_nothing_raised { @pixel.cyan = 255.25 }
-    assert_equal(255, @pixel.cyan)
+    expect(@pixel.cyan).to eq(255)
     assert_raise(TypeError) { @pixel.cyan = 'x' }
   end
 
   def test_magenta
     assert_nothing_raised { @pixel.magenta = 123 }
-    assert_equal(123, @pixel.magenta)
+    expect(@pixel.magenta).to eq(123)
     assert_nothing_raised { @pixel.magenta = 255.25 }
-    assert_equal(255, @pixel.magenta)
+    expect(@pixel.magenta).to eq(255)
     assert_raise(TypeError) { @pixel.magenta = 'x' }
   end
 
   def test_yellow
     assert_nothing_raised { @pixel.yellow = 123 }
-    assert_equal(123, @pixel.yellow)
+    expect(@pixel.yellow).to eq(123)
     assert_nothing_raised { @pixel.yellow = 255.25 }
-    assert_equal(255, @pixel.yellow)
+    expect(@pixel.yellow).to eq(255)
     assert_raise(TypeError) { @pixel.yellow = 'x' }
   end
 
   def test_black
     assert_nothing_raised { @pixel.black = 123 }
-    assert_equal(123, @pixel.black)
+    expect(@pixel.black).to eq(123)
     assert_nothing_raised { @pixel.black = 255.25 }
-    assert_equal(255, @pixel.black)
+    expect(@pixel.black).to eq(255)
     assert_raise(TypeError) { @pixel.black = 'x' }
   end
 
@@ -107,19 +107,19 @@ class PixelUT < Minitest::Test
     hash = nil
     assert_nothing_raised { hash = @pixel.hash }
     assert_not_nil(hash)
-    assert_equal(1_385_502_079, hash)
+    expect(hash).to eq(1_385_502_079)
 
     p = Magick::Pixel.new
-    assert_equal(127, p.hash)
+    expect(p.hash).to eq(127)
 
     p = Magick::Pixel.from_color('red')
-    assert_equal(2_139_095_167, p.hash)
+    expect(p.hash).to eq(2_139_095_167)
 
     # Pixel.hash sacrifices the last bit of the opacity channel
     p = Magick::Pixel.new(0, 0, 0, 72)
     p2 = Magick::Pixel.new(0, 0, 0, 73)
     assert_not_equal(p, p2)
-    assert_equal(p.hash, p2.hash)
+    expect(p2.hash).to eq(p.hash)
   end
 
   def test_eql?
@@ -195,39 +195,39 @@ class PixelUT < Minitest::Test
     marshal = @pixel.marshal_dump
 
     pixel = Magick::Pixel.new
-    assert_equal(@pixel, pixel.marshal_load(marshal))
+    expect(pixel.marshal_load(marshal)).to eq(@pixel)
   end
 
   def test_spaceship
     @pixel.red = 100
     pixel = @pixel.dup
-    assert_equal(0, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(0)
 
     pixel.red -= 10
-    assert_equal(1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(1)
     pixel.red += 20
-    assert_equal(-1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(-1)
 
     @pixel.green = 100
     pixel = @pixel.dup
     pixel.green -= 10
-    assert_equal(1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(1)
     pixel.green += 20
-    assert_equal(-1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(-1)
 
     @pixel.blue = 100
     pixel = @pixel.dup
     pixel.blue -= 10
-    assert_equal(1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(1)
     pixel.blue += 20
-    assert_equal(-1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(-1)
 
     @pixel.alpha = 100
     pixel = @pixel.dup
     pixel.alpha -= 10
-    assert_equal(1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(1)
     pixel.alpha += 20
-    assert_equal(-1, @pixel <=> pixel)
+    expect(@pixel <=> pixel).to eq(-1)
   end
 
   def test_to_color
@@ -243,8 +243,8 @@ class PixelUT < Minitest::Test
     assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 8, true) }
     assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 16, true) }
 
-    assert_equal('#A52A2A', @pixel.to_color(Magick::AllCompliance, false, 8, true))
-    assert_equal('#A5A52A2A2A2A', @pixel.to_color(Magick::AllCompliance, false, 16, true))
+    expect(@pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
+    expect(@pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')
 
     assert_raise(ArgumentError) { @pixel.to_color(Magick::AllCompliance, false, 32) }
     assert_raise(TypeError) { @pixel.to_color(1) }

--- a/test/Struct.rb
+++ b/test/Struct.rb
@@ -32,11 +32,11 @@ class StructUT < Minitest::Test
 
   def test_rectangle_info_to_s
     rect = Magick::Rectangle.new(10, 20, 30, 40)
-    assert_equal('width=10, height=20, x=30, y=40', rect.to_s)
+    expect(rect.to_s).to eq('width=10, height=20, x=30, y=40')
   end
 
   def test_segment_info_to_s
     segment = Magick::Segment.new(10, 20, 30, 40)
-    assert_equal('x1=10, y1=20, x2=30, y2=40', segment.to_s)
+    expect(segment.to_s).to eq('x1=10, y1=20, x2=30, y2=40')
   end
 end

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -9,7 +9,7 @@ class LibDrawUT < Minitest::Test
 
   def test_affine
     @draw.affine(10.5, 12, 15, 20, 22, 25)
-    assert_equal('affine 10.5,12,15,20,22,25', @draw.inspect)
+    expect(@draw.inspect).to eq('affine 10.5,12,15,20,22,25')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.affine('x', 12, 15, 20, 22, 25) }
@@ -34,7 +34,7 @@ class LibDrawUT < Minitest::Test
 
   def test_arc
     @draw.arc(100.5, 120.5, 200, 250, 20, 370)
-    assert_equal('arc 100.5,120.5 200,250 20,370', @draw.inspect)
+    expect(@draw.inspect).to eq('arc 100.5,120.5 200,250 20,370')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.arc('x', 120.5, 200, 250, 20, 370) }
@@ -47,7 +47,7 @@ class LibDrawUT < Minitest::Test
 
   def test_bezier
     @draw.bezier(10, '20', '20.5', 30, 40.5, 50)
-    assert_equal('bezier 10,20,20.5,30,40.5,50', @draw.inspect)
+    expect(@draw.inspect).to eq('bezier 10,20,20.5,30,40.5,50')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.bezier }
@@ -57,7 +57,7 @@ class LibDrawUT < Minitest::Test
 
   def test_circle
     @draw.circle(10, '20.5', 30, 40.5)
-    assert_equal('circle 10,20.5 30,40.5', @draw.inspect)
+    expect(@draw.inspect).to eq('circle 10,20.5 30,40.5')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.circle('x', 20, 30, 40) }
@@ -68,19 +68,19 @@ class LibDrawUT < Minitest::Test
 
   def test_clip_path
     @draw.clip_path('test')
-    assert_equal('clip-path test', @draw.inspect)
+    expect(@draw.inspect).to eq('clip-path test')
     assert_nothing_raised { @draw.draw(@img) }
   end
 
   def test_clip_rule
     draw = Magick::Draw.new
     draw.clip_rule('evenodd')
-    assert_equal('clip-rule evenodd', draw.inspect)
+    expect(draw.inspect).to eq('clip-rule evenodd')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.clip_rule('nonzero')
-    assert_equal('clip-rule nonzero', draw.inspect)
+    expect(draw.inspect).to eq('clip-rule nonzero')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.clip_rule('foo') }
@@ -89,17 +89,17 @@ class LibDrawUT < Minitest::Test
   def test_clip_units
     draw = Magick::Draw.new
     draw.clip_units('userspace')
-    assert_equal('clip-units userspace', draw.inspect)
+    expect(draw.inspect).to eq('clip-units userspace')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.clip_units('userspaceonuse')
-    assert_equal('clip-units userspaceonuse', draw.inspect)
+    expect(draw.inspect).to eq('clip-units userspaceonuse')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.clip_units('objectboundingbox')
-    assert_equal('clip-units objectboundingbox', draw.inspect)
+    expect(draw.inspect).to eq('clip-units objectboundingbox')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.clip_units('foo') }
@@ -108,27 +108,27 @@ class LibDrawUT < Minitest::Test
   def test_color
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::PointMethod)
-    assert_equal('color 50.5,50,point', draw.inspect)
+    expect(draw.inspect).to eq('color 50.5,50,point')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::ReplaceMethod)
-    assert_equal('color 50.5,50,replace', draw.inspect)
+    expect(draw.inspect).to eq('color 50.5,50,replace')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::FloodfillMethod)
-    assert_equal('color 50.5,50,floodfill', draw.inspect)
+    expect(draw.inspect).to eq('color 50.5,50,floodfill')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::FillToBorderMethod)
-    assert_equal('color 50.5,50,filltoborder', draw.inspect)
+    expect(draw.inspect).to eq('color 50.5,50,filltoborder')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::ResetMethod)
-    assert_equal('color 50.5,50,reset', draw.inspect)
+    expect(draw.inspect).to eq('color 50.5,50,reset')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.color(10, 20, 'unknown') }
@@ -139,43 +139,43 @@ class LibDrawUT < Minitest::Test
   def test_decorate
     draw = Magick::Draw.new
     draw.decorate(Magick::NoDecoration)
-    assert_equal('decorate none', draw.inspect)
+    expect(draw.inspect).to eq('decorate none')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.decorate(Magick::UnderlineDecoration)
-    assert_equal('decorate underline', draw.inspect)
+    expect(draw.inspect).to eq('decorate underline')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.decorate(Magick::OverlineDecoration)
-    assert_equal('decorate overline', draw.inspect)
+    expect(draw.inspect).to eq('decorate overline')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.decorate(Magick::OverlineDecoration)
-    assert_equal('decorate overline', draw.inspect)
+    expect(draw.inspect).to eq('decorate overline')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     # draw = Magick::Draw.new
     # draw.decorate('tomato')
-    # assert_equal('decorate "tomato"', draw.inspect)
+    # expect(draw.inspect).to eq('decorate "tomato"')
     # draw.text(50, 50, 'Hello world')
     # assert_nothing_raised { draw.draw(@img) }
   end
 
   def test_define_clip_path
     assert_nothing_raised { @draw.define_clip_path('test') { @draw } }
-    assert_equal("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs", @draw.inspect)
+    expect(@draw.inspect).to eq("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs")
   end
 
   def test_ellipse
     @draw.ellipse(50.5, 30, 25, 25, 60, 120)
-    assert_equal('ellipse 50.5,30 25,25 60,120', @draw.inspect)
+    expect(@draw.inspect).to eq('ellipse 50.5,30 25,25 60,120')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.ellipse('x', 20, 30, 40, 50, 60) }
@@ -188,26 +188,26 @@ class LibDrawUT < Minitest::Test
 
   def test_encoding
     @draw.encoding('UTF-8')
-    assert_equal('encoding UTF-8', @draw.inspect)
+    expect(@draw.inspect).to eq('encoding UTF-8')
     assert_nothing_raised { @draw.draw(@img) }
   end
 
   def test_fill
     draw = Magick::Draw.new
     draw.fill('tomato')
-    assert_equal('fill "tomato"', draw.inspect)
+    expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.fill_color('tomato')
-    assert_equal('fill "tomato"', draw.inspect)
+    expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.fill_pattern('tomato')
-    assert_equal('fill "tomato"', draw.inspect)
+    expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
@@ -219,13 +219,13 @@ class LibDrawUT < Minitest::Test
   def test_fill_opacity
     draw = Magick::Draw.new
     draw.fill_opacity(0.5)
-    assert_equal('fill-opacity 0.5', draw.inspect)
+    expect(draw.inspect).to eq('fill-opacity 0.5')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.fill_opacity('50%')
-    assert_equal('fill-opacity 50%', draw.inspect)
+    expect(draw.inspect).to eq('fill-opacity 50%')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
@@ -245,13 +245,13 @@ class LibDrawUT < Minitest::Test
   def test_fill_rule
     draw = Magick::Draw.new
     draw.fill_rule('evenodd')
-    assert_equal('fill-rule evenodd', draw.inspect)
+    expect(draw.inspect).to eq('fill-rule evenodd')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.fill_rule('nonzero')
-    assert_equal('fill-rule nonzero', draw.inspect)
+    expect(draw.inspect).to eq('fill-rule nonzero')
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
@@ -262,7 +262,7 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     font_name = Magick.fonts.first.name
     draw.font(font_name)
-    assert_equal("font '#{font_name}'", draw.inspect)
+    expect(draw.inspect).to eq("font '#{font_name}'")
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
   end
@@ -270,7 +270,7 @@ class LibDrawUT < Minitest::Test
   def test_font_family
     draw = Magick::Draw.new
     draw.font_family('sans-serif')
-    assert_equal("font-family 'sans-serif'", draw.inspect)
+    expect(draw.inspect).to eq("font-family 'sans-serif'")
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
   end
@@ -291,19 +291,19 @@ class LibDrawUT < Minitest::Test
   def test_font_style
     draw = Magick::Draw.new
     draw.font_style(Magick::NormalStyle)
-    assert_equal('font-style normal', draw.inspect)
+    expect(draw.inspect).to eq('font-style normal')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.font_style(Magick::ItalicStyle)
-    assert_equal('font-style italic', draw.inspect)
+    expect(draw.inspect).to eq('font-style italic')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.font_style(Magick::ObliqueStyle)
-    assert_equal('font-style oblique', draw.inspect)
+    expect(draw.inspect).to eq('font-style oblique')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
@@ -320,7 +320,7 @@ class LibDrawUT < Minitest::Test
 
     draw = Magick::Draw.new
     draw.font_weight(400)
-    assert_equal('font-weight 400', draw.inspect)
+    expect(draw.inspect).to eq('font-weight 400')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
@@ -359,12 +359,12 @@ class LibDrawUT < Minitest::Test
   def test_interline_spacing
     draw = Magick::Draw.new
     draw.interline_spacing(40.5)
-    assert_equal('interline-spacing 40.5', draw.inspect)
+    expect(draw.inspect).to eq('interline-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.interline_spacing('40.5')
-    assert_equal('interline-spacing 40.5', draw.inspect)
+    expect(draw.inspect).to eq('interline-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     # assert_raise(ArgumentError) { @draw.interline_spacing(Float::NAN) }
@@ -376,12 +376,12 @@ class LibDrawUT < Minitest::Test
   def test_interword_spacing
     draw = Magick::Draw.new
     draw.interword_spacing(40.5)
-    assert_equal('interword-spacing 40.5', draw.inspect)
+    expect(draw.inspect).to eq('interword-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.interword_spacing('40.5')
-    assert_equal('interword-spacing 40.5', draw.inspect)
+    expect(draw.inspect).to eq('interword-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     # assert_raise(ArgumentError) { @draw.interword_spacing(Float::NAN) }
@@ -393,12 +393,12 @@ class LibDrawUT < Minitest::Test
   def test_kerning
     draw = Magick::Draw.new
     draw.kerning(40.5)
-    assert_equal('kerning 40.5', draw.inspect)
+    expect(draw.inspect).to eq('kerning 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.kerning('40.5')
-    assert_equal('kerning 40.5', draw.inspect)
+    expect(draw.inspect).to eq('kerning 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
     # assert_raise(ArgumentError) { @draw.kerning(Float::NAN) }
@@ -409,7 +409,7 @@ class LibDrawUT < Minitest::Test
 
   def test_line
     @draw.line(10, '20.5', 30, 40.5)
-    assert_equal('line 10,20.5 30,40.5', @draw.inspect)
+    expect(@draw.inspect).to eq('line 10,20.5 30,40.5')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.line('x', '20.5', 30, 40.5) }
@@ -420,7 +420,7 @@ class LibDrawUT < Minitest::Test
 
   def test_opacity
     @draw.opacity(0.8)
-    assert_equal('opacity 0.8', @draw.inspect)
+    expect(@draw.inspect).to eq('opacity 0.8')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_nothing_raised { @draw.opacity(0.0) }
@@ -438,13 +438,13 @@ class LibDrawUT < Minitest::Test
 
   def test_path
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    assert_equal("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'", @draw.inspect)
+    expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'")
     assert_nothing_raised { @draw.draw(@img) }
   end
 
   def test_pattern
     @draw.pattern('hat', 0, 10.5, 20, '20') {}
-    assert_equal("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs", @draw.inspect)
+    expect(@draw.inspect).to eq("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs")
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.pattern('hat', 'x', 0, 20, 20) {} }
@@ -455,7 +455,7 @@ class LibDrawUT < Minitest::Test
 
   def test_point
     @draw.point(10.5, '20')
-    assert_equal('point 10.5,20', @draw.inspect)
+    expect(@draw.inspect).to eq('point 10.5,20')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.point('x', 20) }
@@ -464,7 +464,7 @@ class LibDrawUT < Minitest::Test
 
   def test_pointsize
     @draw.pointsize(20.5)
-    assert_equal('font-size 20.5', @draw.inspect)
+    expect(@draw.inspect).to eq('font-size 20.5')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.pointsize('x') }
@@ -472,7 +472,7 @@ class LibDrawUT < Minitest::Test
 
   def test_font_size
     @draw.font_size(20)
-    assert_equal('font-size 20', @draw.inspect)
+    expect(@draw.inspect).to eq('font-size 20')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.font_size('x') }
@@ -480,7 +480,7 @@ class LibDrawUT < Minitest::Test
 
   def test_polygon
     @draw.polygon(0, '0.5', 8.5, 16, 16, 0, 0, 0)
-    assert_equal('polygon 0,0.5,8.5,16,16,0,0,0', @draw.inspect)
+    expect(@draw.inspect).to eq('polygon 0,0.5,8.5,16,16,0,0,0')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.polygon }
@@ -490,7 +490,7 @@ class LibDrawUT < Minitest::Test
 
   def test_polyline
     @draw.polyline(0, '0.5', 16.5, 16)
-    assert_equal('polyline 0,0.5,16.5,16', @draw.inspect)
+    expect(@draw.inspect).to eq('polyline 0,0.5,16.5,16')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.polyline }
@@ -500,7 +500,7 @@ class LibDrawUT < Minitest::Test
 
   def test_rectangle
     @draw.rectangle(10, '10', 100, 100)
-    assert_equal('rectangle 10,10 100,100', @draw.inspect)
+    expect(@draw.inspect).to eq('rectangle 10,10 100,100')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.rectangle('x', 10, 20, 20) }
@@ -511,7 +511,7 @@ class LibDrawUT < Minitest::Test
 
   def test_rotate
     @draw.rotate(45)
-    assert_equal('rotate 45', @draw.inspect)
+    expect(@draw.inspect).to eq('rotate 45')
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -520,7 +520,7 @@ class LibDrawUT < Minitest::Test
 
   def test_roundrectangle
     @draw.roundrectangle(10, '10', 100, 100, 20, 20)
-    assert_equal('roundrectangle 10,10,100,100,20,20', @draw.inspect)
+    expect(@draw.inspect).to eq('roundrectangle 10,10,100,100,20,20')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }
@@ -533,7 +533,7 @@ class LibDrawUT < Minitest::Test
 
   def test_scale
     @draw.scale('0.5', 1.5)
-    assert_equal('scale 0.5,1.5', @draw.inspect)
+    expect(@draw.inspect).to eq('scale 0.5,1.5')
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -543,7 +543,7 @@ class LibDrawUT < Minitest::Test
 
   def test_skewx
     @draw.skewx(45)
-    assert_equal('skewX 45', @draw.inspect)
+    expect(@draw.inspect).to eq('skewX 45')
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -552,7 +552,7 @@ class LibDrawUT < Minitest::Test
 
   def test_skewy
     @draw.skewy(45)
-    assert_equal('skewY 45', @draw.inspect)
+    expect(@draw.inspect).to eq('skewY 45')
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -561,7 +561,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke
     @draw.stroke('red')
-    assert_equal('stroke "red"', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -570,7 +570,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke_color
     @draw.stroke_color('red')
-    assert_equal('stroke "red"', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -579,7 +579,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke_pattern
     @draw.stroke_pattern('red')
-    assert_equal('stroke "red"', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
@@ -589,7 +589,7 @@ class LibDrawUT < Minitest::Test
   def test_stroke_antialias
     draw = Magick::Draw.new
     draw.stroke_antialias(true)
-    assert_equal('stroke-antialias 1', draw.inspect)
+    expect(draw.inspect).to eq('stroke-antialias 1')
     draw.stroke_pattern('red')
     draw.stroke_width(5)
     draw.circle(10, '20.5', 30, 40.5)
@@ -597,7 +597,7 @@ class LibDrawUT < Minitest::Test
 
     draw = Magick::Draw.new
     draw.stroke_antialias(false)
-    assert_equal('stroke-antialias 0', draw.inspect)
+    expect(draw.inspect).to eq('stroke-antialias 0')
     draw.stroke_pattern('red')
     draw.stroke_width(5)
     draw.circle(10, '20.5', 30, 40.5)
@@ -607,7 +607,7 @@ class LibDrawUT < Minitest::Test
   def test_stroke_dasharray
     draw = Magick::Draw.new
     draw.stroke_dasharray(2, 2)
-    assert_equal('stroke-dasharray 2,2', draw.inspect)
+    expect(draw.inspect).to eq('stroke-dasharray 2,2')
     draw.stroke_pattern('red')
     draw.stroke_width(2)
     draw.rectangle(10, '10', 100, 100)
@@ -615,7 +615,7 @@ class LibDrawUT < Minitest::Test
 
     draw = Magick::Draw.new
     draw.stroke_dasharray
-    assert_equal('stroke-dasharray none', draw.inspect)
+    expect(draw.inspect).to eq('stroke-dasharray none')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_dasharray(-0.1) }
@@ -624,7 +624,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke_dashoffset
     @draw.stroke_dashoffset(10)
-    assert_equal('stroke-dashoffset 10', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke-dashoffset 10')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_dashoffset('x') }
@@ -633,17 +633,17 @@ class LibDrawUT < Minitest::Test
   def test_stroke_linecap
     draw = Magick::Draw.new
     draw.stroke_linecap('butt')
-    assert_equal('stroke-linecap butt', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linecap butt')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.stroke_linecap('round')
-    assert_equal('stroke-linecap round', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linecap round')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.stroke_linecap('square')
-    assert_equal('stroke-linecap square', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linecap square')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_linecap('foo') }
@@ -652,17 +652,17 @@ class LibDrawUT < Minitest::Test
   def test_stroke_linejoin
     draw = Magick::Draw.new
     draw.stroke_linejoin('round')
-    assert_equal('stroke-linejoin round', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linejoin round')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.stroke_linejoin('miter')
-    assert_equal('stroke-linejoin miter', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linejoin miter')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.stroke_linejoin('bevel')
-    assert_equal('stroke-linejoin bevel', draw.inspect)
+    expect(draw.inspect).to eq('stroke-linejoin bevel')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_linejoin('foo') }
@@ -671,7 +671,7 @@ class LibDrawUT < Minitest::Test
   def test_stroke_miterlimit
     draw = Magick::Draw.new
     draw.stroke_miterlimit(1.0)
-    assert_equal('stroke-miterlimit 1.0', draw.inspect)
+    expect(draw.inspect).to eq('stroke-miterlimit 1.0')
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_miterlimit(0.9) }
@@ -680,7 +680,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke_opacity
     @draw.stroke_opacity(0.8)
-    assert_equal('stroke-opacity 0.8', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke-opacity 0.8')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_nothing_raised { @draw.stroke_opacity(0.0) }
@@ -698,7 +698,7 @@ class LibDrawUT < Minitest::Test
 
   def test_stroke_width
     @draw.stroke_width(2.5)
-    assert_equal('stroke-width 2.5', @draw.inspect)
+    expect(@draw.inspect).to eq('stroke-width 2.5')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.stroke_width('xxx') }
@@ -707,27 +707,27 @@ class LibDrawUT < Minitest::Test
   def test_text
     draw = Magick::Draw.new
     draw.text(50, 50, 'Hello world')
-    assert_equal("text 50,50 'Hello world'", draw.inspect)
+    expect(draw.inspect).to eq("text 50,50 'Hello world'")
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello 'world'")
-    assert_equal("text 50,50 \"Hello 'world'\"", draw.inspect)
+    expect(draw.inspect).to eq("text 50,50 \"Hello 'world'\"")
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text(50, 50, 'Hello "world"')
-    assert_equal("text 50,50 'Hello \"world\"'", draw.inspect)
+    expect(draw.inspect).to eq("text 50,50 'Hello \"world\"'")
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello 'world\"")
-    assert_equal("text 50,50 {Hello 'world\"}", draw.inspect)
+    expect(draw.inspect).to eq("text 50,50 {Hello 'world\"}")
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello {'world\"")
-    assert_equal("text 50,50 {Hello {'world\"}", draw.inspect)
+    expect(draw.inspect).to eq("text 50,50 {Hello {'world\"}")
     assert_nothing_raised { draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.text(50, 50, '') }
@@ -738,19 +738,19 @@ class LibDrawUT < Minitest::Test
   def test_text_align
     draw = Magick::Draw.new
     draw.text_align(Magick::LeftAlign)
-    assert_equal('text-align left', draw.inspect)
+    expect(draw.inspect).to eq('text-align left')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text_align(Magick::RightAlign)
-    assert_equal('text-align right', draw.inspect)
+    expect(draw.inspect).to eq('text-align right')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text_align(Magick::CenterAlign)
-    assert_equal('text-align center', draw.inspect)
+    expect(draw.inspect).to eq('text-align center')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
@@ -760,19 +760,19 @@ class LibDrawUT < Minitest::Test
   def test_text_anchor
     draw = Magick::Draw.new
     draw.text_anchor(Magick::StartAnchor)
-    assert_equal('text-anchor start', draw.inspect)
+    expect(draw.inspect).to eq('text-anchor start')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text_anchor(Magick::MiddleAnchor)
-    assert_equal('text-anchor middle', draw.inspect)
+    expect(draw.inspect).to eq('text-anchor middle')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text_anchor(Magick::EndAnchor)
-    assert_equal('text-anchor end', draw.inspect)
+    expect(draw.inspect).to eq('text-anchor end')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
@@ -782,27 +782,27 @@ class LibDrawUT < Minitest::Test
   def test_text_antialias
     draw = Magick::Draw.new
     draw.text_antialias(true)
-    assert_equal('text-antialias 1', draw.inspect)
+    expect(draw.inspect).to eq('text-antialias 1')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
     draw = Magick::Draw.new
     draw.text_antialias(false)
-    assert_equal('text-antialias 0', draw.inspect)
+    expect(draw.inspect).to eq('text-antialias 0')
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
   end
 
   def test_text_undercolor
     @draw.text_undercolor('red')
-    assert_equal('text-undercolor "red"', @draw.inspect)
+    expect(@draw.inspect).to eq('text-undercolor "red"')
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
   end
 
   def test_translate
     @draw.translate('200', 300)
-    assert_equal('translate 200,300', @draw.inspect)
+    expect(@draw.inspect).to eq('translate 200,300')
     assert_nothing_raised { @draw.draw(@img) }
 
     assert_raise(ArgumentError) { @draw.translate('x', 300) }

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -4,28 +4,28 @@ require 'minitest/autorun'
 class LibGeometryUT < Minitest::Test
   def test_constants
     assert_kind_of(Magick::GeometryValue, Magick::PercentGeometry)
-    assert_equal('PercentGeometry', Magick::PercentGeometry.to_s)
-    assert_equal(1, Magick::PercentGeometry.to_i)
+    expect(Magick::PercentGeometry.to_s).to eq('PercentGeometry')
+    expect(Magick::PercentGeometry.to_i).to eq(1)
 
     assert_kind_of(Magick::GeometryValue, Magick::AspectGeometry)
-    assert_equal('AspectGeometry', Magick::AspectGeometry.to_s)
-    assert_equal(2, Magick::AspectGeometry.to_i)
+    expect(Magick::AspectGeometry.to_s).to eq('AspectGeometry')
+    expect(Magick::AspectGeometry.to_i).to eq(2)
 
     assert_kind_of(Magick::GeometryValue, Magick::LessGeometry)
-    assert_equal('LessGeometry', Magick::LessGeometry.to_s)
-    assert_equal(3, Magick::LessGeometry.to_i)
+    expect(Magick::LessGeometry.to_s).to eq('LessGeometry')
+    expect(Magick::LessGeometry.to_i).to eq(3)
 
     assert_kind_of(Magick::GeometryValue, Magick::GreaterGeometry)
-    assert_equal('GreaterGeometry', Magick::GreaterGeometry.to_s)
-    assert_equal(4, Magick::GreaterGeometry.to_i)
+    expect(Magick::GreaterGeometry.to_s).to eq('GreaterGeometry')
+    expect(Magick::GreaterGeometry.to_i).to eq(4)
 
     assert_kind_of(Magick::GeometryValue, Magick::AreaGeometry)
-    assert_equal('AreaGeometry', Magick::AreaGeometry.to_s)
-    assert_equal(5, Magick::AreaGeometry.to_i)
+    expect(Magick::AreaGeometry.to_s).to eq('AreaGeometry')
+    expect(Magick::AreaGeometry.to_i).to eq(5)
 
     assert_kind_of(Magick::GeometryValue, Magick::MinimumGeometry)
-    assert_equal('MinimumGeometry', Magick::MinimumGeometry.to_s)
-    assert_equal(6, Magick::MinimumGeometry.to_i)
+    expect(Magick::MinimumGeometry.to_s).to eq('MinimumGeometry')
+    expect(Magick::MinimumGeometry.to_i).to eq(6)
   end
 
   def test_initialize
@@ -38,53 +38,53 @@ class LibGeometryUT < Minitest::Test
     assert_raise(ArgumentError) { Magick::Geometry.new(0, -1) }
 
     geometry = Magick::Geometry.new
-    assert_equal(0, geometry.width)
-    assert_equal(0, geometry.height)
-    assert_equal(0, geometry.x)
-    assert_equal(0, geometry.y)
+    expect(geometry.width).to eq(0)
+    expect(geometry.height).to eq(0)
+    expect(geometry.x).to eq(0)
+    expect(geometry.y).to eq(0)
     assert_nil(geometry.flag)
 
     geometry = Magick::Geometry.new(10, 20, 30, 40)
-    assert_equal(10, geometry.width)
-    assert_equal(20, geometry.height)
-    assert_equal(30, geometry.x)
-    assert_equal(40, geometry.y)
+    expect(geometry.width).to eq(10)
+    expect(geometry.height).to eq(20)
+    expect(geometry.x).to eq(30)
+    expect(geometry.y).to eq(40)
   end
 
   def test_to_s
-    assert_equal('', Magick::Geometry.new.to_s)
-    assert_equal('10x', Magick::Geometry.new(10).to_s)
-    assert_equal('10x20', Magick::Geometry.new(10, 20).to_s)
-    assert_equal('10x20+30+0', Magick::Geometry.new(10, 20, 30).to_s)
-    assert_equal('10x20+30+40', Magick::Geometry.new(10, 20, 30, 40).to_s)
-    assert_equal('x20+30+40', Magick::Geometry.new(0, 20, 30, 40).to_s)
-    assert_equal('+30+40', Magick::Geometry.new(0, 0, 30, 40).to_s)
-    assert_equal('+0+40', Magick::Geometry.new(0, 0, 0, 40).to_s)
+    expect(Magick::Geometry.new.to_s).to eq('')
+    expect(Magick::Geometry.new(10).to_s).to eq('10x')
+    expect(Magick::Geometry.new(10, 20).to_s).to eq('10x20')
+    expect(Magick::Geometry.new(10, 20, 30).to_s).to eq('10x20+30+0')
+    expect(Magick::Geometry.new(10, 20, 30, 40).to_s).to eq('10x20+30+40')
+    expect(Magick::Geometry.new(0, 20, 30, 40).to_s).to eq('x20+30+40')
+    expect(Magick::Geometry.new(0, 0, 30, 40).to_s).to eq('+30+40')
+    expect(Magick::Geometry.new(0, 0, 0, 40).to_s).to eq('+0+40')
 
-    assert_equal('10%x20%+30+40', Magick::Geometry.new(10, 20, 30, 40, Magick::PercentGeometry).to_s)
-    assert_equal('x20%+30+40', Magick::Geometry.new(0, 20, 30, 40, Magick::PercentGeometry).to_s)
+    expect(Magick::Geometry.new(10, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('10%x20%+30+40')
+    expect(Magick::Geometry.new(0, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('x20%+30+40')
 
-    assert_equal('10.20x20.50+30+40', Magick::Geometry.new(10.2, 20.5, 30, 40).to_s)
-    assert_equal('10.20%x20.50%+30+40', Magick::Geometry.new(10.2, 20.5, 30, 40, Magick::PercentGeometry).to_s)
+    expect(Magick::Geometry.new(10.2, 20.5, 30, 40).to_s).to eq('10.20x20.50+30+40')
+    expect(Magick::Geometry.new(10.2, 20.5, 30, 40, Magick::PercentGeometry).to_s).to eq('10.20%x20.50%+30+40')
   end
 
   def test_from_s
-    assert_equal('', Magick::Geometry.from_s('').to_s)
-    assert_equal('', Magick::Geometry.from_s('x').to_s)
-    assert_equal('10x', Magick::Geometry.from_s('10').to_s)
-    assert_equal('10x', Magick::Geometry.from_s('10x').to_s)
-    assert_equal('10x20', Magick::Geometry.from_s('10x20').to_s)
-    assert_equal('10x20+30+40', Magick::Geometry.from_s('10x20+30+40').to_s)
-    assert_equal('x20+30+40', Magick::Geometry.from_s('x20+30+40').to_s)
-    assert_equal('+30+40', Magick::Geometry.from_s('+30+40').to_s)
-    assert_equal('+0+40', Magick::Geometry.from_s('+0+40').to_s)
-    assert_equal('+30+0', Magick::Geometry.from_s('+30').to_s)
+    expect(Magick::Geometry.from_s('').to_s).to eq('')
+    expect(Magick::Geometry.from_s('x').to_s).to eq('')
+    expect(Magick::Geometry.from_s('10').to_s).to eq('10x')
+    expect(Magick::Geometry.from_s('10x').to_s).to eq('10x')
+    expect(Magick::Geometry.from_s('10x20').to_s).to eq('10x20')
+    expect(Magick::Geometry.from_s('10x20+30+40').to_s).to eq('10x20+30+40')
+    expect(Magick::Geometry.from_s('x20+30+40').to_s).to eq('x20+30+40')
+    expect(Magick::Geometry.from_s('+30+40').to_s).to eq('+30+40')
+    expect(Magick::Geometry.from_s('+0+40').to_s).to eq('+0+40')
+    expect(Magick::Geometry.from_s('+30').to_s).to eq('+30+0')
 
-    assert_equal('10%x20%+30+40', Magick::Geometry.from_s('10%x20%+30+40').to_s)
-    assert_equal('x20%+30+40', Magick::Geometry.from_s('x20%+30+40').to_s)
+    expect(Magick::Geometry.from_s('10%x20%+30+40').to_s).to eq('10%x20%+30+40')
+    expect(Magick::Geometry.from_s('x20%+30+40').to_s).to eq('x20%+30+40')
 
-    assert_equal('10.20x20.50+30+40', Magick::Geometry.from_s('10.2x20.5+30+40').to_s)
-    assert_equal('10.20%x20.50%+30+40', Magick::Geometry.from_s('10.2%x20.500%+30+40').to_s)
+    expect(Magick::Geometry.from_s('10.2x20.5+30+40').to_s).to eq('10.20x20.50+30+40')
+    expect(Magick::Geometry.from_s('10.2%x20.500%+30+40').to_s).to eq('10.20%x20.50%+30+40')
 
     assert_raise(ArgumentError) { Magick::Geometry.from_s('10x20+') }
     assert_raise(ArgumentError) { Magick::Geometry.from_s('+30.000+40') }

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -20,7 +20,7 @@ class LibMagickUT < Minitest::Test
       assert(which == :c)
       assert_instance_of(String, description)
       assert_instance_of(String, id)
-      assert_equal(:initialize, method)
+      expect(method).to eq(:initialize)
     end
     img = Magick::Image.new(20, 20)
 
@@ -28,7 +28,7 @@ class LibMagickUT < Minitest::Test
       assert(which == :d)
       assert_instance_of(String, description)
       assert_instance_of(String, id)
-      assert_equal(:"destroy!", method)
+      expect(method).to eq(:"destroy!")
     end
     img.destroy!
   ensure

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -38,6 +38,25 @@ module Minitest
       assert(yield)
     end
 
+    def expect(actual)
+      @actual = actual
+      self
+    end
+
+    def to(matcher)
+      case matcher
+      when :eq
+        assert_equal(@expected, @actual)
+      else
+        raise ArgumentError, "no matcher: #{matcher.inspect}"
+      end
+    end
+
+    def eq(expected)
+      @expected = expected
+      :eq
+    end
+
     alias assert_nothing_thrown assert_nothing_raised
     alias assert_raise assert_raises
     alias assert_not_same refute_same

--- a/test/tmpnam_test.rb
+++ b/test/tmpnam_test.rb
@@ -18,24 +18,24 @@ class TmpnamTest < Minitest::Test
 
     # now it exists
     assert_nothing_raised { Magick._tmpnam_ }
-    assert_equal(1, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(1)
 
     info.texture = texture
-    assert_equal(2, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(2)
 
     mon = Magick::ImageList::Montage.new
     mon.texture = texture
-    assert_equal(3, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(3)
 
     mon.texture = texture
-    assert_equal(4, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(4)
 
     gc = Magick::Draw.new
     gc.composite(0, 0, 20, 20, texture)
-    assert_equal(5, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(5)
 
     gc.composite(0, 0, 20, 20, texture)
-    assert_equal(6, Magick._tmpnam_)
+    expect(Magick._tmpnam_).to eq(6)
 
     tmpfiles2 = Dir[ENV['HOME'] + '/tmp/magick*'].length
 
@@ -43,8 +43,8 @@ class TmpnamTest < Minitest::Test
     # The 2nd info texture deletes the first.
     # Both composite images are still alive.
     # Therefore only 4 tmp files are left.
-    # assert_equal(tmpfiles+4, tmpfiles2)
+    # expect(tmpfiles2).to eq(tmpfiles+4)
     # 6.4.1-5 - only 1 tmpfile?
-    assert_equal(tmpfiles, tmpfiles2)
+    expect(tmpfiles2).to eq(tmpfiles)
   end
 end


### PR DESCRIPTION
This demonstrates the approach I want to take with converting tests to
RSpec. Rather than trying to convert tests file-by-file, we can sweep
through all of the tests and replace the matchers with the RSpec syntax.
Subsequent commits will continue to replace the existing `assert` style
matchers with `expect`. Once that is finished, we can swap in `minitest`
`spec` style, then move everything to the `spec/` folder, and finally
split the tests up and refactor them in place.