### PR TITLE
Replace remaining assertions with RSpec style matcher

### DIFF
--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -39,9 +39,9 @@ class EnumUT < Minitest::Test
     enum1 = Magick::Enum.new(:foo, 42)
     enum2 = Magick::Enum.new(:foo, 56)
 
-    assert_true(enum1 === enum1)
-    assert_false(enum1 === enum2)
-    assert_false(enum1 === 'x')
+    expect(enum1 === enum1).to be(true)
+    expect(enum1 === enum2).to be(false)
+    expect(enum1 === 'x').to be(false)
   end
 
   def test_bitwise_or

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -156,18 +156,18 @@ class Image1_UT < Minitest::Test
   # test alpha backward compatibility. Image#alpha w/o arguments acts like alpha?
   def test_alpha_compat
     expect { @img.alpha }.not_to raise_error
-    assert !@img.alpha
+    expect(@img.alpha).to be(false)
     expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
-    assert @img.alpha
+    expect(@img.alpha).to be(true)
   end
 
   def test_alpha
     expect { @img.alpha? }.not_to raise_error
-    assert !@img.alpha?
+    expect(@img.alpha?).to be(false)
     expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
-    assert @img.alpha?
+    expect(@img.alpha?).to be(true)
     expect { @img.alpha Magick::DeactivateAlphaChannel }.not_to raise_error
-    assert !@img.alpha?
+    expect(@img.alpha?).to be(false)
     expect { @img.alpha Magick::OpaqueAlphaChannel }.not_to raise_error
     expect { @img.alpha Magick::SetAlphaChannel }.not_to raise_error
     expect { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }.to raise_error(ArgumentError)

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -378,14 +378,14 @@ class Image2_UT < Minitest::Test
       m = id.split(/ /)
       name = File.basename m[0]
 
-      assert(%i[c d].include?(which), "unexpected value for which: #{which}")
+      expect(%i[c d]).to include(which)
       expect(method).to eq(:destroy!) if which == :d
 
       if which == :c
-        assert(!images.key?(addr), 'duplicate image addresses')
+        expect(images).not_to have_key(addr)
         images[addr] = name
       else
-        assert(images.key?(addr), 'destroying image that was not created')
+        expect(images).to have_key(addr)
         expect(images[addr]).to eq(name)
       end
     end
@@ -707,8 +707,8 @@ class Image2_UT < Minitest::Test
     region = girl.crop(10, 10, 50, 50)
     expect do
       x, y = girl.find_similar_region(region)
-      assert_not_nil(x)
-      assert_not_nil(y)
+      expect(x).not_to be(nil)
+      expect(y).not_to be(nil)
       expect(x).to eq(10)
       expect(y).to eq(10)
     end.not_to raise_error
@@ -919,14 +919,14 @@ class Image2_UT < Minitest::Test
 
   def test_gray?
     gray = Magick::Image.new(20, 20) { self.background_color = 'gray50' }
-    assert(gray.gray?)
+    expect(gray.gray?).to be(true)
     red = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    assert(!red.gray?)
+    expect(red.gray?).to be(false)
   end
 
   def test_histogram?
     expect { @img.histogram? }.not_to raise_error
-    assert(@img.histogram?)
+    expect(@img.histogram?).to be(true)
   end
 
   def test_implode
@@ -1103,7 +1103,7 @@ class Image2_UT < Minitest::Test
     expect { @img.mask(cimg) }.not_to raise_error
     res = nil
     expect { res = @img.mask }.not_to raise_error
-    assert_not_nil(res)
+    expect(res).not_to be(nil)
     expect(res).not_to be(cimg)
     expect(res.columns).to eq(20)
     expect(res.rows).to eq(20)
@@ -1285,7 +1285,7 @@ class Image2_UT < Minitest::Test
   def test_opaque_channel
     res = nil
     expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
-    assert_not_nil(res)
+    expect(res).not_to be(nil)
     expect(res).to be_instance_of(Magick::Image)
     expect(@img).not_to be(res)
     expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
@@ -1328,7 +1328,7 @@ class Image2_UT < Minitest::Test
   def test_paint_transparent
     res = nil
     expect { res = @img.paint_transparent('red') }.not_to raise_error
-    assert_not_nil(res)
+    expect(res).not_to be(nil)
     expect(res).to be_instance_of(Magick::Image)
     expect(@img).not_to be(res)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -72,7 +72,7 @@ class Image3_UT < Minitest::Test
   def test_radial_blur_channel
     res = nil
     expect { res = @img.radial_blur_channel(30) }.not_to raise_error
-    assert_not_nil(res)
+    expect(res).not_to be(nil)
     expect(res).to be_instance_of(Magick::Image)
     expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
     expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
@@ -277,7 +277,7 @@ class Image3_UT < Minitest::Test
     img = Magick::Image.new(200, 250)
     res = nil
     expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
