### PR TITLE
Replace `assert_raise(s)` with RSpec style matcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ AllCops:
   Exclude:
     - 'vendor/bundle/**/*'
     - '**/*\.spec'
+
+# we may not need this after finishing RSpec conversion
+# seems like `rubocop-rspec` already excludes the `spec/` directory
+Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -10,7 +10,7 @@ class DrawUT < Minitest::Test
     assert_nothing_raised do
       @draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
     end
-    assert_raise(TypeError) { @draw.affine = [1, 2, 3, 4, 5, 6] }
+    expect { @draw.affine = [1, 2, 3, 4, 5, 6] }.to raise_error(TypeError)
   end
 
   def test_align
@@ -29,18 +29,18 @@ class DrawUT < Minitest::Test
     assert_nothing_raised { @draw.density = '90x90' }
     assert_nothing_raised { @draw.density = 'x90' }
     assert_nothing_raised { @draw.density = '90' }
-    assert_raise(TypeError) { @draw.density = 2 }
+    expect { @draw.density = 2 }.to raise_error(TypeError)
   end
 
   def test_encoding
     assert_nothing_raised { @draw.encoding = 'AdobeCustom' }
-    assert_raise(TypeError) { @draw.encoding = 2 }
+    expect { @draw.encoding = 2 }.to raise_error(TypeError)
   end
 
   def test_fill
     assert_nothing_raised { @draw.fill = 'white' }
     assert_nothing_raised { @draw.fill = Magick::Pixel.from_color('white') }
-    assert_raise(TypeError) { @draw.fill = 2 }
+    expect { @draw.fill = 2 }.to raise_error(TypeError)
   end
 
   def test_fill_pattern
@@ -53,17 +53,17 @@ class DrawUT < Minitest::Test
       @draw.fill_pattern = img2
     end
 
-    assert_raise(NoMethodError) { @draw.fill_pattern = 'x' }
+    expect { @draw.fill_pattern = 'x' }.to raise_error(NoMethodError)
   end
 
   def test_font
     assert_nothing_raised { @draw.font = 'Arial-Bold' }
-    assert_raise(TypeError) { @draw.font = 2 }
+    expect { @draw.font = 2 }.to raise_error(TypeError)
   end
 
   def test_font_family
     assert_nothing_raised { @draw.font_family = 'Arial' }
-    assert_raise(TypeError) { @draw.font_family = 2 }
+    expect { @draw.font_family = 2 }.to raise_error(TypeError)
   end
 
   def test_font_stretch
@@ -71,7 +71,7 @@ class DrawUT < Minitest::Test
       assert_nothing_raised { @draw.font_stretch = stretch }
     end
 
-    assert_raise(TypeError) { @draw.font_stretch = 2 }
+    expect { @draw.font_stretch = 2 }.to raise_error(TypeError)
   end
 
   def test_font_style
@@ -79,7 +79,7 @@ class DrawUT < Minitest::Test
       assert_nothing_raised { @draw.font_style = style }
     end
 
-    assert_raise(TypeError) { @draw.font_style = 2 }
+    expect { @draw.font_style = 2 }.to raise_error(TypeError)
   end
 
   def test_font_weight
@@ -87,8 +87,8 @@ class DrawUT < Minitest::Test
       assert_nothing_raised { @draw.font_weight = weight }
     end
 
-    assert_raise(ArgumentError) { @draw.font_weight = 99 }
-    assert_raise(ArgumentError) { @draw.font_weight = 901 }
+    expect { @draw.font_weight = 99 }.to raise_error(ArgumentError)
+    expect { @draw.font_weight = 901 }.to raise_error(ArgumentError)
   end
 
   def test_gravity
@@ -96,38 +96,38 @@ class DrawUT < Minitest::Test
       assert_nothing_raised { @draw.gravity = gravity }
     end
 
-    assert_raise(TypeError) { @draw.gravity = 2 }
+    expect { @draw.gravity = 2 }.to raise_error(TypeError)
   end
 
   def test_interline_spacing
     assert_nothing_raised { @draw.interline_spacing = 2 }
-    assert_raise(TypeError) { @draw.interline_spacing = 'x' }
+    expect { @draw.interline_spacing = 'x' }.to raise_error(TypeError)
   end
 
   def test_interword_spacing
     assert_nothing_raised { @draw.interword_spacing = 2 }
-    assert_raise(TypeError) { @draw.interword_spacing = 'x' }
+    expect { @draw.interword_spacing = 'x' }.to raise_error(TypeError)
   end
 
   def test_kerning
     assert_nothing_raised { @draw.kerning = 2 }
-    assert_raise(TypeError) { @draw.kerning = 'x' }
+    expect { @draw.kerning = 'x' }.to raise_error(TypeError)
   end
 
   def test_pointsize
     assert_nothing_raised { @draw.pointsize = 2 }
-    assert_raise(TypeError) { @draw.pointsize = 'x' }
+    expect { @draw.pointsize = 'x' }.to raise_error(TypeError)
   end
 
   def test_rotation
     assert_nothing_raised { @draw.rotation = 15 }
-    assert_raise(TypeError) { @draw.rotation = 'x' }
+    expect { @draw.rotation = 'x' }.to raise_error(TypeError)
   end
 
   def test_stroke
     assert_nothing_raised { @draw.stroke = Magick::Pixel.from_color('white') }
     assert_nothing_raised { @draw.stroke = 'white' }
-    assert_raise(TypeError) { @draw.stroke = 2 }
+    expect { @draw.stroke = 2 }.to raise_error(TypeError)
   end
 
   def test_stroke_pattern
@@ -140,12 +140,12 @@ class DrawUT < Minitest::Test
       @draw.stroke_pattern = img2
     end
 
-    assert_raise(NoMethodError) { @draw.stroke_pattern = 'x' }
+    expect { @draw.stroke_pattern = 'x' }.to raise_error(NoMethodError)
   end
 
   def test_stroke_width
     assert_nothing_raised { @draw.stroke_width = 15 }
-    assert_raise(TypeError) { @draw.stroke_width = 'x' }
+    expect { @draw.stroke_width = 'x' }.to raise_error(TypeError)
   end
 
   def test_text_antialias
@@ -167,7 +167,7 @@ class DrawUT < Minitest::Test
   def test_undercolor
     assert_nothing_raised { @draw.undercolor = Magick::Pixel.from_color('white') }
     assert_nothing_raised { @draw.undercolor = 'white' }
-    assert_raise(TypeError) { @draw.undercolor = 2 }
+    expect { @draw.undercolor = 2 }.to raise_error(TypeError)
   end
 
   def test_annotate
@@ -182,12 +182,12 @@ class DrawUT < Minitest::Test
       assert_instance_of(Magick::Draw, yield_obj)
     end
 
-    assert_raise(TypeError) do
+    expect do
       img = Magick::Image.new(10, 10)
       @draw.annotate(img, 0, 0, 0, 20, nil)
-    end
+    end.to raise_error(TypeError)
 
-    assert_raise(NoMethodError) { @draw.annotate('x', 0, 0, 0, 20, 'Hello world') }
+    expect { @draw.annotate('x', 0, 0, 0, 20, 'Hello world') }.to raise_error(NoMethodError)
   end
 
   def test_annotate_stack_buffer_overflow
@@ -223,14 +223,14 @@ class DrawUT < Minitest::Test
       assert_nothing_raised { @draw.composite(0, 0, 10, 10, img, op) }
     end
 
-    assert_raise(TypeError) { @draw.composite('x', 0, 10, 10, img) }
-    assert_raise(TypeError) { @draw.composite(0, 'y', 10, 10, img) }
-    assert_raise(TypeError) { @draw.composite(0, 0, 'w', 10, img) }
-    assert_raise(TypeError) { @draw.composite(0, 0, 10, 'h', img) }
-    assert_raise(TypeError) { @draw.composite(0, 0, 10, 10, img, Magick::CenterAlign) }
-    assert_raise(NoMethodError) { @draw.composite(0, 0, 10, 10, 'image') }
-    assert_raise(ArgumentError) { @draw.composite(0, 0, 10, 10) }
-    assert_raise(ArgumentError) { @draw.composite(0, 0, 10, 10, img, Magick::ModulusAddCompositeOp, 'x') }
+    expect { @draw.composite('x', 0, 10, 10, img) }.to raise_error(TypeError)
+    expect { @draw.composite(0, 'y', 10, 10, img) }.to raise_error(TypeError)
+    expect { @draw.composite(0, 0, 'w', 10, img) }.to raise_error(TypeError)
+    expect { @draw.composite(0, 0, 10, 'h', img) }.to raise_error(TypeError)
+    expect { @draw.composite(0, 0, 10, 10, img, Magick::CenterAlign) }.to raise_error(TypeError)
+    expect { @draw.composite(0, 0, 10, 10, 'image') }.to raise_error(NoMethodError)
+    expect { @draw.composite(0, 0, 10, 10) }.to raise_error(ArgumentError)
+    expect { @draw.composite(0, 0, 10, 10, img, Magick::ModulusAddCompositeOp, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_draw
@@ -240,8 +240,8 @@ class DrawUT < Minitest::Test
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     assert_nothing_raised { @draw.draw(img) }
 
-    assert_raise(ArgumentError) { draw.draw(img) }
-    assert_raise(NoMethodError) { draw.draw('x') }
+    expect { draw.draw(img) }.to raise_error(ArgumentError)
+    expect { draw.draw('x') }.to raise_error(NoMethodError)
   end
 
   def test_get_type_metrics
@@ -249,10 +249,10 @@ class DrawUT < Minitest::Test
     assert_nothing_raised { @draw.get_type_metrics('ABCDEF') }
     assert_nothing_raised { @draw.get_type_metrics(img, 'ABCDEF') }
 
-    assert_raise(ArgumentError) { @draw.get_type_metrics }
-    assert_raise(ArgumentError) { @draw.get_type_metrics(img, 'ABCDEF', 20) }
-    assert_raise(ArgumentError) { @draw.get_type_metrics(img, '') }
-    assert_raise(NoMethodError) { @draw.get_type_metrics('x', 'ABCDEF') }
+    expect { @draw.get_type_metrics }.to raise_error(ArgumentError)
+    expect { @draw.get_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
+    expect { @draw.get_type_metrics(img, '') }.to raise_error(ArgumentError)
+    expect { @draw.get_type_metrics('x', 'ABCDEF') }.to raise_error(NoMethodError)
   end
 
   def test_get_multiline_type_metrics
@@ -260,9 +260,9 @@ class DrawUT < Minitest::Test
     assert_nothing_raised { @draw.get_multiline_type_metrics('ABCDEF') }
     assert_nothing_raised { @draw.get_multiline_type_metrics(img, 'ABCDEF') }
 
-    assert_raise(ArgumentError) { @draw.get_multiline_type_metrics }
-    assert_raise(ArgumentError) { @draw.get_multiline_type_metrics(img, 'ABCDEF', 20) }
-    assert_raise(ArgumentError) { @draw.get_multiline_type_metrics(img, '') }
+    expect { @draw.get_multiline_type_metrics }.to raise_error(ArgumentError)
+    expect { @draw.get_multiline_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
+    expect { @draw.get_multiline_type_metrics(img, '') }.to raise_error(ArgumentError)
   end
 
   def test_inspect
@@ -311,7 +311,7 @@ class DrawUT < Minitest::Test
   def test_primitive
     assert_nothing_raised { @draw.primitive('ABCDEF') }
     assert_nothing_raised { @draw.primitive('12345') }
-    assert_raise(TypeError) { @draw.primitive(nil) }
+    expect { @draw.primitive(nil) }.to raise_error(TypeError)
   end
 
   def test_draw_options

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -6,8 +6,8 @@ class EnumUT < Minitest::Test
     assert_nothing_raised { Magick::Enum.new(:foo, 42) }
     assert_nothing_raised { Magick::Enum.new('foo', 42) }
 
-    assert_raise(TypeError) { Magick::Enum.new(Object.new, 42) }
-    assert_raise(TypeError) { Magick::Enum.new(:foo, 'x') }
+    expect { Magick::Enum.new(Object.new, 42) }.to raise_error(TypeError)
+    expect { Magick::Enum.new(:foo, 'x') }.to raise_error(TypeError)
   end
 
   def test_to_s
@@ -52,7 +52,7 @@ class EnumUT < Minitest::Test
     expect(enum.to_i).to eq(58)
     expect(enum.to_s).to eq('foo|bar')
 
-    assert_raise(ArgumentError) { enum1 | 'x' }
+    expect { enum1 | 'x' }.to raise_error(ArgumentError)
   end
 
   def test_type_values
@@ -198,9 +198,9 @@ class EnumUT < Minitest::Test
     img = Magick::Image.new(20, 20)
     pixels = img.export_pixels(0, 0, 20, 20, 'RGB').pack('D*')
 
-    error = assert_raise(ArgumentError) do
+    error = expect do
       img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
-    end
+    end.to raise_error(ArgumentError)
     assert_match(/UndefinedPixel/, error.message)
   end
 

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -6,12 +6,12 @@ class GradientFillUT < Minitest::Test
     assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000'))
     assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red'))
 
-    assert_raise(ArgumentError) { Magick::GradientFill.new(0, 0, 0, 100, 'foo', '#000') }
-    assert_raise(ArgumentError) { Magick::GradientFill.new(0, 0, 0, 100, '#900', 'bar') }
-    assert_raise(TypeError) { Magick::GradientFill.new('x1', 0, 0, 100, '#900', '#000') }
-    assert_raise(TypeError) { Magick::GradientFill.new(0, 'y1', 0, 100, '#900', '#000') }
-    assert_raise(TypeError) { Magick::GradientFill.new(0, 0, 'x2', 100, '#900', '#000') }
-    assert_raise(TypeError) { Magick::GradientFill.new(0, 0, 0, 'y2', '#900', '#000') }
+    expect { Magick::GradientFill.new(0, 0, 0, 100, 'foo', '#000') }.to raise_error(ArgumentError)
+    expect { Magick::GradientFill.new(0, 0, 0, 100, '#900', 'bar') }.to raise_error(ArgumentError)
+    expect { Magick::GradientFill.new('x1', 0, 0, 100, '#900', '#000') }.to raise_error(TypeError)
+    expect { Magick::GradientFill.new(0, 'y1', 0, 100, '#900', '#000') }.to raise_error(TypeError)
+    expect { Magick::GradientFill.new(0, 0, 'x2', 100, '#900', '#000') }.to raise_error(TypeError)
+    expect { Magick::GradientFill.new(0, 0, 0, 'y2', '#900', '#000') }.to raise_error(TypeError)
   end
 
   def test_fill

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -14,8 +14,8 @@ class Image1_UT < Minitest::Test
     assert_instance_of(Array, res)
     assert_instance_of(Magick::Image, res[0])
     expect(res[0]).to eq(img)
-    assert_raise(ArgumentError) { Magick::Image.read(nil) }
-    assert_raise(ArgumentError) { Magick::Image.read("") }
+    expect { Magick::Image.read(nil) }.to raise_error(ArgumentError)
+    expect { Magick::Image.read("") }.to raise_error(ArgumentError)
   end
 
   def test_spaceship
@@ -40,7 +40,7 @@ class Image1_UT < Minitest::Test
     end
     assert_nothing_raised { @img.adaptive_blur(2) }
     assert_nothing_raised { @img.adaptive_blur(3, 2) }
-    assert_raise(ArgumentError) { @img.adaptive_blur(3, 2, 2) }
+    expect { @img.adaptive_blur(3, 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_adaptive_blur_channel
@@ -52,7 +52,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.adaptive_blur_channel(3, 2) }
     assert_nothing_raised { @img.adaptive_blur_channel(3, 2, Magick::RedChannel) }
     assert_nothing_raised { @img.adaptive_blur_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.adaptive_blur_channel(3, 2, 2) }
+    expect { @img.adaptive_blur_channel(3, 2, 2) }.to raise_error(TypeError)
   end
 
   def test_adaptive_resize
@@ -61,10 +61,10 @@ class Image1_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.adaptive_resize(2) }
-    assert_raise(ArgumentError) { @img.adaptive_resize(-1.0) }
-    assert_raise(ArgumentError) { @img.adaptive_resize(10, 10, 10) }
-    assert_raise(ArgumentError) { @img.adaptive_resize }
-    assert_raise(RangeError) { @img.adaptive_resize(Float::MAX) }
+    expect { @img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
+    expect { @img.adaptive_resize(10, 10, 10) }.to raise_error(ArgumentError)
+    expect { @img.adaptive_resize }.to raise_error(ArgumentError)
+    expect { @img.adaptive_resize(Float::MAX) }.to raise_error(RangeError)
   end
 
   def test_adaptive_sharpen
@@ -74,7 +74,7 @@ class Image1_UT < Minitest::Test
     end
     assert_nothing_raised { @img.adaptive_sharpen(2) }
     assert_nothing_raised { @img.adaptive_sharpen(3, 2) }
-    assert_raise(ArgumentError) { @img.adaptive_sharpen(3, 2, 2) }
+    expect { @img.adaptive_sharpen(3, 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_adaptive_sharpen_channel
@@ -86,7 +86,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2) }
     assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }
     assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.adaptive_sharpen_channel(3, 2, 2) }
+    expect { @img.adaptive_sharpen_channel(3, 2, 2) }.to raise_error(TypeError)
   end
 
   def test_adaptive_threshold
@@ -97,7 +97,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.adaptive_threshold(2) }
     assert_nothing_raised { @img.adaptive_threshold(2, 4) }
     assert_nothing_raised { @img.adaptive_threshold(2, 4, 1) }
-    assert_raise(ArgumentError) { @img.adaptive_threshold(2, 4, 1, 2) }
+    expect { @img.adaptive_threshold(2, 4, 1, 2) }.to raise_error(ArgumentError)
   end
 
   def test_add_compose_mask
@@ -110,14 +110,14 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.delete_compose_mask }
 
     mask = Magick::Image.new(10, 10)
-    assert_raise(ArgumentError) { @img.add_compose_mask(mask) }
+    expect { @img.add_compose_mask(mask) }.to raise_error(ArgumentError)
   end
 
   def test_add_noise
     Magick::NoiseType.values do |noise|
       assert_nothing_raised { @img.add_noise(noise) }
     end
-    assert_raise(TypeError) { @img.add_noise(0) }
+    expect { @img.add_noise(0) }.to raise_error(TypeError)
   end
 
   def test_add_noise_channel
@@ -129,17 +129,17 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.add_noise_channel(Magick::PoissonNoise, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel) }
 
     # Not a NoiseType
-    assert_raise(TypeError) { @img.add_noise_channel(1) }
+    expect { @img.add_noise_channel(1) }.to raise_error(TypeError)
     # Not a ChannelType
-    assert_raise(TypeError) { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel, 1) }
+    expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel, 1) }.to raise_error(TypeError)
     # Too few arguments
-    assert_raise(ArgumentError) { @img.add_noise_channel }
+    expect { @img.add_noise_channel }.to raise_error(ArgumentError)
   end
 
   def test_add_delete_profile
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     assert_nothing_raised { img.add_profile(File.join(__dir__, 'cmyk.icm')) }
-    # assert_raise(Magick::ImageMagickError) { img.add_profile(File.join(__dir__, 'srgb.icm')) }
+    # expect { img.add_profile(File.join(__dir__, 'srgb.icm')) }.to raise_error(Magick::ImageMagickError)
 
     img.each_profile { |name, _value| expect(name).to eq('icc') }
     assert_nothing_raised { img.delete_profile('icc') }
@@ -148,7 +148,7 @@ class Image1_UT < Minitest::Test
   def test_affine_matrix
     affine = Magick::AffineMatrix.new(1, Math::PI / 6, Math::PI / 6, 1, 0, 0)
     assert_nothing_raised { @img.affine_transform(affine) }
-    assert_raise(TypeError) { @img.affine_transform(0) }
+    expect { @img.affine_transform(0) }.to raise_error(TypeError)
     res = @img.affine_transform(affine)
     assert_instance_of(Magick::Image,  res)
   end
@@ -170,9 +170,9 @@ class Image1_UT < Minitest::Test
     assert !@img.alpha?
     assert_nothing_raised { @img.alpha Magick::OpaqueAlphaChannel }
     assert_nothing_raised { @img.alpha Magick::SetAlphaChannel }
-    assert_raise(ArgumentError) { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }
+    expect { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }.to raise_error(ArgumentError)
     @img.freeze
-    assert_raise(FreezeError) { @img.alpha Magick::SetAlphaChannel }
+    expect { @img.alpha Magick::SetAlphaChannel }.to raise_error(FreezeError)
   end
 
   def test_aref
@@ -197,7 +197,7 @@ class Image1_UT < Minitest::Test
     assert_not_same(@img, res)
     assert_nothing_raised { res = @img.auto_gamma_channel Magick::RedChannel }
     assert_nothing_raised { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }
-    assert_raise(TypeError) { @img.auto_gamma_channel(1) }
+    expect { @img.auto_gamma_channel(1) }.to raise_error(TypeError)
   end
 
   def test_auto_level
@@ -207,7 +207,7 @@ class Image1_UT < Minitest::Test
     assert_not_same(@img, res)
     assert_nothing_raised { res = @img.auto_level_channel Magick::RedChannel }
     assert_nothing_raised { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }
-    assert_raise(TypeError) { @img.auto_level_channel(1) }
+    expect { @img.auto_level_channel(1) }.to raise_error(TypeError)
   end
 
   def test_auto_orient
@@ -229,14 +229,14 @@ class Image1_UT < Minitest::Test
   end
 
   def test_bilevel_channel
-    assert_raise(ArgumentError) { @img.bilevel_channel }
+    expect { @img.bilevel_channel }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.bilevel_channel(100) }
     assert_nothing_raised { @img.bilevel_channel(100, Magick::RedChannel) }
     assert_nothing_raised { @img.bilevel_channel(100, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }
     assert_nothing_raised { @img.bilevel_channel(100, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.bilevel_channel(100, Magick::GrayChannel) }
     assert_nothing_raised { @img.bilevel_channel(100, Magick::AllChannels) }
-    assert_raise(TypeError) { @img.bilevel_channel(100, 2) }
+    expect { @img.bilevel_channel(100, 2) }.to raise_error(TypeError)
     res = @img.bilevel_channel(100)
     assert_instance_of(Magick::Image, res)
   end
@@ -256,22 +256,22 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.blend(@img2, '25%') }
     assert_nothing_raised { @img.blend(@img2, 0.25, 0.75) }
     assert_nothing_raised { @img.blend(@img2, '25%', '75%') }
-    assert_raise(ArgumentError) { @img.blend }
-    assert_raise(ArgumentError) { @img.blend(@img2, 'x') }
-    assert_raise(TypeError) { @img.blend(@img2, 0.25, []) }
-    assert_raise(TypeError) { @img.blend(@img2, 0.25, 0.75, 'x') }
-    assert_raise(TypeError) { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 'x') }
-    assert_raise(TypeError) { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 10, []) }
+    expect { @img.blend }.to raise_error(ArgumentError)
+    expect { @img.blend(@img2, 'x') }.to raise_error(ArgumentError)
+    expect { @img.blend(@img2, 0.25, []) }.to raise_error(TypeError)
+    expect { @img.blend(@img2, 0.25, 0.75, 'x') }.to raise_error(TypeError)
+    expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
+    expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
 
     @img2.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.blend(@img2, '25%') }
+    expect { @img.blend(@img2, '25%') }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_blue_shift
     assert_not_same(@img, @img.blue_shift)
     assert_not_same(@img, @img.blue_shift(2.0))
-    assert_raise(TypeError) { @img.blue_shift('x') }
-    assert_raise(ArgumentError) { @img.blue_shift(2, 2) }
+    expect { @img.blue_shift('x') }.to raise_error(TypeError)
+    expect { @img.blue_shift(2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_blur_channel
@@ -283,7 +283,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.blur_channel(1, 2, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.blur_channel(1, 2, Magick::GrayChannel) }
     assert_nothing_raised { @img.blur_channel(1, 2, Magick::AllChannels) }
-    assert_raise(TypeError) { @img.blur_channel(1, 2, 2) }
+    expect { @img.blur_channel(1, 2, 2) }.to raise_error(TypeError)
     res = @img.blur_channel
     assert_instance_of(Magick::Image, res)
   end
@@ -292,21 +292,21 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.blur_image }
     assert_nothing_raised { @img.blur_image(1) }
     assert_nothing_raised { @img.blur_image(1, 2) }
-    assert_raise(ArgumentError) { @img.blur_image(1, 2, 3) }
+    expect { @img.blur_image(1, 2, 3) }.to raise_error(ArgumentError)
     res = @img.blur_image
     assert_instance_of(Magick::Image, res)
   end
 
   def test_black_threshold
-    assert_raise(ArgumentError) { @img.black_threshold }
+    expect { @img.black_threshold }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.black_threshold(50) }
     assert_nothing_raised { @img.black_threshold(50, 50) }
     assert_nothing_raised { @img.black_threshold(50, 50, 50) }
-    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, 50) }
+    expect { @img.black_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.black_threshold(50, 50, 50, alpha: 50) }
-    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, wrong: 50) }
-    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }
-    assert_raise(ArgumentError) { @img.black_threshold(50, 50, 50, 50, 50) }
+    expect { @img.black_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
+    expect { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
+    expect { @img.black_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
     res = @img.black_threshold(50)
     assert_instance_of(Magick::Image, res)
   end
@@ -317,7 +317,7 @@ class Image1_UT < Minitest::Test
     res = @img.border(2, 2, 'red')
     assert_instance_of(Magick::Image, res)
     @img.freeze
-    assert_raise(FreezeError) { @img.border!(2, 2, 'red') }
+    expect { @img.border!(2, 2, 'red') }.to raise_error(FreezeError)
   end
 
   def test_capture
@@ -327,17 +327,17 @@ class Image1_UT < Minitest::Test
     # assert_nothing_raised { Magick::Image.capture(true, true, true) }
     # assert_nothing_raised { Magick::Image.capture(true, true, true, true) }
     # assert_nothing_raised { Magick::Image.capture(true, true, true, true, true) }
-    assert_raise(ArgumentError) { Magick::Image.capture(true, true, true, true, true, true) }
+    expect { Magick::Image.capture(true, true, true, true, true, true) }.to raise_error(ArgumentError)
   end
 
   def test_change_geometry
-    assert_raise(ArgumentError) { @img.change_geometry('sss') }
-    assert_raise(LocalJumpError) { @img.change_geometry('100x100') }
+    expect { @img.change_geometry('sss') }.to raise_error(ArgumentError)
+    expect { @img.change_geometry('100x100') }.to raise_error(LocalJumpError)
     assert_nothing_raised do
       res = @img.change_geometry('100x100') { 1 }
       expect(res).to eq(1)
     end
-    assert_raise(ArgumentError) { @img.change_geometry([]) }
+    expect { @img.change_geometry([]) }.to raise_error(ArgumentError)
   end
 
   def test_changed?
@@ -352,7 +352,7 @@ class Image1_UT < Minitest::Test
     end
 
     assert_instance_of(Magick::Image, @img.channel(Magick::RedChannel))
-    assert_raise(TypeError) { @img.channel(2) }
+    expect { @img.channel(2) }.to raise_error(TypeError)
   end
 
   def test_channel_depth
@@ -363,7 +363,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.channel_depth(Magick::MagentaChannel, Magick::CyanChannel) }
     assert_nothing_raised { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.channel_depth(Magick::GrayChannel) }
-    assert_raise(TypeError) { @img.channel_depth(2) }
+    expect { @img.channel_depth(2) }.to raise_error(TypeError)
     assert_kind_of(Integer, @img.channel_depth(Magick::RedChannel))
   end
 
@@ -381,7 +381,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.channel_extrema(Magick::MagentaChannel, Magick::CyanChannel) }
     assert_nothing_raised { @img.channel_extrema(Magick::CyanChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.channel_extrema(Magick::GrayChannel) }
-    assert_raise(TypeError) { @img.channel_extrema(2) }
+    expect { @img.channel_extrema(2) }.to raise_error(TypeError)
   end
 
   def test_channel_mean
@@ -398,7 +398,7 @@ class Image1_UT < Minitest::Test
     assert_nothing_raised { @img.channel_mean(Magick::MagentaChannel, Magick::CyanChannel) }
     assert_nothing_raised { @img.channel_mean(Magick::CyanChannel, Magick::BlackChannel) }
     assert_nothing_raised { @img.channel_mean(Magick::GrayChannel) }
-    assert_raise(TypeError) { @img.channel_mean(2) }
+    expect { @img.channel_mean(2) }.to raise_error(TypeError)
   end
 
   def test_charcoal
@@ -408,7 +408,7 @@ class Image1_UT < Minitest::Test
     end
     assert_nothing_raised { @img.charcoal(1.0) }
     assert_nothing_raised { @img.charcoal(1.0, 2.0) }
-    assert_raise(ArgumentError) { @img.charcoal(1.0, 2.0, 3.0) }
+    expect { @img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
   end
 
   def test_chop
@@ -439,13 +439,13 @@ class Image1_UT < Minitest::Test
     assert_same(res, img)
     assert_nothing_raised { img.clut_channel(clut, Magick::RedChannel) }
     assert_nothing_raised { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raises(ArgumentError) { img.clut_channel }
-    assert_raises(ArgumentError) { img.clut_channel(clut, 1, Magick::RedChannel) }
+    expect { img.clut_channel }.to raise_error(ArgumentError)
+    expect { img.clut_channel(clut, 1, Magick::RedChannel) }.to raise_error(ArgumentError)
   end
 
   def test_color_fill_to_border
-    assert_raise(ArgumentError) { @img.color_fill_to_border(-1, 1, 'red') }
-    assert_raise(ArgumentError) { @img.color_fill_to_border(1, 100, 'red') }
+    expect { @img.color_fill_to_border(-1, 1, 'red') }.to raise_error(ArgumentError)
+    expect { @img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, 'red')
       assert_instance_of(Magick::Image, res)
@@ -455,8 +455,8 @@ class Image1_UT < Minitest::Test
   end
 
   def test_color_floodfill
-    assert_raise(ArgumentError) { @img.color_floodfill(-1, 1, 'red') }
-    assert_raise(ArgumentError) { @img.color_floodfill(1, 100, 'red') }
+    expect { @img.color_floodfill(-1, 1, 'red') }.to raise_error(ArgumentError)
+    expect { @img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @img.color_floodfill(@img.columns / 2, @img.rows / 2, 'red')
       assert_instance_of(Magick::Image, res)
@@ -487,26 +487,26 @@ class Image1_UT < Minitest::Test
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @img.colorize(0.25, 0.25, 0.25, pixel) }
     assert_nothing_raised { @img.colorize(0.25, 0.25, 0.25, 0.25, pixel) }
-    assert_raise(ArgumentError) { @img.colorize }
-    assert_raise(ArgumentError) { @img.colorize(0.25) }
-    assert_raise(ArgumentError) { @img.colorize(0.25, 0.25) }
-    assert_raise(ArgumentError) { @img.colorize(0.25, 0.25, 0.25) }
-    assert_raise(ArgumentError) { @img.colorize(0.25, 0.25, 0.25, 'X') }
+    expect { @img.colorize }.to raise_error(ArgumentError)
+    expect { @img.colorize(0.25) }.to raise_error(ArgumentError)
+    expect { @img.colorize(0.25, 0.25) }.to raise_error(ArgumentError)
+    expect { @img.colorize(0.25, 0.25, 0.25) }.to raise_error(ArgumentError)
+    expect { @img.colorize(0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
     # last argument must be a color name or pixel
-    assert_raise(TypeError) { @img.colorize(0.25, 0.25, 0.25, 0.25) }
-    assert_raise(ArgumentError) { @img.colorize(0.25, 0.25, 0.25, 0.25, 'X') }
-    assert_raise(TypeError) { @img.colorize(0.25, 0.25, 0.25, 0.25, [2]) }
+    expect { @img.colorize(0.25, 0.25, 0.25, 0.25) }.to raise_error(TypeError)
+    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
+    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, [2]) }.to raise_error(TypeError)
   end
 
   def test_colormap
     # IndexError b/c @img is DirectClass
-    assert_raise(IndexError) { @img.colormap(0) }
+    expect { @img.colormap(0) }.to raise_error(IndexError)
     # Read PseudoClass image
     pc_img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     assert_nothing_raised { pc_img.colormap(0) }
     ncolors = pc_img.colors
-    assert_raise(IndexError) { pc_img.colormap(ncolors + 1) }
-    assert_raise(IndexError) { pc_img.colormap(-1) }
+    expect { pc_img.colormap(ncolors + 1) }.to raise_error(IndexError)
+    expect { pc_img.colormap(-1) }.to raise_error(IndexError)
     assert_nothing_raised { pc_img.colormap(ncolors - 1) }
     res = pc_img.colormap(0)
     assert_instance_of(String, res)
@@ -521,11 +521,11 @@ class Image1_UT < Minitest::Test
     end
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { pc_img.colormap(0, pixel) }
-    assert_raise(ArgumentError) { pc_img.colormap }
-    assert_raise(ArgumentError) { pc_img.colormap(0, pixel, Magick::BlackChannel) }
-    assert_raise(TypeError) { pc_img.colormap(0, [2]) }
+    expect { pc_img.colormap }.to raise_error(ArgumentError)
+    expect { pc_img.colormap(0, pixel, Magick::BlackChannel) }.to raise_error(ArgumentError)
+    expect { pc_img.colormap(0, [2]) }.to raise_error(TypeError)
     pc_img.freeze
-    assert_raise(FreezeError) { pc_img.colormap(0, 'red') }
+    expect { pc_img.colormap(0, 'red') }.to raise_error(FreezeError)
   end
 
   def test_color_point
@@ -545,10 +545,10 @@ class Image1_UT < Minitest::Test
     end
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @img.color_reset!(pixel) }
-    assert_raise(TypeError) { @img.color_reset!([2]) }
-    assert_raise(ArgumentError) { @img.color_reset!('x') }
+    expect { @img.color_reset!([2]) }.to raise_error(TypeError)
+    expect { @img.color_reset!('x') }.to raise_error(ArgumentError)
     @img.freeze
-    assert_raise(FreezeError) { @img.color_reset!('red') }
+    expect { @img.color_reset!('red') }.to raise_error(FreezeError)
   end
 
   def test_compare_channel
@@ -558,8 +558,8 @@ class Image1_UT < Minitest::Test
     Magick::MetricType.values do |metric|
       assert_nothing_raised { img1.compare_channel(img2, metric) }
     end
-    assert_raise(TypeError) { img1.compare_channel(img2, 2) }
-    assert_raise(ArgumentError) { img1.compare_channel }
+    expect { img1.compare_channel(img2, 2) }.to raise_error(TypeError)
+    expect { img1.compare_channel }.to raise_error(ArgumentError)
 
     ilist = Magick::ImageList.new
     ilist << img2
@@ -567,8 +567,8 @@ class Image1_UT < Minitest::Test
 
     assert_nothing_raised { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel) }
     assert_nothing_raised { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, 2) }
-    assert_raise(TypeError) { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }
+    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, 2) }.to raise_error(TypeError)
+    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }.to raise_error(TypeError)
 
     res = img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric)
     assert_instance_of(Array, res)
@@ -576,7 +576,7 @@ class Image1_UT < Minitest::Test
     assert_instance_of(Float, res[1])
 
     img2.destroy!
-    assert_raise(Magick::DestroyedImageError) { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric) }
+    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric) }.to raise_error(Magick::DestroyedImageError)
   end
 end
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -27,10 +27,10 @@ class Image2_UT < Minitest::Test
       assert_not_same(img1, res)
     end
 
-    assert_raise(TypeError) { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }
-    assert_raise(TypeError) { img1.composite(img2, 5, 'y', Magick::OverCompositeOp) }
-    assert_raise(TypeError) { img1.composite(img2, Magick::NorthWestGravity, 'x', 5, Magick::OverCompositeOp) }
-    assert_raise(TypeError) { img1.composite(img2, Magick::NorthWestGravity, 5, 'y', Magick::OverCompositeOp) }
+    expect { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
+    expect { img1.composite(img2, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
+    expect { img1.composite(img2, Magick::NorthWestGravity, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
+    expect { img1.composite(img2, Magick::NorthWestGravity, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
 
     img1.freeze
     assert_nothing_raised { img1.composite(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }
@@ -50,7 +50,7 @@ class Image2_UT < Minitest::Test
       end
     end
     img1.freeze
-    assert_raise(FreezeError) { img1.composite!(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }
+    expect { img1.composite!(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.to raise_error(FreezeError)
   end
 
   def test_composite_affine
@@ -80,8 +80,8 @@ class Image2_UT < Minitest::Test
       end
     end
 
-    assert_raise(ArgumentError) { img1.composite_channel(img2, Magick::NorthWestGravity) }
-    assert_raise(TypeError) { img1.composite_channel(img2, Magick::NorthWestGravity, 5, 5, Magick::OverCompositeOp, 'x') }
+    expect { img1.composite_channel(img2, Magick::NorthWestGravity) }.to raise_error(ArgumentError)
+    expect { img1.composite_channel(img2, Magick::NorthWestGravity, 5, 5, Magick::OverCompositeOp, 'x') }.to raise_error(TypeError)
   end
 
   def test_composite_mathematics
@@ -96,9 +96,9 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }
 
     # too few arguments
-    assert_raise(ArgumentError) { bg.composite_mathematics(fg, 1, 0, 0, 0) }
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)
     # too many arguments
-    assert_raise(ArgumentError) { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0, 'x') }
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_composite_tiled
@@ -117,12 +117,12 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { bg.composite_tiled(fg, Magick::RedChannel) }
     assert_nothing_raised { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }
 
-    assert_raise(ArgumentError) { bg.composite_tiled }
-    assert_raise(TypeError) { bg.composite_tiled(fg, 'x') }
-    assert_raise(TypeError) { bg.composite_tiled(fg, Magick::AtopCompositeOp, Magick::RedChannel, 'x') }
+    expect { bg.composite_tiled }.to raise_error(ArgumentError)
+    expect { bg.composite_tiled(fg, 'x') }.to raise_error(TypeError)
+    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp, Magick::RedChannel, 'x') }.to raise_error(TypeError)
 
     fg.destroy!
-    assert_raise(Magick::DestroyedImageError) { bg.composite_tiled(fg) }
+    expect { bg.composite_tiled(fg) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_compress_colormap!
@@ -142,7 +142,7 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.contrast(true) }
-    assert_raise(ArgumentError) { @img.contrast(true, 2) }
+    expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
   end
 
   def test_contrast_stretch_channel
@@ -156,10 +156,10 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.contrast_stretch_channel('10%', '50%') }
     assert_nothing_raised { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }
     assert_nothing_raised { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }
-    assert_raise(TypeError) { @img.contrast_stretch_channel(25, 50, 'x') }
-    assert_raise(ArgumentError) { @img.contrast_stretch_channel }
-    assert_raise(ArgumentError) { @img.contrast_stretch_channel('x') }
-    assert_raise(ArgumentError) { @img.contrast_stretch_channel(25, 'x') }
+    expect { @img.contrast_stretch_channel(25, 50, 'x') }.to raise_error(TypeError)
+    expect { @img.contrast_stretch_channel }.to raise_error(ArgumentError)
+    expect { @img.contrast_stretch_channel('x') }.to raise_error(ArgumentError)
+    expect { @img.contrast_stretch_channel(25, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_morphology
@@ -174,11 +174,11 @@ class Image2_UT < Minitest::Test
   end
 
   def test_morphology_channel
-    assert_raise(ArgumentError) { @img.morphology_channel }
-    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel) }
-    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }
-    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }
-    assert_raise(ArgumentError) { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }
+    expect { @img.morphology_channel }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
 
     kernel = Magick::KernelInfo.new('Octagon')
     assert_nothing_raised do
@@ -196,21 +196,21 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
     end
-    assert_raise(ArgumentError) { @img.convolve }
-    assert_raise(ArgumentError) { @img.convolve(0) }
-    assert_raise(ArgumentError) { @img.convolve(-1) }
-    assert_raise(ArgumentError) { @img.convolve(order) }
-    assert_raise(IndexError) { @img.convolve(5, kernel) }
-    assert_raise(IndexError) { @img.convolve(order, 'x') }
-    assert_raise(TypeError) { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }
-    assert_raise(ArgumentError) { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }
+    expect { @img.convolve }.to raise_error(ArgumentError)
+    expect { @img.convolve(0) }.to raise_error(ArgumentError)
+    expect { @img.convolve(-1) }.to raise_error(ArgumentError)
+    expect { @img.convolve(order) }.to raise_error(ArgumentError)
+    expect { @img.convolve(5, kernel) }.to raise_error(IndexError)
+    expect { @img.convolve(order, 'x') }.to raise_error(IndexError)
+    expect { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }.to raise_error(TypeError)
+    expect { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }.to raise_error(ArgumentError)
   end
 
   def test_convolve_channel
-    assert_raise(ArgumentError) { @img.convolve_channel }
-    assert_raise(ArgumentError) { @img.convolve_channel(0) }
-    assert_raise(ArgumentError) { @img.convolve_channel(-1) }
-    assert_raise(ArgumentError) { @img.convolve_channel(3) }
+    expect { @img.convolve_channel }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(0) }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(-1) }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(3) }.to raise_error(ArgumentError)
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3
     assert_nothing_raised do
@@ -220,7 +220,7 @@ class Image2_UT < Minitest::Test
     end
 
     assert_nothing_raised { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }
-    assert_raise(TypeError) { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }
+    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_copy
@@ -236,8 +236,8 @@ class Image2_UT < Minitest::Test
   end
 
   def test_crop
-    assert_raise(ArgumentError) { @img.crop }
-    assert_raise(ArgumentError) { @img.crop(0, 0) }
+    expect { @img.crop }.to raise_error(ArgumentError)
+    expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
       assert_instance_of(Magick::Image, res)
@@ -248,22 +248,22 @@ class Image2_UT < Minitest::Test
     Magick::GravityType.values do |grav|
       assert_nothing_raised { @img.crop(grav, @img.columns / 2, @img.rows / 2) }
     end
-    assert_raise(TypeError) { @img.crop(2, @img.columns / 2, @img.rows / 2) }
-    assert_raise(TypeError) { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }
+    expect { @img.crop(2, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
 
     # 4-argument form
-    assert_raise(TypeError) { @img.crop(0, 0, @img.columns / 2, 'x') }
-    assert_raise(TypeError) { @img.crop(0, 0, 'x', @img.rows / 2) }
-    assert_raise(TypeError) { @img.crop(0, 'x', @img.columns / 2, @img.rows / 2) }
-    assert_raise(TypeError) { @img.crop('x', 0, @img.columns / 2, @img.rows / 2) }
-    assert_raise(TypeError) { @img.crop(0, 0, @img.columns / 2, @img.rows / 2, 2) }
+    expect { @img.crop(0, 0, @img.columns / 2, 'x') }.to raise_error(TypeError)
+    expect { @img.crop(0, 0, 'x', @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(0, 'x', @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop('x', 0, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
 
     # 5-argument form
     Magick::GravityType.values do |grav|
       assert_nothing_raised { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }
     end
 
-    assert_raise(ArgumentError) { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }
+    expect { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_crop!
@@ -314,9 +314,9 @@ class Image2_UT < Minitest::Test
 
     assert_nothing_raised { @img.deskew(0.10) }
     assert_nothing_raised { @img.deskew('95%') }
-    assert_raise(ArgumentError) { @img.deskew('x') }
-    assert_raise(TypeError) { @img.deskew(0.40, 'x') }
-    assert_raise(ArgumentError) { @img.deskew(0.40, 20, [1]) }
+    expect { @img.deskew('x') }.to raise_error(ArgumentError)
+    expect { @img.deskew(0.40, 'x') }.to raise_error(TypeError)
+    expect { @img.deskew(0.40, 20, [1]) }.to raise_error(ArgumentError)
   end
 
   def test_despeckle
@@ -335,33 +335,33 @@ class Image2_UT < Minitest::Test
     expect(@img.destroyed?).to eq(false)
     @img.destroy!
     expect(@img.destroyed?).to eq(true)
-    assert_raises(Magick::DestroyedImageError) { @img.check_destroyed }
+    expect { @img.check_destroyed }.to raise_error(Magick::DestroyedImageError)
 
     methods.each do |method|
       arity = @img.method(method).arity
       method = method.to_s
 
       if method == '[]='
-        assert_raises(Magick::DestroyedImageError) { @img['foo'] = 1 }
+        expect { @img['foo'] = 1 }.to raise_error(Magick::DestroyedImageError)
       elsif method == 'difference'
         other = Magick::Image.new(20, 20)
-        assert_raises(Magick::DestroyedImageError) { @img.difference(other) }
+        expect { @img.difference(other) }.to raise_error(Magick::DestroyedImageError)
       elsif method == 'channel_entropy' && IM_VERSION < Gem::Version.new('6.9')
-        assert_raises(NotImplementedError) { @img.channel_entropy }
+        expect { @img.channel_entropy }.to raise_error(NotImplementedError)
       elsif method == 'get_iptc_dataset'
-        assert_raises(Magick::DestroyedImageError) { @img.get_iptc_dataset('x') }
+        expect { @img.get_iptc_dataset('x') }.to raise_error(Magick::DestroyedImageError)
       elsif method == 'profile!'
-        assert_raises(Magick::DestroyedImageError) { @img.profile!('x', 'y') }
+        expect { @img.profile!('x', 'y') }.to raise_error(Magick::DestroyedImageError)
       elsif /=\Z/.match(method)
-        assert_raises(Magick::DestroyedImageError) { @img.send(method, 1) }
+        expect { @img.send(method, 1) }.to raise_error(Magick::DestroyedImageError)
       elsif arity.zero?
-        assert_raises(Magick::DestroyedImageError) { @img.send(method) }
+        expect { @img.send(method) }.to raise_error(Magick::DestroyedImageError)
       elsif arity < 0
         args = (1..-arity).to_a
-        assert_raises(Magick::DestroyedImageError) { @img.send(method, *args) }
+        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
       elsif arity > 0
         args = (1..arity).to_a
-        assert_raises(Magick::DestroyedImageError) { @img.send(method, *args) }
+        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
       else
         # Don't know how to test!
         flunk("don't know how to test method #{method}")
@@ -413,9 +413,9 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Float, res[2])
     end
 
-    assert_raise(NoMethodError) { img1.difference(2) }
+    expect { img1.difference(2) }.to raise_error(NoMethodError)
     img2.destroy!
-    assert_raise(Magick::DestroyedImageError) { img1.difference(img2) }
+    expect { img1.difference(img2) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_displace
@@ -430,15 +430,15 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity) }
     assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }
     assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }
-    assert_raise(ArgumentError) { @img.displace }
-    assert_raise(TypeError) { @img.displace(@img2, 'x') }
-    assert_raise(TypeError) { @img.displace(@img2, 25, []) }
-    assert_raise(TypeError) { @img.displace(@img2, 25, 25, 'x') }
-    assert_raise(TypeError) { @img.displace(@img2, 25, 25, Magick::CenterGravity, 'x') }
-    assert_raise(TypeError) { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, []) }
+    expect { @img.displace }.to raise_error(ArgumentError)
+    expect { @img.displace(@img2, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, []) }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
 
     @img2.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.displace(@img2, 25, 25) }
+    expect { @img.displace(@img2, 25, 25) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_dissolve
@@ -454,14 +454,14 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10) }
     assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10, 10) }
 
-    assert_raise(ArgumentError) { @img.dissolve }
-    assert_raise(ArgumentError) { @img.dissolve(src, 'x') }
-    assert_raise(ArgumentError) { @img.dissolve(src, 0.50, 'x') }
-    assert_raise(TypeError) { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 'x') }
-    assert_raise(TypeError) { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 10, 'x') }
+    expect { @img.dissolve }.to raise_error(ArgumentError)
+    expect { @img.dissolve(src, 'x') }.to raise_error(ArgumentError)
+    expect { @img.dissolve(src, 0.50, 'x') }.to raise_error(ArgumentError)
+    expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
+    expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
 
     src.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.dissolve(src, 0.50) }
+    expect { @img.dissolve(src, 0.50) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_distort
@@ -472,10 +472,10 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }
     assert_nothing_raised { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }
     assert_nothing_raised { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }
-    assert_raise(ArgumentError) { @img.distort }
-    assert_raise(ArgumentError) { @img.distort(Magick::AffineDistortion) }
-    assert_raise(TypeError) { @img.distort(1, [1]) }
-    assert_raise(TypeError) { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 'x']) }
+    expect { @img.distort }.to raise_error(ArgumentError)
+    expect { @img.distort(Magick::AffineDistortion) }.to raise_error(ArgumentError)
+    expect { @img.distort(1, [1]) }.to raise_error(TypeError)
+    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 'x']) }.to raise_error(TypeError)
   end
 
   def test_distortion_channel