-    assert_not_nil(res)
+    expect(res).not_to be(nil)
     expect(res).to be_instance_of(Magick::Image)
     expect(res).not_to be(img)
     expect(res.columns).to eq(40)
@@ -577,7 +577,7 @@ class Image3_UT < Minitest::Test
   def test_sparse_color
     img = Magick::Image.new(100, 100)
     args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
-    # assert good calls work
+    # ensure good calls work
     Magick::SparseColorMethod.values do |v|
       next if v == Magick::UndefinedColorInterpolate
 

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -127,15 +127,15 @@ class ImageList1UT < Minitest::Test
   def test_all
     q = nil
     expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
-    assert(q)
+    expect(q).to be(true)
   end
 
   def test_any
     q = nil
     expect { q = @list.all? { |_i| false } }.not_to raise_error
-    assert(!q)
+    expect(q).to be(false)
     expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
-    assert(q)
+    expect(q).to be(true)
   end
 
   def test_aref
@@ -456,9 +456,9 @@ class ImageList1UT < Minitest::Test
 
   def test_eql?
     list2 = @list
-    assert(@list.eql?(list2))
+    expect(@list.eql?(list2)).to be(true)
     list2 = @list.copy
-    assert(!@list.eql?(list2))
+    expect(@list.eql?(list2)).to be(false)
   end
 
   def test_fill

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -77,9 +77,9 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_black_point_compensation
     expect { @img.black_point_compensation = true }.not_to raise_error
-    assert(@img.black_point_compensation)
+    expect(@img.black_point_compensation).to be(true)
     expect { @img.black_point_compensation = false }.not_to raise_error
-    expect(@img.black_point_compensation).to eq(false)
+    expect(@img.black_point_compensation).to be(false)
   end
 
   def test_border_color
@@ -530,9 +530,9 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_start_loop
     expect { @img.start_loop }.not_to raise_error
-    assert(!@img.start_loop)
+    expect(@img.start_loop).to be(false)
     expect { @img.start_loop = true }.not_to raise_error
-    assert(@img.start_loop)
+    expect(@img.start_loop).to be(true)
   end
 
   def test_ticks_per_second

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -31,9 +31,9 @@ class InfoUT < Minitest::Test
   end
 
   def test_antialias
-    assert @info.antialias
+    expect(@info.antialias).to be(true)
     expect { @info.antialias = false }.not_to raise_error
-    assert !@info.antialias
+    expect(@info.antialias).to be(false)
   end
 
   def test_aref_aset
@@ -282,7 +282,7 @@ class InfoUT < Minitest::Test
 
   def test_monochrome
     expect { @info.monochrome = true }.not_to raise_error
-    assert @info.monochrome
+    expect(@info.monochrome).to be(true)
     expect { @info.monochrome = nil }.not_to raise_error
   end
 

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -230,7 +230,7 @@ class MagickUT < Minitest::Test
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
-    # assert behavior with empty string argument
+    # check behavior with empty string argument
     expect { g = Magick::Geometry.from_s('') }.not_to raise_error
     expect(g.to_s).to eq('')
 
@@ -262,35 +262,35 @@ class MagickUT < Minitest::Test
 
     expect { cur = Magick.limit_resource(:memory, 500) }.not_to raise_error
     expect(cur).to be_kind_of(Integer)
-    assert(cur > 1024**2)
+    expect(cur > 1024**2).to be(true)
     expect { new = Magick.limit_resource('memory') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:memory, cur)
 
     expect { cur = Magick.limit_resource(:map, 3500) }.not_to raise_error
     expect(cur).to be_kind_of(Integer)
-    assert(cur > 1024**2)
+    expect(cur > 1024**2).to be(true)
     expect { new = Magick.limit_resource('map') }.not_to raise_error
     expect(new).to eq(3500)
     Magick.limit_resource(:map, cur)
 
     expect { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }.not_to raise_error
     expect(cur).to be_kind_of(Integer)
-    assert(cur > 1024**2)
+    expect(cur > 1024**2).to be(true)
     expect { new = Magick.limit_resource('disk') }.not_to raise_error
     expect(new).to eq(3_221_225_472)
     Magick.limit_resource(:disk, cur)
 
     expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
     expect(cur).to be_kind_of(Integer)
-    assert(cur > 512)
+    expect(cur > 512).to be(true)
     expect { new = Magick.limit_resource('file') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:file, cur)
 
     expect { cur = Magick.limit_resource(:time, 300) }.not_to raise_error
     expect(cur).to be_kind_of(Integer)
-    assert(cur > 300)
+    expect(cur > 300).to be(true)
     expect { new = Magick.limit_resource('time') }.not_to raise_error
     expect(new).to eq(300)
     Magick.limit_resource(:time, cur)

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -72,41 +72,41 @@ class PixelUT < Minitest::Test
 
   def test_case_eq
     pixel = Magick::Pixel.from_color('brown')