@@ -491,14 +491,14 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }
     assert_nothing_raised { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }
-    assert_raise(TypeError) { @img.distortion_channel(@img, 2) }
-    assert_raise(TypeError) { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }
-    assert_raise(ArgumentError) { @img.distortion_channel }
-    assert_raise(ArgumentError) { @img.distortion_channel(@img) }
+    expect { @img.distortion_channel(@img, 2) }.to raise_error(TypeError)
+    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }.to raise_error(TypeError)
+    expect { @img.distortion_channel }.to raise_error(ArgumentError)
+    expect { @img.distortion_channel(@img) }.to raise_error(ArgumentError)
 
     img = Magick::Image.new(20, 20)
     img.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.distortion_channel(img, Magick::MeanSquaredErrorMetric) }
+    expect { @img.distortion_channel(img, Magick::MeanSquaredErrorMetric) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test__dump
@@ -544,8 +544,8 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.edge(2.0) }
-    assert_raise(ArgumentError) { @img.edge(2.0, 2) }
-    assert_raise(TypeError) { @img.edge('x') }
+    expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.edge('x') }.to raise_error(TypeError)
   end
 
   def test_emboss
@@ -556,9 +556,9 @@ class Image2_UT < Minitest::Test
     end
     assert_nothing_raised { @img.emboss(1.0) }
     assert_nothing_raised { @img.emboss(1.0, 0.5) }
-    assert_raise(ArgumentError) { @img.emboss(1.0, 0.5, 2) }
-    assert_raise(TypeError) { @img.emboss(1.0, 'x') }
-    assert_raise(TypeError) { @img.emboss('x', 1.0) }
+    expect { @img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)
+    expect { @img.emboss(1.0, 'x') }.to raise_error(TypeError)
+    expect { @img.emboss('x', 1.0) }.to raise_error(TypeError)
   end
 
   def test_enhance
@@ -586,7 +586,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.equalize_channel }
     assert_nothing_raised { @img.equalize_channel(Magick::RedChannel) }
     assert_nothing_raised { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.equalize_channel(Magick::RedChannel, 2) }
+    expect { @img.equalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_erase!
@@ -632,7 +632,7 @@ class Image2_UT < Minitest::Test
     end
 
     # too many arguments
-    assert_raise(ArgumentError) { @img.export_pixels(0, 0, 10, 10, 'I', 2) }
+    expect { @img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
   end
 
   def test_export_pixels_to_str
@@ -677,9 +677,9 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }
 
     # too many arguments
-    assert_raise(ArgumentError) { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }.to raise_error(ArgumentError)
     # last arg s/b StorageType
-    assert_raise(TypeError) { @img.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }.to raise_error(TypeError)
   end
 
   def test_extent
@@ -691,15 +691,15 @@ class Image2_UT < Minitest::Test
     expect(res.rows).to eq(40)
     assert_nothing_raised { @img.extent(40, 40, 5) }
     assert_nothing_raised { @img.extent(40, 40, 5, 5) }
-    assert_raises(ArgumentError) { @img.extent(-40) }
-    assert_raises(ArgumentError) { @img.extent(-40, 40) }
-    assert_raises(ArgumentError) { @img.extent(40, -40) }
-    assert_raises(ArgumentError) { @img.extent(40, 40, 5, 5, 0) }
-    assert_raises(ArgumentError) { @img.extent(0, 0, 5, 5) }
-    assert_raises(TypeError) { @img.extent('x', 40) }
-    assert_raises(TypeError) { @img.extent(40, 'x') }
-    assert_raises(TypeError) { @img.extent(40, 40, 'x') }
-    assert_raises(TypeError) { @img.extent(40, 40, 5, 'x') }
+    expect { @img.extent(-40) }.to raise_error(ArgumentError)
+    expect { @img.extent(-40, 40) }.to raise_error(ArgumentError)
+    expect { @img.extent(40, -40) }.to raise_error(ArgumentError)
+    expect { @img.extent(40, 40, 5, 5, 0) }.to raise_error(ArgumentError)
+    expect { @img.extent(0, 0, 5, 5) }.to raise_error(ArgumentError)
+    expect { @img.extent('x', 40) }.to raise_error(TypeError)
+    expect { @img.extent(40, 'x') }.to raise_error(TypeError)
+    expect { @img.extent(40, 40, 'x') }.to raise_error(TypeError)
+    expect { @img.extent(40, 40, 5, 'x') }.to raise_error(TypeError)
   end
 
   def test_find_similar_region
@@ -734,12 +734,12 @@ class Image2_UT < Minitest::Test
     x = girl.find_similar_region(@img)
     assert_nil(x)
 
-    assert_raise(ArgumentError) { girl.find_similar_region(region, 10, 10, 10) }
-    assert_raise(TypeError) { girl.find_similar_region(region, 10, 'x') }
-    assert_raise(TypeError) { girl.find_similar_region(region, 'x') }
+    expect { girl.find_similar_region(region, 10, 10, 10) }.to raise_error(ArgumentError)
+    expect { girl.find_similar_region(region, 10, 'x') }.to raise_error(TypeError)
+    expect { girl.find_similar_region(region, 'x') }.to raise_error(TypeError)
 
     region.destroy!
-    assert_raise(Magick::DestroyedImageError) { girl.find_similar_region(region) }
+    expect { girl.find_similar_region(region) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_flip
@@ -787,18 +787,18 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.frame(50, 50, 25, 25, 6, 6, 'red') }
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @img.frame(50, 50, 25, 25, 6, 6, red) }
-    assert_raise(TypeError) { @img.frame(50, 50, 25, 25, 6, 6, 2) }
-    assert_raise(ArgumentError) { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }
+    expect { @img.frame(50, 50, 25, 25, 6, 6, 2) }.to raise_error(TypeError)
+    expect { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }.to raise_error(ArgumentError)
   end
 
   def test_fx
     assert_nothing_raised { @img.fx('1/2') }
     assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel) }
     assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }
-    assert_raise(ArgumentError) { @img.fx }
-    assert_raise(ArgumentError) { @img.fx(Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.fx(1) }
-    assert_raise(TypeError) { @img.fx('1/2', 1) }
+    expect { @img.fx }.to raise_error(ArgumentError)
+    expect { @img.fx(Magick::BlueChannel) }.to raise_error(ArgumentError)
+    expect { @img.fx(1) }.to raise_error(TypeError)
+    expect { @img.fx('1/2', 1) }.to raise_error(TypeError)
   end
 
   def test_gamma_channel
@@ -807,10 +807,10 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
     end
-    assert_raise(ArgumentError) { @img.gamma_channel }
+    expect { @img.gamma_channel }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.gamma_channel(0.8, Magick::RedChannel) }
     assert_nothing_raised { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.gamma_channel(0.8, Magick::RedChannel, 2) }
+    expect { @img.gamma_channel(0.8, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_function_channel
@@ -841,17 +841,17 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }
 
     # invalid args
-    assert_raise(ArgumentError) { img.function_channel }
-    assert_raise(TypeError) { img.function_channel 1 }
-    assert_raise(ArgumentError) { img.function_channel Magick::PolynomialFunction }
-    assert_raise(TypeError) { img.function_channel Magick::PolynomialFunction, [] }
-    assert_raise(ArgumentError) { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75, 0.1 }
-    assert_raise(ArgumentError) { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5, 0.1 }
-    assert_raise(ArgumentError) { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75, 0.1 }
+    expect { img.function_channel }.to raise_error(ArgumentError)
+    expect { img.function_channel 1 }.to raise_error(TypeError)
+    expect { img.function_channel Magick::PolynomialFunction }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::PolynomialFunction, [] }.to raise_error(TypeError)
+    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75, 0.1 }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5, 0.1 }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75, 0.1 }.to raise_error(ArgumentError)
   end
 
   def test_gramma_correct
-    assert_raise(ArgumentError) { @img.gamma_correct }
+    expect { @img.gamma_correct }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @img.gamma_correct(0.8)
       assert_instance_of(Magick::Image, res)
@@ -861,7 +861,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.gamma_correct(0.8, 0.9, 1.0) }
     assert_nothing_raised { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }
     # too many arguments
-    assert_raise(ArgumentError) { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }
+    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }.to raise_error(ArgumentError)
   end
 
   def test_gaussian_blur
@@ -873,8 +873,8 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.gaussian_blur(0.0) }
     assert_nothing_raised { @img.gaussian_blur(0.0, 3.0) }
     # sigma must be != 0.0
-    assert_raise(ArgumentError) { @img.gaussian_blur(1.0, 0.0) }
-    assert_raise(ArgumentError) { @img.gaussian_blur(1.0, 3.0, 2) }
+    expect { @img.gaussian_blur(1.0, 0.0) }.to raise_error(ArgumentError)
+    expect { @img.gaussian_blur(1.0, 3.0, 2) }.to raise_error(ArgumentError)
   end
 
   def test_gaussian_blur_channel
@@ -887,7 +887,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0) }
     assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }
     assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_get_exif_by_entry
@@ -913,10 +913,10 @@ class Image2_UT < Minitest::Test
         pixels.all? { |p| p.is_a? Magick::Pixel }
       end
     end
-    assert_raise(RangeError) { @img.get_pixels(0,  0, -1, 1) }
-    assert_raise(RangeError) { @img.get_pixels(0,  0, @img.columns, -1) }
-    assert_raise(RangeError) { @img.get_pixels(0,  0, @img.columns + 1, 1) }
-    assert_raise(RangeError) { @img.get_pixels(0,  0, @img.columns, @img.rows + 1) }
+    expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns + 1, 1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns, @img.rows + 1) }.to raise_error(RangeError)
   end
 
   def test_gray?
@@ -937,7 +937,7 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
     end
-    assert_raise(ArgumentError) { @img.implode(0.5, 0.5) }
+    expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
   end
 
   def test_import_pixels
@@ -946,27 +946,27 @@ class Image2_UT < Minitest::Test
       res = @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels)
       assert_same(@img, res)
     end
-    assert_raise(ArgumentError) { @img.import_pixels }
-    assert_raise(ArgumentError) { @img.import_pixels(0) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns, 1) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns, 1, 'RGB') }
-    assert_raise(TypeError) { @img.import_pixels('x', 0, @img.columns, 1, 'RGB', pixels) }
-    assert_raise(TypeError) { @img.import_pixels(0, 'x', @img.columns, 1, 'RGB', pixels) }
-    assert_raise(TypeError) { @img.import_pixels(0, 0, 'x', 1, 'RGB', pixels) }
-    assert_raise(TypeError) { @img.import_pixels(0, 0, @img.columns, 'x', 'RGB', pixels) }
-    assert_raise(TypeError) { @img.import_pixels(0, 0, @img.columns, 1, [2], pixels) }
-    assert_raise(ArgumentError) { @img.import_pixels(-1, 0, @img.columns, 1, 'RGB', pixels) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, -1, @img.columns, 1, 'RGB', pixels) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, -1, 1, 'RGB', pixels) }
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns, -1, 'RGB', pixels) }
+    expect { @img.import_pixels }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB') }.to raise_error(ArgumentError)
+    expect { @img.import_pixels('x', 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 'x', @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, 'x', 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, @img.columns, 'x', 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1, [2], pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(-1, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, -1, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, -1, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, -1, 'RGB', pixels) }.to raise_error(ArgumentError)
 
     # pixel array is too small
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns, 2, 'RGB', pixels) }
+    expect { @img.import_pixels(0, 0, @img.columns, 2, 'RGB', pixels) }.to raise_error(ArgumentError)
     # pixel array doesn't contain a multiple of the map length
     pixels.shift
-    assert_raise(ArgumentError) { @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels) }
+    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
   end
 
   def test_level
@@ -978,10 +978,10 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.level(0.0) }
     assert_nothing_raised { @img.level(0.0, 1.0) }
     assert_nothing_raised { @img.level(0.0, 1.0, Magick::QuantumRange) }
-    assert_raise(ArgumentError) { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }
-    assert_raise(ArgumentError) { @img.level('x') }
-    assert_raise(ArgumentError) { @img.level(0.0, 'x') }
-    assert_raise(ArgumentError) { @img.level(0.0, 1.0, 'x') }
+    expect { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.level('x') }.to raise_error(ArgumentError)
+    expect { @img.level(0.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.level(0.0, 1.0, 'x') }.to raise_error(ArgumentError)
   end
 
   # Ensure that #level properly swaps old-style arg list
@@ -998,11 +998,11 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.level2(10) }
     assert_nothing_raised { @img.level2(10, 10) }
     assert_nothing_raised { @img.level2(10, 10, 10) }
-    assert_raise(ArgumentError) { @img.level2(10, 10, 10, 10) }
+    expect { @img.level2(10, 10, 10, 10) }.to raise_error(ArgumentError)
   end
 
   def test_level_channel
-    assert_raise(ArgumentError) { @img.level_channel }
+    expect { @img.level_channel }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @img.level_channel(Magick::RedChannel)
       assert_instance_of(Magick::Image, res)
@@ -1013,11 +1013,11 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }
     assert_nothing_raised { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }
 
-    assert_raise(ArgumentError) { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }
-    assert_raise(TypeError) { @img.level_channel(2) }
-    assert_raise(TypeError) { @img.level_channel(Magick::RedChannel, 'x') }
-    assert_raise(TypeError) { @img.level_channel(Magick::RedChannel, 0.0, 'x') }
-    assert_raise(TypeError) { @img.level_channel(Magick::RedChannel, 0.0, 1.0, 'x') }
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.level_channel(2) }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 'x') }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 'x') }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_level_colors
@@ -1034,9 +1034,9 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.level_colors('black', 'white') }
     assert_nothing_raised { @img.level_colors('black', 'white', false) }
 
-    assert_raises(TypeError) { @img.level_colors('black', 'white', false, 1) }
-    assert_raises(TypeError) { @img.level_colors([]) }
-    assert_raises(ArgumentError) { @img.level_colors('xxx') }
+    expect { @img.level_colors('black', 'white', false, 1) }.to raise_error(TypeError)
+    expect { @img.level_colors([]) }.to raise_error(TypeError)
+    expect { @img.level_colors('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_levelize_channel
@@ -1053,8 +1053,8 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }
     assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }
 
-    assert_raise(TypeError) { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }
-    assert_raise(ArgumentError) { @img.levelize_channel }
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }.to raise_error(TypeError)
+    expect { @img.levelize_channel }.to raise_error(ArgumentError)
   end
 
   #     def test_liquid_rescale
@@ -1072,12 +1072,12 @@ class Image2_UT < Minitest::Test
   #       expect(res.columns).to eq(15)
   #       expect(res.rows).to eq(15)
   #       assert_nothing_raised { @img.liquid_rescale(15, 15, 0, 0) }
-  #       assert_raise(ArgumentError) { @img.liquid_rescale(15) }
-  #       assert_raise(ArgumentError) { @img.liquid_rescale(15, 15, 0, 0, 0) }
-  #       assert_raise(TypeError) { @img.liquid_rescale([], 15) }
-  #       assert_raise(TypeError) { @img.liquid_rescale(15, []) }
-  #       assert_raise(TypeError) { @img.liquid_rescale(15, 15, []) }
-  #       assert_raise(TypeError) { @img.liquid_rescale(15, 15, 0, []) }
+  #       expect { @img.liquid_rescale(15) }.to raise_error(ArgumentError)
+  #       expect { @img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)
+  #       expect { @img.liquid_rescale([], 15) }.to raise_error(TypeError)
+  #       expect { @img.liquid_rescale(15, []) }.to raise_error(TypeError)
+  #       expect { @img.liquid_rescale(15, 15, []) }.to raise_error(TypeError)
+  #       expect { @img.liquid_rescale(15, 15, 0, []) }.to raise_error(TypeError)
   #     end
 
   def test_magnify
@@ -1110,15 +1110,15 @@ class Image2_UT < Minitest::Test
     expect(res.columns).to eq(20)
     expect(res.rows).to eq(20)
 
-    assert_raise(ArgumentError) { @img.mask(cimg, 'x') }
+    expect { @img.mask(cimg, 'x') }.to raise_error(ArgumentError)
     # mask expects an Image and calls `cur_image'
-    assert_raise(NoMethodError) { @img.mask = 2 }
+    expect { @img.mask = 2 }.to raise_error(NoMethodError)
 
     img = @img.copy.freeze
-    assert_raise(FreezeError) { img.mask cimg }
+    expect { img.mask cimg }.to raise_error(FreezeError)
 
     @img.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.mask cimg }
+    expect { @img.mask cimg }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_matte_fill_to_border
@@ -1128,8 +1128,8 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.matte_fill_to_border(@img.columns, @img.rows) }
-    assert_raise(ArgumentError) { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }
-    assert_raise(ArgumentError) { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }
+    expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+    expect { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
   end
 
   def test_matte_floodfill
@@ -1143,12 +1143,12 @@ class Image2_UT < Minitest::Test
     Magick::PaintMethod.values do |method|
       next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
 
-      assert_raise(ArgumentError) { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }
+      expect { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
     end
-    assert_raise(ArgumentError) { @img.matte_floodfill(@img.columns + 1, @img.rows) }
-    assert_raise(ArgumentError) { @img.matte_floodfill(@img.columns, @img.rows + 1) }
+    expect { @img.matte_floodfill(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+    expect { @img.matte_floodfill(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }
+    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
 
   def test_matte_replace
@@ -1173,8 +1173,8 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.median_filter(0.5) }
-    assert_raise(ArgumentError) { @img.median_filter(0.5, 'x') }
-    assert_raise(TypeError) { @img.median_filter('x') }
+    expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
+    expect { @img.median_filter('x') }.to raise_error(TypeError)
   end
 
   def test_minify
@@ -1197,11 +1197,11 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.modulate(0.5) }
     assert_nothing_raised { @img.modulate(0.5, 0.5) }
     assert_nothing_raised { @img.modulate(0.5, 0.5, 0.5) }
-    assert_raise(ArgumentError) { @img.modulate(0.0, 0.5, 0.5) }
-    assert_raise(ArgumentError) { @img.modulate(0.5, 0.5, 0.5, 0.5) }
-    assert_raise(TypeError) { @img.modulate('x', 0.5, 0.5) }
-    assert_raise(TypeError) { @img.modulate(0.5, 'x', 0.5) }
-    assert_raise(TypeError) { @img.modulate(0.5, 0.5, 'x') }
+    expect { @img.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
+    expect { @img.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
+    expect { @img.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
+    expect { @img.modulate(0.5, 'x', 0.5) }.to raise_error(TypeError)
+    expect { @img.modulate(0.5, 0.5, 'x') }.to raise_error(TypeError)
   end
 
   def test_monochrome?
@@ -1216,7 +1216,7 @@ class Image2_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
     end
-    assert_raise(ArgumentError) { @img.motion_blur(1.0, 0.0, 180) }
+    expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.motion_blur(1.0, -1.0, 180) }
   end
 
@@ -1227,7 +1227,7 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.negate(true) }
-    assert_raise(ArgumentError) { @img.negate(true, 2) }
+    expect { @img.negate(true, 2) }.to raise_error(ArgumentError)
   end
 
   def test_negate_channel
@@ -1239,7 +1239,7 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.negate_channel(true) }
     assert_nothing_raised { @img.negate_channel(true, Magick::RedChannel) }
     assert_nothing_raised { @img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.negate_channel(true, Magick::RedChannel, 2) }
+    expect { @img.negate_channel(true, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_normalize
@@ -1258,7 +1258,7 @@ class Image2_UT < Minitest::Test
     end
     assert_nothing_raised { @img.normalize_channel(Magick::RedChannel) }
     assert_nothing_raised { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.normalize_channel(Magick::RedChannel, 2) }
+    expect { @img.normalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_oil_paint
@@ -1268,7 +1268,7 @@ class Image2_UT < Minitest::Test
       assert_not_same(@img, res)
     end
     assert_nothing_raised { @img.oil_paint(2.0) }
-    assert_raise(ArgumentError) { @img.oil_paint(2.0, 1.0) }
+    expect { @img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
   end
 
   def test_opaque
@@ -1280,8 +1280,8 @@ class Image2_UT < Minitest::Test
     red = Magick::Pixel.new(Magick::QuantumRange)
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     assert_nothing_raised { @img.opaque(red, blue) }
-    assert_raise(TypeError) { @img.opaque(red, 2) }
-    assert_raise(TypeError) { @img.opaque(2, blue) }
+    expect { @img.opaque(red, 2) }.to raise_error(TypeError)
+    expect { @img.opaque(2, blue) }.to raise_error(TypeError)
   end
 
   def test_opaque_channel
@@ -1298,11 +1298,11 @@ class Image2_UT < Minitest::Test
       @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel)
     end
 
-    assert_raise(TypeError) { @img.opaque_channel('red', 'blue', true, 50, 50) }
-    assert_raise(TypeError) { @img.opaque_channel('red', 'blue', true, []) }
-    assert_raise(ArgumentError) { @img.opaque_channel('red') }
-    assert_raise(ArgumentError) { @img.opaque_channel('red', 'blue', true, -0.1) }
-    assert_raise(TypeError) { @img.opaque_channel('red', []) }
+    expect { @img.opaque_channel('red', 'blue', true, 50, 50) }.to raise_error(TypeError)
+    expect { @img.opaque_channel('red', 'blue', true, []) }.to raise_error(TypeError)
+    expect { @img.opaque_channel('red') }.to raise_error(ArgumentError)
+    expect { @img.opaque_channel('red', 'blue', true, -0.1) }.to raise_error(ArgumentError)
+    expect { @img.opaque_channel('red', []) }.to raise_error(TypeError)
   end
 
   def test_opaque?
@@ -1323,8 +1323,8 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.ordered_dither(2) }
     assert_nothing_raised { @img.ordered_dither(3) }
     assert_nothing_raised { @img.ordered_dither(4) }
-    assert_raise(ArgumentError) { @img.ordered_dither(5) }
-    assert_raise(ArgumentError) { @img.ordered_dither(2, 1) }
+    expect { @img.ordered_dither(5) }.to raise_error(ArgumentError)
+    expect { @img.ordered_dither(2, 1) }.to raise_error(ArgumentError)
   end
 
   def test_paint_transparent
@@ -1333,23 +1333,23 @@ class Image2_UT < Minitest::Test
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
     assert_not_same(res, @img)
-    assert_raise(ArgumentError) { @img.paint_transparent('red', Magick::TransparentAlpha) }
+    expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', Magick::TransparentAlpha, true) }
+    expect { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.paint_transparent('red', Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', Magick::TransparentAlpha, true, 50) }
+    expect { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.paint_transparent('red', Magick::TransparentAlpha, true, 50) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }
+    expect { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
 
     # Too many arguments
-    assert_raise(ArgumentError) { @img.paint_transparent('red', true, 50, 50, 50) }
+    expect { @img.paint_transparent('red', true, 50, 50, 50) }.to raise_error(ArgumentError)
     # Not enough
-    assert_raise(ArgumentError) { @img.paint_transparent }
-    assert_raise(TypeError) { @img.paint_transparent('red', true, [], alpha: Magick::TransparentAlpha) }
-    assert_raise(TypeError) { @img.paint_transparent(50) }
+    expect { @img.paint_transparent }.to raise_error(ArgumentError)
+    expect { @img.paint_transparent('red', true, [], alpha: Magick::TransparentAlpha) }.to raise_error(TypeError)
+    expect { @img.paint_transparent(50) }.to raise_error(TypeError)
   end
 
   def test_palette?
@@ -1390,8 +1390,8 @@ class Image2_UT < Minitest::Test
     assert_nothing_raised { @img.polaroid }
     assert_nothing_raised { @img.polaroid(5) }
     assert_instance_of(Magick::Image, @img.polaroid)
-    assert_raises(TypeError) { @img.polaroid('x') }
-    assert_raises(ArgumentError) { @img.polaroid(5, 'x') }
+    expect { @img.polaroid('x') }.to raise_error(TypeError)
+    expect { @img.polaroid(5, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_posterize
@@ -1402,7 +1402,7 @@ class Image2_UT < Minitest::Test
     end
     assert_nothing_raised { @img.posterize(5) }
     assert_nothing_raised { @img.posterize(5, true) }
-    assert_raise(ArgumentError) { @img.posterize(5, true, 'x') }
+    expect { @img.posterize(5, true, 'x') }.to raise_error(ArgumentError)
   end
 end
 

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -18,11 +18,11 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.profile!('icc', nil) }
     assert_nothing_raised { @img.profile!('iptc', nil) }
 
-    assert_raise(ArgumentError) { @img.profile!('test', 'foobarbaz') }
+    expect { @img.profile!('test', 'foobarbaz') }.to raise_error(ArgumentError)
 
     @img.freeze
-    assert_raise(FreezeError) { @img.profile!('icc', 'xxx') }
-    assert_raise(FreezeError) { @img.profile!('*', nil) }
+    expect { @img.profile!('icc', 'xxx') }.to raise_error(FreezeError)
+    expect { @img.profile!('*', nil) }.to raise_error(FreezeError)
   end
 
   def test_quantize
@@ -41,10 +41,10 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }
     assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, true, 2) }
     assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }
-    assert_raise(TypeError) { @img.quantize('x') }
-    assert_raise(TypeError) { @img.quantize(16, 2) }
-    assert_raise(TypeError) { @img.quantize(16, Magick::RGBColorspace, false, 'x') }
-    assert_raise(ArgumentError) { @img.quantize(256, Magick::RGBColorspace, true, 2, true, true) }
+    expect { @img.quantize('x') }.to raise_error(TypeError)
+    expect { @img.quantize(16, 2) }.to raise_error(TypeError)
+    expect { @img.quantize(16, Magick::RGBColorspace, false, 'x') }.to raise_error(TypeError)
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true, true) }.to raise_error(ArgumentError)
   end
 
   def test_quantum_operator
@@ -56,10 +56,10 @@ class Image3_UT < Minitest::Test
       assert_nothing_raised { @img.quantum_operator(op, 2) }
     end
     assert_nothing_raised { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }
-    assert_raise(TypeError) { @img.quantum_operator(2, 2) }
-    assert_raise(TypeError) { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }
-    assert_raise(TypeError) { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }
-    assert_raise(ArgumentError) { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel, 2) }
+    expect { @img.quantum_operator(2, 2) }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel, 2) }.to raise_error(ArgumentError)
   end
 
   def test_radial_blur
@@ -77,8 +77,8 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { res = @img.radial_blur_channel(30, Magick::RedChannel) }
     assert_nothing_raised { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }
 
-    assert_raise(ArgumentError) { @img.radial_blur_channel }
-    assert_raise(TypeError) { @img.radial_blur_channel(30, 2) }
+    expect { @img.radial_blur_channel }.to raise_error(ArgumentError)
+    expect { @img.radial_blur_channel(30, 2) }.to raise_error(TypeError)
   end
 
   def test_raise
@@ -89,9 +89,9 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.raise(4) }
     assert_nothing_raised { @img.raise(4, 4) }
     assert_nothing_raised { @img.raise(4, 4, false) }
-    assert_raise(TypeError) { @img.raise('x') }
-    assert_raise(TypeError) { @img.raise(2, 'x') }
-    assert_raise(ArgumentError) { @img.raise(4, 4, false, 2) }
+    expect { @img.raise('x') }.to raise_error(TypeError)
+    expect { @img.raise(2, 'x') }.to raise_error(TypeError)
+    expect { @img.raise(4, 4, false, 2) }.to raise_error(ArgumentError)
   end
 
   def test_random_threshold_channel
@@ -103,14 +103,14 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.random_threshold_channel(threshold) }
     assert_nothing_raised { @img.random_threshold_channel(threshold, Magick::RedChannel) }
     assert_nothing_raised { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(ArgumentError) { @img.random_threshold_channel }
-    assert_raise(TypeError) { @img.random_threshold_channel('20%', 2) }
+    expect { @img.random_threshold_channel }.to raise_error(ArgumentError)
+    expect { @img.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
   end
 
   def test_recolor
     assert_nothing_raised { @img.recolor([1, 1, 2, 1]) }
-    assert_raise(TypeError) { @img.recolor('x') }
-    assert_raise(TypeError) { @img.recolor([1, 1, 'x', 1]) }
+    expect { @img.recolor('x') }.to raise_error(TypeError)
+    expect { @img.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
   end
 
   def test_reduce_noise
@@ -128,9 +128,9 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }
     assert_nothing_raised { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }
 
-    assert_raise(ArgumentError) { @img.remap }
-    assert_raise(ArgumentError) { @img.remap(remap_image, Magick::NoDitherMethod, 1) }
-    assert_raise(TypeError) { @img.remap(remap_image, 1) }
+    expect { @img.remap }.to raise_error(ArgumentError)
+    expect { @img.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
+    expect { @img.remap(remap_image, 1) }.to raise_error(TypeError)
   end
 
   def test_resample
@@ -164,13 +164,13 @@ class Image3_UT < Minitest::Test
     end
     assert_nothing_raised { @img.resample(50, 50, Magick::PointFilter, 2.0) }
 
-    assert_raise(TypeError) { @img.resample('x') }
-    assert_raise(TypeError) { @img.resample(100, 'x') }
-    assert_raise(TypeError) { @img.resample(50, 50, 2) }
-    assert_raise(TypeError) { @img.resample(50, 50, Magick::CubicFilter, 'x') }
-    assert_raise(ArgumentError) { @img.resample(50, 50, Magick::SincFilter, 2.0, 'x') }
-    assert_raise(ArgumentError) { @img.resample(-100) }
-    assert_raise(ArgumentError) { @img.resample(100, -100) }
+    expect { @img.resample('x') }.to raise_error(TypeError)
+    expect { @img.resample(100, 'x') }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, 2) }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.resample(-100) }.to raise_error(ArgumentError)
+    expect { @img.resample(100, -100) }.to raise_error(ArgumentError)
   end
 
   def test_resample!
@@ -179,7 +179,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.resample!(50) }
+    expect { @img.resample!(50) }.to raise_error(FreezeError)
   end
 
   def test_resize
@@ -193,15 +193,15 @@ class Image3_UT < Minitest::Test
       assert_nothing_raised { @img.resize(50, 50, filter) }
     end
     assert_nothing_raised { @img.resize(50, 50, Magick::PointFilter, 2.0) }
-    assert_raise(TypeError) { @img.resize('x') }
-    assert_raise(TypeError) { @img.resize(50, 'x') }
-    assert_raise(TypeError) { @img.resize(50, 50, 2) }
-    assert_raise(TypeError) { @img.resize(50, 50, Magick::CubicFilter, 'x') }
-    assert_raise(ArgumentError) { @img.resize(-1.0) }
-    assert_raise(ArgumentError) { @img.resize(0, 50) }
-    assert_raise(ArgumentError) { @img.resize(50, 0) }
-    assert_raise(ArgumentError) { @img.resize(50, 50, Magick::SincFilter, 2.0, 'x') }
-    assert_raise(ArgumentError) { @img.resize }
+    expect { @img.resize('x') }.to raise_error(TypeError)
+    expect { @img.resize(50, 'x') }.to raise_error(TypeError)
+    expect { @img.resize(50, 50, 2) }.to raise_error(TypeError)
+    expect { @img.resize(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+    expect { @img.resize(-1.0) }.to raise_error(ArgumentError)
+    expect { @img.resize(0, 50) }.to raise_error(ArgumentError)
+    expect { @img.resize(50, 0) }.to raise_error(ArgumentError)
+    expect { @img.resize(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.resize }.to raise_error(ArgumentError)
   end
 
   def test_resize!
@@ -210,7 +210,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.resize!(0.50) }
+    expect { @img.resize!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_resize_to_fill_0
@@ -328,8 +328,8 @@ class Image3_UT < Minitest::Test
       res = img.rotate(90, '<')
       assert_nil(res)
     end
-    assert_raise(ArgumentError) { img.rotate(90, 't') }
-    assert_raise(TypeError) { img.rotate(90, []) }
+    expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
+    expect { img.rotate(90, []) }.to raise_error(TypeError)
   end
 
   def test_rotate!
@@ -338,7 +338,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.rotate!(45) }
+    expect { @img.rotate!(45) }.to raise_error(FreezeError)
   end
 
   def test_sample
@@ -347,13 +347,13 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.sample(2) }
-    assert_raise(ArgumentError) { @img.sample }
-    assert_raise(ArgumentError) { @img.sample(0) }
-    assert_raise(ArgumentError) { @img.sample(0, 25) }
-    assert_raise(ArgumentError) { @img.sample(25, 0) }
-    assert_raise(ArgumentError) { @img.sample(25, 25, 25) }
-    assert_raise(TypeError) { @img.sample('x') }
-    assert_raise(TypeError) { @img.sample(10, 'x') }
+    expect { @img.sample }.to raise_error(ArgumentError)
+    expect { @img.sample(0) }.to raise_error(ArgumentError)
+    expect { @img.sample(0, 25) }.to raise_error(ArgumentError)
+    expect { @img.sample(25, 0) }.to raise_error(ArgumentError)
+    expect { @img.sample(25, 25, 25) }.to raise_error(ArgumentError)
+    expect { @img.sample('x') }.to raise_error(TypeError)
+    expect { @img.sample(10, 'x') }.to raise_error(TypeError)
   end
 
   def test_sample!
@@ -362,7 +362,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.sample!(0.50) }
+    expect { @img.sample!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_scale
@@ -371,10 +371,10 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.scale(2) }
-    assert_raise(ArgumentError) { @img.scale }
-    assert_raise(ArgumentError) { @img.scale(25, 25, 25) }
-    assert_raise(TypeError) { @img.scale('x') }
-    assert_raise(TypeError) { @img.scale(10, 'x') }
+    expect { @img.scale }.to raise_error(ArgumentError)
+    expect { @img.scale(25, 25, 25) }.to raise_error(ArgumentError)
+    expect { @img.scale('x') }.to raise_error(TypeError)
+    expect { @img.scale(10, 'x') }.to raise_error(TypeError)
   end
 
   def test_scale!
@@ -383,7 +383,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.scale!(0.50) }
+    expect { @img.scale!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_segment
@@ -411,10 +411,10 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }
     assert_nothing_raised { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }
 
-    assert_raise(ArgumentError) { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }
-    assert_raise(TypeError) { @img.segment(2) }
-    assert_raise(TypeError) { @img.segment(Magick::RGBColorspace, 'x') }
-    assert_raise(TypeError) { @img.segment(Magick::RGBColorspace, 2.0, 'x') }
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }.to raise_error(ArgumentError)
+    expect { @img.segment(2) }.to raise_error(TypeError)
+    expect { @img.segment(Magick::RGBColorspace, 'x') }.to raise_error(TypeError)
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_selective_blur_channel
@@ -429,14 +429,14 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }
     assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }
 
-    assert_raise(ArgumentError) { @img.selective_blur_channel(0, 1) }
-    assert_raise(TypeError) { @img.selective_blur_channel(0, 1, 0.1, '10%') }
+    expect { @img.selective_blur_channel(0, 1) }.to raise_error(ArgumentError)
+    expect { @img.selective_blur_channel(0, 1, 0.1, '10%') }.to raise_error(TypeError)
   end
 
   def test_separate
     assert_instance_of(Magick::ImageList, @img.separate)
     assert_instance_of(Magick::ImageList, @img.separate(Magick::BlueChannel))
-    assert_raise(TypeError) { @img.separate('x') }
+    expect { @img.separate('x') }.to raise_error(TypeError)
   end
 
   def test_sepiatone
@@ -445,8 +445,8 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.sepiatone(Magick::QuantumRange * 0.80) }
-    assert_raise(ArgumentError) { @img.sepiatone(Magick::QuantumRange, 2) }
-    assert_raise(TypeError) { @img.sepiatone('x') }
+    expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.sepiatone('x') }.to raise_error(TypeError)
   end
 
   def test_set_channel_depth
@@ -463,9 +463,9 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.shade(true) }
     assert_nothing_raised { @img.shade(true, 30) }
     assert_nothing_raised { @img.shade(true, 30, 30) }
-    assert_raise(ArgumentError) { @img.shade(true, 30, 30, 2) }
-    assert_raise(TypeError) { @img.shade(true, 'x') }
-    assert_raise(TypeError) { @img.shade(true, 30, 'x') }
+    expect { @img.shade(true, 30, 30, 2) }.to raise_error(ArgumentError)
+    expect { @img.shade(true, 'x') }.to raise_error(TypeError)
+    expect { @img.shade(true, 30, 'x') }.to raise_error(TypeError)
   end
 
   def test_shadow
@@ -478,11 +478,11 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.shadow(5, 5, 3.0) }
     assert_nothing_raised { @img.shadow(5, 5, 3.0, 0.50) }
     assert_nothing_raised { @img.shadow(5, 5, 3.0, '50%') }
-    assert_raise(ArgumentError) { @img.shadow(5, 5, 3.0, 0.50, 2) }
-    assert_raise(TypeError) { @img.shadow('x') }
-    assert_raise(TypeError) { @img.shadow(5, 'x') }
-    assert_raise(TypeError) { @img.shadow(5, 5, 'x') }
-    assert_raise(ArgumentError) { @img.shadow(5, 5, 3.0, 'x') }
+    expect { @img.shadow(5, 5, 3.0, 0.50, 2) }.to raise_error(ArgumentError)
+    expect { @img.shadow('x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 'x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 5, 'x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 5, 3.0, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_sharpen
@@ -492,9 +492,9 @@ class Image3_UT < Minitest::Test
     end
     assert_nothing_raised { @img.sharpen(2.0) }
     assert_nothing_raised { @img.sharpen(2.0, 1.0) }
-    assert_raise(ArgumentError) { @img.sharpen(2.0, 1.0, 2) }
-    assert_raise(TypeError) { @img.sharpen('x') }
-    assert_raise(TypeError) { @img.sharpen(2.0, 'x') }
+    expect { @img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.sharpen('x') }.to raise_error(TypeError)
+    expect { @img.sharpen(2.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_sharpen_channel
@@ -506,9 +506,9 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.sharpen_channel(2.0, 1.0) }
     assert_nothing_raised { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }
     assert_nothing_raised { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }
-    assert_raise(TypeError) { @img.sharpen_channel('x') }
-    assert_raise(TypeError) { @img.sharpen_channel(2.0, 'x') }
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { @img.sharpen_channel('x') }.to raise_error(TypeError)
+    expect { @img.sharpen_channel(2.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_shave
@@ -521,7 +521,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.shave!(2, 2) }
+    expect { @img.shave!(2, 2) }.to raise_error(FreezeError)
   end
 
   def test_shear
@@ -541,9 +541,9 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }
     assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }
     assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }
-    assert_raise(TypeError) { @img.sigmoidal_contrast_channel('x') }
-    assert_raise(TypeError) { @img.sigmoidal_contrast_channel(3.0, 'x') }
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { @img.sigmoidal_contrast_channel('x') }.to raise_error(TypeError)
+    expect { @img.sigmoidal_contrast_channel(3.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_signature
@@ -558,10 +558,10 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.sketch(0) }
     assert_nothing_raised { @img.sketch(0, 1) }
     assert_nothing_raised { @img.sketch(0, 1, 0) }
-    assert_raise(ArgumentError) { @img.sketch(0, 1, 0, 1) }
-    assert_raise(TypeError) { @img.sketch('x') }
-    assert_raise(TypeError) { @img.sketch(0, 'x') }
-    assert_raise(TypeError) { @img.sketch(0, 1, 'x') }
+    expect { @img.sketch(0, 1, 0, 1) }.to raise_error(ArgumentError)
+    expect { @img.sketch('x') }.to raise_error(TypeError)
+    expect { @img.sketch(0, 'x') }.to raise_error(TypeError)
+    expect { @img.sketch(0, 1, 'x') }.to raise_error(TypeError)
   end
 
   def test_solarize
@@ -570,10 +570,10 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.solarize(100) }
-    assert_raise(ArgumentError) { @img.solarize(-100) }
-    assert_raise(ArgumentError) { @img.solarize(Magick::QuantumRange + 1) }
-    assert_raise(ArgumentError) { @img.solarize(100, 2) }
-    assert_raise(TypeError) { @img.solarize('x') }
+    expect { @img.solarize(-100) }.to raise_error(ArgumentError)
+    expect { @img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)
+    expect { @img.solarize(100, 2) }.to raise_error(ArgumentError)
+    expect { @img.solarize('x') }.to raise_error(TypeError)
   end
 
   def test_sparse_color
@@ -595,17 +595,17 @@ class Image3_UT < Minitest::Test
     # bad calls
     args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
     # invalid method
-    assert_raise(TypeError) { img.sparse_color(1, *args) }
+    expect { img.sparse_color(1, *args) }.to raise_error(TypeError)
     # missing arguments
-    assert_raise(ArgumentError) { img.sparse_color(Magick::VoronoiColorInterpolate) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate) }.to raise_error(ArgumentError)
     args << 10 # too many arguments
-    assert_raise(ArgumentError) { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
     args.shift
     args.shift # too few
-    assert_raise(ArgumentError) { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
 
     args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, '20', 'yellow']
-    assert_raise(TypeError) { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(TypeError)
   end
 
   def test_splice
@@ -616,12 +616,12 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.splice(0, 0, 2, 2, 'red') }
     red = Magick::Pixel.new(Magick::QuantumRange)
     assert_nothing_raised { @img.splice(0, 0, 2, 2, red) }
-    assert_raise(ArgumentError) { @img.splice(0, 0, 2, 2, red, 'x') }
-    assert_raise(TypeError) { @img.splice([], 0, 2, 2, red) }
-    assert_raise(TypeError) { @img.splice(0, 'x', 2, 2, red) }
-    assert_raise(TypeError) { @img.splice(0, 0, 'x', 2, red) }
-    assert_raise(TypeError) { @img.splice(0, 0, 2, [], red) }
-    assert_raise(TypeError) { @img.splice(0, 0, 2, 2, /m/) }
+    expect { @img.splice(0, 0, 2, 2, red, 'x') }.to raise_error(ArgumentError)
+    expect { @img.splice([], 0, 2, 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 'x', 2, 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 'x', 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 2, [], red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 2, 2, /m/) }.to raise_error(TypeError)
   end
 
   def test_spread
@@ -630,8 +630,8 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.spread(3.0) }
-    assert_raise(ArgumentError) { @img.spread(3.0, 2) }
-    assert_raise(TypeError) { @img.spread('x') }
+    expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.spread('x') }.to raise_error(TypeError)
   end
 
   def test_stegano
@@ -643,7 +643,7 @@ class Image3_UT < Minitest::Test
     end
 
     watermark.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.stegano(watermark, 0) }
+    expect { @img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_stereo
@@ -654,7 +654,7 @@ class Image3_UT < Minitest::Test
 
     img = Magick::Image.new(20, 20)
     img.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.stereo(img) }
+    expect { @img.stereo(img) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_store_pixels
@@ -665,12 +665,12 @@ class Image3_UT < Minitest::Test
     end
 
     pixels[0] = 'x'
-    assert_raise(TypeError) { @img.store_pixels(0, 0, @img.columns, 1, pixels) }
-    assert_raise(RangeError) { @img.store_pixels(-1, 0, @img.columns, 1, pixels) }
-    assert_raise(RangeError) { @img.store_pixels(0, -1, @img.columns, 1, pixels) }
-    assert_raise(RangeError) { @img.store_pixels(0, 0, 1 + @img.columns, 1, pixels) }
-    assert_raise(RangeError) { @img.store_pixels(-1, 0, 1, 1 + @img.rows, pixels) }
-    assert_raise(IndexError) { @img.store_pixels(0, 0, @img.columns, 1, ['x']) }
+    expect { @img.store_pixels(0, 0, @img.columns, 1, pixels) }.to raise_error(TypeError)
+    expect { @img.store_pixels(-1, 0, @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, -1, @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, 0, 1 + @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(-1, 0, 1, 1 + @img.rows, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, 0, @img.columns, 1, ['x']) }.to raise_error(IndexError)
   end
 
   def test_strip!
@@ -693,14 +693,14 @@ class Image3_UT < Minitest::Test
       res = @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, texture)
       assert_instance_of(Magick::Image, res)
     end
-    assert_raise(NoMethodError) { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }
-    assert_raise(ArgumentError) { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }
-    assert_raise(ArgumentError) { @img.texture_fill_to_border(@img.columns, @img.rows * 2, texture) }
+    expect { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
+    expect { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }.to raise_error(ArgumentError)
+    expect { @img.texture_fill_to_border(@img.columns, @img.rows * 2, texture) }.to raise_error(ArgumentError)
 
     Magick::PaintMethod.values do |method|
       next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
 
-      assert_raise(ArgumentError) { @img.texture_flood_fill('blue', texture, @img.columns, @img.rows, method) }
+      expect { @img.texture_flood_fill('blue', texture, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
     end
   end
 
@@ -710,9 +710,9 @@ class Image3_UT < Minitest::Test
       res = @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture)
       assert_instance_of(Magick::Image, res)
     end
-    assert_raise(NoMethodError) { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }
+    expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
     texture.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture) }
+    expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_threshold
@@ -728,13 +728,13 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, res)
     end
     assert_nothing_raised { @img.thumbnail(2) }
-    assert_raise(ArgumentError) { @img.thumbnail }
-    assert_raise(ArgumentError) { @img.thumbnail(-1.0) }
-    assert_raise(ArgumentError) { @img.thumbnail(0, 25) }
-    assert_raise(ArgumentError) { @img.thumbnail(25, 0) }
-    assert_raise(ArgumentError) { @img.thumbnail(25, 25, 25) }
-    assert_raise(TypeError) { @img.thumbnail('x') }
-    assert_raise(TypeError) { @img.thumbnail(10, 'x') }
+    expect { @img.thumbnail }.to raise_error(ArgumentError)
+    expect { @img.thumbnail(-1.0) }.to raise_error(ArgumentError)
+    expect { @img.thumbnail(0, 25) }.to raise_error(ArgumentError)
+    expect { @img.thumbnail(25, 0) }.to raise_error(ArgumentError)
+    expect { @img.thumbnail(25, 25, 25) }.to raise_error(ArgumentError)
+    expect { @img.thumbnail('x') }.to raise_error(TypeError)
+    expect { @img.thumbnail(10, 'x') }.to raise_error(TypeError)
 
     girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     new_img = girl.thumbnail(200, 200)
@@ -752,7 +752,7 @@ class Image3_UT < Minitest::Test
       assert_same(@img, res)
     end
     @img.freeze
-    assert_raise(FreezeError) { @img.thumbnail!(0.50) }
+    expect { @img.thumbnail!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_tint
@@ -764,19 +764,19 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.tint('red', 1.0, 1.0) }
     assert_nothing_raised { @img.tint('red', 1.0, 1.0, 1.0) }
     assert_nothing_raised { @img.tint('red', 1.0, 1.0, 1.0, 1.0) }