-    assert_true(@pixel === pixel)
-    assert_false(@pixel === 'red')
+    expect(@pixel === pixel).to be(true)
+    expect(@pixel === 'red').to be(false)
 
     pixel = Magick::Pixel.from_color('red')
-    assert_false(@pixel === pixel)
+    expect(@pixel === pixel).to be(false)
   end
 
   def test_clone
     pixel = @pixel.clone
-    assert_true(@pixel === pixel)
+    expect(pixel).to eq(@pixel)
     expect(pixel.object_id).not_to eq(@pixel.object_id)
 
     pixel = @pixel.taint.clone
-    assert_true(pixel.tainted?)
+    expect(pixel.tainted?).to be(true)
 
     pixel = @pixel.freeze.clone
-    assert_true(pixel.frozen?)
+    expect(pixel.frozen?).to be(true)
   end
 
   def test_dup
     pixel = @pixel.dup
-    assert_true(@pixel === pixel)
+    expect(@pixel === pixel).to be(true)
     expect(pixel.object_id).not_to eq(@pixel.object_id)
 
     pixel = @pixel.taint.dup
-    assert_true(pixel.tainted?)
+    expect(pixel.tainted?).to be(true)
 
     pixel = @pixel.freeze.dup
-    assert_false(pixel.frozen?)
+    expect(pixel.frozen?).to be(false)
   end
 
   def test_hash
     hash = nil
     expect { hash = @pixel.hash }.not_to raise_error
-    assert_not_nil(hash)
+    expect(hash).not_to be(nil)
     expect(hash).to eq(1_385_502_079)
 
     p = Magick::Pixel.new
@@ -124,17 +124,17 @@ class PixelUT < Minitest::Test
 
   def test_eql?
     p = @pixel
-    assert(@pixel.eql?(p))
+    expect(@pixel.eql?(p)).to be(true)
     p = Magick::Pixel.new
-    assert(!@pixel.eql?(p))
+    expect(@pixel.eql?(p)).to be(false)
   end
 
   def test_fcmp
     red = Magick::Pixel.from_color('red')
     blue = Magick::Pixel.from_color('blue')
     expect { red.fcmp(red) }.not_to raise_error
-    assert(red.fcmp(red))
-    assert(!red.fcmp(blue))
+    expect(red.fcmp(red)).to be(true)
+    expect(red.fcmp(blue)).to be(false)
 
     expect { red.fcmp(blue, 10) }.not_to raise_error
     expect { red.fcmp(blue, 10, Magick::RGBColorspace) }.not_to raise_error

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -17,7 +17,7 @@ class LibMagickUT < Minitest::Test
 
   def test_trace_proc
     Magick.trace_proc = proc do |which, description, id, method|
-      assert(which == :c)
+      expect(which).to eq(:c)
       expect(description).to be_instance_of(String)
       expect(id).to be_instance_of(String)
       expect(method).to eq(:initialize)
@@ -25,7 +25,7 @@ class LibMagickUT < Minitest::Test
     img = Magick::Image.new(20, 20)
 
     Magick.trace_proc = proc do |which, description, id, method|
-      assert(which == :d)
+      expect(which).to eq(:d)
       expect(description).to be_instance_of(String)
       expect(id).to be_instance_of(String)
       expect(method).to eq(:"destroy!")

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -48,6 +48,10 @@ module Minitest
         assert_in_delta(@expected, @actual, @delta)
       when :eq
         assert_equal(@expected, @actual)
+      when :have_key
+        assert(@actual.key?(@expected))
+      when :include
+        assert(@actual.include?(@expected))
       when :match
         assert_match(@expected, @actual)
       when :raise_error
@@ -65,6 +69,8 @@ module Minitest
         refute_same(@expected, @actual)
       when :eq
         refute_equal(@expected, @actual)
+      when :have_key
+        refute(@actual.key?(@expected))
       when :raise_error
         @actual_block.call
       else
@@ -92,6 +98,16 @@ module Minitest
       self
     end
 
+    def have_key(expected) # rubocop:disable Naming/PredicateName
+      @expected = expected
+      :have_key
+    end
+
+    def include(expected)
+      @expected = expected
+      :include
+    end
+
     def match(expected)
       @expected = expected
       :match
@@ -116,10 +132,6 @@ module Minitest
       @expected = expected
       :respond_to
     end
-
-    alias assert_not_nil refute_nil
-    alias assert_true assert
-    alias assert_false refute
   end
 end
 


### PR DESCRIPTION
This changes `assert`, `assert_not_nil`, `assert_true`, and
`assert_false` assertions to use mostly `be(true)`, `be(false)` and
`be(nil)` checks, with the introduction of `have_key` and `include` checks
as well.

This should be the last step in switching the matchers to use RSpec syntax.
Next up is switching the test files to use `spec` syntax.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/predicate-matchers#should-have-key-(based-on-hash#has-key?) 
https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/include-matcher