-    assert_raise(ArgumentError) { @img.tint }
-    assert_raise(ArgumentError) { @img.tint('red') }
-    assert_raise(ArgumentError) { @img.tint('red', 1.0, 1.0, 1.0, 1.0, 1.0) }
-    assert_raise(ArgumentError) { @img.tint('x', 1.0) }
-    assert_raise(ArgumentError) { @img.tint('red', -1.0, 1.0, 1.0, 1.0) }
-    assert_raise(ArgumentError) { @img.tint('red', 1.0, -1.0, 1.0, 1.0) }
-    assert_raise(ArgumentError) { @img.tint('red', 1.0, 1.0, -1.0, 1.0) }
-    assert_raise(ArgumentError) { @img.tint('red', 1.0, 1.0, 1.0, -1.0) }
-    assert_raise(TypeError) { @img.tint(1.0, 1.0) }
-    assert_raise(TypeError) { @img.tint('red', 'green') }
-    assert_raise(TypeError) { @img.tint('red', 1.0, 'green') }
-    assert_raise(TypeError) { @img.tint('red', 1.0, 1.0, 'green') }
-    assert_raise(TypeError) { @img.tint('red', 1.0, 1.0, 1.0, 'green') }
+    expect { @img.tint }.to raise_error(ArgumentError)
+    expect { @img.tint('red') }.to raise_error(ArgumentError)
+    expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint('x', 1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint('red', -1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint('red', 1.0, -1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint('red', 1.0, 1.0, -1.0, 1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint('red', 1.0, 1.0, 1.0, -1.0) }.to raise_error(ArgumentError)
+    expect { @img.tint(1.0, 1.0) }.to raise_error(TypeError)
+    expect { @img.tint('red', 'green') }.to raise_error(TypeError)
+    expect { @img.tint('red', 1.0, 'green') }.to raise_error(TypeError)
+    expect { @img.tint('red', 1.0, 1.0, 'green') }.to raise_error(TypeError)
+    expect { @img.tint('red', 1.0, 1.0, 1.0, 'green') }.to raise_error(TypeError)
   end
 
   def test_to_blob
@@ -802,25 +802,25 @@ class Image3_UT < Minitest::Test
     end
     pixel = Magick::Pixel.new
     assert_nothing_raised { @img.transparent(pixel) }
-    assert_raise(ArgumentError) { @img.transparent('white', Magick::TransparentAlpha) }
+    expect { @img.transparent('white', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.transparent('white', alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent('white', wrong: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent('white', Magick::TransparentAlpha, 2) }
-    assert_raise(ArgumentError) { @img.transparent('white', Magick::QuantumRange / 2) }
-    assert_raise(TypeError) { @img.transparent(2) }
+    expect { @img.transparent('white', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.transparent('white', Magick::TransparentAlpha, 2) }.to raise_error(ArgumentError)
+    expect { @img.transparent('white', Magick::QuantumRange / 2) }.to raise_error(ArgumentError)
+    expect { @img.transparent(2) }.to raise_error(TypeError)
   end
 
   def test_transparent_chroma
     assert_instance_of(Magick::Image, @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)))
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }
-    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha, true) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), true, alpha: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }
-    assert_raise(ArgumentError) { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
 
   def test_transpose
@@ -856,7 +856,7 @@ class Image3_UT < Minitest::Test
       assert_instance_of(Magick::Image, hat.trim)
       assert_instance_of(Magick::Image, hat.trim(10))
     end
-    assert_raise(ArgumentError) { hat.trim(10, 10) }
+    expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
 
     assert_nothing_raised do
       res = hat.trim!
@@ -865,7 +865,7 @@ class Image3_UT < Minitest::Test
       res = hat.trim!(10)
       assert_same(hat, res)
     end
-    assert_raise(ArgumentError) { hat.trim!(10, 10) }
+    expect { hat.trim!(10, 10) }.to raise_error(ArgumentError)
   end
 
   def test_unique_colors
@@ -887,15 +887,15 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.unsharp_mask(2.0, 1.0) }
     assert_nothing_raised { @img.unsharp_mask(2.0, 1.0, 0.50) }
     assert_nothing_raised { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10) }
-    assert_raise(ArgumentError) { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10, 2) }
-    assert_raise(ArgumentError) { @img.unsharp_mask(-2.0, 1.0, 0.50, 0.10) }
-    assert_raise(ArgumentError) { @img.unsharp_mask(2.0, 0.0, 0.50, 0.10) }
-    assert_raise(ArgumentError) { @img.unsharp_mask(2.0, 1.0, 0.0, 0.10) }
-    assert_raise(ArgumentError) { @img.unsharp_mask(2.0, 1.0, 0.01, -0.10) }
-    assert_raise(TypeError) { @img.unsharp_mask('x') }
-    assert_raise(TypeError) { @img.unsharp_mask(2.0, 'x') }
-    assert_raise(TypeError) { @img.unsharp_mask(2.0, 1.0, 'x') }
-    assert_raise(TypeError) { @img.unsharp_mask(2.0, 1.0, 0.50, 'x') }
+    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(ArgumentError)
+    expect { @img.unsharp_mask(-2.0, 1.0, 0.50, 0.10) }.to raise_error(ArgumentError)
+    expect { @img.unsharp_mask(2.0, 0.0, 0.50, 0.10) }.to raise_error(ArgumentError)
+    expect { @img.unsharp_mask(2.0, 1.0, 0.0, 0.10) }.to raise_error(ArgumentError)
+    expect { @img.unsharp_mask(2.0, 1.0, 0.01, -0.10) }.to raise_error(ArgumentError)
+    expect { @img.unsharp_mask('x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask(2.0, 'x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask(2.0, 1.0, 'x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
   end
 
   def test_unsharp_mask_channel
@@ -910,12 +910,12 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10) }
     assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel) }
     assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, 2) }
-    assert_raise(TypeError) { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, 2) }
-    assert_raise(TypeError) { @img.unsharp_mask_channel('x') }
-    assert_raise(TypeError) { @img.unsharp_mask_channel(2.0, 'x') }
-    assert_raise(TypeError) { @img.unsharp_mask_channel(2.0, 1.0, 'x') }
-    assert_raise(TypeError) { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 'x') }
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(TypeError)
+    expect { @img.unsharp_mask_channel('x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask_channel(2.0, 'x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 'x') }.to raise_error(TypeError)
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
   end
 
   def test_view
@@ -926,12 +926,12 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised do
       @img.view(0, 0, 5, 5) { |v| assert_instance_of(Magick::Image::View, v) }
     end
-    assert_raise(RangeError) { @img.view(-1, 0, 5, 5) }
-    assert_raise(RangeError) { @img.view(0, -1, 5, 5) }
-    assert_raise(RangeError) { @img.view(1, 0, @img.columns, 5) }
-    assert_raise(RangeError) { @img.view(0, 1, 5, @img.rows) }
-    assert_raise(ArgumentError) { @img.view(0, 0, 0, 1) }
-    assert_raise(ArgumentError) { @img.view(0, 0, 1, 0) }
+    expect { @img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
+    expect { @img.view(0, -1, 5, 5) }.to raise_error(RangeError)
+    expect { @img.view(1, 0, @img.columns, 5) }.to raise_error(RangeError)
+    expect { @img.view(0, 1, 5, @img.rows) }.to raise_error(RangeError)
+    expect { @img.view(0, 0, 0, 1) }.to raise_error(ArgumentError)
+    expect { @img.view(0, 0, 1, 0) }.to raise_error(ArgumentError)
   end
 
   def test_vignette
@@ -945,7 +945,7 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.vignette(0, 0, 0) }
     assert_nothing_raised { @img.vignette(0, 0, 0, 1) }
     # too many arguments
-    assert_raise(ArgumentError) { @img.vignette(0, 0, 0, 1, 1) }
+    expect { @img.vignette(0, 0, 0, 1, 1) }.to raise_error(ArgumentError)
   end
 
   def test_watermark
@@ -964,16 +964,16 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10) }
     assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 10) }
 
-    assert_raise(ArgumentError) { @img.watermark }
-    assert_raise(ArgumentError) { @img.watermark(mark, 'x') }
-    assert_raise(ArgumentError) { @img.watermark(mark, 0.50, 'x') }
-    assert_raise(ArgumentError) { @img.watermark(mark, 0.50, '1500%') }
-    assert_raise(TypeError) { @img.watermark(mark, 0.50, 0.50, 'x') }
-    assert_raise(TypeError) { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 'x') }
-    assert_raise(TypeError) { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 'x') }
+    expect { @img.watermark }.to raise_error(ArgumentError)
+    expect { @img.watermark(mark, 'x') }.to raise_error(ArgumentError)
+    expect { @img.watermark(mark, 0.50, 'x') }.to raise_error(ArgumentError)
+    expect { @img.watermark(mark, 0.50, '1500%') }.to raise_error(ArgumentError)
+    expect { @img.watermark(mark, 0.50, 0.50, 'x') }.to raise_error(TypeError)
+    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
+    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
 
     mark.destroy!
-    assert_raise(Magick::DestroyedImageError) { @img.watermark(mark) }
+    expect { @img.watermark(mark) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_wave
@@ -983,9 +983,9 @@ class Image3_UT < Minitest::Test
     end
     assert_nothing_raised { @img.wave(25) }
     assert_nothing_raised { @img.wave(25, 200) }
-    assert_raise(ArgumentError) { @img.wave(25, 200, 2) }
-    assert_raise(TypeError) { @img.wave('x') }
-    assert_raise(TypeError) { @img.wave(25, 'x') }
+    expect { @img.wave(25, 200, 2) }.to raise_error(ArgumentError)
+    expect { @img.wave('x') }.to raise_error(TypeError)
+    expect { @img.wave(25, 'x') }.to raise_error(TypeError)
   end
 
   def test_wet_floor
@@ -995,22 +995,22 @@ class Image3_UT < Minitest::Test
     assert_nothing_raised { @img.wet_floor(0.5, 10) }
     assert_nothing_raised { @img.wet_floor(0.5, 0.0) }
 
-    assert_raise(ArgumentError) { @img.wet_floor(2.0) }
-    assert_raise(ArgumentError) { @img.wet_floor(-2.0) }
-    assert_raise(ArgumentError) { @img.wet_floor(0.5, -1.0) }
-    assert_raise(ArgumentError) { @img.wet_floor(0.5, 10, 0.5) }
+    expect { @img.wet_floor(2.0) }.to raise_error(ArgumentError)
+    expect { @img.wet_floor(-2.0) }.to raise_error(ArgumentError)
+    expect { @img.wet_floor(0.5, -1.0) }.to raise_error(ArgumentError)
+    expect { @img.wet_floor(0.5, 10, 0.5) }.to raise_error(ArgumentError)
   end
 
   def test_white_threshold
-    assert_raise(ArgumentError) { @img.white_threshold }
+    expect { @img.white_threshold }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.white_threshold(50) }
     assert_nothing_raised { @img.white_threshold(50, 50) }
     assert_nothing_raised { @img.white_threshold(50, 50, 50) }
-    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, 50) }
+    expect { @img.white_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
     assert_nothing_raised { @img.white_threshold(50, 50, 50, alpha: 50) }
-    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, wrong: 50) }
-    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }
-    assert_raise(ArgumentError) { @img.white_threshold(50, 50, 50, 50, 50) }
+    expect { @img.white_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
+    expect { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
+    expect { @img.white_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
     res = @img.white_threshold(50)
     assert_instance_of(Magick::Image, res)
   end
@@ -1048,9 +1048,9 @@ class Image3_UT < Minitest::Test
     img = Magick::Image.read('temp.0')
     expect(img.first.format).to eq('JPEG')
 
-    assert_raise(RuntimeError) do
+    expect do
       @img.write('gif:temp.0') { self.format = 'JPEG' }
-    end
+    end.to raise_error(RuntimeError)
 
     f = File.new('test.0', 'w')
     @img.write(f) { self.format = 'JPEG' }

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -20,7 +20,7 @@ class ImageList1UT < Minitest::Test
     alpha = Magick::Image.new(20, 20) { self.background_color = 'transparent' }
 
     list = Magick::ImageList.new
-    assert_raise(ArgumentError) { list.combine }
+    expect { list.combine }.to raise_error(ArgumentError)
 
     list << red
     assert_nothing_raised { list.combine }
@@ -46,13 +46,13 @@ class ImageList1UT < Minitest::Test
 
     list << alpha
     assert_nothing_raised { list.combine(Magick::CMYKColorspace) }
-    assert_raise(ArgumentError) { list.combine(Magick::SRGBColorspace) }
+    expect { list.combine(Magick::SRGBColorspace) }.to raise_error(ArgumentError)
 
     list << alpha
-    assert_raise(ArgumentError) { list.combine }
+    expect { list.combine }.to raise_error(ArgumentError)
 
-    assert_raise(TypeError) { list.combine(nil) }
-    assert_raise(ArgumentError) { list.combine(Magick::SRGBColorspace, 1) }
+    expect { list.combine(nil) }.to raise_error(TypeError)
+    expect { list.combine(Magick::SRGBColorspace, 1) }.to raise_error(ArgumentError)
   end
 
   def test_composite_layers
@@ -61,7 +61,7 @@ class ImageList1UT < Minitest::Test
       assert_nothing_raised { @list.composite_layers(@list2, op) }
     end
 
-    assert_raise(ArgumentError) { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }
+    expect { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }.to raise_error(ArgumentError)
   end
 
   def test_delay
@@ -69,7 +69,7 @@ class ImageList1UT < Minitest::Test
     expect(@list.delay).to eq(0)
     assert_nothing_raised { @list.delay = 20 }
     expect(@list.delay).to eq(20)
-    assert_raise(ArgumentError) { @list.delay = 'x' }
+    expect { @list.delay = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_flatten_images
@@ -81,7 +81,7 @@ class ImageList1UT < Minitest::Test
     expect(@list.ticks_per_second).to eq(100)
     assert_nothing_raised { @list.ticks_per_second = 1000 }
     expect(@list.ticks_per_second).to eq(1000)
-    assert_raise(ArgumentError) { @list.ticks_per_second = 'x' }
+    expect { @list.ticks_per_second = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_iterations
@@ -89,14 +89,14 @@ class ImageList1UT < Minitest::Test
     assert_kind_of(Integer, @list.iterations)
     assert_nothing_raised { @list.iterations = 20 }
     expect(@list.iterations).to eq(20)
-    assert_raise(ArgumentError) { @list.iterations = 'x' }
+    expect { @list.iterations = 'x' }.to raise_error(ArgumentError)
   end
 
   # also tests #size
   def test_length
     assert_nothing_raised { @list.length }
     expect(@list.length).to eq(10)
-    assert_raise(NoMethodError) { @list.length = 2 }
+    expect { @list.length = 2 }.to raise_error(NoMethodError)
   end
 
   def test_scene
@@ -106,9 +106,9 @@ class ImageList1UT < Minitest::Test
     expect(@list.scene).to eq(0)
     assert_nothing_raised { @list.scene = 1 }
     expect(@list.scene).to eq(1)
-    assert_raise(IndexError) { @list.scene = -1 }
-    assert_raise(IndexError) { @list.scene = 1000 }
-    assert_raise(IndexError) { @list.scene = nil }
+    expect { @list.scene = -1 }.to raise_error(IndexError)
+    expect { @list.scene = 1000 }.to raise_error(IndexError)
+    expect { @list.scene = nil }.to raise_error(IndexError)
 
     # allow nil on empty list
     empty_list = Magick::ImageList.new
@@ -116,12 +116,12 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_undef_array_methods
-    assert_raise(NoMethodError) { @list.assoc }
-    assert_raise(NoMethodError) { @list.flatten }
-    assert_raise(NoMethodError) { @list.flatten! }
-    assert_raise(NoMethodError) { @list.join }
-    assert_raise(NoMethodError) { @list.pack }
-    assert_raise(NoMethodError) { @list.rassoc }
+    expect { @list.assoc }.to raise_error(NoMethodError)
+    expect { @list.flatten }.to raise_error(NoMethodError)
+    expect { @list.flatten! }.to raise_error(NoMethodError)
+    expect { @list.join }.to raise_error(NoMethodError)
+    expect { @list.pack }.to raise_error(NoMethodError)
+    expect { @list.rassoc }.to raise_error(NoMethodError)
   end
 
   def test_all
@@ -206,9 +206,9 @@ class ImageList1UT < Minitest::Test
       expect(@list.scene).to eq(8)
     end
 
-    assert_raise(ArgumentError) { @list[0] = 1 }
-    assert_raise(ArgumentError) { @list[0, 1] = [1, 2] }
-    assert_raise(ArgumentError) { @list[2..3] = 'x' }
+    expect { @list[0] = 1 }.to raise_error(ArgumentError)
+    expect { @list[0, 1] = [1, 2] }.to raise_error(ArgumentError)
+    expect { @list[2..3] = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_and
@@ -232,7 +232,7 @@ class ImageList1UT < Minitest::Test
       expect(res.scene).to eq(4)
     end
 
-    assert_raise(ArgumentError) { @list & 2 }
+    expect { @list & 2 }.to raise_error(ArgumentError)
   end
 
   def test_at
@@ -261,7 +261,7 @@ class ImageList1UT < Minitest::Test
       assert_same(cur, res.cur_image)
     end
 
-    assert_raise(ArgumentError) { @list * 'x' }
+    expect { @list * 'x' }.to raise_error(ArgumentError)
   end
 
   def test_plus
@@ -276,7 +276,7 @@ class ImageList1UT < Minitest::Test
       assert_same(cur, res.cur_image)
     end
 
-    assert_raise(ArgumentError) { @list + [2] }
+    expect { @list + [2] }.to raise_error(ArgumentError)
   end
 
   def test_minus
@@ -309,8 +309,8 @@ class ImageList1UT < Minitest::Test
       expect(@list.scene).to eq(14)
     end
 
-    assert_raise(ArgumentError) { @list << 2 }
-    assert_raise(ArgumentError) { @list << [2] }
+    expect { @list << 2 }.to raise_error(ArgumentError)
+    expect { @list << [2] }.to raise_error(ArgumentError)
   end
 
   def test_or
@@ -332,8 +332,8 @@ class ImageList1UT < Minitest::Test
     expect(res.length).to eq(15)
     expect(res.scene).to eq(7)
 
-    assert_raise(ArgumentError) { @list | 2 }
-    assert_raise(ArgumentError) { @list | [2] }
+    expect { @list | 2 }.to raise_error(ArgumentError)
+    expect { @list | [2] }.to raise_error(ArgumentError)
   end
 
   def test_clear
@@ -381,8 +381,8 @@ class ImageList1UT < Minitest::Test
       expect(res.length).to eq(15)
       assert_same(res[14], res.cur_image)
     end
-    assert_raise(ArgumentError) { @list.concat(2) }
-    assert_raise(ArgumentError) { @list.concat([2]) }
+    expect { @list.concat(2) }.to raise_error(ArgumentError)
+    expect { @list.concat([2]) }.to raise_error(ArgumentError)
   end
 
   def test_delete
@@ -397,8 +397,8 @@ class ImageList1UT < Minitest::Test
       assert_same(cur, @list.delete(cur))
       assert_same(@list[-1], @list.cur_image)
 
-      assert_raise(ArgumentError) { @list.delete(2) }
-      assert_raise(ArgumentError) { @list.delete([2]) }
+      expect { @list.delete(2) }.to raise_error(ArgumentError)
+      expect { @list.delete([2]) }.to raise_error(ArgumentError)
 
       # Try deleting something that isn't in the list.
       # Should return the value of the block.
@@ -485,7 +485,7 @@ class ImageList1UT < Minitest::Test
     list.fill(0, 3) { |i| list[i] = img }
     0.upto(2) { |i| assert_same(img, list[i]) }
 
-    assert_raise(ArgumentError) { list.fill('x', 0) }
+    expect { list.fill('x', 0) }.to raise_error(ArgumentError)
   end
 
   def test_find
@@ -511,8 +511,8 @@ class ImageList1UT < Minitest::Test
       assert_same(cur, @list.cur_image)
     end
 
-    assert_raise(ArgumentError) { @list.insert(0, 'x') }
-    assert_raise(ArgumentError) { @list.insert(0, 'x', 'y') }
+    expect { @list.insert(0, 'x') }.to raise_error(ArgumentError)
+    expect { @list.insert(0, 'x', 'y') }.to raise_error(ArgumentError)
   end
 
   def test_last
@@ -539,7 +539,7 @@ class ImageList1UT < Minitest::Test
       @list.__map__ { |_x| img }
     end
     assert_instance_of(Magick::ImageList, @list)
-    assert_raise(ArgumentError) { @list.__map__ { 2 } }
+    expect { @list.__map__ { 2 } }.to raise_error(ArgumentError)
   end
 
   def test_map!
@@ -548,7 +548,7 @@ class ImageList1UT < Minitest::Test
       @list.map! { img }
     end
     assert_instance_of(Magick::ImageList, @list)
-    assert_raise(ArgumentError) { @list.map! { 2 } }
+    expect { @list.map! { 2 } }.to raise_error(ArgumentError)
   end
 
   def test_partition
@@ -652,7 +652,7 @@ class ImageList1UT < Minitest::Test
     end
 
     # Try to replace with illegal values
-    assert_raise(ArgumentError) { @list.replace([1, 2, 3]) }
+    expect { @list.replace([1, 2, 3]) }.to raise_error(ArgumentError)
   end
 
   def test_replace2
@@ -814,8 +814,8 @@ class ImageList1UT < Minitest::Test
     @list.scene = 7
     @list.unshift(img)
     expect(@list.scene).to eq(0)
-    assert_raise(ArgumentError) { @list.unshift(2) }
-    assert_raise(ArgumentError) { @list.unshift([1, 2]) }
+    expect { @list.unshift(2) }.to raise_error(ArgumentError)
+    expect { @list.unshift([1, 2]) }.to raise_error(ArgumentError)
   end
 
   def test_values_at
@@ -839,11 +839,11 @@ class ImageList1UT < Minitest::Test
     list2 << @list[9]
     assert_not_equal(@list, list2)
 
-    assert_raise(TypeError) { @list <=> 2 }
+    expect { @list <=> 2 }.to raise_error(TypeError)
     list = Magick::ImageList.new
     list2 = Magick::ImageList.new
-    assert_raise(TypeError) { list2 <=> @list }
-    assert_raise(TypeError) { @list <=> list2 }
+    expect { list2 <=> @list }.to raise_error(TypeError)
+    expect { @list <=> list2 }.to raise_error(TypeError)
     assert_nothing_raised { list <=> list2 }
   end
 end

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -17,8 +17,8 @@ class ImageList2UT < Minitest::Test
       img = @ilist.append(false)
       assert_instance_of(Magick::Image, img)
     end
-    assert_raise(ArgumentError) { @ilist.append }
-    assert_raise(ArgumentError) { @ilist.append(true, 1) }
+    expect { @ilist.append }.to raise_error(ArgumentError)
+    expect { @ilist.append(true, 1) }.to raise_error(ArgumentError)
   end
 
   def test_average
@@ -27,7 +27,7 @@ class ImageList2UT < Minitest::Test
       img = @ilist.average
       assert_instance_of(Magick::Image, img)
     end
-    assert_raise(ArgumentError) { @ilist.average(1) }
+    expect { @ilist.average(1) }.to raise_error(ArgumentError)
   end
 
   def test_clone
@@ -155,62 +155,62 @@ class ImageList2UT < Minitest::Test
     # test illegal option arguments
     # looks like IM doesn't diagnose invalid geometry args
     # to tile= and geometry=
-    assert_raise(TypeError) do
+    expect do
       montage = ilist.montage { self.background_color = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.border_color = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.border_width = [2] }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.compose = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.filename = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.fill = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.font = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.gravity = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.matte_color = 2 }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(TypeError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.pointsize = 'x' }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(ArgumentError) do
+    end.to raise_error(TypeError)
+    expect do
       montage = ilist.montage { self.stroke = 'x' }
       expect(ilist).to eq(@ilist)
-    end
-    assert_raise(NoMethodError) do
+    end.to raise_error(ArgumentError)
+    expect do
       montage = ilist.montage { self.texture = 'x' }
       expect(ilist).to eq(@ilist)
-    end
+    end.to raise_error(NoMethodError)
   end
 
   def test_morph
     # can't morph an empty list
-    assert_raise(ArgumentError) { @ilist.morph(1) }
+    expect { @ilist.morph(1) }.to raise_error(ArgumentError)
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     # can't specify a negative argument
-    assert_raise(ArgumentError) { @ilist.morph(-1) }
+    expect { @ilist.morph(-1) }.to raise_error(ArgumentError)
     assert_nothing_raised do
       res = @ilist.morph(2)
       assert_instance_of(Magick::ImageList, res)
@@ -230,7 +230,7 @@ class ImageList2UT < Minitest::Test
   def test_mosaic_with_invalid_imagelist
     list = @ilist.copy
     list.instance_variable_set("@images", nil)
-    assert_raise(Magick::ImageMagickError) { list.mosaic }
+    expect { list.mosaic }.to raise_error(Magick::ImageMagickError)
   end
 
   def test_new_image
@@ -260,9 +260,9 @@ class ImageList2UT < Minitest::Test
     end
 
     assert_nothing_raised { @ilist.optimize_layers(Magick::CompareClearLayer) }
-    assert_raise(ArgumentError) { @ilist.optimize_layers(Magick::UndefinedLayer) }
-    assert_raise(TypeError) { @ilist.optimize_layers(2) }
-    assert_raise(NotImplementedError) { @ilist.optimize_layers(Magick::CompositeLayer) }
+    expect { @ilist.optimize_layers(Magick::UndefinedLayer) }.to raise_error(ArgumentError)
+    expect { @ilist.optimize_layers(2) }.to raise_error(TypeError)
+    expect { @ilist.optimize_layers(Magick::CompositeLayer) }.to raise_error(NotImplementedError)
   end
 
   def test_ping
@@ -285,9 +285,9 @@ class ImageList2UT < Minitest::Test
       expect(res.scene).to eq(1)
     end
     assert_nothing_raised { @ilist.quantize(128) }
-    assert_raise(TypeError) { @ilist.quantize('x') }
+    expect { @ilist.quantize('x') }.to raise_error(TypeError)
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace) }
-    assert_raise(TypeError) { @ilist.quantize(128, 'x') }
+    expect { @ilist.quantize(128, 'x') }.to raise_error(TypeError)
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, true, 0) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, true) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, false) }
@@ -297,8 +297,8 @@ class ImageList2UT < Minitest::Test
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }
     assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }
-    assert_raise(TypeError) { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }
-    assert_raise(ArgumentError) { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }
+    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }.to raise_error(TypeError)
+    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }.to raise_error(ArgumentError)
   end
 
   def test_read
@@ -321,11 +321,11 @@ class ImageList2UT < Minitest::Test
     assert_nothing_raised { @ilist.remap(remap_image, Magick::NoDitherMethod) }
     assert_nothing_raised { @ilist.remap(remap_image, Magick::RiemersmaDitherMethod) }
     assert_nothing_raised { @ilist.remap(remap_image, Magick::FloydSteinbergDitherMethod) }
-    assert_raise(ArgumentError) { @ilist.remap(remap_image, Magick::NoDitherMethod, 1) }
+    expect { @ilist.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
 
     remap_image.destroy!
-    assert_raise(Magick::DestroyedImageError) { @ilist.remap(remap_image) }
-    # assert_raise(TypeError) { @ilist.affinity(affinity_image, 1) }
+    expect { @ilist.remap(remap_image) }.to raise_error(Magick::DestroyedImageError)
+    # expect { @ilist.affinity(affinity_image, 1) }.to raise_error(TypeError)
   end
 
   def test_to_blob

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -39,25 +39,25 @@ class Image_Attributes_UT < Minitest::Test
     else
       expect(background_color).to eq('#FFFF7FFF7FFFFFFF')
     end
-    assert_raise(TypeError) { @img.background_color = 2 }
+    expect { @img.background_color = 2 }.to raise_error(TypeError)
   end
 
   def test_base_columns
     assert_nothing_raised { @img.base_columns }
     expect(@img.base_columns).to eq(0)
-    assert_raise(NoMethodError) { @img.base_columns = 1 }
+    expect { @img.base_columns = 1 }.to raise_error(NoMethodError)
   end
 
   def test_base_filename
     assert_nothing_raised { @img.base_filename }
     expect(@img.base_filename).to eq('')
-    assert_raise(NoMethodError) { @img.base_filename = 'xxx' }
+    expect { @img.base_filename = 'xxx' }.to raise_error(NoMethodError)
   end
 
   def test_base_rows
     assert_nothing_raised { @img.base_rows }
     expect(@img.base_rows).to eq(0)
-    assert_raise(NoMethodError) { @img.base_rows = 1 }
+    expect { @img.base_rows = 1 }.to raise_error(NoMethodError)
   end
 
   def test_bias
@@ -71,8 +71,8 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.bias = '10%' }
     assert_in_delta(Magick::QuantumRange * 0.10, @img.bias, 0.1)
 
-    assert_raise(TypeError) { @img.bias = [] }
-    assert_raise(ArgumentError) { @img.bias = 'x' }
+    expect { @img.bias = [] }.to raise_error(TypeError)
+    expect { @img.bias = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_black_point_compensation
@@ -101,7 +101,7 @@ class Image_Attributes_UT < Minitest::Test
     else
       expect(border_color).to eq('#FFFF7FFF7FFFFFFF')
     end
-    assert_raise(TypeError) { @img.border_color = 2 }
+    expect { @img.border_color = 2 }.to raise_error(TypeError)
   end
 
   def test_bounding_box
@@ -111,7 +111,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(box.height).to eq(87)
     expect(box.x).to eq(7)
     expect(box.y).to eq(7)
-    assert_raise(NoMethodError) { @img.bounding_box = 2 }
+    expect { @img.bounding_box = 2 }.to raise_error(NoMethodError)
   end
 
   def test_chromaticity
@@ -131,7 +131,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(chrom.white_point.y).to eq(0)
     expect(chrom.white_point.z).to eq(0)
     assert_nothing_raised { @img.chromaticity = chrom }
-    assert_raise(TypeError) { @img.chromaticity = 2 }
+    expect { @img.chromaticity = 2 }.to raise_error(TypeError)
   end
 
   def test_class_type
@@ -140,7 +140,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.class_type).to eq(Magick::DirectClass)
     assert_nothing_raised { @img.class_type = Magick::PseudoClass }
     expect(@img.class_type).to eq(Magick::PseudoClass)
-    assert_raise(TypeError) { @img.class_type = 2 }
+    expect { @img.class_type = 2 }.to raise_error(TypeError)
 
     assert_nothing_raised do
       @img.class_type = Magick::PseudoClass
@@ -154,7 +154,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_nil(@img.color_profile)
     assert_nothing_raised { @img.color_profile = @p }
     expect(@img.color_profile).to eq(@p)
-    assert_raise(TypeError) { @img.color_profile = 2 }
+    expect { @img.color_profile = 2 }.to raise_error(TypeError)
   end
 
   def test_colors
@@ -163,7 +163,7 @@ class Image_Attributes_UT < Minitest::Test
     img = @img.copy
     img.class_type = Magick::PseudoClass
     assert_kind_of(Integer, img.colors)
-    assert_raise(NoMethodError) { img.colors = 2 }
+    expect { img.colors = 2 }.to raise_error(NoMethodError)
   end
 
   def test_colorspace
@@ -175,7 +175,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::ColorspaceType.values do |colorspace|
       assert_nothing_raised { img.colorspace = colorspace }
     end
-    assert_raise(TypeError) { @img.colorspace = 2 }
+    expect { @img.colorspace = 2 }.to raise_error(TypeError)
     Magick::ColorspaceType.values.each do |cs|
       assert_nothing_raised { img.colorspace = cs }
     end
@@ -184,21 +184,21 @@ class Image_Attributes_UT < Minitest::Test
   def test_columns
     assert_nothing_raised { @img.columns }
     expect(@img.columns).to eq(100)
-    assert_raise(NoMethodError) { @img.columns = 2 }
+    expect { @img.columns = 2 }.to raise_error(NoMethodError)
   end
 
   def test_compose
     assert_nothing_raised { @img.compose }
     assert_instance_of(Magick::CompositeOperator, @img.compose)
     expect(@img.compose).to eq(Magick::OverCompositeOp)
-    assert_raise(TypeError) { @img.compose = 2 }
+    expect { @img.compose = 2 }.to raise_error(TypeError)
     assert_nothing_raised { @img.compose = Magick::UndefinedCompositeOp }
     expect(@img.compose).to eq(Magick::UndefinedCompositeOp)
 
     Magick::CompositeOperator.values do |composite|
       assert_nothing_raised { @img.compose = composite }
     end
-    assert_raise(TypeError) { @img.compose = 2 }
+    expect { @img.compose = 2 }.to raise_error(TypeError)
   end
 
   def test_compression
@@ -211,7 +211,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::CompressionType.values do |compression|
       assert_nothing_raised { @img.compression = compression }
     end
-    assert_raise(TypeError) { @img.compression = 2 }
+    expect { @img.compression = 2 }.to raise_error(TypeError)
   end
 
   def test_delay
@@ -219,7 +219,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.delay).to eq(0)
     assert_nothing_raised { @img.delay = 10 }
     expect(@img.delay).to eq(10)
-    assert_raise(TypeError) { @img.delay = 'x' }
+    expect { @img.delay = 'x' }.to raise_error(TypeError)
   end
 
   def test_density
@@ -228,18 +228,18 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.density = 'x90' }
     assert_nothing_raised { @img.density = '90' }
     assert_nothing_raised { @img.density = Magick::Geometry.new(@img.columns / 2, @img.rows / 2, 5, 5) }
-    assert_raise(TypeError) { @img.density = 2 }
+    expect { @img.density = 2 }.to raise_error(TypeError)
   end
 
   def test_depth
     expect(@img.depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
-    assert_raise(NoMethodError) { @img.depth = 2 }
+    expect { @img.depth = 2 }.to raise_error(NoMethodError)
   end
 
   def test_directory
     assert_nothing_raised { @img.directory }
     assert_nil(@img.directory)
-    assert_raise(NoMethodError) { @img.directory = nil }
+    expect { @img.directory = nil }.to raise_error(NoMethodError)
   end
 
   def test_dispose
@@ -252,7 +252,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::DisposeType.values do |dispose|
       assert_nothing_raised { @img.dispose = dispose }
     end
-    assert_raise(TypeError) { @img.dispose = 2 }
+    expect { @img.dispose = 2 }.to raise_error(TypeError)
   end
 
   def test_endian
@@ -262,7 +262,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.endian = Magick::LSBEndian }
     expect(@img.endian).to eq(Magick::LSBEndian)
     assert_nothing_raised { @img.endian = Magick::MSBEndian }
-    assert_raise(TypeError) { @img.endian = 2 }
+    expect { @img.endian = 2 }.to raise_error(TypeError)
   end
 
   def test_extract_info
@@ -279,13 +279,13 @@ class Image_Attributes_UT < Minitest::Test
     expect(ext.height).to eq(2)
     expect(ext.x).to eq(3)
     expect(ext.y).to eq(4)
-    assert_raise(TypeError) { @img.extract_info = 2 }
+    expect { @img.extract_info = 2 }.to raise_error(TypeError)
   end
 
   def test_filename
     assert_nothing_raised { @img.filename }
     expect(@img.filename).to eq('')
-    assert_raises(NoMethodError) { @img.filename = 'xxx' }
+    expect { @img.filename = 'xxx' }.to raise_error(NoMethodError)
   end
 
   def test_filter
@@ -298,7 +298,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::FilterType.values do |filter|
       assert_nothing_raised { @img.filter = filter }
     end
-    assert_raise(TypeError) { @img.filter = 2 }
+    expect { @img.filter = 2 }.to raise_error(TypeError)
   end
 
   def test_format
@@ -311,9 +311,9 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { @img.format = 'MPEG' }
     v = $VERBOSE
     $VERBOSE = nil
-    assert_raise(ArgumentError) { @img.format = 'shit' }
+    expect { @img.format = 'shit' }.to raise_error(ArgumentError)
     $VERBOSE = v
-    assert_raise(TypeError) { @img.format = 2 }
+    expect { @img.format = 2 }.to raise_error(TypeError)
   end
 
   def test_fuzz
@@ -324,8 +324,8 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.fuzz).to eq(50.0)
     assert_nothing_raised { @img.fuzz = '50%' }
     assert_in_delta(Magick::QuantumRange * 0.50, @img.fuzz, 0.1)
-    assert_raise(TypeError) { @img.fuzz = [] }
-    assert_raise(ArgumentError) { @img.fuzz = 'xxx' }
+    expect { @img.fuzz = [] }.to raise_error(TypeError)
+    expect { @img.fuzz = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_gamma
@@ -334,7 +334,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.gamma).to eq(0.45454543828964233)
     assert_nothing_raised { @img.gamma = 2.0 }
     expect(@img.gamma).to eq(2.0)
-    assert_raise(TypeError) { @img.gamma = 'x' }
+    expect { @img.gamma = 'x' }.to raise_error(TypeError)
   end
 
   def test_geometry
@@ -345,7 +345,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.geometry).to eq('90x90')
     assert_nothing_raised { @img.geometry = Magick::Geometry.new(100, 80) }
     expect(@img.geometry).to eq('100x80')
-    assert_raise(TypeError) { @img.geometry = [] }
+    expect { @img.geometry = [] }.to raise_error(TypeError)
   end
 
   def test_gravity
@@ -354,8 +354,8 @@ class Image_Attributes_UT < Minitest::Test
     Magick::GravityType.values do |gravity|
       assert_nothing_raised { @img.gravity = gravity }
     end
-    assert_raise(TypeError) { @img.gravity = nil }
-    assert_raise(TypeError) { @img.gravity = Magick::PointFilter }
+    expect { @img.gravity = nil }.to raise_error(TypeError)
+    expect { @img.gravity = Magick::PointFilter }.to raise_error(TypeError)
   end
 
   def test_image_type
@@ -364,8 +364,8 @@ class Image_Attributes_UT < Minitest::Test
     Magick::ImageType.values do |image_type|
       assert_nothing_raised { @img.image_type = image_type }
     end
-    assert_raise(TypeError) { @img.image_type = nil }
-    assert_raise(TypeError) { @img.image_type = Magick::PointFilter }
+    expect { @img.image_type = nil }.to raise_error(TypeError)
+    expect { @img.image_type = Magick::PointFilter }.to raise_error(TypeError)
   end
 
   def test_interlace_type
@@ -378,7 +378,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::InterlaceType.values do |interlace|
       assert_nothing_raised { @img.interlace = interlace }
     end
-    assert_raise(TypeError) { @img.interlace = 2 }
+    expect { @img.interlace = 2 }.to raise_error(TypeError)
   end
 
   def test_iptc_profile
@@ -386,7 +386,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_nil(@img.iptc_profile)
     assert_nothing_raised { @img.iptc_profile = 'xxx' }
     expect(@img.iptc_profile).to eq('xxx')
-    assert_raise(TypeError) { @img.iptc_profile = 2 }
+    expect { @img.iptc_profile = 2 }.to raise_error(TypeError)
   end
 
   def test_mean_error
@@ -402,9 +402,9 @@ class Image_Attributes_UT < Minitest::Test
     assert_not_equal(0.0, hat.mean_error_per_pixel)
     assert_not_equal(0.0, hat.normalized_mean_error)
     assert_not_equal(0.0, hat.normalized_maximum_error)
-    assert_raise(NoMethodError) { hat.mean_error_per_pixel = 1 }
-    assert_raise(NoMethodError) { hat.normalized_mean_error = 1 }
-    assert_raise(NoMethodError) { hat.normalized_maximum_error = 1 }
+    expect { hat.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
+    expect { hat.normalized_mean_error = 1 }.to raise_error(NoMethodError)
+    expect { hat.normalized_maximum_error = 1 }.to raise_error(NoMethodError)
   end
 
   def test_mime_type
@@ -414,11 +414,11 @@ class Image_Attributes_UT < Minitest::Test
     expect(img.mime_type).to eq('image/gif')
     img.format = 'JPG'
     expect(img.mime_type).to eq('image/jpeg')
-    assert_raise(NoMethodError) { img.mime_type = 'image/jpeg' }
+    expect { img.mime_type = 'image/jpeg' }.to raise_error(NoMethodError)
   end
 
   def test_monitor
-    assert_raise(NoMethodError) { @img.monitor }
+    expect { @img.monitor }.to raise_error(NoMethodError)
     monitor = proc { |name, _q, _s| puts name }
     assert_nothing_raised { @img.monitor = monitor }
     assert_nothing_raised { @img.monitor = nil }
@@ -432,7 +432,7 @@ class Image_Attributes_UT < Minitest::Test
   def test_number_colors
     assert_nothing_raised { @hat.number_colors }
     assert_kind_of(Integer, @hat.number_colors)
-    assert_raise(NoMethodError) { @hat.number_colors = 2 }
+    expect { @hat.number_colors = 2 }.to raise_error(NoMethodError)
   end
 
   def test_offset
@@ -440,7 +440,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.offset).to eq(0)
     assert_nothing_raised { @img.offset = 10 }
     expect(@img.offset).to eq(10)
-    assert_raise(TypeError) { @img.offset = 'x' }
+    expect { @img.offset = 'x' }.to raise_error(TypeError)
   end
 
   def test_orientation
@@ -453,7 +453,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::OrientationType.values do |orientation|
       assert_nothing_raised { @img.orientation = orientation }
     end
-    assert_raise(TypeError) { @img.orientation = 2 }
+    expect { @img.orientation = 2 }.to raise_error(TypeError)
   end
 
   def test_page
@@ -469,7 +469,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(page.height).to eq(2)
     expect(page.x).to eq(3)
     expect(page.y).to eq(4)
-    assert_raise(TypeError) { @img.page = 2 }
+    expect { @img.page = 2 }.to raise_error(TypeError)
   end
 
   def test_pixel_interpolation_method
@@ -482,19 +482,19 @@ class Image_Attributes_UT < Minitest::Test
     Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
       assert_nothing_raised { @img.pixel_interpolation_method = interpolate_pixel_method }
     end
-    assert_raise(TypeError) { @img.pixel_interpolation_method = 2 }
+    expect { @img.pixel_interpolation_method = 2 }.to raise_error(TypeError)
   end
 
   def test_quality
     assert_nothing_raised { @hat.quality }
     expect(@hat.quality).to eq(75)
-    assert_raise(NoMethodError) { @img.quality = 80 }
+    expect { @img.quality = 80 }.to raise_error(NoMethodError)
   end
 
   def test_quantum_depth
     assert_nothing_raised { @img.quantum_depth }
     expect(@img.quantum_depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
-    assert_raise(NoMethodError) { @img.quantum_depth = 8 }
+    expect { @img.quantum_depth = 8 }.to raise_error(NoMethodError)
   end
 
   def test_rendering_intent
@@ -505,13 +505,13 @@ class Image_Attributes_UT < Minitest::Test
     Magick::RenderingIntent.values do |rendering_intent|
       assert_nothing_raised { @img.rendering_intent = rendering_intent }
     end
-    assert_raise(TypeError) { @img.rendering_intent = 2 }
+    expect { @img.rendering_intent = 2 }.to raise_error(TypeError)
   end
 
   def test_rows
     assert_nothing_raised { @img.rows }
     expect(@img.rows).to eq(100)
-    assert_raise(NoMethodError) { @img.rows = 2 }
+    expect { @img.rows = 2 }.to raise_error(NoMethodError)
   end
 
   def test_scene
@@ -525,7 +525,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_nothing_raised { img.scene }
     expect(@img.scene).to eq(0)
     expect(img.scene).to eq(1)
-    assert_raise(NoMethodError) { img.scene = 2 }
+    expect { img.scene = 2 }.to raise_error(NoMethodError)
   end
 
   def test_start_loop
@@ -540,13 +540,13 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.ticks_per_second).to eq(100)
     assert_nothing_raised { @img.ticks_per_second = 1000 }
     expect(@img.ticks_per_second).to eq(1000)
-    assert_raise(TypeError) { @img.ticks_per_second = 'x' }
+    expect { @img.ticks_per_second = 'x' }.to raise_error(TypeError)
   end
 
   def test_total_colors
     assert_nothing_raised { @hat.total_colors }
     assert_kind_of(Integer, @hat.total_colors)
-    assert_raise(NoMethodError) { @img.total_colors = 2 }
+    expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
   end
 
   def test_units
@@ -559,7 +559,7 @@ class Image_Attributes_UT < Minitest::Test
     Magick::ResolutionType.values do |resolution|
       assert_nothing_raised { @img.units = resolution }
     end
-    assert_raise(TypeError) { @img.units = 2 }
+    expect { @img.units = 2 }.to raise_error(TypeError)
   end
 
   def test_virtual_pixel_method
@@ -571,58 +571,58 @@ class Image_Attributes_UT < Minitest::Test
     Magick::VirtualPixelMethod.values do |virtual_pixel_method|
       assert_nothing_raised { @img.virtual_pixel_method = virtual_pixel_method }
     end
-    assert_raise(TypeError) { @img.virtual_pixel_method = 2 }
+    expect { @img.virtual_pixel_method = 2 }.to raise_error(TypeError)
   end
 
   def test_x_resolution
     assert_nothing_raised { @img.x_resolution }
     assert_nothing_raised { @img.x_resolution = 90 }
     expect(@img.x_resolution).to eq(90.0)
-    assert_raise(TypeError) { @img.x_resolution = 'x' }
+    expect { @img.x_resolution = 'x' }.to raise_error(TypeError)
   end
 
   def test_y_resolution
     assert_nothing_raised { @img.y_resolution }
     assert_nothing_raised { @img.y_resolution = 90 }
     expect(@img.y_resolution).to eq(90.0)
-    assert_raise(TypeError) { @img.y_resolution = 'x' }
+    expect { @img.y_resolution = 'x' }.to raise_error(TypeError)
   end
 
   def test_frozen
     @img.freeze
-    assert_raise(FreezeError) { @img.background_color = 'xxx' }
-    assert_raise(FreezeError) { @img.border_color = 'xxx' }
+    expect { @img.background_color = 'xxx' }.to raise_error(FreezeError)
+    expect { @img.border_color = 'xxx' }.to raise_error(FreezeError)
     rp = Magick::Point.new(1, 1)
     gp = Magick::Point.new(1, 1)
     bp = Magick::Point.new(1, 1)
     wp = Magick::Point.new(1, 1)
-    assert_raise(FreezeError) { @img.chromaticity = Magick::Chromaticity.new(rp, gp, bp, wp) }
-    assert_raise(FreezeError) { @img.class_type = Magick::DirectClass }
-    assert_raise(FreezeError) { @img.color_profile = 'xxx' }
-    assert_raise(FreezeError) { @img.colorspace = Magick::RGBColorspace }
-    assert_raise(FreezeError) { @img.compose = Magick::OverCompositeOp }
-    assert_raise(FreezeError) { @img.compression = Magick::RLECompression }
-    assert_raise(FreezeError) { @img.delay = 2 }
-    assert_raise(FreezeError) { @img.density = '72.0x72.0' }
-    assert_raise(FreezeError) { @img.dispose = Magick::NoneDispose }
-    assert_raise(FreezeError) { @img.endian = Magick::MSBEndian }
-    assert_raise(FreezeError) { @img.extract_info = Magick::Rectangle.new(1, 2, 3, 4) }
-    assert_raise(FreezeError) { @img.filter = Magick::PointFilter }
-    assert_raise(FreezeError) { @img.format = 'GIF' }
-    assert_raise(FreezeError) { @img.fuzz = 50.0 }
-    assert_raise(FreezeError) { @img.gamma = 2.0 }
-    assert_raise(FreezeError) { @img.geometry = '100x100' }
-    assert_raise(FreezeError) { @img.interlace = Magick::NoInterlace }
-    assert_raise(FreezeError) { @img.iptc_profile = 'xxx' }
-    assert_raise(FreezeError) { @img.monitor = proc { |name, _q, _s| puts name } }
-    assert_raise(FreezeError) { @img.offset = 100 }
-    assert_raise(FreezeError) { @img.page = Magick::Rectangle.new(1, 2, 3, 4) }
-    assert_raise(FreezeError) { @img.rendering_intent = Magick::SaturationIntent }
-    assert_raise(FreezeError) { @img.start_loop = true }
-    assert_raise(FreezeError) { @img.ticks_per_second = 1000 }
-    assert_raise(FreezeError) { @img.units = Magick::PixelsPerInchResolution }
-    assert_raise(FreezeError) { @img.x_resolution = 72.0 }
-    assert_raise(FreezeError) { @img.y_resolution = 72.0 }
+    expect { @img.chromaticity = Magick::Chromaticity.new(rp, gp, bp, wp) }.to raise_error(FreezeError)
+    expect { @img.class_type = Magick::DirectClass }.to raise_error(FreezeError)
+    expect { @img.color_profile = 'xxx' }.to raise_error(FreezeError)
+    expect { @img.colorspace = Magick::RGBColorspace }.to raise_error(FreezeError)
+    expect { @img.compose = Magick::OverCompositeOp }.to raise_error(FreezeError)
+    expect { @img.compression = Magick::RLECompression }.to raise_error(FreezeError)
+    expect { @img.delay = 2 }.to raise_error(FreezeError)
+    expect { @img.density = '72.0x72.0' }.to raise_error(FreezeError)
+    expect { @img.dispose = Magick::NoneDispose }.to raise_error(FreezeError)
+    expect { @img.endian = Magick::MSBEndian }.to raise_error(FreezeError)
+    expect { @img.extract_info = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
+    expect { @img.filter = Magick::PointFilter }.to raise_error(FreezeError)
+    expect { @img.format = 'GIF' }.to raise_error(FreezeError)
+    expect { @img.fuzz = 50.0 }.to raise_error(FreezeError)
+    expect { @img.gamma = 2.0 }.to raise_error(FreezeError)
+    expect { @img.geometry = '100x100' }.to raise_error(FreezeError)
+    expect { @img.interlace = Magick::NoInterlace }.to raise_error(FreezeError)
+    expect { @img.iptc_profile = 'xxx' }.to raise_error(FreezeError)
+    expect { @img.monitor = proc { |name, _q, _s| puts name } }.to raise_error(FreezeError)
+    expect { @img.offset = 100 }.to raise_error(FreezeError)
+    expect { @img.page = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
+    expect { @img.rendering_intent = Magick::SaturationIntent }.to raise_error(FreezeError)
+    expect { @img.start_loop = true }.to raise_error(FreezeError)
+    expect { @img.ticks_per_second = 1000 }.to raise_error(FreezeError)
+    expect { @img.units = Magick::PixelsPerInchResolution }.to raise_error(FreezeError)
+    expect { @img.x_resolution = 72.0 }.to raise_error(FreezeError)
+    expect { @img.y_resolution = 72.0 }.to raise_error(FreezeError)
   end
 end # class Image_Attributes_UT
 

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -27,7 +27,7 @@ class InfoUT < Minitest::Test
 
     assert_nothing_raised { @info.undefine('tiff', 'bits-per-sample') }
     assert_nil(@info['tiff', 'bits-per-sample'])
-    assert_raise(ArgumentError) { @info.undefine('tiff', 'a' * 10_000) }
+    expect { @info.undefine('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
 
   def test_antialias
@@ -41,10 +41,10 @@ class InfoUT < Minitest::Test
     expect(@info['tiff']).to eq('xxx')
     assert_nothing_raised { @info['tiff', 'bits-per-sample'] = 'abc' }
     expect(@info['tiff', 'bits-per-sample']).to eq('abc')
-    assert_raise(ArgumentError) { @info['tiff', 'a', 'b'] }
-    assert_raise(ArgumentError) { @info['tiff', 'a' * 10_000] }
-    assert_raise(ArgumentError) { @info['tiff', 'a' * 10_000] = 'abc' }
-    assert_raise(ArgumentError) { @info['tiff', 'a', 'b'] = 'abc' }
+    expect { @info['tiff', 'a', 'b'] }.to raise_error(ArgumentError)
+    expect { @info['tiff', 'a' * 10_000] }.to raise_error(ArgumentError)
+    expect { @info['tiff', 'a' * 10_000] = 'abc' }.to raise_error(ArgumentError)
+    expect { @info['tiff', 'a', 'b'] = 'abc' }.to raise_error(ArgumentError)
   end
 
   def test_attenuate
@@ -94,8 +94,8 @@ class InfoUT < Minitest::Test
   def test_channel
     assert_nothing_raised { @info.channel(Magick::RedChannel) }
     assert_nothing_raised { @info.channel(Magick::RedChannel, Magick::BlueChannel) }
-    assert_raise(TypeError) { @info.channel(1) }
-    assert_raise(TypeError) { @info.channel(Magick::RedChannel, 1) }
+    expect { @info.channel(1) }.to raise_error(TypeError)
+    expect { @info.channel(Magick::RedChannel, 1) }.to raise_error(TypeError)
   end
 
   def test_colorspace
@@ -120,8 +120,8 @@ class InfoUT < Minitest::Test
   def test_define
     assert_nothing_raised { @info.define('tiff', 'bits-per-sample', 2) }
     assert_nothing_raised { @info.undefine('tiff', 'bits-per-sample') }
-    assert_raise(ArgumentError) { @info.define('tiff', 'bits-per-sample', 2, 2) }
-    assert_raise(ArgumentError) { @info.define('tiff', 'a' * 10_000) }
+    expect { @info.define('tiff', 'bits-per-sample', 2, 2) }.to raise_error(ArgumentError)
+    expect { @info.define('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
 
   def test_density
@@ -131,7 +131,7 @@ class InfoUT < Minitest::Test
     expect(@info.density).to eq('72x72')
     assert_nothing_raised { @info.density = nil }
     assert_nil(@info.density)
-    assert_raise(ArgumentError) { @info.density = 'aaa' }
+    expect { @info.density = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_delay
@@ -139,7 +139,7 @@ class InfoUT < Minitest::Test
     expect(@info.delay).to eq(60)
     assert_nothing_raised { @info.delay = nil }
     assert_nil(@info.delay)
-    assert_raise(TypeError) { @info.delay = '60' }
+    expect { @info.delay = '60' }.to raise_error(TypeError)
   end
 
   def test_depth
@@ -147,7 +147,7 @@ class InfoUT < Minitest::Test
     expect(@info.depth).to eq(8)
     assert_nothing_raised { @info.depth = 16 }
     expect(@info.depth).to eq(16)
-    assert_raise(ArgumentError) { @info.depth = 32 }
+    expect { @info.depth = 32 }.to raise_error(ArgumentError)
   end
 
   def test_dispose
@@ -178,7 +178,7 @@ class InfoUT < Minitest::Test
     expect(@info.extract).to eq('100x100')
     assert_nothing_raised { @info.extract = nil }
     assert_nil(@info.extract)
-    assert_raise(ArgumentError) { @info.extract = 'aaa' }
+    expect { @info.extract = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_filename
@@ -198,7 +198,7 @@ class InfoUT < Minitest::Test
     assert_nothing_raised { @info.fill = nil }
     assert_nil(@info.fill)
 
-    assert_raise(ArgumentError) { @info.fill = 'xxx' }
+    expect { @info.fill = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_font
@@ -211,7 +211,7 @@ class InfoUT < Minitest::Test
   def test_format
     assert_nothing_raised { @info.format = 'GIF' }
     expect(@info.format).to eq('GIF')
-    assert_raise(TypeError) { @info.format = nil }
+    expect { @info.format = nil }.to raise_error(TypeError)
   end
 
   def test_fuzz
@@ -219,8 +219,8 @@ class InfoUT < Minitest::Test
     expect(@info.fuzz).to eq(50)
     assert_nothing_raised { @info.fuzz = '50%' }
     expect(@info.fuzz).to eq(Magick::QuantumRange * 0.5)
-    assert_raise(TypeError) { @info.fuzz = nil }
-    assert_raise(ArgumentError) { @info.fuzz = 'xxx' }
+    expect { @info.fuzz = nil }.to raise_error(TypeError)
+    expect { @info.fuzz = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_gravity
@@ -236,7 +236,7 @@ class InfoUT < Minitest::Test
       assert_nothing_raised { @info.image_type = v }
       expect(@info.image_type).to eq(v)
     end
-    assert_raise(TypeError) { @info.image_type = nil }
+    expect { @info.image_type = nil }.to raise_error(TypeError)
   end
 
   def test_interlace
@@ -244,7 +244,7 @@ class InfoUT < Minitest::Test
       assert_nothing_raised { @info.interlace = v }
       expect(@info.interlace).to eq(v)
     end
-    assert_raise(TypeError) { @info.interlace = nil }
+    expect { @info.interlace = nil }.to raise_error(TypeError)
   end
 
   def test_label
@@ -261,7 +261,7 @@ class InfoUT < Minitest::Test
     expect(@info.matte_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.matte_color = 'red' }
     expect(img.matte_color).to eq('red')
-    assert_raise(TypeError) { @info.matte_color = nil }
+    expect { @info.matte_color = nil }.to raise_error(TypeError)
   end
 
   def test_monitor
@@ -290,8 +290,8 @@ class InfoUT < Minitest::Test
     assert_kind_of(Integer, @info.number_scenes)
     assert_nothing_raised { @info.number_scenes = 50 }
     expect(@info.number_scenes).to eq(50)
-    assert_raise(TypeError) { @info.number_scenes = nil }
-    assert_raise(TypeError) { @info.number_scenes = 'xxx' }
+    expect { @info.number_scenes = nil }.to raise_error(TypeError)
+    expect { @info.number_scenes = 'xxx' }.to raise_error(TypeError)
   end
 
   def test_orientation
@@ -299,7 +299,7 @@ class InfoUT < Minitest::Test
       assert_nothing_raised { @info.orientation = v }
       expect(@info.orientation).to eq(v)
     end
-    assert_raise(TypeError) { @info.orientation = nil }
+    expect { @info.orientation = nil }.to raise_error(TypeError)
   end
 
   def test_origin
@@ -309,7 +309,7 @@ class InfoUT < Minitest::Test
     expect(@info.origin).to eq('+10+10')
     assert_nothing_raised { @info.origin = nil }
     assert_nil(@info.origin)
-    assert_raise(ArgumentError) { @info.origin = 'aaa' }
+    expect { @info.origin = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_page
@@ -339,7 +339,7 @@ class InfoUT < Minitest::Test
   def test_scene
     assert_nothing_raised { @info.scene = 123 }
     expect(@info.scene).to eq(123)
-    assert_raise(TypeError) { @info.scene = 'xxx' }
+    expect { @info.scene = 'xxx' }.to raise_error(TypeError)
   end
 
   def test_server_name
@@ -356,7 +356,7 @@ class InfoUT < Minitest::Test
     expect(@info.size).to eq('100x200')
     assert_nothing_raised { @info.size = nil }
     assert_nil(@info.size)
-    assert_raise(ArgumentError) { @info.size = 'aaa' }
+    expect { @info.size = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_stroke
@@ -369,7 +369,7 @@ class InfoUT < Minitest::Test
     assert_nothing_raised { @info.stroke = nil }
     assert_nil(@info.stroke)
 
-    assert_raise(ArgumentError) { @info.stroke = 'xxx' }
+    expect { @info.stroke = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_stroke_width
@@ -379,7 +379,7 @@ class InfoUT < Minitest::Test
     expect(@info.stroke_width).to eq(5.25)
     assert_nothing_raised { @info.stroke_width = nil }
     assert_nil(@info.stroke_width)
-    assert_raise(TypeError) { @info.stroke_width = 'xxx' }
+    expect { @info.stroke_width = 'xxx' }.to raise_error(TypeError)
   end
 
   def test_texture
@@ -393,13 +393,13 @@ class InfoUT < Minitest::Test
     expect(@info.tile_offset).to eq('200x100')
     assert_nothing_raised { @info.tile_offset = Magick::Geometry.new(100, 200) }
     expect(@info.tile_offset).to eq('100x200')
-    assert_raise(ArgumentError) { @info.tile_offset = nil }
+    expect { @info.tile_offset = nil }.to raise_error(ArgumentError)
   end
 
   def test_transparent_color
     assert_nothing_raised { @info.transparent_color = 'white' }
     expect(@info.transparent_color).to eq('white')
-    assert_raise(TypeError) { @info.transparent_color = nil }
+    expect { @info.transparent_color = nil }.to raise_error(TypeError)
   end
 
   def test_undercolor
@@ -412,7 +412,7 @@ class InfoUT < Minitest::Test
     assert_nothing_raised { @info.undercolor = nil }
     assert_nil(@info.undercolor)
 
-    assert_raise(ArgumentError) { @info.undercolor = 'xxx' }
+    expect { @info.undercolor = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_units

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -11,19 +11,19 @@ class KernelInfoUT < Minitest::Test
       k = kernel.to_s.sub('Kernel', '')
 
       if kernel == Magick::UserDefinedKernel
-        assert_raise(RuntimeError) { Magick::KernelInfo.new(k) }
+        expect { Magick::KernelInfo.new(k) }.to raise_error(RuntimeError)
       else
         assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.new(k))
       end
     end
-    assert_raise(RuntimeError) { Magick::KernelInfo.new('') }
-    assert_raise(TypeError) { Magick::KernelInfo.new(42) }
+    expect { Magick::KernelInfo.new('') }.to raise_error(RuntimeError)
+    expect { Magick::KernelInfo.new(42) }.to raise_error(TypeError)
   end
 
   def test_unity_add
     assert_nil(@kernel.unity_add(1.0))
     assert_nil(@kernel.unity_add(12))
-    assert_raise(TypeError) { @kernel.unity_add('x') }
+    expect { @kernel.unity_add('x') }.to raise_error(TypeError)
   end
 
   def test_scale
@@ -31,13 +31,13 @@ class KernelInfoUT < Minitest::Test
       assert_nil(@kernel.scale(1.0, flag))
       assert_nil(@kernel.scale(42, flag))
     end
-    assert_raise(ArgumentError) { @kernel.scale(42, 'x') }
-    assert_raise(ArgumentError) { @kernel.scale(42, Magick::BoldWeight) }
+    expect { @kernel.scale(42, 'x') }.to raise_error(ArgumentError)
+    expect { @kernel.scale(42, Magick::BoldWeight) }.to raise_error(ArgumentError)
   end
 
   def test_scale_geometry
     assert_nil(@kernel.scale_geometry('-set option:convolve:scale 1.0'))
-    assert_raise(TypeError) { @kernel.scale_geometry(42) }
+    expect { @kernel.scale_geometry(42) }.to raise_error(TypeError)
   end
 
   def test_clone

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -234,10 +234,10 @@ class MagickUT < Minitest::Test
     assert_nothing_raised { g = Magick::Geometry.from_s('') }
     expect(g.to_s).to eq('')
 
-    assert_raise(ArgumentError) { Magick::Geometry.new(Magick::AreaGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(40, Magick::AreaGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(40, 20, Magick::AreaGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(40, 20, 10, Magick::AreaGeometry) }
+    expect { Magick::Geometry.new(Magick::AreaGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(40, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(40, 20, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(40, 20, 10, Magick::AreaGeometry) }.to raise_error(ArgumentError)
   end
 
   def test_init_formats
@@ -295,10 +295,10 @@ class MagickUT < Minitest::Test
     expect(new).to eq(300)
     Magick.limit_resource(:time, cur)
 
-    assert_raise(ArgumentError) { Magick.limit_resource(:xxx) }
-    assert_raise(ArgumentError) { Magick.limit_resource('xxx') }
-    assert_raise(ArgumentError) { Magick.limit_resource('map', 3500, 2) }
-    assert_raise(ArgumentError) { Magick.limit_resource }
+    expect { Magick.limit_resource(:xxx) }.to raise_error(ArgumentError)
+    expect { Magick.limit_resource('xxx') }.to raise_error(ArgumentError)
+    expect { Magick.limit_resource('map', 3500, 2) }.to raise_error(ArgumentError)
+    expect { Magick.limit_resource }.to raise_error(ArgumentError)
   end
 
   def test_transparent_alpha

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -11,7 +11,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.red).to eq(123)
     assert_nothing_raised { @pixel.red = 255.25 }
     expect(@pixel.red).to eq(255)
-    assert_raise(TypeError) { @pixel.red = 'x' }
+    expect { @pixel.red = 'x' }.to raise_error(TypeError)
   end
 
   def test_green
@@ -19,7 +19,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.green).to eq(123)
     assert_nothing_raised { @pixel.green = 255.25 }
     expect(@pixel.green).to eq(255)
-    assert_raise(TypeError) { @pixel.green = 'x' }
+    expect { @pixel.green = 'x' }.to raise_error(TypeError)
   end
 
   def test_blue
@@ -27,7 +27,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.blue).to eq(123)
     assert_nothing_raised { @pixel.blue = 255.25 }
     expect(@pixel.blue).to eq(255)
-    assert_raise(TypeError) { @pixel.blue = 'x' }
+    expect { @pixel.blue = 'x' }.to raise_error(TypeError)
   end
 
   def test_alpha
@@ -35,7 +35,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.alpha).to eq(123)
     assert_nothing_raised { @pixel.alpha = 255.25 }
     expect(@pixel.alpha).to eq(255)
-    assert_raise(TypeError) { @pixel.alpha = 'x' }
+    expect { @pixel.alpha = 'x' }.to raise_error(TypeError)
   end
 
   def test_cyan
@@ -43,7 +43,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.cyan).to eq(123)
     assert_nothing_raised { @pixel.cyan = 255.25 }
     expect(@pixel.cyan).to eq(255)
-    assert_raise(TypeError) { @pixel.cyan = 'x' }
+    expect { @pixel.cyan = 'x' }.to raise_error(TypeError)
   end
 
   def test_magenta
@@ -51,7 +51,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.magenta).to eq(123)
     assert_nothing_raised { @pixel.magenta = 255.25 }
     expect(@pixel.magenta).to eq(255)
-    assert_raise(TypeError) { @pixel.magenta = 'x' }
+    expect { @pixel.magenta = 'x' }.to raise_error(TypeError)
   end
 
   def test_yellow
@@ -59,7 +59,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.yellow).to eq(123)
     assert_nothing_raised { @pixel.yellow = 255.25 }
     expect(@pixel.yellow).to eq(255)
-    assert_raise(TypeError) { @pixel.yellow = 'x' }
+    expect { @pixel.yellow = 'x' }.to raise_error(TypeError)
   end
 
   def test_black
@@ -67,7 +67,7 @@ class PixelUT < Minitest::Test
     expect(@pixel.black).to eq(123)
     assert_nothing_raised { @pixel.black = 255.25 }
     expect(@pixel.black).to eq(255)
-    assert_raise(TypeError) { @pixel.black = 'x' }
+    expect { @pixel.black = 'x' }.to raise_error(TypeError)
   end
 
   def test_case_eq
@@ -138,10 +138,10 @@ class PixelUT < Minitest::Test
 
     assert_nothing_raised { red.fcmp(blue, 10) }
     assert_nothing_raised { red.fcmp(blue, 10, Magick::RGBColorspace) }
-    assert_raises(TypeError) { red.fcmp(blue, 'x') }
-    assert_raises(TypeError) { red.fcmp(blue, 10, 'x') }
-    assert_raises(ArgumentError) { red.fcmp }
-    assert_raises(ArgumentError) { red.fcmp(blue, 10, 'x', 'y') }
+    expect { red.fcmp(blue, 'x') }.to raise_error(TypeError)
+    expect { red.fcmp(blue, 10, 'x') }.to raise_error(TypeError)
+    expect { red.fcmp }.to raise_error(ArgumentError)
+    expect { red.fcmp(blue, 10, 'x', 'y') }.to raise_error(ArgumentError)
   end
 
   def test_from_hsla
@@ -150,19 +150,19 @@ class PixelUT < Minitest::Test
     assert_nothing_raised { Magick::Pixel.from_hsla('99%', '100%', '100%', '100%') }
     assert_nothing_raised { Magick::Pixel.from_hsla(0, 0, 0, 0) }
     assert_nothing_raised { Magick::Pixel.from_hsla(359, 255, 255, 1.0) }
-    assert_raise(TypeError) { Magick::Pixel.from_hsla([], 50, 50, 0) }
-    assert_raise(TypeError) { Magick::Pixel.from_hsla(127, [], 50, 0) }
-    assert_raise(TypeError) { Magick::Pixel.from_hsla(127, 50, [], 0) }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla(127, 50, 50, 50, 50) }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla(-0.01, 0, 0) }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla(0, -0.01, 0) }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla(0, 0, -0.01) }
-    assert_raise(ArgumentError) { Magick::Pixel.from_hsla(0, 0, 0, -0.01) }
-    assert_raise(RangeError) { Magick::Pixel.from_hsla(0, 0, 0, 1.01) }
-    assert_raise(RangeError) { Magick::Pixel.from_hsla(360, 0, 0) }
-    assert_raise(RangeError) { Magick::Pixel.from_hsla(0, 256, 0) }
-    assert_raise(RangeError) { Magick::Pixel.from_hsla(0, 0, 256) }
+    expect { Magick::Pixel.from_hsla([], 50, 50, 0) }.to raise_error(TypeError)
+    expect { Magick::Pixel.from_hsla(127, [], 50, 0) }.to raise_error(TypeError)
+    expect { Magick::Pixel.from_hsla(127, 50, [], 0) }.to raise_error(TypeError)
+    expect { Magick::Pixel.from_hsla }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(127, 50, 50, 50, 50) }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(-0.01, 0, 0) }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(0, -0.01, 0) }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(0, 0, -0.01) }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(0, 0, 0, -0.01) }.to raise_error(ArgumentError)
+    expect { Magick::Pixel.from_hsla(0, 0, 0, 1.01) }.to raise_error(RangeError)
+    expect { Magick::Pixel.from_hsla(360, 0, 0) }.to raise_error(RangeError)
+    expect { Magick::Pixel.from_hsla(0, 256, 0) }.to raise_error(RangeError)
+    expect { Magick::Pixel.from_hsla(0, 0, 256) }.to raise_error(RangeError)
     assert_nothing_raised { @pixel.to_hsla }
 
     args = [200, 125.125, 250.5, 0.6]
@@ -246,8 +246,8 @@ class PixelUT < Minitest::Test
     expect(@pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
     expect(@pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')
 
-    assert_raise(ArgumentError) { @pixel.to_color(Magick::AllCompliance, false, 32) }
-    assert_raise(TypeError) { @pixel.to_color(1) }
+    expect { @pixel.to_color(Magick::AllCompliance, false, 32) }.to raise_error(ArgumentError)
+    expect { @pixel.to_color(1) }.to raise_error(TypeError)
   end
 
   def test_to_s

--- a/test/PolaroidOptions.rb
+++ b/test/PolaroidOptions.rb
@@ -10,13 +10,13 @@ class PolaroidOptionsUT < Minitest::Test
     assert_nothing_raised { @options.shadow_color = "gray50" }
 
     @options.freeze
-    assert_raise(FreezeError) { @options.shadow_color = "gray50" }
+    expect { @options.shadow_color = "gray50" }.to raise_error(FreezeError)
   end
 
   def test_border_color
     assert_nothing_raised { @options.border_color = "gray50" }
 
     @options.freeze
-    assert_raise(FreezeError) { @options.border_color = "gray50" }
+    expect { @options.border_color = "gray50" }.to raise_error(FreezeError)
   end
 end

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -11,7 +11,7 @@ class PreviewUT < Minitest::Test
     Magick::PreviewType.values do |type|
       assert_nothing_raised { hat.preview(type) }
     end
-    assert_raise(TypeError) { hat.preview(2) }
+    expect { hat.preview(2) }.to raise_error(TypeError)
   end
 end
 

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -12,12 +12,12 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('affine 10.5,12,15,20,22,25')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.affine('x', 12, 15, 20, 22, 25) }
-    assert_raise(ArgumentError) { @draw.affine(10, 'x', 15, 20, 22, 25) }
-    assert_raise(ArgumentError) { @draw.affine(10, 12, 'x', 20, 22, 25) }
-    assert_raise(ArgumentError) { @draw.affine(10, 12, 15, 'x', 22, 25) }
-    assert_raise(ArgumentError) { @draw.affine(10, 12, 15, 20, 'x', 25) }
-    assert_raise(ArgumentError) { @draw.affine(10, 12, 15, 20, 22, 'x') }
+    expect { @draw.affine('x', 12, 15, 20, 22, 25) }.to raise_error(ArgumentError)
+    expect { @draw.affine(10, 'x', 15, 20, 22, 25) }.to raise_error(ArgumentError)
+    expect { @draw.affine(10, 12, 'x', 20, 22, 25) }.to raise_error(ArgumentError)
+    expect { @draw.affine(10, 12, 15, 'x', 22, 25) }.to raise_error(ArgumentError)
+    expect { @draw.affine(10, 12, 15, 20, 'x', 25) }.to raise_error(ArgumentError)
+    expect { @draw.affine(10, 12, 15, 20, 22, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_alpha
@@ -27,9 +27,9 @@ class LibDrawUT < Minitest::Test
       assert_nothing_raised { draw.draw(@img) }
     end
 
-    assert_raise(ArgumentError) { @draw.alpha(10, '20.5', 'xxx') }
-    assert_raise(ArgumentError) { @draw.alpha('x', 10, Magick::PointMethod) }
-    assert_raise(ArgumentError) { @draw.alpha(10, 'x', Magick::PointMethod) }
+    expect { @draw.alpha(10, '20.5', 'xxx') }.to raise_error(ArgumentError)
+    expect { @draw.alpha('x', 10, Magick::PointMethod) }.to raise_error(ArgumentError)
+    expect { @draw.alpha(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
   end
 
   def test_arc
@@ -37,12 +37,12 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('arc 100.5,120.5 200,250 20,370')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.arc('x', 120.5, 200, 250, 20, 370) }
-    assert_raise(ArgumentError) { @draw.arc(100.5, 'x', 200, 250, 20, 370) }
-    assert_raise(ArgumentError) { @draw.arc(100.5, 120.5, 'x', 250, 20, 370) }
-    assert_raise(ArgumentError) { @draw.arc(100.5, 120.5, 200, 'x', 20, 370) }
-    assert_raise(ArgumentError) { @draw.arc(100.5, 120.5, 200, 250, 'x', 370) }
-    assert_raise(ArgumentError) { @draw.arc(100.5, 120.5, 200, 250, 20, 'x') }
+    expect { @draw.arc('x', 120.5, 200, 250, 20, 370) }.to raise_error(ArgumentError)
+    expect { @draw.arc(100.5, 'x', 200, 250, 20, 370) }.to raise_error(ArgumentError)
+    expect { @draw.arc(100.5, 120.5, 'x', 250, 20, 370) }.to raise_error(ArgumentError)
+    expect { @draw.arc(100.5, 120.5, 200, 'x', 20, 370) }.to raise_error(ArgumentError)
+    expect { @draw.arc(100.5, 120.5, 200, 250, 'x', 370) }.to raise_error(ArgumentError)
+    expect { @draw.arc(100.5, 120.5, 200, 250, 20, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_bezier
@@ -50,9 +50,9 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('bezier 10,20,20.5,30,40.5,50')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.bezier }
-    assert_raise(ArgumentError) { @draw.bezier(1) }
-    assert_raise(ArgumentError) { @draw.bezier('x', 20, 30, 40.5) }
+    expect { @draw.bezier }.to raise_error(ArgumentError)
+    expect { @draw.bezier(1) }.to raise_error(ArgumentError)
+    expect { @draw.bezier('x', 20, 30, 40.5) }.to raise_error(ArgumentError)
   end
 
   def test_circle
@@ -60,10 +60,10 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('circle 10,20.5 30,40.5')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.circle('x', 20, 30, 40) }
-    assert_raise(ArgumentError) { @draw.circle(10, 'x', 30, 40) }
-    assert_raise(ArgumentError) { @draw.circle(10, 20, 'x', 40) }
-    assert_raise(ArgumentError) { @draw.circle(10, 20, 30, 'x') }
+    expect { @draw.circle('x', 20, 30, 40) }.to raise_error(ArgumentError)
+    expect { @draw.circle(10, 'x', 30, 40) }.to raise_error(ArgumentError)
+    expect { @draw.circle(10, 20, 'x', 40) }.to raise_error(ArgumentError)
+    expect { @draw.circle(10, 20, 30, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_clip_path
@@ -83,7 +83,7 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('clip-rule nonzero')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.clip_rule('foo') }
+    expect { @draw.clip_rule('foo') }.to raise_error(ArgumentError)
   end
 
   def test_clip_units
@@ -102,7 +102,7 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('clip-units objectboundingbox')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.clip_units('foo') }
+    expect { @draw.clip_units('foo') }.to raise_error(ArgumentError)
   end
 
   def test_color
@@ -131,9 +131,9 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('color 50.5,50,reset')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.color(10, 20, 'unknown') }
-    assert_raise(ArgumentError) { @draw.color('x', 20, Magick::PointMethod) }
-    assert_raise(ArgumentError) { @draw.color(10, 'x', Magick::PointMethod) }
+    expect { @draw.color(10, 20, 'unknown') }.to raise_error(ArgumentError)
+    expect { @draw.color('x', 20, Magick::PointMethod) }.to raise_error(ArgumentError)
+    expect { @draw.color(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
   end
 
   def test_decorate
@@ -178,12 +178,12 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('ellipse 50.5,30 25,25 60,120')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.ellipse('x', 20, 30, 40, 50, 60) }
-    assert_raise(ArgumentError) { @draw.ellipse(10, 'x', 30, 40, 50, 60) }
-    assert_raise(ArgumentError) { @draw.ellipse(10, 20, 'x', 40, 50, 60) }
-    assert_raise(ArgumentError) { @draw.ellipse(10, 20, 30, 'x', 50, 60) }
-    assert_raise(ArgumentError) { @draw.ellipse(10, 20, 30, 40, 'x', 60) }
-    assert_raise(ArgumentError) { @draw.ellipse(10, 20, 30, 40, 50, 'x') }
+    expect { @draw.ellipse('x', 20, 30, 40, 50, 60) }.to raise_error(ArgumentError)
+    expect { @draw.ellipse(10, 'x', 30, 40, 50, 60) }.to raise_error(ArgumentError)
+    expect { @draw.ellipse(10, 20, 'x', 40, 50, 60) }.to raise_error(ArgumentError)
+    expect { @draw.ellipse(10, 20, 30, 'x', 50, 60) }.to raise_error(ArgumentError)
+    expect { @draw.ellipse(10, 20, 30, 40, 'x', 60) }.to raise_error(ArgumentError)
+    expect { @draw.ellipse(10, 20, 30, 40, 50, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_encoding
@@ -235,11 +235,11 @@ class LibDrawUT < Minitest::Test
     assert_nothing_raised { @draw.fill_opacity('1.0') }
     assert_nothing_raised { @draw.fill_opacity('20%') }
 
-    assert_raise(ArgumentError) { @draw.fill_opacity(-0.01) }
-    assert_raise(ArgumentError) { @draw.fill_opacity(1.01) }
-    assert_raise(ArgumentError) { @draw.fill_opacity('-0.01') }
-    assert_raise(ArgumentError) { @draw.fill_opacity('1.01') }
-    assert_raise(ArgumentError) { @draw.fill_opacity('xxx') }
+    expect { @draw.fill_opacity(-0.01) }.to raise_error(ArgumentError)
+    expect { @draw.fill_opacity(1.01) }.to raise_error(ArgumentError)
+    expect { @draw.fill_opacity('-0.01') }.to raise_error(ArgumentError)
+    expect { @draw.fill_opacity('1.01') }.to raise_error(ArgumentError)
+    expect { @draw.fill_opacity('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_fill_rule
@@ -255,7 +255,7 @@ class LibDrawUT < Minitest::Test
     draw.circle(10, '20.5', 30, 40.5)
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.fill_rule('zero') }
+    expect { @draw.fill_rule('zero') }.to raise_error(ArgumentError)
   end
 
   def test_font
@@ -285,7 +285,7 @@ class LibDrawUT < Minitest::Test
       assert_nothing_raised { draw.draw(@img) }
     end
 
-    assert_raise(ArgumentError) { @draw.font_stretch('xxx') }
+    expect { @draw.font_stretch('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_font_style
@@ -307,7 +307,7 @@ class LibDrawUT < Minitest::Test
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.font_style('xxx') }
+    expect { @draw.font_style('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_font_weight
@@ -324,7 +324,7 @@ class LibDrawUT < Minitest::Test
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.font_weight('xxx') }
+    expect { @draw.font_weight('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_gravity
@@ -337,7 +337,7 @@ class LibDrawUT < Minitest::Test
       assert_nothing_raised { draw.draw(@img) }
     end
 
-    assert_raise(ArgumentError) { @draw.gravity('xxx') }
+    expect { @draw.gravity('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_image
@@ -349,11 +349,11 @@ class LibDrawUT < Minitest::Test
       assert_nothing_raised { draw.draw(@img) }
     end
 
-    assert_raise(ArgumentError) { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
-    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 'x', 100, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
-    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 'x', 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
-    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 100, 'x', 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }
-    assert_raise(ArgumentError) { @draw.image(Magick::AtopCompositeOp, 100, 100, 200, 'x', "#{IMAGES_DIR}/Flower_Hat.jpg") }
+    expect { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+    expect { @draw.image(Magick::AtopCompositeOp, 'x', 100, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+    expect { @draw.image(Magick::AtopCompositeOp, 100, 'x', 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+    expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 'x', 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+    expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 200, 'x', "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
   end
 
   def test_interline_spacing
@@ -367,10 +367,10 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('interline-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.interline_spacing(Float::NAN) }
-    assert_raise(ArgumentError) { @draw.interline_spacing('nan') }
-    assert_raise(ArgumentError) { @draw.interline_spacing('xxx') }
-    assert_raise(TypeError) { @draw.interline_spacing(nil) }
+    # expect { @draw.interline_spacing(Float::NAN) }.to raise_error(ArgumentError)
+    expect { @draw.interline_spacing('nan') }.to raise_error(ArgumentError)
+    expect { @draw.interline_spacing('xxx') }.to raise_error(ArgumentError)
+    expect { @draw.interline_spacing(nil) }.to raise_error(TypeError)
   end
 
   def test_interword_spacing
@@ -384,10 +384,10 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('interword-spacing 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.interword_spacing(Float::NAN) }
-    assert_raise(ArgumentError) { @draw.interword_spacing('nan') }
-    assert_raise(ArgumentError) { @draw.interword_spacing('xxx') }
-    assert_raise(TypeError) { @draw.interword_spacing(nil) }
+    # expect { @draw.interword_spacing(Float::NAN) }.to raise_error(ArgumentError)
+    expect { @draw.interword_spacing('nan') }.to raise_error(ArgumentError)
+    expect { @draw.interword_spacing('xxx') }.to raise_error(ArgumentError)
+    expect { @draw.interword_spacing(nil) }.to raise_error(TypeError)
   end
 
   def test_kerning
@@ -401,10 +401,10 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('kerning 40.5')
     assert_nothing_raised { draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.kerning(Float::NAN) }
-    assert_raise(ArgumentError) { @draw.kerning('nan') }
-    assert_raise(ArgumentError) { @draw.kerning('xxx') }
-    assert_raise(TypeError) { @draw.kerning(nil) }
+    # expect { @draw.kerning(Float::NAN) }.to raise_error(ArgumentError)
+    expect { @draw.kerning('nan') }.to raise_error(ArgumentError)
+    expect { @draw.kerning('xxx') }.to raise_error(ArgumentError)
+    expect { @draw.kerning(nil) }.to raise_error(TypeError)
   end
 
   def test_line
@@ -412,10 +412,10 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('line 10,20.5 30,40.5')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.line('x', '20.5', 30, 40.5) }
-    assert_raise(ArgumentError) { @draw.line(10, 'x', 30, 40.5) }
-    assert_raise(ArgumentError) { @draw.line(10, '20.5', 'x', 40.5) }
-    assert_raise(ArgumentError) { @draw.line(10, '20.5', 30, 'x') }
+    expect { @draw.line('x', '20.5', 30, 40.5) }.to raise_error(ArgumentError)
+    expect { @draw.line(10, 'x', 30, 40.5) }.to raise_error(ArgumentError)
+    expect { @draw.line(10, '20.5', 'x', 40.5) }.to raise_error(ArgumentError)
+    expect { @draw.line(10, '20.5', 30, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_opacity
@@ -429,11 +429,11 @@ class LibDrawUT < Minitest::Test
     assert_nothing_raised { @draw.opacity('1.0') }
     assert_nothing_raised { @draw.opacity('20%') }
 
-    assert_raise(ArgumentError) { @draw.opacity(-0.01) }
-    assert_raise(ArgumentError) { @draw.opacity(1.01) }
-    assert_raise(ArgumentError) { @draw.opacity('-0.01') }
-    assert_raise(ArgumentError) { @draw.opacity('1.01') }
-    assert_raise(ArgumentError) { @draw.opacity('xxx') }
+    expect { @draw.opacity(-0.01) }.to raise_error(ArgumentError)
+    expect { @draw.opacity(1.01) }.to raise_error(ArgumentError)
+    expect { @draw.opacity('-0.01') }.to raise_error(ArgumentError)
+    expect { @draw.opacity('1.01') }.to raise_error(ArgumentError)
+    expect { @draw.opacity('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_path
@@ -447,10 +447,10 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs")
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.pattern('hat', 'x', 0, 20, 20) {} }
-    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 'x', 20, 20) {} }
-    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 'x', 20) {} }
-    assert_raise(ArgumentError) { @draw.pattern('hat', 0, 0, 20, 'x') {} }
+    expect { @draw.pattern('hat', 'x', 0, 20, 20) {} }.to raise_error(ArgumentError)
+    expect { @draw.pattern('hat', 0, 'x', 20, 20) {} }.to raise_error(ArgumentError)
+    expect { @draw.pattern('hat', 0, 0, 'x', 20) {} }.to raise_error(ArgumentError)
+    expect { @draw.pattern('hat', 0, 0, 20, 'x') {} }.to raise_error(ArgumentError)
   end
 
   def test_point
@@ -458,8 +458,8 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('point 10.5,20')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.point('x', 20) }
-    assert_raise(ArgumentError) { @draw.point(10, 'x') }
+    expect { @draw.point('x', 20) }.to raise_error(ArgumentError)
+    expect { @draw.point(10, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_pointsize
@@ -467,7 +467,7 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('font-size 20.5')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.pointsize('x') }
+    expect { @draw.pointsize('x') }.to raise_error(ArgumentError)
   end
 
   def test_font_size
@@ -475,7 +475,7 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('font-size 20')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.font_size('x') }
+    expect { @draw.font_size('x') }.to raise_error(ArgumentError)
   end
 
   def test_polygon
@@ -483,9 +483,9 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('polygon 0,0.5,8.5,16,16,0,0,0')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.polygon }
-    assert_raise(ArgumentError) { @draw.polygon(0) }
-    assert_raise(ArgumentError) { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }
+    expect { @draw.polygon }.to raise_error(ArgumentError)
+    expect { @draw.polygon(0) }.to raise_error(ArgumentError)
+    expect { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }.to raise_error(ArgumentError)
   end
 
   def test_polyline
@@ -493,9 +493,9 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('polyline 0,0.5,16.5,16')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.polyline }
-    assert_raise(ArgumentError) { @draw.polyline(0) }
-    assert_raise(ArgumentError) { @draw.polyline('x', 0, 16, 16) }
+    expect { @draw.polyline }.to raise_error(ArgumentError)
+    expect { @draw.polyline(0) }.to raise_error(ArgumentError)
+    expect { @draw.polyline('x', 0, 16, 16) }.to raise_error(ArgumentError)
   end
 
   def test_rectangle
@@ -503,10 +503,10 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('rectangle 10,10 100,100')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.rectangle('x', 10, 20, 20) }
-    assert_raise(ArgumentError) { @draw.rectangle(10, 'x', 20, 20) }
-    assert_raise(ArgumentError) { @draw.rectangle(10, 10, 'x', 20) }
-    assert_raise(ArgumentError) { @draw.rectangle(10, 10, 20, 'x') }
+    expect { @draw.rectangle('x', 10, 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.rectangle(10, 'x', 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.rectangle(10, 10, 'x', 20) }.to raise_error(ArgumentError)
+    expect { @draw.rectangle(10, 10, 20, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_rotate
@@ -515,7 +515,7 @@ class LibDrawUT < Minitest::Test
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.rotate('x') }
+    expect { @draw.rotate('x') }.to raise_error(ArgumentError)
   end
 
   def test_roundrectangle
@@ -523,12 +523,12 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('roundrectangle 10,10,100,100,20,20')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }
-    assert_raise(ArgumentError) { @draw.roundrectangle(10, 'x', 100, 100, 20, 20) }
-    assert_raise(ArgumentError) { @draw.roundrectangle(10, '10', 'x', 100, 20, 20) }
-    assert_raise(ArgumentError) { @draw.roundrectangle(10, '10', 100, 'x', 20, 20) }
-    assert_raise(ArgumentError) { @draw.roundrectangle(10, '10', 100, 100, 'x', 20) }
-    assert_raise(ArgumentError) { @draw.roundrectangle(10, '10', 100, 100, 20, 'x') }
+    expect { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.roundrectangle(10, 'x', 100, 100, 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.roundrectangle(10, '10', 'x', 100, 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.roundrectangle(10, '10', 100, 'x', 20, 20) }.to raise_error(ArgumentError)
+    expect { @draw.roundrectangle(10, '10', 100, 100, 'x', 20) }.to raise_error(ArgumentError)
+    expect { @draw.roundrectangle(10, '10', 100, 100, 20, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_scale
@@ -537,8 +537,8 @@ class LibDrawUT < Minitest::Test
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.scale('x', 1.5) }
-    assert_raise(ArgumentError) { @draw.scale(0.5, 'x') }
+    expect { @draw.scale('x', 1.5) }.to raise_error(ArgumentError)
+    expect { @draw.scale(0.5, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_skewx
@@ -547,7 +547,7 @@ class LibDrawUT < Minitest::Test
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.skewx('x') }
+    expect { @draw.skewx('x') }.to raise_error(ArgumentError)
   end
 
   def test_skewy
@@ -556,7 +556,7 @@ class LibDrawUT < Minitest::Test
     @draw.text(50, 50, 'Hello world')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.skewy('x') }
+    expect { @draw.skewy('x') }.to raise_error(ArgumentError)
   end
 
   def test_stroke
@@ -565,7 +565,7 @@ class LibDrawUT < Minitest::Test
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.stroke(100) }
+    # expect { @draw.stroke(100) }.to raise_error(ArgumentError)
   end
 
   def test_stroke_color
@@ -574,7 +574,7 @@ class LibDrawUT < Minitest::Test
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.stroke_color(100) }
+    # expect { @draw.stroke_color(100) }.to raise_error(ArgumentError)
   end
 
   def test_stroke_pattern
@@ -583,7 +583,7 @@ class LibDrawUT < Minitest::Test
     @draw.rectangle(10, '10', 100, 100)
     assert_nothing_raised { @draw.draw(@img) }
 
-    # assert_raise(ArgumentError) { @draw.stroke_pattern(100) }
+    # expect { @draw.stroke_pattern(100) }.to raise_error(ArgumentError)
   end
 
   def test_stroke_antialias
@@ -618,8 +618,8 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('stroke-dasharray none')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_dasharray(-0.1) }
-    assert_raise(ArgumentError) { @draw.stroke_dasharray('x') }
+    expect { @draw.stroke_dasharray(-0.1) }.to raise_error(ArgumentError)
+    expect { @draw.stroke_dasharray('x') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_dashoffset
@@ -627,7 +627,7 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('stroke-dashoffset 10')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_dashoffset('x') }
+    expect { @draw.stroke_dashoffset('x') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_linecap
@@ -646,7 +646,7 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('stroke-linecap square')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_linecap('foo') }
+    expect { @draw.stroke_linecap('foo') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_linejoin
@@ -665,7 +665,7 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('stroke-linejoin bevel')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_linejoin('foo') }
+    expect { @draw.stroke_linejoin('foo') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_miterlimit
@@ -674,8 +674,8 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq('stroke-miterlimit 1.0')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_miterlimit(0.9) }
-    assert_raise(ArgumentError) { @draw.stroke_miterlimit('foo') }
+    expect { @draw.stroke_miterlimit(0.9) }.to raise_error(ArgumentError)
+    expect { @draw.stroke_miterlimit('foo') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_opacity
@@ -689,11 +689,11 @@ class LibDrawUT < Minitest::Test
     assert_nothing_raised { @draw.stroke_opacity('1.0') }
     assert_nothing_raised { @draw.stroke_opacity('20%') }
 
-    assert_raise(ArgumentError) { @draw.stroke_opacity(-0.01) }
-    assert_raise(ArgumentError) { @draw.stroke_opacity(1.01) }
-    assert_raise(ArgumentError) { @draw.stroke_opacity('-0.01') }
-    assert_raise(ArgumentError) { @draw.stroke_opacity('1.01') }
-    assert_raise(ArgumentError) { @draw.stroke_opacity('xxx') }
+    expect { @draw.stroke_opacity(-0.01) }.to raise_error(ArgumentError)
+    expect { @draw.stroke_opacity(1.01) }.to raise_error(ArgumentError)
+    expect { @draw.stroke_opacity('-0.01') }.to raise_error(ArgumentError)
+    expect { @draw.stroke_opacity('1.01') }.to raise_error(ArgumentError)
+    expect { @draw.stroke_opacity('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_stroke_width
@@ -701,7 +701,7 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('stroke-width 2.5')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.stroke_width('xxx') }
+    expect { @draw.stroke_width('xxx') }.to raise_error(ArgumentError)
   end
 
   def test_text
@@ -730,9 +730,9 @@ class LibDrawUT < Minitest::Test
     expect(draw.inspect).to eq("text 50,50 {Hello {'world\"}")
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.text(50, 50, '') }
-    assert_raise(ArgumentError) { @draw.text('x', 50, 'Hello world') }
-    assert_raise(ArgumentError) { @draw.text(50, 'x', 'Hello world') }
+    expect { @draw.text(50, 50, '') }.to raise_error(ArgumentError)
+    expect { @draw.text('x', 50, 'Hello world') }.to raise_error(ArgumentError)
+    expect { @draw.text(50, 'x', 'Hello world') }.to raise_error(ArgumentError)
   end
 
   def test_text_align
@@ -754,7 +754,7 @@ class LibDrawUT < Minitest::Test
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.text_align('x') }
+    expect { @draw.text_align('x') }.to raise_error(ArgumentError)
   end
 
   def test_text_anchor
@@ -776,7 +776,7 @@ class LibDrawUT < Minitest::Test
     draw.text(50, 50, 'Hello world')
     assert_nothing_raised { draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.text_anchor('x') }
+    expect { @draw.text_anchor('x') }.to raise_error(ArgumentError)
   end
 
   def test_text_antialias
@@ -805,7 +805,7 @@ class LibDrawUT < Minitest::Test
     expect(@draw.inspect).to eq('translate 200,300')
     assert_nothing_raised { @draw.draw(@img) }
 
-    assert_raise(ArgumentError) { @draw.translate('x', 300) }
-    assert_raise(ArgumentError) { @draw.translate(200, 'x') }
+    expect { @draw.translate('x', 300) }.to raise_error(ArgumentError)
+    expect { @draw.translate(200, 'x') }.to raise_error(ArgumentError)
   end
 end

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -29,13 +29,13 @@ class LibGeometryUT < Minitest::Test
   end
 
   def test_initialize
-    assert_raise(ArgumentError) { Magick::Geometry.new(Magick::PercentGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(0, Magick::PercentGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(0, 0, Magick::PercentGeometry) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(0, 0, 0, Magick::PercentGeometry) }
+    expect { Magick::Geometry.new(Magick::PercentGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(0, 0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
 
-    assert_raise(ArgumentError) { Magick::Geometry.new(-1) }
-    assert_raise(ArgumentError) { Magick::Geometry.new(0, -1) }
+    expect { Magick::Geometry.new(-1) }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.new(0, -1) }.to raise_error(ArgumentError)
 
     geometry = Magick::Geometry.new
     expect(geometry.width).to eq(0)
@@ -86,10 +86,10 @@ class LibGeometryUT < Minitest::Test
     expect(Magick::Geometry.from_s('10.2x20.5+30+40').to_s).to eq('10.20x20.50+30+40')
     expect(Magick::Geometry.from_s('10.2%x20.500%+30+40').to_s).to eq('10.20%x20.50%+30+40')
 
-    assert_raise(ArgumentError) { Magick::Geometry.from_s('10x20+') }
-    assert_raise(ArgumentError) { Magick::Geometry.from_s('+30.000+40') }
-    assert_raise(ArgumentError) { Magick::Geometry.from_s('+30.000+40.000') }
-    assert_raise(ArgumentError) { Magick::Geometry.from_s('10x20+30.000+40') }
-    assert_raise(ArgumentError) { Magick::Geometry.from_s('10x20+30.000+40.000') }
+    expect { Magick::Geometry.from_s('10x20+') }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.from_s('+30.000+40') }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.from_s('+30.000+40.000') }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.from_s('10x20+30.000+40') }.to raise_error(ArgumentError)
+    expect { Magick::Geometry.from_s('10x20+30.000+40.000') }.to raise_error(ArgumentError)
   end
 end

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -38,8 +38,9 @@ module Minitest
       assert(yield)
     end
 
-    def expect(actual)
+    def expect(actual = :__not_set__, &actual_block)
       @actual = actual
+      @actual_block = actual_block
       self
     end
 
@@ -47,6 +48,8 @@ module Minitest
       case matcher
       when :eq
         assert_equal(@expected, @actual)
+      when :raise_error
+        assert_raises(@expected, &@actual_block)
       else
         raise ArgumentError, "no matcher: #{matcher.inspect}"
       end
@@ -57,8 +60,12 @@ module Minitest
       :eq
     end
 
+    def raise_error(expected)
+      @expected = expected
+      :raise_error
+    end
+
     alias assert_nothing_thrown assert_nothing_raised
-    alias assert_raise assert_raises
     alias assert_not_same refute_same
     alias assert_not_equal refute_equal
     alias assert_not_nil refute_nil

--- a/test/tmpnam_test.rb
+++ b/test/tmpnam_test.rb
@@ -12,7 +12,7 @@ class TmpnamTest < Minitest::Test
     info = Magick::Image::Info.new
 
     # does not exist at first
-    assert_raise(NameError) { Magick._tmpnam_ }
+    expect { Magick._tmpnam_ }.to raise_error(NameError)
 
     info.texture = texture
 


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/raise-error-matcher