### PR TITLE
Replace `assert_nothing_raised` with RSpec style matcher

### DIFF
--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -7,68 +7,68 @@ class DrawUT < Minitest::Test
   end
 
   def test_affine
-    assert_nothing_raised do
+    expect do
       @draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
-    end
+    end.not_to raise_error
     expect { @draw.affine = [1, 2, 3, 4, 5, 6] }.to raise_error(TypeError)
   end
 
   def test_align
     Magick::AlignType.values do |align|
-      assert_nothing_raised { @draw.align = align }
+      expect { @draw.align = align }.not_to raise_error
     end
   end
 
   def test_decorate
     Magick::DecorationType.values do |decoration|
-      assert_nothing_raised { @draw.decorate = decoration }
+      expect { @draw.decorate = decoration }.not_to raise_error
     end
   end
 
   def test_density
-    assert_nothing_raised { @draw.density = '90x90' }
-    assert_nothing_raised { @draw.density = 'x90' }
-    assert_nothing_raised { @draw.density = '90' }
+    expect { @draw.density = '90x90' }.not_to raise_error
+    expect { @draw.density = 'x90' }.not_to raise_error
+    expect { @draw.density = '90' }.not_to raise_error
     expect { @draw.density = 2 }.to raise_error(TypeError)
   end
 
   def test_encoding
-    assert_nothing_raised { @draw.encoding = 'AdobeCustom' }
+    expect { @draw.encoding = 'AdobeCustom' }.not_to raise_error
     expect { @draw.encoding = 2 }.to raise_error(TypeError)
   end
 
   def test_fill
-    assert_nothing_raised { @draw.fill = 'white' }
-    assert_nothing_raised { @draw.fill = Magick::Pixel.from_color('white') }
+    expect { @draw.fill = 'white' }.not_to raise_error
+    expect { @draw.fill = Magick::Pixel.from_color('white') }.not_to raise_error
     expect { @draw.fill = 2 }.to raise_error(TypeError)
   end
 
   def test_fill_pattern
-    assert_nothing_raised { @draw.fill_pattern = nil }
-    assert_nothing_raised do
+    expect { @draw.fill_pattern = nil }.not_to raise_error
+    expect do
       img1 = Magick::Image.new(10, 10)
       img2 = Magick::Image.new(20, 20)
 
       @draw.fill_pattern = img1
       @draw.fill_pattern = img2
-    end
+    end.not_to raise_error
 
     expect { @draw.fill_pattern = 'x' }.to raise_error(NoMethodError)
   end
 
   def test_font
-    assert_nothing_raised { @draw.font = 'Arial-Bold' }
+    expect { @draw.font = 'Arial-Bold' }.not_to raise_error
     expect { @draw.font = 2 }.to raise_error(TypeError)
   end
 
   def test_font_family
-    assert_nothing_raised { @draw.font_family = 'Arial' }
+    expect { @draw.font_family = 'Arial' }.not_to raise_error
     expect { @draw.font_family = 2 }.to raise_error(TypeError)
   end
 
   def test_font_stretch
     Magick::StretchType.values do |stretch|
-      assert_nothing_raised { @draw.font_stretch = stretch }
+      expect { @draw.font_stretch = stretch }.not_to raise_error
     end
 
     expect { @draw.font_stretch = 2 }.to raise_error(TypeError)
@@ -76,7 +76,7 @@ class DrawUT < Minitest::Test
 
   def test_font_style
     Magick::StyleType.values do |style|
-      assert_nothing_raised { @draw.font_style = style }
+      expect { @draw.font_style = style }.not_to raise_error
     end
 
     expect { @draw.font_style = 2 }.to raise_error(TypeError)
@@ -84,7 +84,7 @@ class DrawUT < Minitest::Test
 
   def test_font_weight
     Magick::WeightType.values do |weight|
-      assert_nothing_raised { @draw.font_weight = weight }
+      expect { @draw.font_weight = weight }.not_to raise_error
     end
 
     expect { @draw.font_weight = 99 }.to raise_error(ArgumentError)
@@ -93,85 +93,85 @@ class DrawUT < Minitest::Test
 
   def test_gravity
     Magick::GravityType.values do |gravity|
-      assert_nothing_raised { @draw.gravity = gravity }
+      expect { @draw.gravity = gravity }.not_to raise_error
     end
 
     expect { @draw.gravity = 2 }.to raise_error(TypeError)
   end
 
   def test_interline_spacing
-    assert_nothing_raised { @draw.interline_spacing = 2 }
+    expect { @draw.interline_spacing = 2 }.not_to raise_error
     expect { @draw.interline_spacing = 'x' }.to raise_error(TypeError)
   end
 
   def test_interword_spacing
-    assert_nothing_raised { @draw.interword_spacing = 2 }
+    expect { @draw.interword_spacing = 2 }.not_to raise_error
     expect { @draw.interword_spacing = 'x' }.to raise_error(TypeError)
   end
 
   def test_kerning
-    assert_nothing_raised { @draw.kerning = 2 }
+    expect { @draw.kerning = 2 }.not_to raise_error
     expect { @draw.kerning = 'x' }.to raise_error(TypeError)
   end
 
   def test_pointsize
-    assert_nothing_raised { @draw.pointsize = 2 }
+    expect { @draw.pointsize = 2 }.not_to raise_error
     expect { @draw.pointsize = 'x' }.to raise_error(TypeError)
   end
 
   def test_rotation
-    assert_nothing_raised { @draw.rotation = 15 }
+    expect { @draw.rotation = 15 }.not_to raise_error
     expect { @draw.rotation = 'x' }.to raise_error(TypeError)
   end
 
   def test_stroke
-    assert_nothing_raised { @draw.stroke = Magick::Pixel.from_color('white') }
-    assert_nothing_raised { @draw.stroke = 'white' }
+    expect { @draw.stroke = Magick::Pixel.from_color('white') }.not_to raise_error
+    expect { @draw.stroke = 'white' }.not_to raise_error
     expect { @draw.stroke = 2 }.to raise_error(TypeError)
   end
 
   def test_stroke_pattern
-    assert_nothing_raised { @draw.stroke_pattern = nil }
-    assert_nothing_raised do
+    expect { @draw.stroke_pattern = nil }.not_to raise_error
+    expect do
       img1 = Magick::Image.new(10, 10)
       img2 = Magick::Image.new(20, 20)
 
       @draw.stroke_pattern = img1
       @draw.stroke_pattern = img2
-    end
+    end.not_to raise_error
 
     expect { @draw.stroke_pattern = 'x' }.to raise_error(NoMethodError)
   end
 
   def test_stroke_width
-    assert_nothing_raised { @draw.stroke_width = 15 }
+    expect { @draw.stroke_width = 15 }.not_to raise_error
     expect { @draw.stroke_width = 'x' }.to raise_error(TypeError)
   end
 
   def test_text_antialias
-    assert_nothing_raised { @draw.text_antialias = true }
-    assert_nothing_raised { @draw.text_antialias = false }
+    expect { @draw.text_antialias = true }.not_to raise_error
+    expect { @draw.text_antialias = false }.not_to raise_error
   end
 
   def test_tile
-    assert_nothing_raised { @draw.tile = nil }
-    assert_nothing_raised do
+    expect { @draw.tile = nil }.not_to raise_error
+    expect do
       img1 = Magick::Image.new(10, 10)
       img2 = Magick::Image.new(20, 20)
 
       @draw.tile = img1
       @draw.tile = img2
-    end
+    end.not_to raise_error
   end
 
   def test_undercolor
-    assert_nothing_raised { @draw.undercolor = Magick::Pixel.from_color('white') }
-    assert_nothing_raised { @draw.undercolor = 'white' }
+    expect { @draw.undercolor = Magick::Pixel.from_color('white') }.not_to raise_error
+    expect { @draw.undercolor = 'white' }.not_to raise_error
     expect { @draw.undercolor = 2 }.to raise_error(TypeError)
   end
 
   def test_annotate
-    assert_nothing_raised do
+    expect do
       img = Magick::Image.new(10, 10)
       @draw.annotate(img, 0, 0, 0, 20, 'Hello world')
 
@@ -180,7 +180,7 @@ class DrawUT < Minitest::Test
         yield_obj = draw
       end
       assert_instance_of(Magick::Draw, yield_obj)
-    end
+    end.not_to raise_error
 
     expect do
       img = Magick::Image.new(10, 10)
@@ -191,13 +191,13 @@ class DrawUT < Minitest::Test
   end
 
   def test_annotate_stack_buffer_overflow
-    assert_nothing_raised do
+    expect do
       if 1.size == 8
         # 64-bit environment can use larger value for Integer and it can causes stack buffer overflow.
         img = Magick::Image.new(10, 10)
         @draw.annotate(img, 2**63, 2**63, 2**62, 2**62, 'Hello world')
       end
-    end
+    end.not_to raise_error
   end
 
   def test_dup
@@ -217,10 +217,10 @@ class DrawUT < Minitest::Test
 
   def test_composite
     img = Magick::Image.new(10, 10)
-    assert_nothing_raised { @draw.composite(0, 0, 10, 10, img) }
+    expect { @draw.composite(0, 0, 10, 10, img) }.not_to raise_error
 
     Magick::CompositeOperator.values do |op|
-      assert_nothing_raised { @draw.composite(0, 0, 10, 10, img, op) }
+      expect { @draw.composite(0, 0, 10, 10, img, op) }.not_to raise_error
     end
 
     expect { @draw.composite('x', 0, 10, 10, img) }.to raise_error(TypeError)
@@ -238,7 +238,7 @@ class DrawUT < Minitest::Test
 
     img = Magick::Image.new(10, 10)
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    assert_nothing_raised { @draw.draw(img) }
+    expect { @draw.draw(img) }.not_to raise_error
 
     expect { draw.draw(img) }.to raise_error(ArgumentError)
     expect { draw.draw('x') }.to raise_error(NoMethodError)
@@ -246,8 +246,8 @@ class DrawUT < Minitest::Test
 
   def test_get_type_metrics
     img = Magick::Image.new(10, 10)
-    assert_nothing_raised { @draw.get_type_metrics('ABCDEF') }
-    assert_nothing_raised { @draw.get_type_metrics(img, 'ABCDEF') }
+    expect { @draw.get_type_metrics('ABCDEF') }.not_to raise_error
+    expect { @draw.get_type_metrics(img, 'ABCDEF') }.not_to raise_error
 
     expect { @draw.get_type_metrics }.to raise_error(ArgumentError)
     expect { @draw.get_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
@@ -257,8 +257,8 @@ class DrawUT < Minitest::Test
 
   def test_get_multiline_type_metrics
     img = Magick::Image.new(10, 10)
-    assert_nothing_raised { @draw.get_multiline_type_metrics('ABCDEF') }
-    assert_nothing_raised { @draw.get_multiline_type_metrics(img, 'ABCDEF') }
+    expect { @draw.get_multiline_type_metrics('ABCDEF') }.not_to raise_error
+    expect { @draw.get_multiline_type_metrics(img, 'ABCDEF') }.not_to raise_error
 
     expect { @draw.get_multiline_type_metrics }.to raise_error(ArgumentError)
     expect { @draw.get_multiline_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
@@ -299,30 +299,30 @@ class DrawUT < Minitest::Test
     draw.circle(20, 25, 20, 28)
 
     dumped = nil
-    assert_nothing_raised { dumped = draw.marshal_dump }
+    expect { dumped = draw.marshal_dump }.not_to raise_error
 
     draw2 = @draw.dup
-    assert_nothing_raised do
+    expect do
       draw2.marshal_load(dumped)
-    end
+    end.not_to raise_error
     expect(draw2.inspect).to eq(draw.inspect)
   end
 
   def test_primitive
-    assert_nothing_raised { @draw.primitive('ABCDEF') }
-    assert_nothing_raised { @draw.primitive('12345') }
+    expect { @draw.primitive('ABCDEF') }.not_to raise_error
+    expect { @draw.primitive('12345') }.not_to raise_error
     expect { @draw.primitive(nil) }.to raise_error(TypeError)
   end
 
   def test_draw_options
-    assert_nothing_raised do
+    expect do
       yield_obj = nil
 
       Magick::Draw.new do |option|
         yield_obj = option
       end
       assert_instance_of(Magick::Image::DrawOptions, yield_obj)
-    end
+    end.not_to raise_error
   end
 
   def test_issue_604

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -3,8 +3,8 @@ require 'minitest/autorun'
 
 class EnumUT < Minitest::Test
   def test_new
-    assert_nothing_raised { Magick::Enum.new(:foo, 42) }
-    assert_nothing_raised { Magick::Enum.new('foo', 42) }
+    expect { Magick::Enum.new(:foo, 42) }.not_to raise_error
+    expect { Magick::Enum.new('foo', 42) }.not_to raise_error
 
     expect { Magick::Enum.new(Object.new, 42) }.to raise_error(TypeError)
     expect { Magick::Enum.new(:foo, 'x') }.to raise_error(TypeError)

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -17,59 +17,59 @@ class GradientFillUT < Minitest::Test
   def test_fill
     img = Magick::Image.new(10, 10)
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 0, 0, 0, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 0, 0, 10, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 0, 10, 0, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 0, 10, 10, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 0, 5, 20, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(-10, 0, -10, 10, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, -10, 10, -10, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, -10, 10, -20, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       gradient = Magick::GradientFill.new(0, 100, 100, 200, '#900', '#000')
       obj = gradient.fill(img)
       expect(obj).to eq(gradient)
-    end
+    end.not_to raise_error
   end
 end
 

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -34,33 +34,33 @@ class Image1_UT < Minitest::Test
   end
 
   def test_adaptive_blur
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_blur
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_blur(2) }
-    assert_nothing_raised { @img.adaptive_blur(3, 2) }
+    end.not_to raise_error
+    expect { @img.adaptive_blur(2) }.not_to raise_error
+    expect { @img.adaptive_blur(3, 2) }.not_to raise_error
     expect { @img.adaptive_blur(3, 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_adaptive_blur_channel
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_blur_channel
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_blur_channel(2) }
-    assert_nothing_raised { @img.adaptive_blur_channel(3, 2) }
-    assert_nothing_raised { @img.adaptive_blur_channel(3, 2, Magick::RedChannel) }
-    assert_nothing_raised { @img.adaptive_blur_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.adaptive_blur_channel(2) }.not_to raise_error
+    expect { @img.adaptive_blur_channel(3, 2) }.not_to raise_error
+    expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel) }.not_to raise_error
+    expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.adaptive_blur_channel(3, 2, 2) }.to raise_error(TypeError)
   end
 
   def test_adaptive_resize
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_resize(10, 10)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_resize(2) }
+    end.not_to raise_error
+    expect { @img.adaptive_resize(2) }.not_to raise_error
     expect { @img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
     expect { @img.adaptive_resize(10, 10, 10) }.to raise_error(ArgumentError)
     expect { @img.adaptive_resize }.to raise_error(ArgumentError)
@@ -68,46 +68,46 @@ class Image1_UT < Minitest::Test
   end
 
   def test_adaptive_sharpen
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_sharpen
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_sharpen(2) }
-    assert_nothing_raised { @img.adaptive_sharpen(3, 2) }
+    end.not_to raise_error
+    expect { @img.adaptive_sharpen(2) }.not_to raise_error
+    expect { @img.adaptive_sharpen(3, 2) }.not_to raise_error
     expect { @img.adaptive_sharpen(3, 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_adaptive_sharpen_channel
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_sharpen_channel
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_sharpen_channel(2) }
-    assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2) }
-    assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }
-    assert_nothing_raised { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.adaptive_sharpen_channel(2) }.not_to raise_error
+    expect { @img.adaptive_sharpen_channel(3, 2) }.not_to raise_error
+    expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }.not_to raise_error
+    expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.adaptive_sharpen_channel(3, 2, 2) }.to raise_error(TypeError)
   end
 
   def test_adaptive_threshold
-    assert_nothing_raised do
+    expect do
       res = @img.adaptive_threshold
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.adaptive_threshold(2) }
-    assert_nothing_raised { @img.adaptive_threshold(2, 4) }
-    assert_nothing_raised { @img.adaptive_threshold(2, 4, 1) }
+    end.not_to raise_error
+    expect { @img.adaptive_threshold(2) }.not_to raise_error
+    expect { @img.adaptive_threshold(2, 4) }.not_to raise_error
+    expect { @img.adaptive_threshold(2, 4, 1) }.not_to raise_error
     expect { @img.adaptive_threshold(2, 4, 1, 2) }.to raise_error(ArgumentError)
   end
 
   def test_add_compose_mask
     mask = Magick::Image.new(20, 20)
-    assert_nothing_raised { @img.add_compose_mask(mask) }
-    assert_nothing_raised { @img.delete_compose_mask }
-    assert_nothing_raised { @img.add_compose_mask(mask) }
-    assert_nothing_raised { @img.add_compose_mask(mask) }
-    assert_nothing_raised { @img.delete_compose_mask }
-    assert_nothing_raised { @img.delete_compose_mask }
+    expect { @img.add_compose_mask(mask) }.not_to raise_error
+    expect { @img.delete_compose_mask }.not_to raise_error
+    expect { @img.add_compose_mask(mask) }.not_to raise_error
+    expect { @img.add_compose_mask(mask) }.not_to raise_error
+    expect { @img.delete_compose_mask }.not_to raise_error
+    expect { @img.delete_compose_mask }.not_to raise_error
 
     mask = Magick::Image.new(10, 10)
     expect { @img.add_compose_mask(mask) }.to raise_error(ArgumentError)
@@ -115,18 +115,18 @@ class Image1_UT < Minitest::Test
 
   def test_add_noise
     Magick::NoiseType.values do |noise|
-      assert_nothing_raised { @img.add_noise(noise) }
+      expect { @img.add_noise(noise) }.not_to raise_error
     end
     expect { @img.add_noise(0) }.to raise_error(TypeError)
   end
 
   def test_add_noise_channel
-    assert_nothing_raised { @img.add_noise_channel(Magick::UniformNoise) }
-    assert_nothing_raised { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel) }
-    assert_nothing_raised { @img.add_noise_channel(Magick::GaussianNoise, Magick::BlueChannel) }
-    assert_nothing_raised { @img.add_noise_channel(Magick::ImpulseNoise, Magick::GreenChannel) }
-    assert_nothing_raised { @img.add_noise_channel(Magick::LaplacianNoise, Magick::RedChannel, Magick::GreenChannel) }
-    assert_nothing_raised { @img.add_noise_channel(Magick::PoissonNoise, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel) }
+    expect { @img.add_noise_channel(Magick::UniformNoise) }.not_to raise_error
+    expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel) }.not_to raise_error
+    expect { @img.add_noise_channel(Magick::GaussianNoise, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.add_noise_channel(Magick::ImpulseNoise, Magick::GreenChannel) }.not_to raise_error
+    expect { @img.add_noise_channel(Magick::LaplacianNoise, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+    expect { @img.add_noise_channel(Magick::PoissonNoise, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel) }.not_to raise_error
 
     # Not a NoiseType
     expect { @img.add_noise_channel(1) }.to raise_error(TypeError)
@@ -138,38 +138,38 @@ class Image1_UT < Minitest::Test
 
   def test_add_delete_profile
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_nothing_raised { img.add_profile(File.join(__dir__, 'cmyk.icm')) }
+    expect { img.add_profile(File.join(__dir__, 'cmyk.icm')) }.not_to raise_error
     # expect { img.add_profile(File.join(__dir__, 'srgb.icm')) }.to raise_error(Magick::ImageMagickError)
 
     img.each_profile { |name, _value| expect(name).to eq('icc') }
-    assert_nothing_raised { img.delete_profile('icc') }
+    expect { img.delete_profile('icc') }.not_to raise_error
   end
 
   def test_affine_matrix
     affine = Magick::AffineMatrix.new(1, Math::PI / 6, Math::PI / 6, 1, 0, 0)
-    assert_nothing_raised { @img.affine_transform(affine) }
+    expect { @img.affine_transform(affine) }.not_to raise_error
     expect { @img.affine_transform(0) }.to raise_error(TypeError)
     res = @img.affine_transform(affine)
-    assert_instance_of(Magick::Image,  res)
+    assert_instance_of(Magick::Image, res)
   end
 
   # test alpha backward compatibility. Image#alpha w/o arguments acts like alpha?
   def test_alpha_compat
-    assert_nothing_raised { @img.alpha }
+    expect { @img.alpha }.not_to raise_error
     assert !@img.alpha
-    assert_nothing_raised { @img.alpha Magick::ActivateAlphaChannel }
+    expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
     assert @img.alpha
   end
 
   def test_alpha
-    assert_nothing_raised { @img.alpha? }
+    expect { @img.alpha? }.not_to raise_error
     assert !@img.alpha?
-    assert_nothing_raised { @img.alpha Magick::ActivateAlphaChannel }
+    expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
     assert @img.alpha?
-    assert_nothing_raised { @img.alpha Magick::DeactivateAlphaChannel }
+    expect { @img.alpha Magick::DeactivateAlphaChannel }.not_to raise_error
     assert !@img.alpha?
-    assert_nothing_raised { @img.alpha Magick::OpaqueAlphaChannel }
-    assert_nothing_raised { @img.alpha Magick::SetAlphaChannel }
+    expect { @img.alpha Magick::OpaqueAlphaChannel }.not_to raise_error
+    expect { @img.alpha Magick::SetAlphaChannel }.not_to raise_error
     expect { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }.to raise_error(ArgumentError)
     @img.freeze
     expect { @img.alpha Magick::SetAlphaChannel }.to raise_error(FreezeError)
@@ -187,55 +187,55 @@ class Image1_UT < Minitest::Test
     @img[:comment] = 'Hello world'
     expect(@img['label']).to eq('foobarbaz')
     expect(@img['comment']).to eq('Hello world')
-    assert_nothing_raised { @img[nil] = 'foobarbaz' }
+    expect { @img[nil] = 'foobarbaz' }.not_to raise_error
   end
 
   def test_auto_gamma
     res = nil
-    assert_nothing_raised { res = @img.auto_gamma_channel }
+    expect { res = @img.auto_gamma_channel }.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_nothing_raised { res = @img.auto_gamma_channel Magick::RedChannel }
-    assert_nothing_raised { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }
+    expect { res = @img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
+    expect { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { @img.auto_gamma_channel(1) }.to raise_error(TypeError)
   end
 
   def test_auto_level
     res = nil
-    assert_nothing_raised { res = @img.auto_level_channel }
+    expect { res = @img.auto_level_channel }.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_nothing_raised { res = @img.auto_level_channel Magick::RedChannel }
-    assert_nothing_raised { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }
+    expect { res = @img.auto_level_channel Magick::RedChannel }.not_to raise_error
+    expect { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { @img.auto_level_channel(1) }.to raise_error(TypeError)
   end
 
   def test_auto_orient
     Magick::OrientationType.values.each do |v|
-      assert_nothing_raised do
+      expect do
         img = Magick::Image.new(10, 10)
         img.orientation = v
         res = img.auto_orient
         assert_instance_of(Magick::Image, res)
         assert_not_same(img, res)
-      end
+      end.not_to raise_error
     end
 
-    assert_nothing_raised do
+    expect do
       res = @img.auto_orient!
       # When not changed, returns nil
       assert_nil(res)
-    end
+    end.not_to raise_error
   end
 
   def test_bilevel_channel
     expect { @img.bilevel_channel }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.bilevel_channel(100) }
-    assert_nothing_raised { @img.bilevel_channel(100, Magick::RedChannel) }
-    assert_nothing_raised { @img.bilevel_channel(100, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }
-    assert_nothing_raised { @img.bilevel_channel(100, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }
-    assert_nothing_raised { @img.bilevel_channel(100, Magick::GrayChannel) }
-    assert_nothing_raised { @img.bilevel_channel(100, Magick::AllChannels) }
+    expect { @img.bilevel_channel(100) }.not_to raise_error
+    expect { @img.bilevel_channel(100, Magick::RedChannel) }.not_to raise_error
+    expect { @img.bilevel_channel(100, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+    expect { @img.bilevel_channel(100, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
+    expect { @img.bilevel_channel(100, Magick::GrayChannel) }.not_to raise_error
+    expect { @img.bilevel_channel(100, Magick::AllChannels) }.not_to raise_error
     expect { @img.bilevel_channel(100, 2) }.to raise_error(TypeError)
     res = @img.bilevel_channel(100)
     assert_instance_of(Magick::Image, res)
@@ -243,19 +243,19 @@ class Image1_UT < Minitest::Test
 
   def test_blend
     @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    assert_nothing_raised { @img.blend(@img2, 0.25) }
+    expect { @img.blend(@img2, 0.25) }.not_to raise_error
     res = @img.blend(@img2, 0.25)
 
     Magick::GravityType.values do |gravity|
-      assert_nothing_raised { @img.blend(@img2, 0.25, 0.75, gravity) }
-      assert_nothing_raised { @img.blend(@img2, 0.25, 0.75, gravity, 10) }
-      assert_nothing_raised { @img.blend(@img2, 0.25, 0.75, gravity, 10, 10) }
+      expect { @img.blend(@img2, 0.25, 0.75, gravity) }.not_to raise_error
+      expect { @img.blend(@img2, 0.25, 0.75, gravity, 10) }.not_to raise_error
+      expect { @img.blend(@img2, 0.25, 0.75, gravity, 10, 10) }.not_to raise_error
     end
 
     assert_instance_of(Magick::Image, res)
-    assert_nothing_raised { @img.blend(@img2, '25%') }
-    assert_nothing_raised { @img.blend(@img2, 0.25, 0.75) }
-    assert_nothing_raised { @img.blend(@img2, '25%', '75%') }
+    expect { @img.blend(@img2, '25%') }.not_to raise_error
+    expect { @img.blend(@img2, 0.25, 0.75) }.not_to raise_error
+    expect { @img.blend(@img2, '25%', '75%') }.not_to raise_error
     expect { @img.blend }.to raise_error(ArgumentError)
     expect { @img.blend(@img2, 'x') }.to raise_error(ArgumentError)
     expect { @img.blend(@img2, 0.25, []) }.to raise_error(TypeError)
@@ -275,23 +275,23 @@ class Image1_UT < Minitest::Test
   end
 
   def test_blur_channel
-    assert_nothing_raised { @img.blur_channel }
-    assert_nothing_raised { @img.blur_channel(1) }
-    assert_nothing_raised { @img.blur_channel(1, 2) }
-    assert_nothing_raised { @img.blur_channel(1, 2, Magick::RedChannel) }
-    assert_nothing_raised { @img.blur_channel(1, 2, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }
-    assert_nothing_raised { @img.blur_channel(1, 2, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }
-    assert_nothing_raised { @img.blur_channel(1, 2, Magick::GrayChannel) }
-    assert_nothing_raised { @img.blur_channel(1, 2, Magick::AllChannels) }
+    expect { @img.blur_channel }.not_to raise_error
+    expect { @img.blur_channel(1) }.not_to raise_error
+    expect { @img.blur_channel(1, 2) }.not_to raise_error
+    expect { @img.blur_channel(1, 2, Magick::RedChannel) }.not_to raise_error
+    expect { @img.blur_channel(1, 2, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+    expect { @img.blur_channel(1, 2, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
+    expect { @img.blur_channel(1, 2, Magick::GrayChannel) }.not_to raise_error
+    expect { @img.blur_channel(1, 2, Magick::AllChannels) }.not_to raise_error
     expect { @img.blur_channel(1, 2, 2) }.to raise_error(TypeError)
     res = @img.blur_channel
     assert_instance_of(Magick::Image, res)
   end
 
   def test_blur_image
-    assert_nothing_raised { @img.blur_image }
-    assert_nothing_raised { @img.blur_image(1) }
-    assert_nothing_raised { @img.blur_image(1, 2) }
+    expect { @img.blur_image }.not_to raise_error
+    expect { @img.blur_image(1) }.not_to raise_error
+    expect { @img.blur_image(1, 2) }.not_to raise_error
     expect { @img.blur_image(1, 2, 3) }.to raise_error(ArgumentError)
     res = @img.blur_image
     assert_instance_of(Magick::Image, res)
@@ -299,11 +299,11 @@ class Image1_UT < Minitest::Test
 
   def test_black_threshold
     expect { @img.black_threshold }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.black_threshold(50) }
-    assert_nothing_raised { @img.black_threshold(50, 50) }
-    assert_nothing_raised { @img.black_threshold(50, 50, 50) }
+    expect { @img.black_threshold(50) }.not_to raise_error
+    expect { @img.black_threshold(50, 50) }.not_to raise_error
+    expect { @img.black_threshold(50, 50, 50) }.not_to raise_error
     expect { @img.black_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.black_threshold(50, 50, 50, alpha: 50) }
+    expect { @img.black_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
     expect { @img.black_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
     expect { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
     expect { @img.black_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
@@ -312,8 +312,8 @@ class Image1_UT < Minitest::Test
   end
 
   def test_border
-    assert_nothing_raised { @img.border(2, 2, 'red') }
-    assert_nothing_raised { @img.border!(2, 2, 'red') }
+    expect { @img.border(2, 2, 'red') }.not_to raise_error
+    expect { @img.border!(2, 2, 'red') }.not_to raise_error
     res = @img.border(2, 2, 'red')
     assert_instance_of(Magick::Image, res)
     @img.freeze
@@ -321,22 +321,22 @@ class Image1_UT < Minitest::Test
   end
 
   def test_capture
-    # assert_nothing_raised { Magick::Image.capture }
-    # assert_nothing_raised { Magick::Image.capture(true) }
-    # assert_nothing_raised { Magick::Image.capture(true, true) }
-    # assert_nothing_raised { Magick::Image.capture(true, true, true) }
-    # assert_nothing_raised { Magick::Image.capture(true, true, true, true) }
-    # assert_nothing_raised { Magick::Image.capture(true, true, true, true, true) }
+    # expect { Magick::Image.capture }.not_to raise_error
+    # expect { Magick::Image.capture(true) }.not_to raise_error
+    # expect { Magick::Image.capture(true, true) }.not_to raise_error
+    # expect { Magick::Image.capture(true, true, true) }.not_to raise_error
+    # expect { Magick::Image.capture(true, true, true, true) }.not_to raise_error
+    # expect { Magick::Image.capture(true, true, true, true, true) }.not_to raise_error
     expect { Magick::Image.capture(true, true, true, true, true, true) }.to raise_error(ArgumentError)
   end
 
   def test_change_geometry
     expect { @img.change_geometry('sss') }.to raise_error(ArgumentError)
     expect { @img.change_geometry('100x100') }.to raise_error(LocalJumpError)
-    assert_nothing_raised do
+    expect do
       res = @img.change_geometry('100x100') { 1 }
       expect(res).to eq(1)
-    end
+    end.not_to raise_error
     expect { @img.change_geometry([]) }.to raise_error(ArgumentError)
   end
 
@@ -348,7 +348,7 @@ class Image1_UT < Minitest::Test
 
   def test_channel
     Magick::ChannelType.values do |channel|
-      assert_nothing_raised { @img.channel(channel) }
+      expect { @img.channel(channel) }.not_to raise_error
     end
 
     assert_instance_of(Magick::Image, @img.channel(Magick::RedChannel))
@@ -356,74 +356,74 @@ class Image1_UT < Minitest::Test
   end
 
   def test_channel_depth
-    assert_nothing_raised { @img.channel_depth }
-    assert_nothing_raised { @img.channel_depth(Magick::RedChannel) }
-    assert_nothing_raised { @img.channel_depth(Magick::RedChannel, Magick::BlueChannel) }
-    assert_nothing_raised { @img.channel_depth(Magick::GreenChannel, Magick::OpacityChannel) }
-    assert_nothing_raised { @img.channel_depth(Magick::MagentaChannel, Magick::CyanChannel) }
-    assert_nothing_raised { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }
-    assert_nothing_raised { @img.channel_depth(Magick::GrayChannel) }
+    expect { @img.channel_depth }.not_to raise_error
+    expect { @img.channel_depth(Magick::RedChannel) }.not_to raise_error
+    expect { @img.channel_depth(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.channel_depth(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+    expect { @img.channel_depth(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+    expect { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+    expect { @img.channel_depth(Magick::GrayChannel) }.not_to raise_error
     expect { @img.channel_depth(2) }.to raise_error(TypeError)
     assert_kind_of(Integer, @img.channel_depth(Magick::RedChannel))
   end
 
   def test_channel_extrema
-    assert_nothing_raised do
+    expect do
       res = @img.channel_extrema
       assert_instance_of(Array, res)
       expect(res.length).to eq(2)
       assert_kind_of(Integer, res[0])
       assert_kind_of(Integer, res[1])
-    end
-    assert_nothing_raised { @img.channel_extrema(Magick::RedChannel) }
-    assert_nothing_raised { @img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }
-    assert_nothing_raised { @img.channel_extrema(Magick::GreenChannel, Magick::OpacityChannel) }
-    assert_nothing_raised { @img.channel_extrema(Magick::MagentaChannel, Magick::CyanChannel) }
-    assert_nothing_raised { @img.channel_extrema(Magick::CyanChannel, Magick::BlackChannel) }
-    assert_nothing_raised { @img.channel_extrema(Magick::GrayChannel) }
+    end.not_to raise_error
+    expect { @img.channel_extrema(Magick::RedChannel) }.not_to raise_error
+    expect { @img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.channel_extrema(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+    expect { @img.channel_extrema(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+    expect { @img.channel_extrema(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+    expect { @img.channel_extrema(Magick::GrayChannel) }.not_to raise_error
     expect { @img.channel_extrema(2) }.to raise_error(TypeError)
   end
 
   def test_channel_mean
-    assert_nothing_raised do
+    expect do
       res = @img.channel_mean
       assert_instance_of(Array, res)
       expect(res.length).to eq(2)
       assert_instance_of(Float, res[0])
       assert_instance_of(Float, res[1])
-    end
-    assert_nothing_raised { @img.channel_mean(Magick::RedChannel) }
-    assert_nothing_raised { @img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }
-    assert_nothing_raised { @img.channel_mean(Magick::GreenChannel, Magick::OpacityChannel) }
-    assert_nothing_raised { @img.channel_mean(Magick::MagentaChannel, Magick::CyanChannel) }
-    assert_nothing_raised { @img.channel_mean(Magick::CyanChannel, Magick::BlackChannel) }
-    assert_nothing_raised { @img.channel_mean(Magick::GrayChannel) }
+    end.not_to raise_error
+    expect { @img.channel_mean(Magick::RedChannel) }.not_to raise_error
+    expect { @img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.channel_mean(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+    expect { @img.channel_mean(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+    expect { @img.channel_mean(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+    expect { @img.channel_mean(Magick::GrayChannel) }.not_to raise_error
     expect { @img.channel_mean(2) }.to raise_error(TypeError)
   end
 
   def test_charcoal
-    assert_nothing_raised do
+    expect do
       res = @img.charcoal
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.charcoal(1.0) }
-    assert_nothing_raised { @img.charcoal(1.0, 2.0) }
+    end.not_to raise_error
+    expect { @img.charcoal(1.0) }.not_to raise_error
+    expect { @img.charcoal(1.0, 2.0) }.not_to raise_error
     expect { @img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
   end
 
   def test_chop
-    assert_nothing_raised do
+    expect do
       res = @img.chop(10, 10, 10, 10)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_clone
-    assert_nothing_raised do
+    expect do
       res = @img.clone
       assert_instance_of(Magick::Image, res)
       expect(@img).to eq(res)
-    end
+    end.not_to raise_error
     res = @img.clone
     expect(@img.frozen?).to eq(res.frozen?)
     @img.freeze
@@ -435,10 +435,10 @@ class Image1_UT < Minitest::Test
     img = Magick::Image.new(20, 20) { self.colorspace = Magick::GRAYColorspace }
     clut = Magick::Image.new(20, 1) { self.background_color = 'red' }
     res = nil
-    assert_nothing_raised { res = img.clut_channel(clut) }
+    expect { res = img.clut_channel(clut) }.not_to raise_error
     assert_same(res, img)
-    assert_nothing_raised { img.clut_channel(clut, Magick::RedChannel) }
-    assert_nothing_raised { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }
+    expect { img.clut_channel(clut, Magick::RedChannel) }.not_to raise_error
+    expect { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img.clut_channel }.to raise_error(ArgumentError)
     expect { img.clut_channel(clut, 1, Magick::RedChannel) }.to raise_error(ArgumentError)
   end
@@ -446,47 +446,47 @@ class Image1_UT < Minitest::Test
   def test_color_fill_to_border
     expect { @img.color_fill_to_border(-1, 1, 'red') }.to raise_error(ArgumentError)
     expect { @img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, 'red')
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, pixel) }
+    expect { @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
   end
 
   def test_color_floodfill
     expect { @img.color_floodfill(-1, 1, 'red') }.to raise_error(ArgumentError)
     expect { @img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @img.color_floodfill(@img.columns / 2, @img.rows / 2, 'red')
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.color_floodfill(@img.columns / 2, @img.rows / 2, pixel) }
+    expect { @img.color_floodfill(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
   end
 
   def test_color_histogram
-    assert_nothing_raised do
+    expect do
       res = @img.color_histogram
       assert_instance_of(Hash, res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       @img.class_type = Magick::PseudoClass
       res = @img.color_histogram
       expect(@img.class_type).to eq(Magick::PseudoClass)
       assert_instance_of(Hash, res)
-    end
+    end.not_to raise_error
   end
 
   def test_colorize
-    assert_nothing_raised do
+    expect do
       res = @img.colorize(0.25, 0.25, 0.25, 'red')
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }
+    end.not_to raise_error
+    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.colorize(0.25, 0.25, 0.25, pixel) }
-    assert_nothing_raised { @img.colorize(0.25, 0.25, 0.25, 0.25, pixel) }
+    expect { @img.colorize(0.25, 0.25, 0.25, pixel) }.not_to raise_error
+    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, pixel) }.not_to raise_error
     expect { @img.colorize }.to raise_error(ArgumentError)
     expect { @img.colorize(0.25) }.to raise_error(ArgumentError)
     expect { @img.colorize(0.25, 0.25) }.to raise_error(ArgumentError)
@@ -503,24 +503,24 @@ class Image1_UT < Minitest::Test
     expect { @img.colormap(0) }.to raise_error(IndexError)
     # Read PseudoClass image
     pc_img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_nothing_raised { pc_img.colormap(0) }
+    expect { pc_img.colormap(0) }.not_to raise_error
     ncolors = pc_img.colors
     expect { pc_img.colormap(ncolors + 1) }.to raise_error(IndexError)
     expect { pc_img.colormap(-1) }.to raise_error(IndexError)
-    assert_nothing_raised { pc_img.colormap(ncolors - 1) }
+    expect { pc_img.colormap(ncolors - 1) }.not_to raise_error
     res = pc_img.colormap(0)
     assert_instance_of(String, res)
 
     # test 'set' operation
-    assert_nothing_raised do
+    expect do
       old_color = pc_img.colormap(0)
       res = pc_img.colormap(0, 'red')
       expect(res).to eq(old_color)
       res = pc_img.colormap(0)
       expect(res).to eq('red')
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { pc_img.colormap(0, pixel) }
+    expect { pc_img.colormap(0, pixel) }.not_to raise_error
     expect { pc_img.colormap }.to raise_error(ArgumentError)
     expect { pc_img.colormap(0, pixel, Magick::BlackChannel) }.to raise_error(ArgumentError)
     expect { pc_img.colormap(0, [2]) }.to raise_error(TypeError)
@@ -529,22 +529,22 @@ class Image1_UT < Minitest::Test
   end
 
   def test_color_point
-    assert_nothing_raised do
+    expect do
       res = @img.color_point(0, 0, 'red')
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.color_point(0, 0, pixel) }
+    expect { @img.color_point(0, 0, pixel) }.not_to raise_error
   end
 
   def test_color_reset!
-    assert_nothing_raised do
+    expect do
       res = @img.color_reset!('red')
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.color_reset!(pixel) }
+    expect { @img.color_reset!(pixel) }.not_to raise_error
     expect { @img.color_reset!([2]) }.to raise_error(TypeError)
     expect { @img.color_reset!('x') }.to raise_error(ArgumentError)
     @img.freeze
@@ -556,17 +556,17 @@ class Image1_UT < Minitest::Test
     img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
 
     Magick::MetricType.values do |metric|
-      assert_nothing_raised { img1.compare_channel(img2, metric) }
+      expect { img1.compare_channel(img2, metric) }.not_to raise_error
     end
     expect { img1.compare_channel(img2, 2) }.to raise_error(TypeError)
     expect { img1.compare_channel }.to raise_error(ArgumentError)
 
     ilist = Magick::ImageList.new
     ilist << img2
-    assert_nothing_raised { img1.compare_channel(ilist, Magick::MeanAbsoluteErrorMetric) }
+    expect { img1.compare_channel(ilist, Magick::MeanAbsoluteErrorMetric) }.not_to raise_error
 
-    assert_nothing_raised { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel) }
-    assert_nothing_raised { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, Magick::BlueChannel) }
+    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel) }.not_to raise_error
+    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, 2) }.to raise_error(TypeError)
     expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }.to raise_error(TypeError)
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -15,17 +15,17 @@ class Image2_UT < Minitest::Test
     img2.define('compose:args', '1x1')
     Magick::CompositeOperator.values do |op|
       Magick::GravityType.values do |gravity|
-        assert_nothing_raised do
+        expect do
           res = img1.composite(img2, gravity, 5, 5, op)
           assert_not_same(img1, res)
-        end
+        end.not_to raise_error
       end
     end
 
-    assert_nothing_raised do
+    expect do
       res = img1.composite(img2, 5, 5, Magick::OverCompositeOp)
       assert_not_same(img1, res)
-    end
+    end.not_to raise_error
 
     expect { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
     expect { img1.composite(img2, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
@@ -33,7 +33,7 @@ class Image2_UT < Minitest::Test
     expect { img1.composite(img2, Magick::NorthWestGravity, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
 
     img1.freeze
-    assert_nothing_raised { img1.composite(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }
+    expect { img1.composite(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.not_to raise_error
   end
 
   def test_composite!
@@ -43,10 +43,10 @@ class Image2_UT < Minitest::Test
     img2.define('compose:args', '1x1')
     Magick::CompositeOperator.values do |op|
       Magick::GravityType.values do |gravity|
-        assert_nothing_raised do
+        expect do
           res = img1.composite!(img2, gravity, op)
           assert_same(img1, res)
-        end
+        end.not_to raise_error
       end
     end
     img1.freeze
@@ -59,11 +59,11 @@ class Image2_UT < Minitest::Test
     img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
     img1.define('compose:args', '1x1')
     img2.define('compose:args', '1x1')
-    assert_nothing_raised do
+    expect do
       res = img1.composite_affine(img2, affine)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_composite_channel
@@ -73,10 +73,10 @@ class Image2_UT < Minitest::Test
     img2.define('compose:args', '1x1')
     Magick::CompositeOperator.values do |op|
       Magick::GravityType.values do |gravity|
-        assert_nothing_raised do
+        expect do
           res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
           assert_not_same(img1, res)
-        end
+        end.not_to raise_error
       end
     end
 
@@ -88,12 +88,12 @@ class Image2_UT < Minitest::Test
     bg = Magick::Image.new(50, 50)
     fg = Magick::Image.new(50, 50) { self.background_color = 'black' }
     res = nil
-    assert_nothing_raised { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(bg, res)
     assert_not_same(fg, res)
-    assert_nothing_raised { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }
-    assert_nothing_raised { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
 
     # too few arguments
     expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)
@@ -105,17 +105,17 @@ class Image2_UT < Minitest::Test
     bg = Magick::Image.new(200, 200)
     fg = Magick::Image.new(50, 100) { self.background_color = 'black' }
     res = nil
-    assert_nothing_raised do
+    expect do
       res = bg.composite_tiled(fg)
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(bg, res)
     assert_not_same(fg, res)
-    assert_nothing_raised { bg.composite_tiled!(fg) }
-    assert_nothing_raised { bg.composite_tiled(fg, Magick::AtopCompositeOp) }
-    assert_nothing_raised { bg.composite_tiled(fg, Magick::OverCompositeOp) }
-    assert_nothing_raised { bg.composite_tiled(fg, Magick::RedChannel) }
-    assert_nothing_raised { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }
+    expect { bg.composite_tiled!(fg) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::RedChannel) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
 
     expect { bg.composite_tiled }.to raise_error(ArgumentError)
     expect { bg.composite_tiled(fg, 'x') }.to raise_error(TypeError)
@@ -128,34 +128,34 @@ class Image2_UT < Minitest::Test
   def test_compress_colormap!
     # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
     expect(@img.class_type).to eq(Magick::DirectClass)
-    assert_nothing_raised { @img.compress_colormap! }
+    expect { @img.compress_colormap! }.not_to raise_error
     # expect(@img.class_type).to eq(Magick::PseudoClass)
     @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     expect(@img.class_type).to eq(Magick::PseudoClass)
-    assert_nothing_raised { @img.compress_colormap! }
+    expect { @img.compress_colormap! }.not_to raise_error
   end
 
   def test_contrast
-    assert_nothing_raised do
+    expect do
       res = @img.contrast
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.contrast(true) }
+    end.not_to raise_error
+    expect { @img.contrast(true) }.not_to raise_error
     expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
   end
 
   def test_contrast_stretch_channel
-    assert_nothing_raised do
+    expect do
       res = @img.contrast_stretch_channel(25)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.contrast_stretch_channel(25, 50) }
-    assert_nothing_raised { @img.contrast_stretch_channel('10%') }
-    assert_nothing_raised { @img.contrast_stretch_channel('10%', '50%') }
-    assert_nothing_raised { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }
-    assert_nothing_raised { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }
+    end.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
+    expect { @img.contrast_stretch_channel('10%') }.not_to raise_error
+    expect { @img.contrast_stretch_channel('10%', '50%') }.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
     expect { @img.contrast_stretch_channel(25, 50, 'x') }.to raise_error(TypeError)
     expect { @img.contrast_stretch_channel }.to raise_error(ArgumentError)
     expect { @img.contrast_stretch_channel('x') }.to raise_error(ArgumentError)
@@ -165,11 +165,11 @@ class Image2_UT < Minitest::Test
   def test_morphology
     kernel = Magick::KernelInfo.new('Octagon')
     Magick::MorphologyMethod.values do |method|
-      assert_nothing_raised do
+      expect do
         res = @img.morphology(method, 2, kernel)
         assert_instance_of(Magick::Image, res)
         assert_not_same(@img, res)
-      end
+      end.not_to raise_error
     end
   end
 
@@ -181,21 +181,21 @@ class Image2_UT < Minitest::Test
     expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
 
     kernel = Magick::KernelInfo.new('Octagon')
-    assert_nothing_raised do
+    expect do
       res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_convolve
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3
-    assert_nothing_raised do
+    expect do
       res = @img.convolve(order, kernel)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     expect { @img.convolve }.to raise_error(ArgumentError)
     expect { @img.convolve(0) }.to raise_error(ArgumentError)
     expect { @img.convolve(-1) }.to raise_error(ArgumentError)
@@ -213,21 +213,21 @@ class Image2_UT < Minitest::Test
     expect { @img.convolve_channel(3) }.to raise_error(ArgumentError)
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3
-    assert_nothing_raised do
+    expect do
       res = @img.convolve_channel(order, kernel, Magick::RedChannel)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }
+    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
     expect { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_copy
-    assert_nothing_raised do
+    expect do
       ditto = @img.copy
       expect(ditto).to eq(@img)
-    end
+    end.not_to raise_error
     ditto = @img.copy
     expect(ditto.tainted?).to eq(@img.tainted?)
     @img.taint
@@ -238,15 +238,15 @@ class Image2_UT < Minitest::Test
   def test_crop
     expect { @img.crop }.to raise_error(ArgumentError)
     expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
     # 3-argument form
     Magick::GravityType.values do |grav|
-      assert_nothing_raised { @img.crop(grav, @img.columns / 2, @img.rows / 2) }
+      expect { @img.crop(grav, @img.columns / 2, @img.rows / 2) }.not_to raise_error
     end
     expect { @img.crop(2, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
     expect { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
@@ -260,34 +260,34 @@ class Image2_UT < Minitest::Test
 
     # 5-argument form
     Magick::GravityType.values do |grav|
-      assert_nothing_raised { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }
+      expect { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }.not_to raise_error
     end
 
     expect { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(ArgumentError)
   end
 
   def test_crop!
-    assert_nothing_raised do
+    expect do
       res = @img.crop!(0, 0, @img.columns / 2, @img.rows / 2)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_cycle_colormap
-    assert_nothing_raised do
+    expect do
       res = @img.cycle_colormap(5)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
       expect(res.class_type).to eq(Magick::PseudoClass)
-    end
+    end.not_to raise_error
   end
 
   def test_decipher # tests encipher, too.
     res = res2 = nil
-    assert_nothing_raised do
+    expect do
       res = @img.encipher 'passphrase'
       res2 = res.decipher 'passphrase'
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
     expect(res.columns).to eq(@img.columns)
@@ -300,31 +300,31 @@ class Image2_UT < Minitest::Test
   end
 
   def test_define
-    assert_nothing_raised { @img.define('deskew:auto-crop', 40) }
-    assert_nothing_raised { @img.undefine('deskew:auto-crop') }
-    assert_nothing_raised { @img.define('deskew:auto-crop', nil) }
+    expect { @img.define('deskew:auto-crop', 40) }.not_to raise_error
+    expect { @img.undefine('deskew:auto-crop') }.not_to raise_error
+    expect { @img.define('deskew:auto-crop', nil) }.not_to raise_error
   end
 
   def test_deskew
-    assert_nothing_raised do
+    expect do
       res = @img.deskew
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised { @img.deskew(0.10) }
-    assert_nothing_raised { @img.deskew('95%') }
+    expect { @img.deskew(0.10) }.not_to raise_error
+    expect { @img.deskew('95%') }.not_to raise_error
     expect { @img.deskew('x') }.to raise_error(ArgumentError)
     expect { @img.deskew(0.40, 'x') }.to raise_error(TypeError)
     expect { @img.deskew(0.40, 20, [1]) }.to raise_error(ArgumentError)
   end
 
   def test_despeckle
-    assert_nothing_raised do
+    expect do
       res = @img.despeckle
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   # ensure methods detect destroyed images
@@ -404,14 +404,14 @@ class Image2_UT < Minitest::Test
   def test_difference
     img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    assert_nothing_raised do
+    expect do
       res = img1.difference(img2)
       assert_instance_of(Array, res)
       expect(res.length).to eq(3)
       assert_instance_of(Float, res[0])
       assert_instance_of(Float, res[1])
       assert_instance_of(Float, res[2])
-    end
+    end.not_to raise_error
 
     expect { img1.difference(2) }.to raise_error(NoMethodError)
     img2.destroy!
@@ -420,16 +420,16 @@ class Image2_UT < Minitest::Test
 
   def test_displace
     @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    assert_nothing_raised { @img.displace(@img2, 25) }
+    expect { @img.displace(@img2, 25) }.not_to raise_error
     res = @img.displace(@img2, 25)
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
-    assert_nothing_raised { @img.displace(@img2, 25, 25) }
-    assert_nothing_raised { @img.displace(@img2, 25, 25, 10) }
-    assert_nothing_raised { @img.displace(@img2, 25, 25, 10, 10) }
-    assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity) }
-    assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }
-    assert_nothing_raised { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }
+    expect { @img.displace(@img2, 25, 25) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, 10, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }.not_to raise_error
     expect { @img.displace }.to raise_error(ArgumentError)
     expect { @img.displace(@img2, 'x') }.to raise_error(TypeError)
     expect { @img.displace(@img2, 25, []) }.to raise_error(TypeError)
@@ -445,14 +445,14 @@ class Image2_UT < Minitest::Test
     src = Magick::Image.new(@img.columns, @img.rows)
     src_list = Magick::ImageList.new
     src_list << src.copy
-    assert_nothing_raised { @img.dissolve(src, 0.50) }
-    assert_nothing_raised { @img.dissolve(src_list, 0.50) }
-    assert_nothing_raised { @img.dissolve(src, '50%') }
-    assert_nothing_raised { @img.dissolve(src, 0.50, 0.10) }
-    assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, 10) }
-    assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity) }
-    assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10) }
-    assert_nothing_raised { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10, 10) }
+    expect { @img.dissolve(src, 0.50) }.not_to raise_error
+    expect { @img.dissolve(src_list, 0.50) }.not_to raise_error
+    expect { @img.dissolve(src, '50%') }.not_to raise_error
+    expect { @img.dissolve(src, 0.50, 0.10) }.not_to raise_error
+    expect { @img.dissolve(src, 0.50, 0.10, 10) }.not_to raise_error
+    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity) }.not_to raise_error
+    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10) }.not_to raise_error
+    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
 
     expect { @img.dissolve }.to raise_error(ArgumentError)
     expect { @img.dissolve(src, 'x') }.to raise_error(ArgumentError)
@@ -466,12 +466,12 @@ class Image2_UT < Minitest::Test
 
   def test_distort
     @img = Magick::Image.new(200, 200)
-    assert_nothing_raised { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 35]) }
-    assert_nothing_raised { @img.distort(Magick::AffineProjectionDistortion, [1, 0, 0, 1, 0, 0]) }
-    assert_nothing_raised { @img.distort(Magick::BilinearDistortion, [7, 40, 4, 30, 4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }
-    assert_nothing_raised { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }
-    assert_nothing_raised { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }
-    assert_nothing_raised { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }
+    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 35]) }.not_to raise_error
+    expect { @img.distort(Magick::AffineProjectionDistortion, [1, 0, 0, 1, 0, 0]) }.not_to raise_error
+    expect { @img.distort(Magick::BilinearDistortion, [7, 40, 4, 30, 4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+    expect { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }.not_to raise_error
+    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }.not_to raise_error
     expect { @img.distort }.to raise_error(ArgumentError)
     expect { @img.distort(Magick::AffineDistortion) }.to raise_error(ArgumentError)
     expect { @img.distort(1, [1]) }.to raise_error(TypeError)
@@ -479,18 +479,18 @@ class Image2_UT < Minitest::Test
   end
 
   def test_distortion_channel
-    assert_nothing_raised do
+    expect do
       metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
       assert_instance_of(Float, metric)
       expect(metric).to eq(0.0)
-    end
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }
-    assert_nothing_raised { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }
+    end.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }.not_to raise_error
     expect { @img.distortion_channel(@img, 2) }.to raise_error(TypeError)
     expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }.to raise_error(TypeError)
     expect { @img.distortion_channel }.to raise_error(ArgumentError)
@@ -514,10 +514,10 @@ class Image2_UT < Minitest::Test
   end
 
   def test_dup
-    assert_nothing_raised do
+    expect do
       ditto = @img.dup
       expect(ditto).to eq(@img)
-    end
+    end.not_to raise_error
     ditto = @img.dup
     expect(ditto.tainted?).to eq(@img.tainted?)
     @img.taint
@@ -529,152 +529,152 @@ class Image2_UT < Minitest::Test
     assert_nil(@img.each_profile {})
 
     @img.iptc_profile = 'test profile'
-    assert_nothing_raised do
+    expect do
       @img.each_profile do |name, value|
         expect(name).to eq('iptc')
         expect(value).to eq('test profile')
       end
-    end
+    end.not_to raise_error
   end
 
   def test_edge
-    assert_nothing_raised do
+    expect do
       res = @img.edge
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.edge(2.0) }
+    end.not_to raise_error
+    expect { @img.edge(2.0) }.not_to raise_error
     expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
     expect { @img.edge('x') }.to raise_error(TypeError)
   end
 
   def test_emboss
-    assert_nothing_raised do
+    expect do
       res = @img.emboss
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.emboss(1.0) }
-    assert_nothing_raised { @img.emboss(1.0, 0.5) }
+    end.not_to raise_error
+    expect { @img.emboss(1.0) }.not_to raise_error
+    expect { @img.emboss(1.0, 0.5) }.not_to raise_error
     expect { @img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)
     expect { @img.emboss(1.0, 'x') }.to raise_error(TypeError)
     expect { @img.emboss('x', 1.0) }.to raise_error(TypeError)
   end
 
   def test_enhance
-    assert_nothing_raised do
+    expect do
       res = @img.enhance
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_equalize
-    assert_nothing_raised do
+    expect do
       res = @img.equalize
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_equalize_channel
-    assert_nothing_raised do
+    expect do
       res = @img.equalize_channel
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.equalize_channel }
-    assert_nothing_raised { @img.equalize_channel(Magick::RedChannel) }
-    assert_nothing_raised { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.equalize_channel }.not_to raise_error
+    expect { @img.equalize_channel(Magick::RedChannel) }.not_to raise_error
+    expect { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.equalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_erase!
-    assert_nothing_raised do
+    expect do
       res = @img.erase!
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_excerpt
     res = nil
     img = Magick::Image.new(200, 200)
-    assert_nothing_raised { res = @img.excerpt(20, 20, 50, 100) }
+    expect { res = @img.excerpt(20, 20, 50, 100) }.not_to raise_error
     assert_not_same(img, res)
     expect(res.columns).to eq(50)
     expect(res.rows).to eq(100)
 
-    assert_nothing_raised { img.excerpt!(20, 20, 50, 100) }
+    expect { img.excerpt!(20, 20, 50, 100) }.not_to raise_error
     expect(img.columns).to eq(50)
     expect(img.rows).to eq(100)
   end
 
   def test_export_pixels
-    assert_nothing_raised do
+    expect do
       res = @img.export_pixels
       assert_instance_of(Array, res)
       expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
       res.each do |p|
         assert_kind_of(Integer, p)
       end
-    end
-    assert_nothing_raised { @img.export_pixels(0) }
-    assert_nothing_raised { @img.export_pixels(0, 0) }
-    assert_nothing_raised { @img.export_pixels(0, 0, 10) }
-    assert_nothing_raised { @img.export_pixels(0, 0, 10, 10) }
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect { @img.export_pixels(0) }.not_to raise_error
+    expect { @img.export_pixels(0, 0) }.not_to raise_error
+    expect { @img.export_pixels(0, 0, 10) }.not_to raise_error
+    expect { @img.export_pixels(0, 0, 10, 10) }.not_to raise_error
+    expect do
       res = @img.export_pixels(0, 0, 10, 10, 'RGBA')
       expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels(0, 0, 10, 10, 'I')
       expect(res.length).to eq(10 * 10 * 'I'.length)
-    end
+    end.not_to raise_error
 
     # too many arguments
     expect { @img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
   end
 
   def test_export_pixels_to_str
-    assert_nothing_raised do
+    expect do
       res = @img.export_pixels_to_str
       assert_instance_of(String, res)
       expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
-    end
-    assert_nothing_raised { @img.export_pixels_to_str(0) }
-    assert_nothing_raised { @img.export_pixels_to_str(0, 0) }
-    assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10) }
-    assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10, 10) }
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect { @img.export_pixels_to_str(0) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10, 10) }.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
       expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I')
       expect(res.length).to eq(10 * 10 * 'I'.length)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
       expect(res.length).to eq(10 * 10 * 1)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
       expect(res.length).to eq(10 * 10 * 2)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
       expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
       expect(res.length).to eq(10 * 10 * 4)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
       expect(res.length).to eq(10 * 10 * 8)
-    end
-    assert_nothing_raised { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }
+    end.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }.not_to raise_error
 
     # too many arguments
     expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }.to raise_error(ArgumentError)
@@ -683,14 +683,14 @@ class Image2_UT < Minitest::Test
   end
 
   def test_extent
-    assert_nothing_raised { @img.extent(40, 40) }
+    expect { @img.extent(40, 40) }.not_to raise_error
     res = @img.extent(40, 40)
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
     expect(res.columns).to eq(40)
     expect(res.rows).to eq(40)
-    assert_nothing_raised { @img.extent(40, 40, 5) }
-    assert_nothing_raised { @img.extent(40, 40, 5, 5) }
+    expect { @img.extent(40, 40, 5) }.not_to raise_error
+    expect { @img.extent(40, 40, 5, 5) }.not_to raise_error
     expect { @img.extent(-40) }.to raise_error(ArgumentError)
     expect { @img.extent(-40, 40) }.to raise_error(ArgumentError)
     expect { @img.extent(40, -40) }.to raise_error(ArgumentError)
@@ -705,31 +705,31 @@ class Image2_UT < Minitest::Test
   def test_find_similar_region
     girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     region = girl.crop(10, 10, 50, 50)
-    assert_nothing_raised do
+    expect do
       x, y = girl.find_similar_region(region)
       assert_not_nil(x)
       assert_not_nil(y)
       expect(x).to eq(10)
       expect(y).to eq(10)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       x, y = girl.find_similar_region(region, 0)
       expect(x).to eq(10)
       expect(y).to eq(10)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       x, y = girl.find_similar_region(region, 0, 0)
       expect(x).to eq(10)
       expect(y).to eq(10)
-    end
+    end.not_to raise_error
 
     list = Magick::ImageList.new
     list << region
-    assert_nothing_raised do
+    expect do
       x, y = girl.find_similar_region(list, 0, 0)
       expect(x).to eq(10)
       expect(y).to eq(10)
-    end
+    end.not_to raise_error
 
     x = girl.find_similar_region(@img)
     assert_nil(x)
@@ -743,58 +743,58 @@ class Image2_UT < Minitest::Test
   end
 
   def test_flip
-    assert_nothing_raised do
+    expect do
       res = @img.flip
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_flip!
-    assert_nothing_raised do
+    expect do
       res = @img.flip!
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_flop
-    assert_nothing_raised do
+    expect do
       res = @img.flop
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_flop!
-    assert_nothing_raised do
+    expect do
       res = @img.flop!
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_frame
-    assert_nothing_raised do
+    expect do
       res = @img.frame
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.frame(50) }
-    assert_nothing_raised { @img.frame(50, 50) }
-    assert_nothing_raised { @img.frame(50, 50, 25) }
-    assert_nothing_raised { @img.frame(50, 50, 25, 25) }
-    assert_nothing_raised { @img.frame(50, 50, 25, 25, 6) }
-    assert_nothing_raised { @img.frame(50, 50, 25, 25, 6, 6) }
-    assert_nothing_raised { @img.frame(50, 50, 25, 25, 6, 6, 'red') }
+    end.not_to raise_error
+    expect { @img.frame(50) }.not_to raise_error
+    expect { @img.frame(50, 50) }.not_to raise_error
+    expect { @img.frame(50, 50, 25) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6, 6) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6, 6, 'red') }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.frame(50, 50, 25, 25, 6, 6, red) }
+    expect { @img.frame(50, 50, 25, 25, 6, 6, red) }.not_to raise_error
     expect { @img.frame(50, 50, 25, 25, 6, 6, 2) }.to raise_error(TypeError)
     expect { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }.to raise_error(ArgumentError)
   end
 
   def test_fx
-    assert_nothing_raised { @img.fx('1/2') }
-    assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel) }
-    assert_nothing_raised { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }
+    expect { @img.fx('1/2') }.not_to raise_error
+    expect { @img.fx('1/2', Magick::BlueChannel) }.not_to raise_error
+    expect { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }.not_to raise_error
     expect { @img.fx }.to raise_error(ArgumentError)
     expect { @img.fx(Magick::BlueChannel) }.to raise_error(ArgumentError)
     expect { @img.fx(1) }.to raise_error(TypeError)
@@ -802,14 +802,14 @@ class Image2_UT < Minitest::Test
   end
 
   def test_gamma_channel
-    assert_nothing_raised do
+    expect do
       res = @img.gamma_channel(0.8)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     expect { @img.gamma_channel }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.gamma_channel(0.8, Magick::RedChannel) }
-    assert_nothing_raised { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }
+    expect { @img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
+    expect { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.gamma_channel(0.8, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
@@ -817,28 +817,28 @@ class Image2_UT < Minitest::Test
     img = Magick::Image.read('gradient:') { self.size = '20x600' }
     img = img.first
     img.rotate!(90)
-    assert_nothing_raised { img.function_channel Magick::PolynomialFunction, 0.33 }
-    assert_nothing_raised { img.function_channel Magick::PolynomialFunction, 4, -1.5 }
-    assert_nothing_raised { img.function_channel Magick::PolynomialFunction, 4, -4, 1 }
-    assert_nothing_raised { img.function_channel Magick::PolynomialFunction, -25, 53, -36, 8.3, 0.2 }
+    expect { img.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, 4, -1.5 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, 4, -4, 1 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, -25, 53, -36, 8.3, 0.2 }.not_to raise_error
 
-    assert_nothing_raised { img.function_channel Magick::SinusoidFunction, 1 }
-    assert_nothing_raised { img.function_channel Magick::SinusoidFunction, 1, 90 }
-    assert_nothing_raised { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75 }
+    expect { img.function_channel Magick::SinusoidFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 1, 90 }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75 }.not_to raise_error
 
-    assert_nothing_raised { img.function_channel Magick::ArcsinFunction, 1 }
-    assert_nothing_raised { img.function_channel Magick::ArcsinFunction, 0.5 }
-    assert_nothing_raised { img.function_channel Magick::ArcsinFunction, 0.4, 0.7 }
-    assert_nothing_raised { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5 }
+    expect { img.function_channel Magick::ArcsinFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.5 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.4, 0.7 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5 }.not_to raise_error
 
-    assert_nothing_raised { img.function_channel Magick::ArctanFunction, 1 }
-    assert_nothing_raised { img.function_channel Magick::ArctanFunction, 10, 0.7 }
-    assert_nothing_raised { img.function_channel Magick::ArctanFunction, 5, 0.7, 1.2 }
-    assert_nothing_raised { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75 }
+    expect { img.function_channel Magick::ArctanFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 10, 0.7 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 5, 0.7, 1.2 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75 }.not_to raise_error
 
     # with channel args
-    assert_nothing_raised { img.function_channel Magick::PolynomialFunction, 0.33, Magick::RedChannel }
-    assert_nothing_raised { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }
+    expect { img.function_channel Magick::PolynomialFunction, 0.33, Magick::RedChannel }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
 
     # invalid args
     expect { img.function_channel }.to raise_error(ArgumentError)
@@ -852,67 +852,67 @@ class Image2_UT < Minitest::Test
 
   def test_gramma_correct
     expect { @img.gamma_correct }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @img.gamma_correct(0.8)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.gamma_correct(0.8, 0.9) }
-    assert_nothing_raised { @img.gamma_correct(0.8, 0.9, 1.0) }
-    assert_nothing_raised { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }
+    end.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }.not_to raise_error
     # too many arguments
     expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }.to raise_error(ArgumentError)
   end
 
   def test_gaussian_blur
-    assert_nothing_raised do
+    expect do
       res = @img.gaussian_blur
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.gaussian_blur(0.0) }
-    assert_nothing_raised { @img.gaussian_blur(0.0, 3.0) }
+    end.not_to raise_error
+    expect { @img.gaussian_blur(0.0) }.not_to raise_error
+    expect { @img.gaussian_blur(0.0, 3.0) }.not_to raise_error
     # sigma must be != 0.0
     expect { @img.gaussian_blur(1.0, 0.0) }.to raise_error(ArgumentError)
     expect { @img.gaussian_blur(1.0, 3.0, 2) }.to raise_error(ArgumentError)
   end
 
   def test_gaussian_blur_channel
-    assert_nothing_raised do
+    expect do
       res = @img.gaussian_blur_channel
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.gaussian_blur_channel(0.0) }
-    assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0) }
-    assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }
-    assert_nothing_raised { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_get_exif_by_entry
-    assert_nothing_raised do
+    expect do
       res = @img.get_exif_by_entry
       assert_instance_of(Array, res)
-    end
+    end.not_to raise_error
   end
 
   def test_get_exif_by_number
-    assert_nothing_raised do
+    expect do
       res = @img.get_exif_by_number
       assert_instance_of(Hash, res)
-    end
+    end.not_to raise_error
   end
 
   def test_get_pixels
-    assert_nothing_raised do
+    expect do
       pixels = @img.get_pixels(0, 0, @img.columns, 1)
       assert_instance_of(Array, pixels)
       expect(pixels.length).to eq(@img.columns)
       assert_block do
         pixels.all? { |p| p.is_a? Magick::Pixel }
       end
-    end
+    end.not_to raise_error
     expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
     expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
     expect { @img.get_pixels(0,  0, @img.columns + 1, 1) }.to raise_error(RangeError)
@@ -927,25 +927,25 @@ class Image2_UT < Minitest::Test
   end
 
   def test_histogram?
-    assert_nothing_raised { @img.histogram? }
+    expect { @img.histogram? }.not_to raise_error
     assert(@img.histogram?)
   end
 
   def test_implode
-    assert_nothing_raised do
+    expect do
       res = @img.implode(0.5)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
   end
 
   def test_import_pixels
     pixels = @img.export_pixels(0, 0, @img.columns, 1, 'RGB')
-    assert_nothing_raised do
+    expect do
       res = @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     expect { @img.import_pixels }.to raise_error(ArgumentError)
     expect { @img.import_pixels(0) }.to raise_error(ArgumentError)
     expect { @img.import_pixels(0, 0) }.to raise_error(ArgumentError)
@@ -970,14 +970,14 @@ class Image2_UT < Minitest::Test
   end
 
   def test_level
-    assert_nothing_raised do
+    expect do
       res = @img.level
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.level(0.0) }
-    assert_nothing_raised { @img.level(0.0, 1.0) }
-    assert_nothing_raised { @img.level(0.0, 1.0, Magick::QuantumRange) }
+    end.not_to raise_error
+    expect { @img.level(0.0) }.not_to raise_error
+    expect { @img.level(0.0, 1.0) }.not_to raise_error
+    expect { @img.level(0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
     expect { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
     expect { @img.level('x') }.to raise_error(ArgumentError)
     expect { @img.level(0.0, 'x') }.to raise_error(ArgumentError)
@@ -994,24 +994,24 @@ class Image2_UT < Minitest::Test
     img1 = @img.level2(10, 200, 2)
     expect(img1).to eq(img2)
 
-    assert_nothing_raised { @img.level2 }
-    assert_nothing_raised { @img.level2(10) }
-    assert_nothing_raised { @img.level2(10, 10) }
-    assert_nothing_raised { @img.level2(10, 10, 10) }
+    expect { @img.level2 }.not_to raise_error
+    expect { @img.level2(10) }.not_to raise_error
+    expect { @img.level2(10, 10) }.not_to raise_error
+    expect { @img.level2(10, 10, 10) }.not_to raise_error
     expect { @img.level2(10, 10, 10, 10) }.to raise_error(ArgumentError)
   end
 
   def test_level_channel
     expect { @img.level_channel }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @img.level_channel(Magick::RedChannel)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised { @img.level_channel(Magick::RedChannel, 0.0) }
-    assert_nothing_raised { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }
-    assert_nothing_raised { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }
+    expect { @img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }.not_to raise_error
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
 
     expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
     expect { @img.level_channel(2) }.to raise_error(TypeError)
@@ -1022,17 +1022,17 @@ class Image2_UT < Minitest::Test
 
   def test_level_colors
     res = nil
-    assert_nothing_raised do
+    expect do
       res = @img.level_colors
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
 
-    assert_nothing_raised { @img.level_colors('black') }
-    assert_nothing_raised { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }
-    assert_nothing_raised { @img.level_colors(Magick::Pixel.new(0, 0, 0), Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange, Magick::QuantumRange)) }
-    assert_nothing_raised { @img.level_colors('black', 'white') }
-    assert_nothing_raised { @img.level_colors('black', 'white', false) }
+    expect { @img.level_colors('black') }.not_to raise_error
+    expect { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }.not_to raise_error
+    expect { @img.level_colors(Magick::Pixel.new(0, 0, 0), Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange, Magick::QuantumRange)) }.not_to raise_error
+    expect { @img.level_colors('black', 'white') }.not_to raise_error
+    expect { @img.level_colors('black', 'white', false) }.not_to raise_error
 
     expect { @img.level_colors('black', 'white', false, 1) }.to raise_error(TypeError)
     expect { @img.level_colors([]) }.to raise_error(TypeError)
@@ -1041,17 +1041,17 @@ class Image2_UT < Minitest::Test
 
   def test_levelize_channel
     res = nil
-    assert_nothing_raised do
+    expect do
       res = @img.levelize_channel(0, Magick::QuantumRange)
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
 
-    assert_nothing_raised { @img.levelize_channel(0) }
-    assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange) }
-    assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange, 0.5) }
-    assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }
-    assert_nothing_raised { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }
+    expect { @img.levelize_channel(0) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
 
     expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }.to raise_error(TypeError)
     expect { @img.levelize_channel }.to raise_error(ArgumentError)
@@ -1066,12 +1066,12 @@ class Image2_UT < Minitest::Test
   #       end
   #
   #       res = nil
-  #       assert_nothing_raised do
+  #       expect do
   #         res = @img.liquid_rescale(15, 15)
-  #       end
+  #       end.not_to raise_error
   #       expect(res.columns).to eq(15)
   #       expect(res.rows).to eq(15)
-  #       assert_nothing_raised { @img.liquid_rescale(15, 15, 0, 0) }
+  #       expect { @img.liquid_rescale(15, 15, 0, 0) }.not_to raise_error
   #       expect { @img.liquid_rescale(15) }.to raise_error(ArgumentError)
   #       expect { @img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)
   #       expect { @img.liquid_rescale([], 15) }.to raise_error(TypeError)
@@ -1081,11 +1081,11 @@ class Image2_UT < Minitest::Test
   #     end
 
   def test_magnify
-    assert_nothing_raised do
+    expect do
       res = @img.magnify
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
     res = @img.magnify!
     assert_same(@img, res)
@@ -1095,16 +1095,16 @@ class Image2_UT < Minitest::Test
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     d = nil
     img2 = nil
-    assert_nothing_raised { d = Marshal.dump(img) }
-    assert_nothing_raised { img2 = Marshal.load(d) }
+    expect { d = Marshal.dump(img) }.not_to raise_error
+    expect { img2 = Marshal.load(d) }.not_to raise_error
     expect(img2).to eq(img)
   end
 
   def test_mask
     cimg = Magick::Image.new(10, 10)
-    assert_nothing_raised { @img.mask(cimg) }
+    expect { @img.mask(cimg) }.not_to raise_error
     res = nil
-    assert_nothing_raised { res = @img.mask }
+    expect { res = @img.mask }.not_to raise_error
     assert_not_nil(res)
     assert_not_same(cimg, res)
     expect(res.columns).to eq(20)
@@ -1122,23 +1122,23 @@ class Image2_UT < Minitest::Test
   end
 
   def test_matte_fill_to_border
-    assert_nothing_raised do
+    expect do
       res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.matte_fill_to_border(@img.columns, @img.rows) }
+    end.not_to raise_error
+    expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
     expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
     expect { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
   end
 
   def test_matte_floodfill
-    assert_nothing_raised do
+    expect do
       res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.matte_floodfill(@img.columns, @img.rows) }
+    end.not_to raise_error
+    expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
 
     Magick::PaintMethod.values do |method|
       next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
@@ -1147,56 +1147,56 @@ class Image2_UT < Minitest::Test
     end
     expect { @img.matte_floodfill(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
     expect { @img.matte_floodfill(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }
+    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
 
   def test_matte_replace
-    assert_nothing_raised do
+    expect do
       res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_matte_reset!
-    assert_nothing_raised do
+    expect do
       res = @img.matte_reset!
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_median_filter
-    assert_nothing_raised do
+    expect do
       res = @img.median_filter
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.median_filter(0.5) }
+    end.not_to raise_error
+    expect { @img.median_filter(0.5) }.not_to raise_error
     expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
     expect { @img.median_filter('x') }.to raise_error(TypeError)
   end
 
   def test_minify
-    assert_nothing_raised do
+    expect do
       res = @img.minify
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
 
     res = @img.minify!
     assert_same(@img, res)
   end
 
   def test_modulate
-    assert_nothing_raised do
+    expect do
       res = @img.modulate
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.modulate(0.5) }
-    assert_nothing_raised { @img.modulate(0.5, 0.5) }
-    assert_nothing_raised { @img.modulate(0.5, 0.5, 0.5) }
+    end.not_to raise_error
+    expect { @img.modulate(0.5) }.not_to raise_error
+    expect { @img.modulate(0.5, 0.5) }.not_to raise_error
+    expect { @img.modulate(0.5, 0.5, 0.5) }.not_to raise_error
     expect { @img.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
     expect { @img.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
     expect { @img.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
@@ -1211,92 +1211,92 @@ class Image2_UT < Minitest::Test
   end
 
   def test_motion_blur
-    assert_nothing_raised do
+    expect do
       res = @img.motion_blur(1.0, 7.0, 180)
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.motion_blur(1.0, -1.0, 180) }
+    expect { @img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
   end
 
   def test_negate
-    assert_nothing_raised do
+    expect do
       res = @img.negate
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.negate(true) }
+    end.not_to raise_error
+    expect { @img.negate(true) }.not_to raise_error
     expect { @img.negate(true, 2) }.to raise_error(ArgumentError)
   end
 
   def test_negate_channel
-    assert_nothing_raised do
+    expect do
       res = @img.negate_channel
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.negate_channel(true) }
-    assert_nothing_raised { @img.negate_channel(true, Magick::RedChannel) }
-    assert_nothing_raised { @img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.negate_channel(true) }.not_to raise_error
+    expect { @img.negate_channel(true, Magick::RedChannel) }.not_to raise_error
+    expect { @img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.negate_channel(true, Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_normalize
-    assert_nothing_raised do
+    expect do
       res = @img.normalize
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_normalize_channel
-    assert_nothing_raised do
+    expect do
       res = @img.normalize_channel
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.normalize_channel(Magick::RedChannel) }
-    assert_nothing_raised { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.normalize_channel(Magick::RedChannel) }.not_to raise_error
+    expect { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.normalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
   end
 
   def test_oil_paint
-    assert_nothing_raised do
+    expect do
       res = @img.oil_paint
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.oil_paint(2.0) }
+    end.not_to raise_error
+    expect { @img.oil_paint(2.0) }.not_to raise_error
     expect { @img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
   end
 
   def test_opaque
-    assert_nothing_raised do
+    expect do
       res = @img.opaque('white', 'red')
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
+    end.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
-    assert_nothing_raised { @img.opaque(red, blue) }
+    expect { @img.opaque(red, blue) }.not_to raise_error
     expect { @img.opaque(red, 2) }.to raise_error(TypeError)
     expect { @img.opaque(2, blue) }.to raise_error(TypeError)
   end
 
   def test_opaque_channel
     res = nil
-    assert_nothing_raised { res = @img.opaque_channel('white', 'red') }
+    expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
     assert_not_same(res, @img)
-    assert_nothing_raised { @img.opaque_channel('red', 'blue', true) }
-    assert_nothing_raised { @img.opaque_channel('red', 'blue', true, 50) }
-    assert_nothing_raised { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }
-    assert_nothing_raised { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel) }
-    assert_nothing_raised do
+    expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
+    expect { @img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
+    expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }.not_to raise_error
+    expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+    expect do
       @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel)
-    end
+    end.not_to raise_error
 
     expect { @img.opaque_channel('red', 'blue', true, 50, 50) }.to raise_error(TypeError)
     expect { @img.opaque_channel('red', 'blue', true, []) }.to raise_error(TypeError)
@@ -1306,42 +1306,42 @@ class Image2_UT < Minitest::Test
   end
 
   def test_opaque?
-    assert_nothing_raised do
+    expect do
       assert_block { @img.opaque? }
-    end
+    end.not_to raise_error
     @img.alpha(Magick::TransparentAlphaChannel)
     assert_block { !@img.opaque? }
   end
 
   def test_ordered_dither
-    assert_nothing_raised do
+    expect do
       res = @img.ordered_dither
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.ordered_dither('3x3') }
-    assert_nothing_raised { @img.ordered_dither(2) }
-    assert_nothing_raised { @img.ordered_dither(3) }
-    assert_nothing_raised { @img.ordered_dither(4) }
+    end.not_to raise_error
+    expect { @img.ordered_dither('3x3') }.not_to raise_error
+    expect { @img.ordered_dither(2) }.not_to raise_error
+    expect { @img.ordered_dither(3) }.not_to raise_error
+    expect { @img.ordered_dither(4) }.not_to raise_error
     expect { @img.ordered_dither(5) }.to raise_error(ArgumentError)
     expect { @img.ordered_dither(2, 1) }.to raise_error(ArgumentError)
   end
 
   def test_paint_transparent
     res = nil
-    assert_nothing_raised { res = @img.paint_transparent('red') }
+    expect { res = @img.paint_transparent('red') }.not_to raise_error
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
     assert_not_same(res, @img)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }
+    expect { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }
+    expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha, true, 50) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }
+    expect { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
 
     # Too many arguments
@@ -1354,18 +1354,18 @@ class Image2_UT < Minitest::Test
 
   def test_palette?
     img = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    assert_nothing_raised do
+    expect do
       assert_block { !img.palette? }
-    end
+    end.not_to raise_error
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     assert_block { img.palette? }
   end
 
   def test_pixel_color
-    assert_nothing_raised do
+    expect do
       res = @img.pixel_color(0, 0)
       assert_instance_of(Magick::Pixel, res)
-    end
+    end.not_to raise_error
     res = @img.pixel_color(0, 0)
     expect(res.to_color).to eq(@img.background_color)
     res = @img.pixel_color(0, 0, 'red')
@@ -1374,34 +1374,34 @@ class Image2_UT < Minitest::Test
     expect(res.to_color).to eq('red')
 
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
-    assert_nothing_raised { @img.pixel_color(0, 0, blue) }
+    expect { @img.pixel_color(0, 0, blue) }.not_to raise_error
     # If args are out-of-bounds return the background color
     img = Magick::Image.new(10, 10) { self.background_color = 'blue' }
     expect(img.pixel_color(50, 50).to_color).to eq('blue')
 
-    assert_nothing_raised do
+    expect do
       @img.class_type = Magick::PseudoClass
       res = @img.pixel_color(0, 0, 'red')
       expect(res.to_color).to eq('blue')
-    end
+    end.not_to raise_error
   end
 
   def test_polaroid
-    assert_nothing_raised { @img.polaroid }
-    assert_nothing_raised { @img.polaroid(5) }
+    expect { @img.polaroid }.not_to raise_error
+    expect { @img.polaroid(5) }.not_to raise_error
     assert_instance_of(Magick::Image, @img.polaroid)
     expect { @img.polaroid('x') }.to raise_error(TypeError)
     expect { @img.polaroid(5, 'x') }.to raise_error(ArgumentError)
   end
 
   def test_posterize
-    assert_nothing_raised do
+    expect do
       res = @img.posterize
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised { @img.posterize(5) }
-    assert_nothing_raised { @img.posterize(5, true) }
+    end.not_to raise_error
+    expect { @img.posterize(5) }.not_to raise_error
+    expect { @img.posterize(5, true) }.not_to raise_error
     expect { @img.posterize(5, true, 'x') }.to raise_error(ArgumentError)
   end
 end

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -9,14 +9,14 @@ class Image3_UT < Minitest::Test
   end
 
   def test_profile!
-    assert_nothing_raised do
+    expect do
       res = @img.profile!('*', nil)
       assert_same(@img, res)
-    end
-    assert_nothing_raised { @img.profile!('icc', @p) }
-    assert_nothing_raised { @img.profile!('iptc', 'xxx') }
-    assert_nothing_raised { @img.profile!('icc', nil) }
-    assert_nothing_raised { @img.profile!('iptc', nil) }
+    end.not_to raise_error
+    expect { @img.profile!('icc', @p) }.not_to raise_error
+    expect { @img.profile!('iptc', 'xxx') }.not_to raise_error
+    expect { @img.profile!('icc', nil) }.not_to raise_error
+    expect { @img.profile!('iptc', nil) }.not_to raise_error
 
     expect { @img.profile!('test', 'foobarbaz') }.to raise_error(ArgumentError)
 
@@ -26,21 +26,21 @@ class Image3_UT < Minitest::Test
   end
 
   def test_quantize
-    assert_nothing_raised do
+    expect do
       res = @img.quantize
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
     Magick::ColorspaceType.values do |cs|
-      assert_nothing_raised { @img.quantize(256, cs) }
+      expect { @img.quantize(256, cs) }.not_to raise_error
     end
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, false) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, true) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, Magick::NoDitherMethod) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, true, 2) }
-    assert_nothing_raised { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }
+    expect { @img.quantize(256, Magick::RGBColorspace, false) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }.not_to raise_error
     expect { @img.quantize('x') }.to raise_error(TypeError)
     expect { @img.quantize(16, 2) }.to raise_error(TypeError)
     expect { @img.quantize(16, Magick::RGBColorspace, false, 'x') }.to raise_error(TypeError)
@@ -48,14 +48,14 @@ class Image3_UT < Minitest::Test
   end
 
   def test_quantum_operator
-    assert_nothing_raised do
+    expect do
       res = @img.quantum_operator(Magick::AddQuantumOperator, 2)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     Magick::QuantumExpressionOperator.values do |op|
-      assert_nothing_raised { @img.quantum_operator(op, 2) }
+      expect { @img.quantum_operator(op, 2) }.not_to raise_error
     end
-    assert_nothing_raised { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }.not_to raise_error
     expect { @img.quantum_operator(2, 2) }.to raise_error(TypeError)
     expect { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }.to raise_error(TypeError)
     expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }.to raise_error(TypeError)
@@ -63,70 +63,70 @@ class Image3_UT < Minitest::Test
   end
 
   def test_radial_blur
-    assert_nothing_raised do
+    expect do
       res = @img.radial_blur(30)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_radial_blur_channel
     res = nil
-    assert_nothing_raised { res = @img.radial_blur_channel(30) }
+    expect { res = @img.radial_blur_channel(30) }.not_to raise_error
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
-    assert_nothing_raised { res = @img.radial_blur_channel(30, Magick::RedChannel) }
-    assert_nothing_raised { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }
+    expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
+    expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
 
     expect { @img.radial_blur_channel }.to raise_error(ArgumentError)
     expect { @img.radial_blur_channel(30, 2) }.to raise_error(TypeError)
   end
 
   def test_raise
-    assert_nothing_raised do
+    expect do
       res = @img.raise
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.raise(4) }
-    assert_nothing_raised { @img.raise(4, 4) }
-    assert_nothing_raised { @img.raise(4, 4, false) }
+    end.not_to raise_error
+    expect { @img.raise(4) }.not_to raise_error
+    expect { @img.raise(4, 4) }.not_to raise_error
+    expect { @img.raise(4, 4, false) }.not_to raise_error
     expect { @img.raise('x') }.to raise_error(TypeError)
     expect { @img.raise(2, 'x') }.to raise_error(TypeError)
     expect { @img.raise(4, 4, false, 2) }.to raise_error(ArgumentError)
   end
 
   def test_random_threshold_channel
-    assert_nothing_raised do
+    expect do
       res = @img.random_threshold_channel('20%')
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     threshold = Magick::Geometry.new(20)
-    assert_nothing_raised { @img.random_threshold_channel(threshold) }
-    assert_nothing_raised { @img.random_threshold_channel(threshold, Magick::RedChannel) }
-    assert_nothing_raised { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }
+    expect { @img.random_threshold_channel(threshold) }.not_to raise_error
+    expect { @img.random_threshold_channel(threshold, Magick::RedChannel) }.not_to raise_error
+    expect { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.random_threshold_channel }.to raise_error(ArgumentError)
     expect { @img.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
   end
 
   def test_recolor
-    assert_nothing_raised { @img.recolor([1, 1, 2, 1]) }
+    expect { @img.recolor([1, 1, 2, 1]) }.not_to raise_error
     expect { @img.recolor('x') }.to raise_error(TypeError)
     expect { @img.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
   end
 
   def test_reduce_noise
-    assert_nothing_raised do
+    expect do
       res = @img.reduce_noise(0)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.reduce_noise(4) }
+    end.not_to raise_error
+    expect { @img.reduce_noise(4) }.not_to raise_error
   end
 
   def test_remap
     remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    assert_nothing_raised { @img.remap(remap_image) }
-    assert_nothing_raised { @img.remap(remap_image, Magick::NoDitherMethod) }
-    assert_nothing_raised { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }
-    assert_nothing_raised { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }
+    expect { @img.remap(remap_image) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
 
     expect { @img.remap }.to raise_error(ArgumentError)
     expect { @img.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
@@ -136,15 +136,15 @@ class Image3_UT < Minitest::Test
   def test_resample
     @img.x_resolution = 72
     @img.y_resolution = 72
-    assert_nothing_raised { @img.resample }
-    assert_nothing_raised { @img.resample(100) }
-    assert_nothing_raised { @img.resample(100, 100) }
+    expect { @img.resample }.not_to raise_error
+    expect { @img.resample(100) }.not_to raise_error
+    expect { @img.resample(100, 100) }.not_to raise_error
 
     @img.x_resolution = 0
     @img.y_resolution = 0
-    assert_nothing_raised { @img.resample }
-    assert_nothing_raised { @img.resample(100) }
-    assert_nothing_raised { @img.resample(100, 100) }
+    expect { @img.resample }.not_to raise_error
+    expect { @img.resample(100) }.not_to raise_error
+    expect { @img.resample(100, 100) }.not_to raise_error
 
     girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     expect(girl.x_resolution).to eq(240.0)
@@ -160,9 +160,9 @@ class Image3_UT < Minitest::Test
     expect(girl.y_resolution).to eq(240.0)
 
     Magick::FilterType.values do |filter|
-      assert_nothing_raised { @img.resample(50, 50, filter) }
+      expect { @img.resample(50, 50, filter) }.not_to raise_error
     end
-    assert_nothing_raised { @img.resample(50, 50, Magick::PointFilter, 2.0) }
+    expect { @img.resample(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
 
     expect { @img.resample('x') }.to raise_error(TypeError)
     expect { @img.resample(100, 'x') }.to raise_error(TypeError)
@@ -174,25 +174,25 @@ class Image3_UT < Minitest::Test
   end
 
   def test_resample!
-    assert_nothing_raised do
+    expect do
       res = @img.resample!(50)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.resample!(50) }.to raise_error(FreezeError)
   end
 
   def test_resize
-    assert_nothing_raised do
+    expect do
       res = @img.resize(2)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.resize(50, 50) }
+    end.not_to raise_error
+    expect { @img.resize(50, 50) }.not_to raise_error
 
     Magick::FilterType.values do |filter|
-      assert_nothing_raised { @img.resize(50, 50, filter) }
+      expect { @img.resize(50, 50, filter) }.not_to raise_error
     end
-    assert_nothing_raised { @img.resize(50, 50, Magick::PointFilter, 2.0) }
+    expect { @img.resize(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
     expect { @img.resize('x') }.to raise_error(TypeError)
     expect { @img.resize(50, 'x') }.to raise_error(TypeError)
     expect { @img.resize(50, 50, 2) }.to raise_error(TypeError)
@@ -205,10 +205,10 @@ class Image3_UT < Minitest::Test
   end
 
   def test_resize!
-    assert_nothing_raised do
+    expect do
       res = @img.resize!(2)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.resize!(0.50) }.to raise_error(FreezeError)
   end
@@ -276,7 +276,7 @@ class Image3_UT < Minitest::Test
   def test_resize_to_fit
     img = Magick::Image.new(200, 250)
     res = nil
-    assert_nothing_raised { res = img.resize_to_fit(50, 50) }
+    expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
     assert_not_nil(res)
     assert_instance_of(Magick::Image, res)
     assert_not_same(img, res)
@@ -304,49 +304,49 @@ class Image3_UT < Minitest::Test
   end
 
   def test_roll
-    assert_nothing_raised do
+    expect do
       res = @img.roll(5, 5)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_rotate
-    assert_nothing_raised do
+    expect do
       res = @img.rotate(45)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.rotate(-45) }
+    end.not_to raise_error
+    expect { @img.rotate(-45) }.not_to raise_error
 
     img = Magick::Image.new(100, 50)
-    assert_nothing_raised do
+    expect do
       res = img.rotate(90, '>')
       assert_instance_of(Magick::Image, res)
       expect(res.columns).to eq(50)
       expect(res.rows).to eq(100)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = img.rotate(90, '<')
       assert_nil(res)
-    end
+    end.not_to raise_error
     expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
     expect { img.rotate(90, []) }.to raise_error(TypeError)
   end
 
   def test_rotate!
-    assert_nothing_raised do
+    expect do
       res = @img.rotate!(45)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.rotate!(45) }.to raise_error(FreezeError)
   end
 
   def test_sample
-    assert_nothing_raised do
+    expect do
       res = @img.sample(10, 10)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.sample(2) }
+    end.not_to raise_error
+    expect { @img.sample(2) }.not_to raise_error
     expect { @img.sample }.to raise_error(ArgumentError)
     expect { @img.sample(0) }.to raise_error(ArgumentError)
     expect { @img.sample(0, 25) }.to raise_error(ArgumentError)
@@ -357,20 +357,20 @@ class Image3_UT < Minitest::Test
   end
 
   def test_sample!
-    assert_nothing_raised do
+    expect do
       res = @img.sample!(2)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.sample!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_scale
-    assert_nothing_raised do
+    expect do
       res = @img.scale(10, 10)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.scale(2) }
+    end.not_to raise_error
+    expect { @img.scale(2) }.not_to raise_error
     expect { @img.scale }.to raise_error(ArgumentError)
     expect { @img.scale(25, 25, 25) }.to raise_error(ArgumentError)
     expect { @img.scale('x') }.to raise_error(TypeError)
@@ -378,19 +378,19 @@ class Image3_UT < Minitest::Test
   end
 
   def test_scale!
-    assert_nothing_raised do
+    expect do
       res = @img.scale!(2)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.scale!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_segment
-    assert_nothing_raised do
+    expect do
       res = @img.segment
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
     # Don't test colorspaces that require PsuedoColor images
     (Magick::ColorspaceType.values - [Magick::OHTAColorspace,
@@ -404,12 +404,12 @@ class Image3_UT < Minitest::Test
                                       Magick::Rec601YCbCrColorspace,
                                       Magick::Rec709YCbCrColorspace,
                                       Magick::LogColorspace]).each do |cs|
-      assert_nothing_raised { @img.segment(cs) }
+      expect { @img.segment(cs) }.not_to raise_error
     end
 
-    assert_nothing_raised { @img.segment(Magick::RGBColorspace, 2.0) }
-    assert_nothing_raised { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }
-    assert_nothing_raised { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }
+    expect { @img.segment(Magick::RGBColorspace, 2.0) }.not_to raise_error
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }.not_to raise_error
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }.not_to raise_error
 
     expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }.to raise_error(ArgumentError)
     expect { @img.segment(2) }.to raise_error(TypeError)
@@ -419,15 +419,15 @@ class Image3_UT < Minitest::Test
 
   def test_selective_blur_channel
     res = nil
-    assert_nothing_raised { res = @img.selective_blur_channel(0, 1, '10%') }
+    expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
     assert_instance_of(Magick::Image, res)
     assert_not_same(@img, res)
     expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
 
-    assert_nothing_raised { @img.selective_blur_channel(0, 1, 0.1) }
-    assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }
-    assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }
-    assert_nothing_raised { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }
+    expect { @img.selective_blur_channel(0, 1, 0.1) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }.not_to raise_error
 
     expect { @img.selective_blur_channel(0, 1) }.to raise_error(ArgumentError)
     expect { @img.selective_blur_channel(0, 1, 0.1, '10%') }.to raise_error(TypeError)
@@ -440,44 +440,44 @@ class Image3_UT < Minitest::Test
   end
 
   def test_sepiatone
-    assert_nothing_raised do
+    expect do
       res = @img.sepiatone
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.sepiatone(Magick::QuantumRange * 0.80) }
+    end.not_to raise_error
+    expect { @img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
     expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
     expect { @img.sepiatone('x') }.to raise_error(TypeError)
   end
 
   def test_set_channel_depth
     Magick::ChannelType.values do |ch|
-      assert_nothing_raised { @img.set_channel_depth(ch, 8) }
+      expect { @img.set_channel_depth(ch, 8) }.not_to raise_error
     end
   end
 
   def test_shade
-    assert_nothing_raised do
+    expect do
       res = @img.shade
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.shade(true) }
-    assert_nothing_raised { @img.shade(true, 30) }
-    assert_nothing_raised { @img.shade(true, 30, 30) }
+    end.not_to raise_error
+    expect { @img.shade(true) }.not_to raise_error
+    expect { @img.shade(true, 30) }.not_to raise_error
+    expect { @img.shade(true, 30, 30) }.not_to raise_error
     expect { @img.shade(true, 30, 30, 2) }.to raise_error(ArgumentError)
     expect { @img.shade(true, 'x') }.to raise_error(TypeError)
     expect { @img.shade(true, 30, 'x') }.to raise_error(TypeError)
   end
 
   def test_shadow
-    assert_nothing_raised do
+    expect do
       res = @img.shadow
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.shadow(5) }
-    assert_nothing_raised { @img.shadow(5, 5) }
-    assert_nothing_raised { @img.shadow(5, 5, 3.0) }
-    assert_nothing_raised { @img.shadow(5, 5, 3.0, 0.50) }
-    assert_nothing_raised { @img.shadow(5, 5, 3.0, '50%') }
+    end.not_to raise_error
+    expect { @img.shadow(5) }.not_to raise_error
+    expect { @img.shadow(5, 5) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0, 0.50) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0, '50%') }.not_to raise_error
     expect { @img.shadow(5, 5, 3.0, 0.50, 2) }.to raise_error(ArgumentError)
     expect { @img.shadow('x') }.to raise_error(TypeError)
     expect { @img.shadow(5, 'x') }.to raise_error(TypeError)
@@ -486,78 +486,78 @@ class Image3_UT < Minitest::Test
   end
 
   def test_sharpen
-    assert_nothing_raised do
+    expect do
       res = @img.sharpen
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.sharpen(2.0) }
-    assert_nothing_raised { @img.sharpen(2.0, 1.0) }
+    end.not_to raise_error
+    expect { @img.sharpen(2.0) }.not_to raise_error
+    expect { @img.sharpen(2.0, 1.0) }.not_to raise_error
     expect { @img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)
     expect { @img.sharpen('x') }.to raise_error(TypeError)
     expect { @img.sharpen(2.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_sharpen_channel
-    assert_nothing_raised do
+    expect do
       res = @img.sharpen_channel
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.sharpen_channel(2.0) }
-    assert_nothing_raised { @img.sharpen_channel(2.0, 1.0) }
-    assert_nothing_raised { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }
-    assert_nothing_raised { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.sharpen_channel(2.0) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
     expect { @img.sharpen_channel('x') }.to raise_error(TypeError)
     expect { @img.sharpen_channel(2.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_shave
-    assert_nothing_raised do
+    expect do
       res = @img.shave(5, 5)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.shave!(5, 5)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.shave!(2, 2) }.to raise_error(FreezeError)
   end
 
   def test_shear
-    assert_nothing_raised do
+    expect do
       res = @img.shear(30, 30)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_sigmoidal_contrast_channel
-    assert_nothing_raised do
+    expect do
       res = @img.sigmoidal_contrast_channel
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0) }
-    assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0) }
-    assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }
-    assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }
-    assert_nothing_raised { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }
+    end.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }.to raise_error(TypeError)
     expect { @img.sigmoidal_contrast_channel('x') }.to raise_error(TypeError)
     expect { @img.sigmoidal_contrast_channel(3.0, 'x') }.to raise_error(TypeError)
   end
 
   def test_signature
-    assert_nothing_raised do
+    expect do
       res = @img.signature
       assert_instance_of(String, res)
-    end
+    end.not_to raise_error
   end
 
   def test_sketch
-    assert_nothing_raised { @img.sketch }
-    assert_nothing_raised { @img.sketch(0) }
-    assert_nothing_raised { @img.sketch(0, 1) }
-    assert_nothing_raised { @img.sketch(0, 1, 0) }
+    expect { @img.sketch }.not_to raise_error
+    expect { @img.sketch(0) }.not_to raise_error
+    expect { @img.sketch(0, 1) }.not_to raise_error
+    expect { @img.sketch(0, 1, 0) }.not_to raise_error
     expect { @img.sketch(0, 1, 0, 1) }.to raise_error(ArgumentError)
     expect { @img.sketch('x') }.to raise_error(TypeError)
     expect { @img.sketch(0, 'x') }.to raise_error(TypeError)
@@ -565,11 +565,11 @@ class Image3_UT < Minitest::Test
   end
 
   def test_solarize
-    assert_nothing_raised do
+    expect do
       res = @img.solarize
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.solarize(100) }
+    end.not_to raise_error
+    expect { @img.solarize(100) }.not_to raise_error
     expect { @img.solarize(-100) }.to raise_error(ArgumentError)
     expect { @img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)
     expect { @img.solarize(100, 2) }.to raise_error(ArgumentError)
@@ -583,14 +583,14 @@ class Image3_UT < Minitest::Test
     Magick::SparseColorMethod.values do |v|
       next if v == Magick::UndefinedColorInterpolate
 
-      assert_nothing_raised { img.sparse_color(v, *args) }
+      expect { img.sparse_color(v, *args) }.not_to raise_error
     end
     args << Magick::RedChannel
-    assert_nothing_raised { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
     args << Magick::GreenChannel
-    assert_nothing_raised { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
     args << Magick::BlueChannel
-    assert_nothing_raised { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
 
     # bad calls
     args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
@@ -609,13 +609,13 @@ class Image3_UT < Minitest::Test
   end
 
   def test_splice
-    assert_nothing_raised do
+    expect do
       res = @img.splice(0, 0, 2, 2)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.splice(0, 0, 2, 2, 'red') }
+    end.not_to raise_error
+    expect { @img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @img.splice(0, 0, 2, 2, red) }
+    expect { @img.splice(0, 0, 2, 2, red) }.not_to raise_error
     expect { @img.splice(0, 0, 2, 2, red, 'x') }.to raise_error(ArgumentError)
     expect { @img.splice([], 0, 2, 2, red) }.to raise_error(TypeError)
     expect { @img.splice(0, 'x', 2, 2, red) }.to raise_error(TypeError)
@@ -625,11 +625,11 @@ class Image3_UT < Minitest::Test
   end
 
   def test_spread
-    assert_nothing_raised do
+    expect do
       res = @img.spread
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.spread(3.0) }
+    end.not_to raise_error
+    expect { @img.spread(3.0) }.not_to raise_error
     expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
     expect { @img.spread('x') }.to raise_error(TypeError)
   end
@@ -637,20 +637,20 @@ class Image3_UT < Minitest::Test
   def test_stegano
     @img = Magick::Image.new(100, 100) { self.background_color = 'black' }
     watermark = Magick::Image.new(10, 10) { self.background_color = 'white' }
-    assert_nothing_raised do
+    expect do
       res = @img.stegano(watermark, 0)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
     watermark.destroy!
     expect { @img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_stereo
-    assert_nothing_raised do
+    expect do
       res = @img.stereo(@img)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
     img = Magick::Image.new(20, 20)
     img.destroy!
@@ -659,10 +659,10 @@ class Image3_UT < Minitest::Test
 
   def test_store_pixels
     pixels = @img.get_pixels(0, 0, @img.columns, 1)
-    assert_nothing_raised do
+    expect do
       res = @img.store_pixels(0, 0, @img.columns, 1, pixels)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
 
     pixels[0] = 'x'
     expect { @img.store_pixels(0, 0, @img.columns, 1, pixels) }.to raise_error(TypeError)
@@ -674,25 +674,25 @@ class Image3_UT < Minitest::Test
   end
 
   def test_strip!
-    assert_nothing_raised do
+    expect do
       res = @img.strip!
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_swirl
-    assert_nothing_raised do
+    expect do
       res = @img.swirl(30)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_texture_fill_to_border
     texture = Magick::Image.read('granite:').first
-    assert_nothing_raised do
+    expect do
       res = @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, texture)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     expect { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
     expect { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }.to raise_error(ArgumentError)
     expect { @img.texture_fill_to_border(@img.columns, @img.rows * 2, texture) }.to raise_error(ArgumentError)
@@ -706,28 +706,28 @@ class Image3_UT < Minitest::Test
 
   def test_texture_floodfill
     texture = Magick::Image.read('granite:').first
-    assert_nothing_raised do
+    expect do
       res = @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
     texture.destroy!
     expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture) }.to raise_error(Magick::DestroyedImageError)
   end
 
   def test_threshold
-    assert_nothing_raised do
+    expect do
       res = @img.threshold(100)
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_thumbnail
-    assert_nothing_raised do
+    expect do
       res = @img.thumbnail(10, 10)
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.thumbnail(2) }
+    end.not_to raise_error
+    expect { @img.thumbnail(2) }.not_to raise_error
     expect { @img.thumbnail }.to raise_error(ArgumentError)
     expect { @img.thumbnail(-1.0) }.to raise_error(ArgumentError)
     expect { @img.thumbnail(0, 25) }.to raise_error(ArgumentError)
@@ -747,23 +747,23 @@ class Image3_UT < Minitest::Test
   end
 
   def test_thumbnail!
-    assert_nothing_raised do
+    expect do
       res = @img.thumbnail!(2)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
     @img.freeze
     expect { @img.thumbnail!(0.50) }.to raise_error(FreezeError)
   end
 
   def test_tint
-    assert_nothing_raised do
+    expect do
       pixels = @img.get_pixels(0, 0, 1, 1)
       @img.tint(pixels[0], 1.0)
-    end
-    assert_nothing_raised { @img.tint('red', 1.0) }
-    assert_nothing_raised { @img.tint('red', 1.0, 1.0) }
-    assert_nothing_raised { @img.tint('red', 1.0, 1.0, 1.0) }
-    assert_nothing_raised { @img.tint('red', 1.0, 1.0, 1.0, 1.0) }
+    end.not_to raise_error
+    expect { @img.tint('red', 1.0) }.not_to raise_error
+    expect { @img.tint('red', 1.0, 1.0) }.not_to raise_error
+    expect { @img.tint('red', 1.0, 1.0, 1.0) }.not_to raise_error
+    expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0) }.not_to raise_error
     expect { @img.tint }.to raise_error(ArgumentError)
     expect { @img.tint('red') }.to raise_error(ArgumentError)
     expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
@@ -781,7 +781,7 @@ class Image3_UT < Minitest::Test
 
   def test_to_blob
     res = nil
-    assert_nothing_raised { res = @img.to_blob { self.format = 'miff' } }
+    expect { res = @img.to_blob { self.format = 'miff' } }.not_to raise_error
     assert_instance_of(String, res)
     restored = Magick::Image.from_blob(res)
     expect(restored[0]).to eq(@img)
@@ -789,21 +789,21 @@ class Image3_UT < Minitest::Test
 
   def test_to_color
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised do
+    expect do
       res = @img.to_color(red)
       expect(res).to eq('red')
-    end
+    end.not_to raise_error
   end
 
   def test_transparent
-    assert_nothing_raised do
+    expect do
       res = @img.transparent('white')
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
     pixel = Magick::Pixel.new
-    assert_nothing_raised { @img.transparent(pixel) }
+    expect { @img.transparent(pixel) }.not_to raise_error
     expect { @img.transparent('white', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.transparent('white', alpha: Magick::TransparentAlpha) }
+    expect { @img.transparent('white', alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.transparent('white', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.transparent('white', Magick::TransparentAlpha, 2) }.to raise_error(ArgumentError)
@@ -813,80 +813,80 @@ class Image3_UT < Minitest::Test
 
   def test_transparent_chroma
     assert_instance_of(Magick::Image, @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)))
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }.not_to raise_error
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), true, alpha: Magick::TransparentAlpha) }
+    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), true, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
 
   def test_transpose
-    assert_nothing_raised do
+    expect do
       res = @img.transpose
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.transpose!
       assert_instance_of(Magick::Image, res)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_transverse
-    assert_nothing_raised do
+    expect do
       res = @img.transverse
       assert_instance_of(Magick::Image, res)
       assert_not_same(@img, res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @img.transverse!
       assert_instance_of(Magick::Image, res)
       assert_same(@img, res)
-    end
+    end.not_to raise_error
   end
 
   def test_trim
     # Can't use the default image because it's a solid color
     hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    assert_nothing_raised do
+    expect do
       assert_instance_of(Magick::Image, hat.trim)
       assert_instance_of(Magick::Image, hat.trim(10))
-    end
+    end.not_to raise_error
     expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
 
-    assert_nothing_raised do
+    expect do
       res = hat.trim!
       assert_same(hat, res)
 
       res = hat.trim!(10)
       assert_same(hat, res)
-    end
+    end.not_to raise_error
     expect { hat.trim!(10, 10) }.to raise_error(ArgumentError)
   end
 
   def test_unique_colors
-    assert_nothing_raised do
+    expect do
       res = @img.unique_colors
       assert_instance_of(Magick::Image, res)
       expect(res.columns).to eq(1)
       expect(res.rows).to eq(1)
-    end
+    end.not_to raise_error
   end
 
   def test_unsharp_mask
-    assert_nothing_raised do
+    expect do
       res = @img.unsharp_mask
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised { @img.unsharp_mask(2.0) }
-    assert_nothing_raised { @img.unsharp_mask(2.0, 1.0) }
-    assert_nothing_raised { @img.unsharp_mask(2.0, 1.0, 0.50) }
-    assert_nothing_raised { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10) }
+    expect { @img.unsharp_mask(2.0) }.not_to raise_error
+    expect { @img.unsharp_mask(2.0, 1.0) }.not_to raise_error
+    expect { @img.unsharp_mask(2.0, 1.0, 0.50) }.not_to raise_error
+    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
     expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(ArgumentError)
     expect { @img.unsharp_mask(-2.0, 1.0, 0.50, 0.10) }.to raise_error(ArgumentError)
     expect { @img.unsharp_mask(2.0, 0.0, 0.50, 0.10) }.to raise_error(ArgumentError)
@@ -899,17 +899,17 @@ class Image3_UT < Minitest::Test
   end
 
   def test_unsharp_mask_channel
-    assert_nothing_raised do
+    expect do
       res = @img.unsharp_mask_channel
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0) }
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0) }
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50) }
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10) }
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel) }
-    assert_nothing_raised { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, Magick::BlueChannel) }
+    expect { @img.unsharp_mask_channel(2.0) }.not_to raise_error
+    expect { @img.unsharp_mask_channel(2.0, 1.0) }.not_to raise_error
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50) }.not_to raise_error
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel) }.not_to raise_error
+    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, 2) }.to raise_error(TypeError)
     expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(TypeError)
     expect { @img.unsharp_mask_channel('x') }.to raise_error(TypeError)
@@ -919,13 +919,13 @@ class Image3_UT < Minitest::Test
   end
 
   def test_view
-    assert_nothing_raised do
+    expect do
       res = @img.view(0, 0, 5, 5)
       assert_instance_of(Magick::Image::View, res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       @img.view(0, 0, 5, 5) { |v| assert_instance_of(Magick::Image::View, v) }
-    end
+    end.not_to raise_error
     expect { @img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
     expect { @img.view(0, -1, 5, 5) }.to raise_error(RangeError)
     expect { @img.view(1, 0, @img.columns, 5) }.to raise_error(RangeError)
@@ -935,15 +935,15 @@ class Image3_UT < Minitest::Test
   end
 
   def test_vignette
-    assert_nothing_raised do
+    expect do
       res = @img.vignette
       assert_instance_of(Magick::Image, res)
       assert_not_same(res, @img)
-    end
-    assert_nothing_raised { @img.vignette(0) }
-    assert_nothing_raised { @img.vignette(0, 0) }
-    assert_nothing_raised { @img.vignette(0, 0, 0) }
-    assert_nothing_raised { @img.vignette(0, 0, 0, 1) }
+    end.not_to raise_error
+    expect { @img.vignette(0) }.not_to raise_error
+    expect { @img.vignette(0, 0) }.not_to raise_error
+    expect { @img.vignette(0, 0, 0) }.not_to raise_error
+    expect { @img.vignette(0, 0, 0, 1) }.not_to raise_error
     # too many arguments
     expect { @img.vignette(0, 0, 0, 1, 1) }.to raise_error(ArgumentError)
   end
@@ -952,17 +952,17 @@ class Image3_UT < Minitest::Test
     mark = Magick::Image.new(5, 5)
     mark_list = Magick::ImageList.new
     mark_list << mark.copy
-    assert_nothing_raised { @img.watermark(mark) }
-    assert_nothing_raised { @img.watermark(mark_list) }
-    assert_nothing_raised { @img.watermark(mark, 0.50) }
-    assert_nothing_raised { @img.watermark(mark, '50%') }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50) }
-    assert_nothing_raised { @img.watermark(mark, 0.50, '50%') }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, 10) }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, 10, 10) }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity) }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10) }
-    assert_nothing_raised { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 10) }
+    expect { @img.watermark(mark) }.not_to raise_error
+    expect { @img.watermark(mark_list) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50) }.not_to raise_error
+    expect { @img.watermark(mark, '50%') }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, '50%') }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50, 10) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50, 10, 10) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10) }.not_to raise_error
+    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
 
     expect { @img.watermark }.to raise_error(ArgumentError)
     expect { @img.watermark(mark, 'x') }.to raise_error(ArgumentError)
@@ -977,12 +977,12 @@ class Image3_UT < Minitest::Test
   end
 
   def test_wave
-    assert_nothing_raised do
+    expect do
       res = @img.wave
       assert_instance_of(Magick::Image, res)
-    end
-    assert_nothing_raised { @img.wave(25) }
-    assert_nothing_raised { @img.wave(25, 200) }
+    end.not_to raise_error
+    expect { @img.wave(25) }.not_to raise_error
+    expect { @img.wave(25, 200) }.not_to raise_error
     expect { @img.wave(25, 200, 2) }.to raise_error(ArgumentError)
     expect { @img.wave('x') }.to raise_error(TypeError)
     expect { @img.wave(25, 'x') }.to raise_error(TypeError)
@@ -990,10 +990,10 @@ class Image3_UT < Minitest::Test
 
   def test_wet_floor
     assert_instance_of(Magick::Image, @img.wet_floor)
-    assert_nothing_raised { @img.wet_floor(0.0) }
-    assert_nothing_raised { @img.wet_floor(0.5) }
-    assert_nothing_raised { @img.wet_floor(0.5, 10) }
-    assert_nothing_raised { @img.wet_floor(0.5, 0.0) }
+    expect { @img.wet_floor(0.0) }.not_to raise_error
+    expect { @img.wet_floor(0.5) }.not_to raise_error
+    expect { @img.wet_floor(0.5, 10) }.not_to raise_error
+    expect { @img.wet_floor(0.5, 0.0) }.not_to raise_error
 
     expect { @img.wet_floor(2.0) }.to raise_error(ArgumentError)
     expect { @img.wet_floor(-2.0) }.to raise_error(ArgumentError)
@@ -1003,11 +1003,11 @@ class Image3_UT < Minitest::Test
 
   def test_white_threshold
     expect { @img.white_threshold }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.white_threshold(50) }
-    assert_nothing_raised { @img.white_threshold(50, 50) }
-    assert_nothing_raised { @img.white_threshold(50, 50, 50) }
+    expect { @img.white_threshold(50) }.not_to raise_error
+    expect { @img.white_threshold(50, 50) }.not_to raise_error
+    expect { @img.white_threshold(50, 50, 50) }.not_to raise_error
     expect { @img.white_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
-    assert_nothing_raised { @img.white_threshold(50, 50, 50, alpha: 50) }
+    expect { @img.white_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
     expect { @img.white_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
     expect { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
     expect { @img.white_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -23,29 +23,29 @@ class ImageList1UT < Minitest::Test
     expect { list.combine }.to raise_error(ArgumentError)
 
     list << red
-    assert_nothing_raised { list.combine }
+    expect { list.combine }.not_to raise_error
 
     res = list.combine
     assert_instance_of(Magick::Image, res)
 
     list << alpha
-    assert_nothing_raised { list.combine }
+    expect { list.combine }.not_to raise_error
 
     list.pop
     list << green
     list << blue
-    assert_nothing_raised { list.combine }
+    expect { list.combine }.not_to raise_error
 
     list << alpha
-    assert_nothing_raised { list.combine }
+    expect { list.combine }.not_to raise_error
 
     list.pop
     list << black
-    assert_nothing_raised { list.combine(Magick::CMYKColorspace) }
-    assert_nothing_raised { list.combine(Magick::SRGBColorspace) }
+    expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
+    expect { list.combine(Magick::SRGBColorspace) }.not_to raise_error
 
     list << alpha
-    assert_nothing_raised { list.combine(Magick::CMYKColorspace) }
+    expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
     expect { list.combine(Magick::SRGBColorspace) }.to raise_error(ArgumentError)
 
     list << alpha
@@ -56,55 +56,55 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_composite_layers
-    assert_nothing_raised { @list.composite_layers(@list2) }
+    expect { @list.composite_layers(@list2) }.not_to raise_error
     Magick::CompositeOperator.values do |op|
-      assert_nothing_raised { @list.composite_layers(@list2, op) }
+      expect { @list.composite_layers(@list2, op) }.not_to raise_error
     end
 
     expect { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }.to raise_error(ArgumentError)
   end
 
   def test_delay
-    assert_nothing_raised { @list.delay }
+    expect { @list.delay }.not_to raise_error
     expect(@list.delay).to eq(0)
-    assert_nothing_raised { @list.delay = 20 }
+    expect { @list.delay = 20 }.not_to raise_error
     expect(@list.delay).to eq(20)
     expect { @list.delay = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_flatten_images
-    assert_nothing_raised { @list.flatten_images }
+    expect { @list.flatten_images }.not_to raise_error
   end
 
   def test_ticks_per_second
-    assert_nothing_raised { @list.ticks_per_second }
+    expect { @list.ticks_per_second }.not_to raise_error
     expect(@list.ticks_per_second).to eq(100)
-    assert_nothing_raised { @list.ticks_per_second = 1000 }
+    expect { @list.ticks_per_second = 1000 }.not_to raise_error
     expect(@list.ticks_per_second).to eq(1000)
     expect { @list.ticks_per_second = 'x' }.to raise_error(ArgumentError)
   end
 
   def test_iterations
-    assert_nothing_raised { @list.iterations }
+    expect { @list.iterations }.not_to raise_error
     assert_kind_of(Integer, @list.iterations)
-    assert_nothing_raised { @list.iterations = 20 }
+    expect { @list.iterations = 20 }.not_to raise_error
     expect(@list.iterations).to eq(20)
     expect { @list.iterations = 'x' }.to raise_error(ArgumentError)
   end
 
   # also tests #size
   def test_length
-    assert_nothing_raised { @list.length }
+    expect { @list.length }.not_to raise_error
     expect(@list.length).to eq(10)
     expect { @list.length = 2 }.to raise_error(NoMethodError)
   end
 
   def test_scene
-    assert_nothing_raised { @list.scene }
+    expect { @list.scene }.not_to raise_error
     expect(@list.scene).to eq(9)
-    assert_nothing_raised { @list.scene = 0 }
+    expect { @list.scene = 0 }.not_to raise_error
     expect(@list.scene).to eq(0)
-    assert_nothing_raised { @list.scene = 1 }
+    expect { @list.scene = 1 }.not_to raise_error
     expect(@list.scene).to eq(1)
     expect { @list.scene = -1 }.to raise_error(IndexError)
     expect { @list.scene = 1000 }.to raise_error(IndexError)
@@ -112,7 +112,7 @@ class ImageList1UT < Minitest::Test
 
     # allow nil on empty list
     empty_list = Magick::ImageList.new
-    assert_nothing_raised { empty_list.scene = nil }
+    expect { empty_list.scene = nil }.not_to raise_error
   end
 
   def test_undef_array_methods
@@ -126,20 +126,20 @@ class ImageList1UT < Minitest::Test
 
   def test_all
     q = nil
-    assert_nothing_raised { q = @list.all? { |i| i.class == Magick::Image } }
+    expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
     assert(q)
   end
 
   def test_any
     q = nil
-    assert_nothing_raised { q = @list.all? { |_i| false } }
+    expect { q = @list.all? { |_i| false } }.not_to raise_error
     assert(!q)
-    assert_nothing_raised { q = @list.all? { |i| i.class == Magick::Image } }
+    expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
     assert(q)
   end
 
   def test_aref
-    assert_nothing_raised { @list[0] }
+    expect { @list[0] }.not_to raise_error
     assert_instance_of(Magick::Image, @list[0])
     assert_instance_of(Magick::Image, @list[-1])
     assert_instance_of(Magick::ImageList, @list[0, 1])
@@ -149,25 +149,25 @@ class ImageList1UT < Minitest::Test
 
   def test_aset
     img = Magick::Image.new(5, 5)
-    assert_nothing_raised do
+    expect do
       rv = @list[0] = img
       assert_same(img, rv)
       assert_same(img, @list[0])
       expect(@list.scene).to eq(0)
-    end
+    end.not_to raise_error
 
     # replace 2 images with 1
-    assert_nothing_raised do
+    expect do
       img = Magick::Image.new(5, 5)
       rv = @list[1, 2] = img
       assert_same(img, rv)
       expect(@list.length).to eq(9)
       assert_same(img, @list[1])
       expect(@list.scene).to eq(1)
-    end
+    end.not_to raise_error
 
     # replace 1 image with 2
-    assert_nothing_raised do
+    expect do
       img = Magick::Image.new(5, 5)
       img2 = Magick::Image.new(5, 5)
       ary = [img, img2]
@@ -177,18 +177,18 @@ class ImageList1UT < Minitest::Test
       assert_same(img, @list[3])
       assert_same(img2, @list[4])
       expect(@list.scene).to eq(4)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       img = Magick::Image.new(5, 5)
       rv = @list[5..6] = img
       assert_same(img, rv)
       expect(@list.length).to eq(9)
       assert_same(img, @list[5])
       expect(@list.scene).to eq(5)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       ary = [img, img]
       rv = @list[7..8] = ary
       assert_same(ary, rv)
@@ -196,15 +196,15 @@ class ImageList1UT < Minitest::Test
       assert_same(img, @list[7])
       assert_same(img, @list[8])
       expect(@list.scene).to eq(8)
-    end
+    end.not_to raise_error
 
-    assert_nothing_raised do
+    expect do
       rv = @list[-1] = img
       assert_same(img, rv)
       expect(@list.length).to eq(9)
       assert_same(img, @list[8])
       expect(@list.scene).to eq(8)
-    end
+    end.not_to raise_error
 
     expect { @list[0] = 1 }.to raise_error(ArgumentError)
     expect { @list[0, 1] = [1, 2] }.to raise_error(ArgumentError)
@@ -214,7 +214,7 @@ class ImageList1UT < Minitest::Test
   def test_and
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       res = @list & @list2
       assert_instance_of(Magick::ImageList, res)
       assert_not_same(res, @list)
@@ -222,21 +222,21 @@ class ImageList1UT < Minitest::Test
       expect(res.length).to eq(5)
       expect(res.scene).to eq(2)
       assert_same(cur, res.cur_image)
-    end
+    end.not_to raise_error
 
     # current scene not in the result, set result scene to last image in result
     @list.scene = 2
-    assert_nothing_raised do
+    expect do
       res = @list & @list2
       assert_instance_of(Magick::ImageList, res)
       expect(res.scene).to eq(4)
-    end
+    end.not_to raise_error
 
     expect { @list & 2 }.to raise_error(ArgumentError)
   end
 
   def test_at
-    assert_nothing_raised do
+    expect do
       cur = @list.cur_image
       img = @list.at(7)
       assert_same(img, @list[7])
@@ -247,19 +247,19 @@ class ImageList1UT < Minitest::Test
       img = @list.at(-1)
       assert_same(img, @list[9])
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
   end
 
   def test_star
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       res = @list * 2
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(20)
       assert_not_same(res, @list)
       assert_same(cur, res.cur_image)
-    end
+    end.not_to raise_error
 
     expect { @list * 'x' }.to raise_error(ArgumentError)
   end
@@ -267,14 +267,14 @@ class ImageList1UT < Minitest::Test
   def test_plus
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       res = @list + @list2
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(15)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       assert_same(cur, res.cur_image)
-    end
+    end.not_to raise_error
 
     expect { @list + [2] }.to raise_error(ArgumentError)
   end
@@ -282,39 +282,39 @@ class ImageList1UT < Minitest::Test
   def test_minus
     @list.scene = 0
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       res = @list - @list2
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(5)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       assert_same(cur, res.cur_image)
-    end
+    end.not_to raise_error
 
     # current scene not in result - set result scene to last image in result
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       res = @list - @list2
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(5)
       expect(res.scene).to eq(4)
-    end
+    end.not_to raise_error
   end
 
   def test_catenate
-    assert_nothing_raised do
+    expect do
       @list2.each { |img| @list << img }
       expect(@list.length).to eq(15)
       expect(@list.scene).to eq(14)
-    end
+    end.not_to raise_error
 
     expect { @list << 2 }.to raise_error(ArgumentError)
     expect { @list << [2] }.to raise_error(ArgumentError)
   end
 
   def test_or
-    assert_nothing_raised do
+    expect do
       @list.scene = 7
       # The or of these two lists should be the same as @list
       # but not be the *same* list
@@ -323,7 +323,7 @@ class ImageList1UT < Minitest::Test
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       expect(@list).to eq(res)
-    end
+    end.not_to raise_error
 
     # Try or'ing disjoint lists
     temp_list = Magick::ImageList.new(*FILES[10..14])
@@ -337,56 +337,56 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_clear
-    assert_nothing_raised { @list.clear }
+    expect { @list.clear }.not_to raise_error
     assert_instance_of(Magick::ImageList, @list)
     expect(@list.length).to eq(0)
     assert_nil(@list.scene)
   end
 
   def test_collect
-    assert_nothing_raised do
+    expect do
       scene = @list.scene
       res = @list.collect(&:negate)
       assert_instance_of(Magick::ImageList, res)
       assert_not_same(res, @list)
       expect(res.scene).to eq(scene)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       scene = @list.scene
       @list.collect!(&:negate)
       assert_instance_of(Magick::ImageList, @list)
       expect(@list.scene).to eq(scene)
-    end
+    end.not_to raise_error
   end
 
   def test_compact
-    assert_nothing_raised do
+    expect do
       res = @list.compact
       assert_not_same(res, @list)
       expect(@list).to eq(res)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       res = @list
       @list.compact!
       assert_instance_of(Magick::ImageList, @list)
       expect(@list).to eq(res)
       assert_same(res, @list)
-    end
+    end.not_to raise_error
   end
 
   def test_concat
-    assert_nothing_raised do
+    expect do
       res = @list.concat(@list2)
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(15)
       assert_same(res[14], res.cur_image)
-    end
+    end.not_to raise_error
     expect { @list.concat(2) }.to raise_error(ArgumentError)
     expect { @list.concat([2]) }.to raise_error(ArgumentError)
   end
 
   def test_delete
-    assert_nothing_raised do
+    expect do
       cur = @list.cur_image
       img = @list[7]
       assert_same(img, @list.delete(img))
@@ -402,56 +402,56 @@ class ImageList1UT < Minitest::Test
 
       # Try deleting something that isn't in the list.
       # Should return the value of the block.
-      assert_nothing_raised do
+      expect do
         img = Magick::Image.read(FILES[10]).first
         res = @list.delete(img) { 1 }
         expect(res).to eq(1)
-      end
-    end
+      end.not_to raise_error
+    end.not_to raise_error
   end
 
   def test_delete_at
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised { @list.delete_at(9) }
+    expect { @list.delete_at(9) }.not_to raise_error
     assert_same(cur, @list.cur_image)
-    assert_nothing_raised { @list.delete_at(7) }
+    expect { @list.delete_at(7) }.not_to raise_error
     assert_same(@list[-1], @list.cur_image)
   end
 
   def test_delete_if
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       @list.delete_if { |img| File.basename(img.filename) =~ /5/ }
       assert_instance_of(Magick::ImageList, @list)
       expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
 
     # Delete the current image
-    assert_nothing_raised do
+    expect do
       @list.delete_if { |img| File.basename(img.filename) =~ /7/ }
       assert_instance_of(Magick::ImageList, @list)
       expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
-    end
+    end.not_to raise_error
   end
 
   # defined by Enumerable
   def test_enumerables
-    assert_nothing_raised { @list.detect { true } }
-    assert_nothing_raised do
+    expect { @list.detect { true } }.not_to raise_error
+    expect do
       @list.each_with_index { |img, _n| assert_instance_of(Magick::Image, img) }
-    end
-    assert_nothing_raised { @list.entries }
-    assert_nothing_raised { @list.include?(@list[0]) }
-    assert_nothing_raised { @list.inject(0) { 0 } }
-    assert_nothing_raised { @list.max }
-    assert_nothing_raised { @list.min }
-    assert_nothing_raised { @list.sort }
-    assert_nothing_raised { @list.sort_by(&:signature) }
-    assert_nothing_raised { @list.zip }
+    end.not_to raise_error
+    expect { @list.entries }.not_to raise_error
+    expect { @list.include?(@list[0]) }.not_to raise_error
+    expect { @list.inject(0) { 0 } }.not_to raise_error
+    expect { @list.max }.not_to raise_error
+    expect { @list.min }.not_to raise_error
+    expect { @list.sort }.not_to raise_error
+    expect { @list.sort_by(&:signature) }.not_to raise_error
+    expect { @list.zip }.not_to raise_error
   end
 
   def test_eql?
@@ -464,9 +464,9 @@ class ImageList1UT < Minitest::Test
   def test_fill
     list = @list.copy
     img = list[0].copy
-    assert_nothing_raised do
+    expect do
       assert_instance_of(Magick::ImageList, list.fill(img))
-    end
+    end.not_to raise_error
     list.each { |el| assert_same(el, img) }
 
     list = @list.copy
@@ -489,27 +489,27 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_find
-    assert_nothing_raised { @list.find { true } }
+    expect { @list.find { true } }.not_to raise_error
   end
 
   def find_all
-    assert_nothing_raised do
+    expect do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
-    end
+    end.not_to raise_error
   end
 
   def test_insert
-    assert_nothing_raised do
+    expect do
       @list.scene = 7
       cur = @list.cur_image
       assert_instance_of(Magick::ImageList, @list.insert(1, @list[2]))
       assert_same(cur, @list.cur_image)
       @list.insert(1, @list[2], @list[3], @list[4])
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
 
     expect { @list.insert(0, 'x') }.to raise_error(ArgumentError)
     expect { @list.insert(0, 'x', 'y') }.to raise_error(ArgumentError)
@@ -519,13 +519,13 @@ class ImageList1UT < Minitest::Test
     img = Magick::Image.new(5, 5)
     @list << img
     img2 = nil
-    assert_nothing_raised { img2 = @list.last }
+    expect { img2 = @list.last }.not_to raise_error
     assert_instance_of(Magick::Image, img2)
     expect(img).to eq(img2)
     img2 = Magick::Image.new(5, 5)
     @list << img2
     ilist = nil
-    assert_nothing_raised { ilist = @list.last(2) }
+    expect { ilist = @list.last(2) }.not_to raise_error
     assert_instance_of(Magick::ImageList, ilist)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(1)
@@ -535,18 +535,18 @@ class ImageList1UT < Minitest::Test
 
   def test___map__
     img = @list[0]
-    assert_nothing_raised do
+    expect do
       @list.__map__ { |_x| img }
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::ImageList, @list)
     expect { @list.__map__ { 2 } }.to raise_error(ArgumentError)
   end
 
   def test_map!
     img = @list[0]
-    assert_nothing_raised do
+    expect do
       @list.map! { img }
-    end
+    end.not_to raise_error
     assert_instance_of(Magick::ImageList, @list)
     expect { @list.map! { 2 } }.to raise_error(ArgumentError)
   end
@@ -554,12 +554,12 @@ class ImageList1UT < Minitest::Test
   def test_partition
     a = nil
     n = -1
-    assert_nothing_raised do
+    expect do
       a = @list.partition do
         n += 1
         (n & 1).zero?
       end
-    end
+    end.not_to raise_error
     assert_instance_of(Array, a)
     expect(a.size).to eq(2)
     assert_instance_of(Magick::ImageList, a[0])
@@ -574,10 +574,10 @@ class ImageList1UT < Minitest::Test
     @list.scene = 8
     cur = @list.cur_image
     last = @list[-1]
-    assert_nothing_raised do
+    expect do
       assert_same(last, @list.pop)
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
 
     assert_same(cur, @list.pop)
     assert_same(@list[-1], @list.cur_image)
@@ -587,7 +587,7 @@ class ImageList1UT < Minitest::Test
     list = @list
     img1 = @list[0]
     img2 = @list[1]
-    assert_nothing_raised { @list.push(img1, img2) }
+    expect { @list.push(img1, img2) }.not_to raise_error
     assert_same(list, @list) # push returns self
     assert_same(img2, @list.cur_image)
   end
@@ -596,12 +596,12 @@ class ImageList1UT < Minitest::Test
     @list.scene = 7
     cur = @list.cur_image
     list = @list
-    assert_nothing_raised do
+    expect do
       res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
       expect(res.length).to eq(9)
       assert_instance_of(Magick::ImageList, res)
       assert_same(cur, res.cur_image)
-    end
+    end.not_to raise_error
     assert_same(list, @list)
     assert_same(cur, @list.cur_image)
 
@@ -615,20 +615,20 @@ class ImageList1UT < Minitest::Test
   def test_reject!
     @list.scene = 7
     cur = @list.cur_image
-    assert_nothing_raised do
+    expect do
       @list.reject! { |img| File.basename(img.filename) =~ /5/ }
       assert_instance_of(Magick::ImageList, @list)
       expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
 
     # Delete the current image
-    assert_nothing_raised do
+    expect do
       @list.reject! { |img| File.basename(img.filename) =~ /7/ }
       assert_instance_of(Magick::ImageList, @list)
       expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
-    end
+    end.not_to raise_error
 
     # returns nil if no changes are made
     assert_nil(@list.reject! { false })
@@ -636,20 +636,20 @@ class ImageList1UT < Minitest::Test
 
   def test_replace1
     # Replace with empty list
-    assert_nothing_raised do
+    expect do
       res = @list.replace([])
       assert_same(res, @list)
       expect(@list.length).to eq(0)
       assert_nil(@list.scene)
-    end
+    end.not_to raise_error
 
     # Replace empty list with non-empty list
     temp = Magick::ImageList.new
-    assert_nothing_raised do
+    expect do
       temp.replace(@list2)
       expect(temp.length).to eq(5)
       expect(temp.scene).to eq(4)
-    end
+    end.not_to raise_error
 
     # Try to replace with illegal values
     expect { @list.replace([1, 2, 3]) }.to raise_error(ArgumentError)
@@ -657,7 +657,7 @@ class ImageList1UT < Minitest::Test
 
   def test_replace2
     # Replace with shorter list
-    assert_nothing_raised do
+    expect do
       @list.scene = 7
       cur = @list.cur_image
       res = @list.replace(@list2)
@@ -665,12 +665,12 @@ class ImageList1UT < Minitest::Test
       expect(@list.length).to eq(5)
       expect(@list.scene).to eq(2)
       assert_same(cur, @list.cur_image)
-    end
+    end.not_to raise_error
   end
 
   def test_replace3
     # Replace with longer list
-    assert_nothing_raised do
+    expect do
       @list2.scene = 2
       cur = @list2.cur_image
       res = @list2.replace(@list)
@@ -678,13 +678,13 @@ class ImageList1UT < Minitest::Test
       expect(@list2.length).to eq(10)
       expect(@list2.scene).to eq(7)
       assert_same(cur, @list2.cur_image)
-    end
+    end.not_to raise_error
   end
 
   def test_reverse
     list = nil
     cur = @list.cur_image
-    assert_nothing_raised { list = @list.reverse }
+    expect { list = @list.reverse }.not_to raise_error
     expect(@list.length).to eq(list.length)
     assert_same(cur, @list.cur_image)
   end
@@ -692,42 +692,42 @@ class ImageList1UT < Minitest::Test
   def test_reverse!
     list = @list
     cur = @list.cur_image
-    assert_nothing_raised { @list.reverse! }
+    expect { @list.reverse! }.not_to raise_error
     assert_same(list, @list)
     assert_same(cur, @list.cur_image)
   end
 
   # Just validate its existence
   def test_reverse_each
-    assert_nothing_raised do
+    expect do
       @list.reverse_each { |img| assert_instance_of(Magick::Image, img) }
-    end
+    end.not_to raise_error
   end
 
   def test_rindex
     img = @list.last
     n = nil
-    assert_nothing_raised { n = @list.rindex(img) }
+    expect { n = @list.rindex(img) }.not_to raise_error
     expect(n).to eq(9)
   end
 
   def test_select
-    assert_nothing_raised do
+    expect do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
-    end
+    end.not_to raise_error
   end
 
   def test_shift
-    assert_nothing_raised do
+    expect do
       @list.scene = 0
       res = @list[0]
       img = @list.shift
       assert_same(res, img)
       expect(@list.scene).to eq(8)
-    end
+    end.not_to raise_error
     res = @list[0]
     img = @list.shift
     assert_same(res, img)
@@ -735,48 +735,48 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_slice
-    assert_nothing_raised { @list.slice(0) }
-    assert_nothing_raised { @list.slice(-1) }
-    assert_nothing_raised { @list.slice(0, 1) }
-    assert_nothing_raised { @list.slice(0..2) }
-    assert_nothing_raised { @list.slice(20) }
+    expect { @list.slice(0) }.not_to raise_error
+    expect { @list.slice(-1) }.not_to raise_error
+    expect { @list.slice(0, 1) }.not_to raise_error
+    expect { @list.slice(0..2) }.not_to raise_error
+    expect { @list.slice(20) }.not_to raise_error
   end
 
   def test_slice!
     @list.scene = 7
-    assert_nothing_raised do
+    expect do
       img0 = @list[0]
       img = @list.slice!(0)
       assert_same(img0, img)
       expect(@list.length).to eq(9)
       expect(@list.scene).to eq(6)
-    end
+    end.not_to raise_error
     cur = @list.cur_image
     img = @list.slice!(6)
     assert_same(cur, img)
     expect(@list.length).to eq(8)
     expect(@list.scene).to eq(7)
-    assert_nothing_raised { @list.slice!(-1) }
-    assert_nothing_raised { @list.slice!(0, 1) }
-    assert_nothing_raised { @list.slice!(0..2) }
-    assert_nothing_raised { @list.slice!(20) }
+    expect { @list.slice!(-1) }.not_to raise_error
+    expect { @list.slice!(0, 1) }.not_to raise_error
+    expect { @list.slice!(0..2) }.not_to raise_error
+    expect { @list.slice!(20) }.not_to raise_error
   end
 
   # simply ensure existence
   def test_sort
-    assert_nothing_raised { @list.sort }
-    assert_nothing_raised { @list.sort! }
+    expect { @list.sort }.not_to raise_error
+    expect { @list.sort! }.not_to raise_error
   end
 
   def test_to_a
     a = nil
-    assert_nothing_raised { a = @list.to_a }
+    expect { a = @list.to_a }.not_to raise_error
     assert_instance_of(Array, a)
     expect(a.length).to eq(10)
   end
 
   def test_uniq
-    assert_nothing_raised { @list.uniq }
+    expect { @list.uniq }.not_to raise_error
     assert_instance_of(Magick::ImageList, @list.uniq)
     @list[1] = @list[0]
     @list.scene = 7
@@ -792,9 +792,9 @@ class ImageList1UT < Minitest::Test
   end
 
   def test_uniq!
-    assert_nothing_raised do
+    expect do
       assert_nil(@list.uniq!)
-    end
+    end.not_to raise_error
     @list[1] = @list[0]
     @list.scene = 7
     cur = @list.cur_image
@@ -820,7 +820,7 @@ class ImageList1UT < Minitest::Test
 
   def test_values_at
     ilist = nil
-    assert_nothing_raised { ilist = @list.values_at(1, 3, 5) }
+    expect { ilist = @list.values_at(1, 3, 5) }.not_to raise_error
     assert_instance_of(Magick::ImageList, ilist)
     expect(ilist.length).to eq(3)
     expect(ilist.scene).to eq(2)
@@ -844,7 +844,7 @@ class ImageList1UT < Minitest::Test
     list2 = Magick::ImageList.new
     expect { list2 <=> @list }.to raise_error(TypeError)
     expect { @list <=> list2 }.to raise_error(TypeError)
-    assert_nothing_raised { list <=> list2 }
+    expect { list <=> list2 }.not_to raise_error
   end
 end
 

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -9,24 +9,24 @@ class ImageList2UT < Minitest::Test
 
   def test_append
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    assert_nothing_raised do
+    expect do
       img = @ilist.append(true)
       assert_instance_of(Magick::Image, img)
-    end
-    assert_nothing_raised do
+    end.not_to raise_error
+    expect do
       img = @ilist.append(false)
       assert_instance_of(Magick::Image, img)
-    end
+    end.not_to raise_error
     expect { @ilist.append }.to raise_error(ArgumentError)
     expect { @ilist.append(true, 1) }.to raise_error(ArgumentError)
   end
 
   def test_average
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    assert_nothing_raised do
+    expect do
       img = @ilist.average
       assert_instance_of(Magick::Image, img)
-    end
+    end.not_to raise_error
     expect { @ilist.average(1) }.to raise_error(ArgumentError)
   end
 
@@ -46,7 +46,7 @@ class ImageList2UT < Minitest::Test
   def test_coalesce
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
     ilist = nil
-    assert_nothing_raised { ilist = @ilist.coalesce }
+    expect { ilist = @ilist.coalesce }.not_to raise_error
     assert_instance_of(Magick::ImageList, ilist)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(0)
@@ -66,7 +66,7 @@ class ImageList2UT < Minitest::Test
   def test_deconstruct
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     ilist = nil
-    assert_nothing_raised { ilist = @ilist.deconstruct }
+    expect { ilist = @ilist.deconstruct }.not_to raise_error
     assert_instance_of(Magick::ImageList, ilist)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(0)
@@ -87,16 +87,16 @@ class ImageList2UT < Minitest::Test
 
   def flatten_images
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    assert_nothing_thrown do
+    expect do
       img = @ilist.flatten_images
       assert_instance_of(Magick::Image, img)
-    end
+    end.not_to raise_error
   end
 
   def test_from_blob
     hat = File.open(FLOWER_HAT, 'rb')
     blob = hat.read
-    assert_nothing_raised { @ilist.from_blob(blob) }
+    expect { @ilist.from_blob(blob) }.not_to raise_error
     assert_instance_of(Magick::Image, @ilist[0])
     expect(@ilist.scene).to eq(0)
 
@@ -108,8 +108,8 @@ class ImageList2UT < Minitest::Test
     ilist1 = Magick::ImageList.new(*Dir[IMAGES_DIR + '/Button_*.gif'])
     d = nil
     ilist2 = nil
-    assert_nothing_raised { d = Marshal.dump(ilist1) }
-    assert_nothing_raised { ilist2 = Marshal.load(d) }
+    expect { d = Marshal.dump(ilist1) }.not_to raise_error
+    expect { ilist2 = Marshal.load(d) }.not_to raise_error
     expect(ilist2).to eq(ilist1)
   end
 
@@ -117,7 +117,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     ilist = @ilist.copy
     montage = nil
-    assert_nothing_thrown do
+    expect do
       montage = ilist.montage do
         self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
         self.background_color = 'blue'
@@ -150,7 +150,7 @@ class ImageList2UT < Minitest::Test
       montage_image = montage.first
       expect(montage_image.background_color).to eq('blue')
       expect(montage_image.border_color).to eq('red')
-    end
+    end.not_to raise_error
 
     # test illegal option arguments
     # looks like IM doesn't diagnose invalid geometry args
@@ -211,20 +211,20 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     # can't specify a negative argument
     expect { @ilist.morph(-1) }.to raise_error(ArgumentError)
-    assert_nothing_raised do
+    expect do
       res = @ilist.morph(2)
       assert_instance_of(Magick::ImageList, res)
       expect(res.length).to eq(4)
       expect(res.scene).to eq(0)
-    end
+    end.not_to raise_error
   end
 
   def test_mosaic
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    assert_nothing_thrown do
+    expect do
       res = @ilist.mosaic
       assert_instance_of(Magick::Image, res)
-    end
+    end.not_to raise_error
   end
 
   def test_mosaic_with_invalid_imagelist
@@ -234,9 +234,9 @@ class ImageList2UT < Minitest::Test
   end
 
   def test_new_image
-    assert_nothing_raised do
+    expect do
       @ilist.new_image(20, 20)
-    end
+    end.not_to raise_error
     expect(@ilist.length).to eq(1)
     expect(@ilist.scene).to eq(0)
     @ilist.new_image(20, 20, Magick::HatchFill.new('black'))
@@ -252,75 +252,75 @@ class ImageList2UT < Minitest::Test
     Magick::LayerMethod.values do |method|
       next if [Magick::UndefinedLayer, Magick::CompositeLayer, Magick::TrimBoundsLayer].include?(method)
 
-      assert_nothing_raised do
+      expect do
         res = @ilist.optimize_layers(method)
         assert_instance_of(Magick::ImageList, res)
         assert_kind_of(Integer, res.length)
-      end
+      end.not_to raise_error
     end
 
-    assert_nothing_raised { @ilist.optimize_layers(Magick::CompareClearLayer) }
+    expect { @ilist.optimize_layers(Magick::CompareClearLayer) }.not_to raise_error
     expect { @ilist.optimize_layers(Magick::UndefinedLayer) }.to raise_error(ArgumentError)
     expect { @ilist.optimize_layers(2) }.to raise_error(TypeError)
     expect { @ilist.optimize_layers(Magick::CompositeLayer) }.to raise_error(NotImplementedError)
   end
 
   def test_ping
-    assert_nothing_raised { @ilist.ping(FLOWER_HAT) }
+    expect { @ilist.ping(FLOWER_HAT) }.not_to raise_error
     expect(@ilist.length).to eq(1)
     expect(@ilist.scene).to eq(0)
-    assert_nothing_raised { @ilist.ping(FLOWER_HAT, FLOWER_HAT) }
+    expect { @ilist.ping(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(@ilist.length).to eq(3)
     expect(@ilist.scene).to eq(2)
-    assert_nothing_raised { @ilist.ping(FLOWER_HAT) { self.background_color = 'red ' } }
+    expect { @ilist.ping(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
     expect(@ilist.length).to eq(4)
     expect(@ilist.scene).to eq(3)
   end
 
   def test_quantize
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    assert_nothing_raised do
+    expect do
       res = @ilist.quantize
       assert_instance_of(Magick::ImageList, res)
       expect(res.scene).to eq(1)
-    end
-    assert_nothing_raised { @ilist.quantize(128) }
+    end.not_to raise_error
+    expect { @ilist.quantize(128) }.not_to raise_error
     expect { @ilist.quantize('x') }.to raise_error(TypeError)
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace) }
+    expect { @ilist.quantize(128, Magick::RGBColorspace) }.not_to raise_error
     expect { @ilist.quantize(128, 'x') }.to raise_error(TypeError)
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, true, 0) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, true) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, false) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::NoDitherMethod) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }
-    assert_nothing_raised { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }
+    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, true) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, false) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }.not_to raise_error
+    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }.not_to raise_error
     expect { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }.to raise_error(TypeError)
     expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }.to raise_error(ArgumentError)
   end
 
   def test_read
-    assert_nothing_raised { @ilist.read(FLOWER_HAT) }
+    expect { @ilist.read(FLOWER_HAT) }.not_to raise_error
     expect(@ilist.length).to eq(1)
     expect(@ilist.scene).to eq(0)
-    assert_nothing_raised { @ilist.read(FLOWER_HAT, FLOWER_HAT) }
+    expect { @ilist.read(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(@ilist.length).to eq(3)
     expect(@ilist.scene).to eq(2)
-    assert_nothing_raised { @ilist.read(FLOWER_HAT) { self.background_color = 'red ' } }
+    expect { @ilist.read(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
     expect(@ilist.length).to eq(4)
     expect(@ilist.scene).to eq(3)
   end
 
   def test_remap
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    assert_nothing_raised { @ilist.remap }
+    expect { @ilist.remap }.not_to raise_error
     remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    assert_nothing_raised { @ilist.remap(remap_image) }
-    assert_nothing_raised { @ilist.remap(remap_image, Magick::NoDitherMethod) }
-    assert_nothing_raised { @ilist.remap(remap_image, Magick::RiemersmaDitherMethod) }
-    assert_nothing_raised { @ilist.remap(remap_image, Magick::FloydSteinbergDitherMethod) }
+    expect { @ilist.remap(remap_image) }.not_to raise_error
+    expect { @ilist.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @ilist.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @ilist.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
     expect { @ilist.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
 
     remap_image.destroy!
@@ -331,7 +331,7 @@ class ImageList2UT < Minitest::Test
   def test_to_blob
     @ilist.read(IMAGES_DIR + '/Button_0.gif')
     blob = nil
-    assert_nothing_raised { blob = @ilist.to_blob }
+    expect { blob = @ilist.to_blob }.not_to raise_error
     img = @ilist.from_blob(blob)
     expect(img[0]).to eq(@ilist[0])
     expect(img.scene).to eq(1)
@@ -339,9 +339,9 @@ class ImageList2UT < Minitest::Test
 
   def test_write
     @ilist.read(IMAGES_DIR + '/Button_0.gif')
-    assert_nothing_raised do
+    expect do
       @ilist.write('temp.gif')
-    end
+    end.not_to raise_error
     list = Magick::ImageList.new('temp.gif')
     expect(list.format).to eq('GIF')
     FileUtils.rm('temp.gif')

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -21,9 +21,9 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_background_color
-    assert_nothing_raised { @img.background_color }
+    expect { @img.background_color }.not_to raise_error
     expect(@img.background_color).to eq('white')
-    assert_nothing_raised { @img.background_color = '#dfdfdf' }
+    expect { @img.background_color = '#dfdfdf' }.not_to raise_error
     # expect(@img.background_color).to eq("rgb(223,223,223)")
     background_color = @img.background_color
     if background_color.length == 13
@@ -31,7 +31,7 @@ class Image_Attributes_UT < Minitest::Test
     else
       expect(background_color).to eq('#DFDFDFDFDFDFFFFF')
     end
-    assert_nothing_raised { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }
+    expect { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }.not_to raise_error
     # expect(@img.background_color).to eq("rgb(100%,49.9992%,49.9992%)")
     background_color = @img.background_color
     if background_color.length == 13
@@ -43,32 +43,32 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_base_columns
-    assert_nothing_raised { @img.base_columns }
+    expect { @img.base_columns }.not_to raise_error
     expect(@img.base_columns).to eq(0)
     expect { @img.base_columns = 1 }.to raise_error(NoMethodError)
   end
 
   def test_base_filename
-    assert_nothing_raised { @img.base_filename }
+    expect { @img.base_filename }.not_to raise_error
     expect(@img.base_filename).to eq('')
     expect { @img.base_filename = 'xxx' }.to raise_error(NoMethodError)
   end
 
   def test_base_rows
-    assert_nothing_raised { @img.base_rows }
+    expect { @img.base_rows }.not_to raise_error
     expect(@img.base_rows).to eq(0)
     expect { @img.base_rows = 1 }.to raise_error(NoMethodError)
   end
 
   def test_bias
-    assert_nothing_raised { @img.bias }
+    expect { @img.bias }.not_to raise_error
     expect(@img.bias).to eq(0.0)
     assert_instance_of(Float, @img.bias)
 
-    assert_nothing_raised { @img.bias = 0.1 }
+    expect { @img.bias = 0.1 }.not_to raise_error
     assert_in_delta(Magick::QuantumRange * 0.1, @img.bias, 0.1)
 
-    assert_nothing_raised { @img.bias = '10%' }
+    expect { @img.bias = '10%' }.not_to raise_error
     assert_in_delta(Magick::QuantumRange * 0.10, @img.bias, 0.1)
 
     expect { @img.bias = [] }.to raise_error(TypeError)
@@ -76,14 +76,14 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_black_point_compensation
-    assert_nothing_raised { @img.black_point_compensation = true }
+    expect { @img.black_point_compensation = true }.not_to raise_error
     assert(@img.black_point_compensation)
-    assert_nothing_raised { @img.black_point_compensation = false }
+    expect { @img.black_point_compensation = false }.not_to raise_error
     expect(@img.black_point_compensation).to eq(false)
   end
 
   def test_border_color
-    assert_nothing_raised { @img.border_color }
+    expect { @img.border_color }.not_to raise_error
     # expect(@img.border_color).to eq("rgb(223,223,223)")
     border_color = @img.border_color
     if border_color.length == 13
@@ -91,9 +91,9 @@ class Image_Attributes_UT < Minitest::Test
     else
       expect(border_color).to eq('#DFDFDFDFDFDFFFFF')
     end
-    assert_nothing_raised { @img.border_color = 'red' }
+    expect { @img.border_color = 'red' }.not_to raise_error
     expect(@img.border_color).to eq('red')
-    assert_nothing_raised { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }
+    expect { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }.not_to raise_error
     # expect(@img.border_color).to eq("rgb(100%,49.9992%,49.9992%)")
     border_color = @img.border_color
     if border_color.length == 13
@@ -105,7 +105,7 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_bounding_box
-    assert_nothing_raised { @img.bounding_box }
+    expect { @img.bounding_box }.not_to raise_error
     box = @img.bounding_box
     expect(box.width).to eq(87)
     expect(box.height).to eq(87)
@@ -116,7 +116,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_chromaticity
     chrom = @img.chromaticity
-    assert_nothing_raised { @img.chromaticity }
+    expect { @img.chromaticity }.not_to raise_error
     assert_instance_of(Magick::Chromaticity, chrom)
     expect(chrom.red_primary.x).to eq(0)
     expect(chrom.red_primary.y).to eq(0)
@@ -130,35 +130,35 @@ class Image_Attributes_UT < Minitest::Test
     expect(chrom.white_point.x).to eq(0)
     expect(chrom.white_point.y).to eq(0)
     expect(chrom.white_point.z).to eq(0)
-    assert_nothing_raised { @img.chromaticity = chrom }
+    expect { @img.chromaticity = chrom }.not_to raise_error
     expect { @img.chromaticity = 2 }.to raise_error(TypeError)
   end
 
   def test_class_type
-    assert_nothing_raised { @img.class_type }
+    expect { @img.class_type }.not_to raise_error
     assert_instance_of(Magick::ClassType, @img.class_type)
     expect(@img.class_type).to eq(Magick::DirectClass)
-    assert_nothing_raised { @img.class_type = Magick::PseudoClass }
+    expect { @img.class_type = Magick::PseudoClass }.not_to raise_error
     expect(@img.class_type).to eq(Magick::PseudoClass)
     expect { @img.class_type = 2 }.to raise_error(TypeError)
 
-    assert_nothing_raised do
+    expect do
       @img.class_type = Magick::PseudoClass
       @img.class_type = Magick::DirectClass
       expect(@img.class_type).to eq(Magick::DirectClass)
-    end
+    end.not_to raise_error
   end
 
   def test_color_profile
-    assert_nothing_raised { @img.color_profile }
+    expect { @img.color_profile }.not_to raise_error
     assert_nil(@img.color_profile)
-    assert_nothing_raised { @img.color_profile = @p }
+    expect { @img.color_profile = @p }.not_to raise_error
     expect(@img.color_profile).to eq(@p)
     expect { @img.color_profile = 2 }.to raise_error(TypeError)
   end
 
   def test_colors
-    assert_nothing_raised { @img.colors }
+    expect { @img.colors }.not_to raise_error
     expect(@img.colors).to eq(0)
     img = @img.copy
     img.class_type = Magick::PseudoClass
@@ -167,67 +167,67 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_colorspace
-    assert_nothing_raised { @img.colorspace }
+    expect { @img.colorspace }.not_to raise_error
     assert_instance_of(Magick::ColorspaceType, @img.colorspace)
     expect(@img.colorspace).to eq(Magick::SRGBColorspace)
     img = @img.copy
 
     Magick::ColorspaceType.values do |colorspace|
-      assert_nothing_raised { img.colorspace = colorspace }
+      expect { img.colorspace = colorspace }.not_to raise_error
     end
     expect { @img.colorspace = 2 }.to raise_error(TypeError)
     Magick::ColorspaceType.values.each do |cs|
-      assert_nothing_raised { img.colorspace = cs }
+      expect { img.colorspace = cs }.not_to raise_error
     end
   end
 
   def test_columns
-    assert_nothing_raised { @img.columns }
+    expect { @img.columns }.not_to raise_error
     expect(@img.columns).to eq(100)
     expect { @img.columns = 2 }.to raise_error(NoMethodError)
   end
 
   def test_compose
-    assert_nothing_raised { @img.compose }
+    expect { @img.compose }.not_to raise_error
     assert_instance_of(Magick::CompositeOperator, @img.compose)
     expect(@img.compose).to eq(Magick::OverCompositeOp)
     expect { @img.compose = 2 }.to raise_error(TypeError)
-    assert_nothing_raised { @img.compose = Magick::UndefinedCompositeOp }
+    expect { @img.compose = Magick::UndefinedCompositeOp }.not_to raise_error
     expect(@img.compose).to eq(Magick::UndefinedCompositeOp)
 
     Magick::CompositeOperator.values do |composite|
-      assert_nothing_raised { @img.compose = composite }
+      expect { @img.compose = composite }.not_to raise_error
     end
     expect { @img.compose = 2 }.to raise_error(TypeError)
   end
 
   def test_compression
-    assert_nothing_raised { @img.compression }
+    expect { @img.compression }.not_to raise_error
     assert_instance_of(Magick::CompressionType, @img.compression)
     expect(@img.compression).to eq(Magick::UndefinedCompression)
-    assert_nothing_raised { @img.compression = Magick::BZipCompression }
+    expect { @img.compression = Magick::BZipCompression }.not_to raise_error
     expect(@img.compression).to eq(Magick::BZipCompression)
 
     Magick::CompressionType.values do |compression|
-      assert_nothing_raised { @img.compression = compression }
+      expect { @img.compression = compression }.not_to raise_error
     end
     expect { @img.compression = 2 }.to raise_error(TypeError)
   end
 
   def test_delay
-    assert_nothing_raised { @img.delay }
+    expect { @img.delay }.not_to raise_error
     expect(@img.delay).to eq(0)
-    assert_nothing_raised { @img.delay = 10 }
+    expect { @img.delay = 10 }.not_to raise_error
     expect(@img.delay).to eq(10)
     expect { @img.delay = 'x' }.to raise_error(TypeError)
   end
 
   def test_density
-    assert_nothing_raised { @img.density }
-    assert_nothing_raised { @img.density = '90x90' }
-    assert_nothing_raised { @img.density = 'x90' }
-    assert_nothing_raised { @img.density = '90' }
-    assert_nothing_raised { @img.density = Magick::Geometry.new(@img.columns / 2, @img.rows / 2, 5, 5) }
+    expect { @img.density }.not_to raise_error
+    expect { @img.density = '90x90' }.not_to raise_error
+    expect { @img.density = 'x90' }.not_to raise_error
+    expect { @img.density = '90' }.not_to raise_error
+    expect { @img.density = Magick::Geometry.new(@img.columns / 2, @img.rows / 2, 5, 5) }.not_to raise_error
     expect { @img.density = 2 }.to raise_error(TypeError)
   end
 
@@ -237,36 +237,36 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_directory
-    assert_nothing_raised { @img.directory }
+    expect { @img.directory }.not_to raise_error
     assert_nil(@img.directory)
     expect { @img.directory = nil }.to raise_error(NoMethodError)
   end
 
   def test_dispose
-    assert_nothing_raised { @img.dispose }
+    expect { @img.dispose }.not_to raise_error
     assert_instance_of(Magick::DisposeType, @img.dispose)
     expect(@img.dispose).to eq(Magick::UndefinedDispose)
-    assert_nothing_raised { @img.dispose = Magick::NoneDispose }
+    expect { @img.dispose = Magick::NoneDispose }.not_to raise_error
     expect(@img.dispose).to eq(Magick::NoneDispose)
 
     Magick::DisposeType.values do |dispose|
-      assert_nothing_raised { @img.dispose = dispose }
+      expect { @img.dispose = dispose }.not_to raise_error
     end
     expect { @img.dispose = 2 }.to raise_error(TypeError)
   end
 
   def test_endian
-    assert_nothing_raised { @img.endian }
+    expect { @img.endian }.not_to raise_error
     assert_instance_of(Magick::EndianType, @img.endian)
     expect(@img.endian).to eq(Magick::UndefinedEndian)
-    assert_nothing_raised { @img.endian = Magick::LSBEndian }
+    expect { @img.endian = Magick::LSBEndian }.not_to raise_error
     expect(@img.endian).to eq(Magick::LSBEndian)
-    assert_nothing_raised { @img.endian = Magick::MSBEndian }
+    expect { @img.endian = Magick::MSBEndian }.not_to raise_error
     expect { @img.endian = 2 }.to raise_error(TypeError)
   end
 
   def test_extract_info
-    assert_nothing_raised { @img.extract_info }
+    expect { @img.extract_info }.not_to raise_error
     assert_instance_of(Magick::Rectangle, @img.extract_info)
     ext = @img.extract_info
     expect(ext.x).to eq(0)
@@ -274,7 +274,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(ext.width).to eq(0)
     expect(ext.height).to eq(0)
     ext = Magick::Rectangle.new(1, 2, 3, 4)
-    assert_nothing_raised { @img.extract_info = ext }
+    expect { @img.extract_info = ext }.not_to raise_error
     expect(ext.width).to eq(1)
     expect(ext.height).to eq(2)
     expect(ext.x).to eq(3)
@@ -283,32 +283,32 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_filename
-    assert_nothing_raised { @img.filename }
+    expect { @img.filename }.not_to raise_error
     expect(@img.filename).to eq('')
     expect { @img.filename = 'xxx' }.to raise_error(NoMethodError)
   end
 
   def test_filter
-    assert_nothing_raised { @img.filter }
+    expect { @img.filter }.not_to raise_error
     assert_instance_of(Magick::FilterType, @img.filter)
     expect(@img.filter).to eq(Magick::UndefinedFilter)
-    assert_nothing_raised { @img.filter = Magick::PointFilter }
+    expect { @img.filter = Magick::PointFilter }.not_to raise_error
     expect(@img.filter).to eq(Magick::PointFilter)
 
     Magick::FilterType.values do |filter|
-      assert_nothing_raised { @img.filter = filter }
+      expect { @img.filter = filter }.not_to raise_error
     end
     expect { @img.filter = 2 }.to raise_error(TypeError)
   end
 
   def test_format
-    assert_nothing_raised { @img.format }
+    expect { @img.format }.not_to raise_error
     assert_nil(@img.format)
-    assert_nothing_raised { @img.format = 'GIF' }
-    assert_nothing_raised { @img.format = 'JPG' }
-    assert_nothing_raised { @img.format = 'TIFF' }
-    assert_nothing_raised { @img.format = 'MIFF' }
-    assert_nothing_raised { @img.format = 'MPEG' }
+    expect { @img.format = 'GIF' }.not_to raise_error
+    expect { @img.format = 'JPG' }.not_to raise_error
+    expect { @img.format = 'TIFF' }.not_to raise_error
+    expect { @img.format = 'MIFF' }.not_to raise_error
+    expect { @img.format = 'MPEG' }.not_to raise_error
     v = $VERBOSE
     $VERBOSE = nil
     expect { @img.format = 'shit' }.to raise_error(ArgumentError)
@@ -317,33 +317,33 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_fuzz
-    assert_nothing_raised { @img.fuzz }
+    expect { @img.fuzz }.not_to raise_error
     assert_instance_of(Float, @img.fuzz)
     expect(@img.fuzz).to eq(0.0)
-    assert_nothing_raised { @img.fuzz = 50 }
+    expect { @img.fuzz = 50 }.not_to raise_error
     expect(@img.fuzz).to eq(50.0)
-    assert_nothing_raised { @img.fuzz = '50%' }
+    expect { @img.fuzz = '50%' }.not_to raise_error
     assert_in_delta(Magick::QuantumRange * 0.50, @img.fuzz, 0.1)
     expect { @img.fuzz = [] }.to raise_error(TypeError)
     expect { @img.fuzz = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_gamma
-    assert_nothing_raised { @img.gamma }
+    expect { @img.gamma }.not_to raise_error
     assert_instance_of(Float, @img.gamma)
     expect(@img.gamma).to eq(0.45454543828964233)
-    assert_nothing_raised { @img.gamma = 2.0 }
+    expect { @img.gamma = 2.0 }.not_to raise_error
     expect(@img.gamma).to eq(2.0)
     expect { @img.gamma = 'x' }.to raise_error(TypeError)
   end
 
   def test_geometry
-    assert_nothing_raised { @img.geometry }
+    expect { @img.geometry }.not_to raise_error
     assert_nil(@img.geometry)
-    assert_nothing_raised { @img.geometry = nil }
-    assert_nothing_raised { @img.geometry = '90x90' }
+    expect { @img.geometry = nil }.not_to raise_error
+    expect { @img.geometry = '90x90' }.not_to raise_error
     expect(@img.geometry).to eq('90x90')
-    assert_nothing_raised { @img.geometry = Magick::Geometry.new(100, 80) }
+    expect { @img.geometry = Magick::Geometry.new(100, 80) }.not_to raise_error
     expect(@img.geometry).to eq('100x80')
     expect { @img.geometry = [] }.to raise_error(TypeError)
   end
@@ -352,7 +352,7 @@ class Image_Attributes_UT < Minitest::Test
     assert_instance_of(Magick::GravityType, @img.gravity)
 
     Magick::GravityType.values do |gravity|
-      assert_nothing_raised { @img.gravity = gravity }
+      expect { @img.gravity = gravity }.not_to raise_error
     end
     expect { @img.gravity = nil }.to raise_error(TypeError)
     expect { @img.gravity = Magick::PointFilter }.to raise_error(TypeError)
@@ -362,37 +362,37 @@ class Image_Attributes_UT < Minitest::Test
     assert_instance_of(Magick::ImageType, @img.image_type)
 
     Magick::ImageType.values do |image_type|
-      assert_nothing_raised { @img.image_type = image_type }
+      expect { @img.image_type = image_type }.not_to raise_error
     end
     expect { @img.image_type = nil }.to raise_error(TypeError)
     expect { @img.image_type = Magick::PointFilter }.to raise_error(TypeError)
   end
 
   def test_interlace_type
-    assert_nothing_raised { @img.interlace }
+    expect { @img.interlace }.not_to raise_error
     assert_instance_of(Magick::InterlaceType, @img.interlace)
     expect(@img.interlace).to eq(Magick::NoInterlace)
-    assert_nothing_raised { @img.interlace = Magick::LineInterlace }
+    expect { @img.interlace = Magick::LineInterlace }.not_to raise_error
     expect(@img.interlace).to eq(Magick::LineInterlace)
 
     Magick::InterlaceType.values do |interlace|
-      assert_nothing_raised { @img.interlace = interlace }
+      expect { @img.interlace = interlace }.not_to raise_error
     end
     expect { @img.interlace = 2 }.to raise_error(TypeError)
   end
 
   def test_iptc_profile
-    assert_nothing_raised { @img.iptc_profile }
+    expect { @img.iptc_profile }.not_to raise_error
     assert_nil(@img.iptc_profile)
-    assert_nothing_raised { @img.iptc_profile = 'xxx' }
+    expect { @img.iptc_profile = 'xxx' }.not_to raise_error
     expect(@img.iptc_profile).to eq('xxx')
     expect { @img.iptc_profile = 2 }.to raise_error(TypeError)
   end
 
   def test_mean_error
-    assert_nothing_raised { @hat.mean_error_per_pixel }
-    assert_nothing_raised { @hat.normalized_mean_error }
-    assert_nothing_raised { @hat.normalized_maximum_error }
+    expect { @hat.mean_error_per_pixel }.not_to raise_error
+    expect { @hat.normalized_mean_error }.not_to raise_error
+    expect { @hat.normalized_maximum_error }.not_to raise_error
     expect(@hat.mean_error_per_pixel).to eq(0.0)
     expect(@hat.normalized_mean_error).to eq(0.0)
     expect(@hat.normalized_maximum_error).to eq(0.0)
@@ -410,7 +410,7 @@ class Image_Attributes_UT < Minitest::Test
   def test_mime_type
     img = @img.copy
     img.format = 'GIF'
-    assert_nothing_raised { img.mime_type }
+    expect { img.mime_type }.not_to raise_error
     expect(img.mime_type).to eq('image/gif')
     img.format = 'JPG'
     expect(img.mime_type).to eq('image/jpeg')
@@ -420,51 +420,51 @@ class Image_Attributes_UT < Minitest::Test
   def test_monitor
     expect { @img.monitor }.to raise_error(NoMethodError)
     monitor = proc { |name, _q, _s| puts name }
-    assert_nothing_raised { @img.monitor = monitor }
-    assert_nothing_raised { @img.monitor = nil }
+    expect { @img.monitor = monitor }.not_to raise_error
+    expect { @img.monitor = nil }.not_to raise_error
   end
 
   def test_montage
-    assert_nothing_raised { @img.montage }
+    expect { @img.montage }.not_to raise_error
     assert_nil(@img.montage)
   end
 
   def test_number_colors
-    assert_nothing_raised { @hat.number_colors }
+    expect { @hat.number_colors }.not_to raise_error
     assert_kind_of(Integer, @hat.number_colors)
     expect { @hat.number_colors = 2 }.to raise_error(NoMethodError)
   end
 
   def test_offset
-    assert_nothing_raised { @img.offset }
+    expect { @img.offset }.not_to raise_error
     expect(@img.offset).to eq(0)
-    assert_nothing_raised { @img.offset = 10 }
+    expect { @img.offset = 10 }.not_to raise_error
     expect(@img.offset).to eq(10)
     expect { @img.offset = 'x' }.to raise_error(TypeError)
   end
 
   def test_orientation
-    assert_nothing_raised { @img.orientation }
+    expect { @img.orientation }.not_to raise_error
     assert_instance_of(Magick::OrientationType, @img.orientation)
     expect(@img.orientation).to eq(Magick::UndefinedOrientation)
-    assert_nothing_raised { @img.orientation = Magick::TopLeftOrientation }
+    expect { @img.orientation = Magick::TopLeftOrientation }.not_to raise_error
     expect(@img.orientation).to eq(Magick::TopLeftOrientation)
 
     Magick::OrientationType.values do |orientation|
-      assert_nothing_raised { @img.orientation = orientation }
+      expect { @img.orientation = orientation }.not_to raise_error
     end
     expect { @img.orientation = 2 }.to raise_error(TypeError)
   end
 
   def test_page
-    assert_nothing_raised { @img.page }
+    expect { @img.page }.not_to raise_error
     page = @img.page
     expect(page.width).to eq(0)
     expect(page.height).to eq(0)
     expect(page.x).to eq(0)
     expect(page.y).to eq(0)
     page = Magick::Rectangle.new(1, 2, 3, 4)
-    assert_nothing_raised { @img.page = page }
+    expect { @img.page = page }.not_to raise_error
     expect(page.width).to eq(1)
     expect(page.height).to eq(2)
     expect(page.x).to eq(3)
@@ -473,43 +473,43 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_pixel_interpolation_method
-    assert_nothing_raised { @img.pixel_interpolation_method }
+    expect { @img.pixel_interpolation_method }.not_to raise_error
     assert_instance_of(Magick::PixelInterpolateMethod, @img.pixel_interpolation_method)
     expect(@img.pixel_interpolation_method).to eq(Magick::UndefinedInterpolatePixel)
-    assert_nothing_raised { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }
+    expect { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }.not_to raise_error
     expect(@img.pixel_interpolation_method).to eq(Magick::AverageInterpolatePixel)
 
     Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
-      assert_nothing_raised { @img.pixel_interpolation_method = interpolate_pixel_method }
+      expect { @img.pixel_interpolation_method = interpolate_pixel_method }.not_to raise_error
     end
     expect { @img.pixel_interpolation_method = 2 }.to raise_error(TypeError)
   end
 
   def test_quality
-    assert_nothing_raised { @hat.quality }
+    expect { @hat.quality }.not_to raise_error
     expect(@hat.quality).to eq(75)
     expect { @img.quality = 80 }.to raise_error(NoMethodError)
   end
 
   def test_quantum_depth
-    assert_nothing_raised { @img.quantum_depth }
+    expect { @img.quantum_depth }.not_to raise_error
     expect(@img.quantum_depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
     expect { @img.quantum_depth = 8 }.to raise_error(NoMethodError)
   end
 
   def test_rendering_intent
-    assert_nothing_raised { @img.rendering_intent }
+    expect { @img.rendering_intent }.not_to raise_error
     assert_instance_of(Magick::RenderingIntent, @img.rendering_intent)
     expect(@img.rendering_intent).to eq(Magick::PerceptualIntent)
 
     Magick::RenderingIntent.values do |rendering_intent|
-      assert_nothing_raised { @img.rendering_intent = rendering_intent }
+      expect { @img.rendering_intent = rendering_intent }.not_to raise_error
     end
     expect { @img.rendering_intent = 2 }.to raise_error(TypeError)
   end
 
   def test_rows
-    assert_nothing_raised { @img.rows }
+    expect { @img.rows }.not_to raise_error
     expect(@img.rows).to eq(100)
     expect { @img.rows = 2 }.to raise_error(NoMethodError)
   end
@@ -522,68 +522,68 @@ class Image_Attributes_UT < Minitest::Test
     ilist.write('temp.gif')
     FileUtils.rm('temp.gif')
 
-    assert_nothing_raised { img.scene }
+    expect { img.scene }.not_to raise_error
     expect(@img.scene).to eq(0)
     expect(img.scene).to eq(1)
     expect { img.scene = 2 }.to raise_error(NoMethodError)
   end
 
   def test_start_loop
-    assert_nothing_raised { @img.start_loop }
+    expect { @img.start_loop }.not_to raise_error
     assert(!@img.start_loop)
-    assert_nothing_raised { @img.start_loop = true }
+    expect { @img.start_loop = true }.not_to raise_error
     assert(@img.start_loop)
   end
 
   def test_ticks_per_second
-    assert_nothing_raised { @img.ticks_per_second }
+    expect { @img.ticks_per_second }.not_to raise_error
     expect(@img.ticks_per_second).to eq(100)
-    assert_nothing_raised { @img.ticks_per_second = 1000 }
+    expect { @img.ticks_per_second = 1000 }.not_to raise_error
     expect(@img.ticks_per_second).to eq(1000)
     expect { @img.ticks_per_second = 'x' }.to raise_error(TypeError)
   end
 
   def test_total_colors
-    assert_nothing_raised { @hat.total_colors }
+    expect { @hat.total_colors }.not_to raise_error
     assert_kind_of(Integer, @hat.total_colors)
     expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
   end
 
   def test_units
-    assert_nothing_raised { @img.units }
+    expect { @img.units }.not_to raise_error
     assert_instance_of(Magick::ResolutionType, @img.units)
     expect(@img.units).to eq(Magick::UndefinedResolution)
-    assert_nothing_raised { @img.units = Magick::PixelsPerInchResolution }
+    expect { @img.units = Magick::PixelsPerInchResolution }.not_to raise_error
     expect(@img.units).to eq(Magick::PixelsPerInchResolution)
 
     Magick::ResolutionType.values do |resolution|
-      assert_nothing_raised { @img.units = resolution }
+      expect { @img.units = resolution }.not_to raise_error
     end
     expect { @img.units = 2 }.to raise_error(TypeError)
   end
 
   def test_virtual_pixel_method
-    assert_nothing_raised { @img.virtual_pixel_method }
+    expect { @img.virtual_pixel_method }.not_to raise_error
     expect(@img.virtual_pixel_method).to eq(Magick::UndefinedVirtualPixelMethod)
-    assert_nothing_raised { @img.virtual_pixel_method = Magick::EdgeVirtualPixelMethod }
+    expect { @img.virtual_pixel_method = Magick::EdgeVirtualPixelMethod }.not_to raise_error
     expect(@img.virtual_pixel_method).to eq(Magick::EdgeVirtualPixelMethod)
 
     Magick::VirtualPixelMethod.values do |virtual_pixel_method|
-      assert_nothing_raised { @img.virtual_pixel_method = virtual_pixel_method }
+      expect { @img.virtual_pixel_method = virtual_pixel_method }.not_to raise_error
     end
     expect { @img.virtual_pixel_method = 2 }.to raise_error(TypeError)
   end
 
   def test_x_resolution
-    assert_nothing_raised { @img.x_resolution }
-    assert_nothing_raised { @img.x_resolution = 90 }
+    expect { @img.x_resolution }.not_to raise_error
+    expect { @img.x_resolution = 90 }.not_to raise_error
     expect(@img.x_resolution).to eq(90.0)
     expect { @img.x_resolution = 'x' }.to raise_error(TypeError)
   end
 
   def test_y_resolution
-    assert_nothing_raised { @img.y_resolution }
-    assert_nothing_raised { @img.y_resolution = 90 }
+    expect { @img.y_resolution }.not_to raise_error
+    expect { @img.y_resolution = 90 }.not_to raise_error
     expect(@img.y_resolution).to eq(90.0)
     expect { @img.y_resolution = 'x' }.to raise_error(TypeError)
   end

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -8,38 +8,38 @@ class InfoUT < Minitest::Test
 
   def test_options
     # 1-argument form
-    assert_nothing_raised { @info['fill'] }
+    expect { @info['fill'] }.not_to raise_error
     assert_nil(@info['fill'])
 
-    assert_nothing_raised { @info['fill'] = 'red' }
+    expect { @info['fill'] = 'red' }.not_to raise_error
     expect(@info['fill']).to eq('red')
 
-    assert_nothing_raised { @info['fill'] = nil }
+    expect { @info['fill'] = nil }.not_to raise_error
     assert_nil(@info['fill'])
 
     # 2-argument form
-    assert_nothing_raised { @info['tiff', 'bits-per-sample'] = 2 }
+    expect { @info['tiff', 'bits-per-sample'] = 2 }.not_to raise_error
     expect(@info['tiff', 'bits-per-sample']).to eq('2')
 
     # define and undefine
-    assert_nothing_raised { @info.define('tiff', 'bits-per-sample', 4) }
+    expect { @info.define('tiff', 'bits-per-sample', 4) }.not_to raise_error
     expect(@info['tiff', 'bits-per-sample']).to eq('4')
 
-    assert_nothing_raised { @info.undefine('tiff', 'bits-per-sample') }
+    expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
     assert_nil(@info['tiff', 'bits-per-sample'])
     expect { @info.undefine('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
 
   def test_antialias
     assert @info.antialias
-    assert_nothing_raised { @info.antialias = false }
+    expect { @info.antialias = false }.not_to raise_error
     assert !@info.antialias
   end
 
   def test_aref_aset
-    assert_nothing_raised { @info['tiff'] = 'xxx' }
+    expect { @info['tiff'] = 'xxx' }.not_to raise_error
     expect(@info['tiff']).to eq('xxx')
-    assert_nothing_raised { @info['tiff', 'bits-per-sample'] = 'abc' }
+    expect { @info['tiff', 'bits-per-sample'] = 'abc' }.not_to raise_error
     expect(@info['tiff', 'bits-per-sample']).to eq('abc')
     expect { @info['tiff', 'a', 'b'] }.to raise_error(ArgumentError)
     expect { @info['tiff', 'a' * 10_000] }.to raise_error(ArgumentError)
@@ -48,176 +48,176 @@ class InfoUT < Minitest::Test
   end
 
   def test_attenuate
-    assert_nothing_raised { @info.attenuate = 10 }
+    expect { @info.attenuate = 10 }.not_to raise_error
     expect(@info.attenuate).to eq(10)
-    assert_nothing_raised { @info.attenuate = 5.25 }
+    expect { @info.attenuate = 5.25 }.not_to raise_error
     expect(@info.attenuate).to eq(5.25)
-    assert_nothing_raised { @info.attenuate = nil }
+    expect { @info.attenuate = nil }.not_to raise_error
     assert_nil(@info.attenuate)
   end
 
   def test_authenticate
-    assert_nothing_raised { @info.authenticate = 'string' }
+    expect { @info.authenticate = 'string' }.not_to raise_error
     expect(@info.authenticate).to eq('string')
-    assert_nothing_raised { @info.authenticate = nil }
+    expect { @info.authenticate = nil }.not_to raise_error
     assert_nil(@info.authenticate)
-    assert_nothing_raised { @info.authenticate = '' }
+    expect { @info.authenticate = '' }.not_to raise_error
     expect(@info.authenticate).to eq('')
   end
 
   def test_background_color
-    assert_nothing_raised { @info.background_color = 'red' }
+    expect { @info.background_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @info.background_color = red }
+    expect { @info.background_color = red }.not_to raise_error
     expect(@info.background_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.background_color = 'red' }
     expect(img.background_color).to eq('red')
   end
 
   def test_border_color
-    assert_nothing_raised { @info.border_color = 'red' }
+    expect { @info.border_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @info.border_color = red }
+    expect { @info.border_color = red }.not_to raise_error
     expect(@info.border_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.border_color = 'red' }
     expect(img.border_color).to eq('red')
   end
 
   def test_caption
-    assert_nothing_raised { @info.caption = 'string' }
+    expect { @info.caption = 'string' }.not_to raise_error
     expect(@info.caption).to eq('string')
-    assert_nothing_raised { @info.caption = nil }
+    expect { @info.caption = nil }.not_to raise_error
     assert_nil(@info.caption)
-    assert_nothing_raised { Magick::Image.new(20, 20) { self.caption = 'string' } }
+    expect { Magick::Image.new(20, 20) { self.caption = 'string' } }.not_to raise_error
   end
 
   def test_channel
-    assert_nothing_raised { @info.channel(Magick::RedChannel) }
-    assert_nothing_raised { @info.channel(Magick::RedChannel, Magick::BlueChannel) }
+    expect { @info.channel(Magick::RedChannel) }.not_to raise_error
+    expect { @info.channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { @info.channel(1) }.to raise_error(TypeError)
     expect { @info.channel(Magick::RedChannel, 1) }.to raise_error(TypeError)
   end
 
   def test_colorspace
     Magick::ColorspaceType.values.each do |cs|
-      assert_nothing_raised { @info.colorspace = cs }
+      expect { @info.colorspace = cs }.not_to raise_error
       expect(@info.colorspace).to eq(cs)
     end
   end
 
   def test_comment
-    assert_nothing_raised { @info.comment = 'comment' }
+    expect { @info.comment = 'comment' }.not_to raise_error
     expect(@info.comment).to eq('comment')
   end
 
   def test_compression
     Magick::CompressionType.values.each do |v|
-      assert_nothing_raised { @info.compression = v }
+      expect { @info.compression = v }.not_to raise_error
       expect(@info.compression).to eq(v)
     end
   end
 
   def test_define
-    assert_nothing_raised { @info.define('tiff', 'bits-per-sample', 2) }
-    assert_nothing_raised { @info.undefine('tiff', 'bits-per-sample') }
+    expect { @info.define('tiff', 'bits-per-sample', 2) }.not_to raise_error
+    expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
     expect { @info.define('tiff', 'bits-per-sample', 2, 2) }.to raise_error(ArgumentError)
     expect { @info.define('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
 
   def test_density
-    assert_nothing_raised { @info.density = '72x72' }
+    expect { @info.density = '72x72' }.not_to raise_error
     expect(@info.density).to eq('72x72')
-    assert_nothing_raised { @info.density = Magick::Geometry.new(72, 72) }
+    expect { @info.density = Magick::Geometry.new(72, 72) }.not_to raise_error
     expect(@info.density).to eq('72x72')
-    assert_nothing_raised { @info.density = nil }
+    expect { @info.density = nil }.not_to raise_error
     assert_nil(@info.density)
     expect { @info.density = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_delay
-    assert_nothing_raised { @info.delay = 60 }
+    expect { @info.delay = 60 }.not_to raise_error
     expect(@info.delay).to eq(60)
-    assert_nothing_raised { @info.delay = nil }
+    expect { @info.delay = nil }.not_to raise_error
     assert_nil(@info.delay)
     expect { @info.delay = '60' }.to raise_error(TypeError)
   end
 
   def test_depth
-    assert_nothing_raised { @info.depth = 8 }
+    expect { @info.depth = 8 }.not_to raise_error
     expect(@info.depth).to eq(8)
-    assert_nothing_raised { @info.depth = 16 }
+    expect { @info.depth = 16 }.not_to raise_error
     expect(@info.depth).to eq(16)
     expect { @info.depth = 32 }.to raise_error(ArgumentError)
   end
 
   def test_dispose
     Magick::DisposeType.values.each do |v|
-      assert_nothing_raised { @info.dispose = v }
+      expect { @info.dispose = v }.not_to raise_error
       expect(@info.dispose).to eq(v)
     end
-    assert_nothing_raised { @info.dispose = nil }
+    expect { @info.dispose = nil }.not_to raise_error
   end
 
   def test_dither
-    assert_nothing_raised { @info.dither = true }
+    expect { @info.dither = true }.not_to raise_error
     expect(@info.dither).to eq(true)
-    assert_nothing_raised { @info.dither = false }
+    expect { @info.dither = false }.not_to raise_error
     expect(@info.dither).to eq(false)
   end
 
   def test_endian
-    assert_nothing_raised { @info.endian = Magick::LSBEndian }
+    expect { @info.endian = Magick::LSBEndian }.not_to raise_error
     expect(@info.endian).to eq(Magick::LSBEndian)
-    assert_nothing_raised { @info.endian = nil }
+    expect { @info.endian = nil }.not_to raise_error
   end
 
   def test_extract
-    assert_nothing_raised { @info.extract = '100x100' }
+    expect { @info.extract = '100x100' }.not_to raise_error
     expect(@info.extract).to eq('100x100')
-    assert_nothing_raised { @info.extract = Magick::Geometry.new(100, 100) }
+    expect { @info.extract = Magick::Geometry.new(100, 100) }.not_to raise_error
     expect(@info.extract).to eq('100x100')
-    assert_nothing_raised { @info.extract = nil }
+    expect { @info.extract = nil }.not_to raise_error
     assert_nil(@info.extract)
     expect { @info.extract = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_filename
-    assert_nothing_raised { @info.filename = 'string' }
+    expect { @info.filename = 'string' }.not_to raise_error
     expect(@info.filename).to eq('string')
-    assert_nothing_raised { @info.filename = nil }
+    expect { @info.filename = nil }.not_to raise_error
     expect(@info.filename).to eq('')
   end
 
   def test_fill
-    assert_nothing_raised { @info.fill }
+    expect { @info.fill }.not_to raise_error
     assert_nil(@info.fill)
 
-    assert_nothing_raised { @info.fill = 'white' }
+    expect { @info.fill = 'white' }.not_to raise_error
     expect(@info.fill).to eq('white')
 
-    assert_nothing_raised { @info.fill = nil }
+    expect { @info.fill = nil }.not_to raise_error
     assert_nil(@info.fill)
 
     expect { @info.fill = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_font
-    assert_nothing_raised { @info.font = 'Arial' }
+    expect { @info.font = 'Arial' }.not_to raise_error
     expect(@info.font).to eq('Arial')
-    assert_nothing_raised { @info.font = nil }
+    expect { @info.font = nil }.not_to raise_error
     assert_nil(@info.font)
   end
 
   def test_format
-    assert_nothing_raised { @info.format = 'GIF' }
+    expect { @info.format = 'GIF' }.not_to raise_error
     expect(@info.format).to eq('GIF')
     expect { @info.format = nil }.to raise_error(TypeError)
   end
 
   def test_fuzz
-    assert_nothing_raised { @info.fuzz = 50 }
+    expect { @info.fuzz = 50 }.not_to raise_error
     expect(@info.fuzz).to eq(50)
-    assert_nothing_raised { @info.fuzz = '50%' }
+    expect { @info.fuzz = '50%' }.not_to raise_error
     expect(@info.fuzz).to eq(Magick::QuantumRange * 0.5)
     expect { @info.fuzz = nil }.to raise_error(TypeError)
     expect { @info.fuzz = 'xxx' }.to raise_error(ArgumentError)
@@ -225,15 +225,15 @@ class InfoUT < Minitest::Test
 
   def test_gravity
     Magick::GravityType.values.each do |v|
-      assert_nothing_raised { @info.gravity = v }
+      expect { @info.gravity = v }.not_to raise_error
       expect(@info.gravity).to eq(v)
     end
-    assert_nothing_raised { @info.gravity = nil }
+    expect { @info.gravity = nil }.not_to raise_error
   end
 
   def test_image_type
     Magick::ImageType.values.each do |v|
-      assert_nothing_raised { @info.image_type = v }
+      expect { @info.image_type = v }.not_to raise_error
       expect(@info.image_type).to eq(v)
     end
     expect { @info.image_type = nil }.to raise_error(TypeError)
@@ -241,23 +241,23 @@ class InfoUT < Minitest::Test
 
   def test_interlace
     Magick::InterlaceType.values.each do |v|
-      assert_nothing_raised { @info.interlace = v }
+      expect { @info.interlace = v }.not_to raise_error
       expect(@info.interlace).to eq(v)
     end
     expect { @info.interlace = nil }.to raise_error(TypeError)
   end
 
   def test_label
-    assert_nothing_raised { @info.label = 'string' }
+    expect { @info.label = 'string' }.not_to raise_error
     expect(@info.label).to eq('string')
-    assert_nothing_raised { @info.label = nil }
+    expect { @info.label = nil }.not_to raise_error
     assert_nil(@info.label)
   end
 
   def test_matte_color
-    assert_nothing_raised { @info.matte_color = 'red' }
+    expect { @info.matte_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
-    assert_nothing_raised { @info.matte_color = red }
+    expect { @info.matte_color = red }.not_to raise_error
     expect(@info.matte_color).to eq('red')
     img = Magick::Image.new(20, 20) { self.matte_color = 'red' }
     expect(img.matte_color).to eq('red')
@@ -265,7 +265,7 @@ class InfoUT < Minitest::Test
   end
 
   def test_monitor
-    assert_nothing_raised { @info.monitor = -> {} }
+    expect { @info.monitor = -> {} }.not_to raise_error
     monitor = proc do |mth, q, s|
       expect(mth).to eq('resize!')
       assert_kind_of(Integer, q)
@@ -277,18 +277,18 @@ class InfoUT < Minitest::Test
     img.resize!(20, 20)
     img.monitor = nil
 
-    assert_nothing_raised { @info.monitor = nil }
+    expect { @info.monitor = nil }.not_to raise_error
   end
 
   def test_monochrome
-    assert_nothing_raised { @info.monochrome = true }
+    expect { @info.monochrome = true }.not_to raise_error
     assert @info.monochrome
-    assert_nothing_raised { @info.monochrome = nil }
+    expect { @info.monochrome = nil }.not_to raise_error
   end
 
   def test_number_scenes
     assert_kind_of(Integer, @info.number_scenes)
-    assert_nothing_raised { @info.number_scenes = 50 }
+    expect { @info.number_scenes = 50 }.not_to raise_error
     expect(@info.number_scenes).to eq(50)
     expect { @info.number_scenes = nil }.to raise_error(TypeError)
     expect { @info.number_scenes = 'xxx' }.to raise_error(TypeError)
@@ -296,120 +296,120 @@ class InfoUT < Minitest::Test
 
   def test_orientation
     Magick::OrientationType.values.each do |v|
-      assert_nothing_raised { @info.orientation = v }
+      expect { @info.orientation = v }.not_to raise_error
       expect(@info.orientation).to eq(v)
     end
     expect { @info.orientation = nil }.to raise_error(TypeError)
   end
 
   def test_origin
-    assert_nothing_raised { @info.origin = '+10+10' }
+    expect { @info.origin = '+10+10' }.not_to raise_error
     expect(@info.origin).to eq('+10+10')
-    assert_nothing_raised { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }
+    expect { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }.not_to raise_error
     expect(@info.origin).to eq('+10+10')
-    assert_nothing_raised { @info.origin = nil }
+    expect { @info.origin = nil }.not_to raise_error
     assert_nil(@info.origin)
     expect { @info.origin = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_page
-    assert_nothing_raised { @info.page = '612x792>' }
+    expect { @info.page = '612x792>' }.not_to raise_error
     expect(@info.page).to eq('612x792>')
-    assert_nothing_raised { @info.page = nil }
+    expect { @info.page = nil }.not_to raise_error
     assert_nil(@info.page)
   end
 
   def test_pointsize
-    assert_nothing_raised { @info.pointsize = 12 }
+    expect { @info.pointsize = 12 }.not_to raise_error
     expect(@info.pointsize).to eq(12)
   end
 
   def test_quality
-    assert_nothing_raised { @info.quality = 75 }
+    expect { @info.quality = 75 }.not_to raise_error
     expect(@info.quality).to eq(75)
   end
 
   def test_sampling_factor
-    assert_nothing_raised { @info.sampling_factor = '2x1' }
+    expect { @info.sampling_factor = '2x1' }.not_to raise_error
     expect(@info.sampling_factor).to eq('2x1')
-    assert_nothing_raised { @info.sampling_factor = nil }
+    expect { @info.sampling_factor = nil }.not_to raise_error
     assert_nil(@info.sampling_factor)
   end
 
   def test_scene
-    assert_nothing_raised { @info.scene = 123 }
+    expect { @info.scene = 123 }.not_to raise_error
     expect(@info.scene).to eq(123)
     expect { @info.scene = 'xxx' }.to raise_error(TypeError)
   end
 
   def test_server_name
-    assert_nothing_raised { @info.server_name = 'foo' }
+    expect { @info.server_name = 'foo' }.not_to raise_error
     expect(@info.server_name).to eq('foo')
-    assert_nothing_raised { @info.server_name = nil }
+    expect { @info.server_name = nil }.not_to raise_error
     assert_nil(@info.server_name)
   end
 
   def test_size
-    assert_nothing_raised { @info.size = '200x100' }
+    expect { @info.size = '200x100' }.not_to raise_error
     expect(@info.size).to eq('200x100')
-    assert_nothing_raised { @info.size = Magick::Geometry.new(100, 200) }
+    expect { @info.size = Magick::Geometry.new(100, 200) }.not_to raise_error
     expect(@info.size).to eq('100x200')
-    assert_nothing_raised { @info.size = nil }
+    expect { @info.size = nil }.not_to raise_error
     assert_nil(@info.size)
     expect { @info.size = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_stroke
-    assert_nothing_raised { @info.stroke }
+    expect { @info.stroke }.not_to raise_error
     assert_nil(@info.stroke)
 
-    assert_nothing_raised { @info.stroke = 'white' }
+    expect { @info.stroke = 'white' }.not_to raise_error
     expect(@info.stroke).to eq('white')
 
-    assert_nothing_raised { @info.stroke = nil }
+    expect { @info.stroke = nil }.not_to raise_error
     assert_nil(@info.stroke)
 
     expect { @info.stroke = 'xxx' }.to raise_error(ArgumentError)
   end
 
   def test_stroke_width
-    assert_nothing_raised { @info.stroke_width = 10 }
+    expect { @info.stroke_width = 10 }.not_to raise_error
     expect(@info.stroke_width).to eq(10)
-    assert_nothing_raised { @info.stroke_width = 5.25 }
+    expect { @info.stroke_width = 5.25 }.not_to raise_error
     expect(@info.stroke_width).to eq(5.25)
-    assert_nothing_raised { @info.stroke_width = nil }
+    expect { @info.stroke_width = nil }.not_to raise_error
     assert_nil(@info.stroke_width)
     expect { @info.stroke_width = 'xxx' }.to raise_error(TypeError)
   end
 
   def test_texture
     img = Magick::Image.read('granite:') { self.size = '20x20' }
-    assert_nothing_raised { @info.texture = img.first }
-    assert_nothing_raised { @info.texture = nil }
+    expect { @info.texture = img.first }.not_to raise_error
+    expect { @info.texture = nil }.not_to raise_error
   end
 
   def test_tile_offset
-    assert_nothing_raised { @info.tile_offset = '200x100' }
+    expect { @info.tile_offset = '200x100' }.not_to raise_error
     expect(@info.tile_offset).to eq('200x100')
-    assert_nothing_raised { @info.tile_offset = Magick::Geometry.new(100, 200) }
+    expect { @info.tile_offset = Magick::Geometry.new(100, 200) }.not_to raise_error
     expect(@info.tile_offset).to eq('100x200')
     expect { @info.tile_offset = nil }.to raise_error(ArgumentError)
   end
 
   def test_transparent_color
-    assert_nothing_raised { @info.transparent_color = 'white' }
+    expect { @info.transparent_color = 'white' }.not_to raise_error
     expect(@info.transparent_color).to eq('white')
     expect { @info.transparent_color = nil }.to raise_error(TypeError)
   end
 
   def test_undercolor
-    assert_nothing_raised { @info.undercolor }
+    expect { @info.undercolor }.not_to raise_error
     assert_nil(@info.undercolor)
 
-    assert_nothing_raised { @info.undercolor = 'white' }
+    expect { @info.undercolor = 'white' }.not_to raise_error
     expect(@info.undercolor).to eq('white')
 
-    assert_nothing_raised { @info.undercolor = nil }
+    expect { @info.undercolor = nil }.not_to raise_error
     assert_nil(@info.undercolor)
 
     expect { @info.undercolor = 'xxx' }.to raise_error(ArgumentError)
@@ -417,17 +417,17 @@ class InfoUT < Minitest::Test
 
   def test_units
     Magick::ResolutionType.values.each do |v|
-      assert_nothing_raised { @info.units = v }
+      expect { @info.units = v }.not_to raise_error
       expect(@info.units).to eq(v)
     end
   end
 
   def test_view
-    assert_nothing_raised { @info.view = 'string' }
+    expect { @info.view = 'string' }.not_to raise_error
     expect(@info.view).to eq('string')
-    assert_nothing_raised { @info.view = nil }
+    expect { @info.view = nil }.not_to raise_error
     assert_nil(@info.view)
-    assert_nothing_raised { @info.view = '' }
+    expect { @info.view = '' }.not_to raise_error
     expect(@info.view).to eq('')
   end
 end

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -28,7 +28,7 @@ end
 class MagickUT < Minitest::Test
   def test_colors
     res = nil
-    assert_nothing_raised { res = Magick.colors }
+    expect { res = Magick.colors }.not_to raise_error
     assert_instance_of(Array, res)
     res.each do |c|
       assert_instance_of(Magick::Color, c)
@@ -43,33 +43,33 @@ class MagickUT < Minitest::Test
   # No need to test all of them.
   def test_enumerators
     ary = nil
-    assert_nothing_raised do
+    expect do
       ary = Magick::AlphaChannelOption.enumerators
-    end
+    end.not_to raise_error
     assert_instance_of(Array, ary)
 
-    assert_nothing_raised do
+    expect do
       ary = Magick::AlignType.enumerators
-    end
+    end.not_to raise_error
     assert_instance_of(Array, ary)
     expect(ary.length).to eq(4)
 
-    assert_nothing_raised do
+    expect do
       ary = Magick::AnchorType.enumerators
-    end
+    end.not_to raise_error
     assert_instance_of(Array, ary)
     expect(ary.length).to eq(3)
   end
 
   def test_features
     res = nil
-    assert_nothing_raised { res = Magick::Magick_features }
+    expect { res = Magick::Magick_features }.not_to raise_error
     assert_instance_of(String, res)
   end
 
   def test_fonts
     res = nil
-    assert_nothing_raised { res = Magick.fonts }
+    expect { res = Magick.fonts }.not_to raise_error
     assert_instance_of(Array, res)
     res.each do |f|
       assert_instance_of(Magick::Font, f)
@@ -90,15 +90,15 @@ class MagickUT < Minitest::Test
     g = nil
     gs = nil
     g2 = nil
-    assert_nothing_raised { g = Magick::Geometry.new }
-    assert_nothing_raised { gs = g.to_s }
+    expect { g = Magick::Geometry.new }.not_to raise_error
+    expect { gs = g.to_s }.not_to raise_error
     expect(gs).to eq('')
 
     g = Magick::Geometry.new(40)
     gs = g.to_s
     expect(gs).to eq('40x')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -106,7 +106,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -114,7 +114,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50+10+0')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -122,7 +122,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50+10-15')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -130,7 +130,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50@')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -138,7 +138,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50!')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -146,7 +146,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50<')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -154,7 +154,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50>')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -162,7 +162,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40x50^')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -170,7 +170,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40%')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -178,7 +178,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40%x60%')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -186,7 +186,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40%x60%+10+0')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -194,7 +194,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40%x60%+10+20')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -202,7 +202,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40.50x60.75')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -210,7 +210,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('40.50%x60.75%')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -218,7 +218,7 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('+10+20')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
@@ -226,12 +226,12 @@ class MagickUT < Minitest::Test
     gs = g.to_s
     expect(gs).to eq('+10+0')
 
-    assert_nothing_raised { g2 = Magick::Geometry.from_s(gs) }
+    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
     gs2 = g2.to_s
     expect(gs2).to eq(gs)
 
     # assert behavior with empty string argument
-    assert_nothing_raised { g = Magick::Geometry.from_s('') }
+    expect { g = Magick::Geometry.from_s('') }.not_to raise_error
     expect(g.to_s).to eq('')
 
     expect { Magick::Geometry.new(Magick::AreaGeometry) }.to raise_error(ArgumentError)
@@ -249,49 +249,49 @@ class MagickUT < Minitest::Test
   end
 
   def test_set_log_event_mask
-    assert_nothing_raised { Magick.set_log_event_mask('Module,Coder') }
-    assert_nothing_raised { Magick.set_log_event_mask('None') }
+    expect { Magick.set_log_event_mask('Module,Coder') }.not_to raise_error
+    expect { Magick.set_log_event_mask('None') }.not_to raise_error
   end
 
   def test_set_log_format
-    assert_nothing_raised { Magick.set_log_format('format %d%e%f') }
+    expect { Magick.set_log_format('format %d%e%f') }.not_to raise_error
   end
 
   def test_limit_resources
     cur = new = nil
 
-    assert_nothing_raised { cur = Magick.limit_resource(:memory, 500) }
+    expect { cur = Magick.limit_resource(:memory, 500) }.not_to raise_error
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
-    assert_nothing_raised { new = Magick.limit_resource('memory') }
+    expect { new = Magick.limit_resource('memory') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:memory, cur)
 
-    assert_nothing_raised { cur = Magick.limit_resource(:map, 3500) }
+    expect { cur = Magick.limit_resource(:map, 3500) }.not_to raise_error
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
-    assert_nothing_raised { new = Magick.limit_resource('map') }
+    expect { new = Magick.limit_resource('map') }.not_to raise_error
     expect(new).to eq(3500)
     Magick.limit_resource(:map, cur)
 
-    assert_nothing_raised { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }
+    expect { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }.not_to raise_error
     assert_kind_of(Integer, cur)
     assert(cur > 1024**2)
-    assert_nothing_raised { new = Magick.limit_resource('disk') }
+    expect { new = Magick.limit_resource('disk') }.not_to raise_error
     expect(new).to eq(3_221_225_472)
     Magick.limit_resource(:disk, cur)
 
-    assert_nothing_raised { cur = Magick.limit_resource(:file, 500) }
+    expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
     assert_kind_of(Integer, cur)
     assert(cur > 512)
-    assert_nothing_raised { new = Magick.limit_resource('file') }
+    expect { new = Magick.limit_resource('file') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:file, cur)
 
-    assert_nothing_raised { cur = Magick.limit_resource(:time, 300) }
+    expect { cur = Magick.limit_resource(:time, 300) }.not_to raise_error
     assert_kind_of(Integer, cur)
     assert(cur > 300)
-    assert_nothing_raised { new = Magick.limit_resource('time') }
+    expect { new = Magick.limit_resource('time') }.not_to raise_error
     expect(new).to eq(300)
     Magick.limit_resource(:time, cur)
 

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -7,65 +7,65 @@ class PixelUT < Minitest::Test
   end
 
   def test_red
-    assert_nothing_raised { @pixel.red = 123 }
+    expect { @pixel.red = 123 }.not_to raise_error
     expect(@pixel.red).to eq(123)
-    assert_nothing_raised { @pixel.red = 255.25 }
+    expect { @pixel.red = 255.25 }.not_to raise_error
     expect(@pixel.red).to eq(255)
     expect { @pixel.red = 'x' }.to raise_error(TypeError)
   end
 
   def test_green
-    assert_nothing_raised { @pixel.green = 123 }
+    expect { @pixel.green = 123 }.not_to raise_error
     expect(@pixel.green).to eq(123)
-    assert_nothing_raised { @pixel.green = 255.25 }
+    expect { @pixel.green = 255.25 }.not_to raise_error
     expect(@pixel.green).to eq(255)
     expect { @pixel.green = 'x' }.to raise_error(TypeError)
   end
 
   def test_blue
-    assert_nothing_raised { @pixel.blue = 123 }
+    expect { @pixel.blue = 123 }.not_to raise_error
     expect(@pixel.blue).to eq(123)
-    assert_nothing_raised { @pixel.blue = 255.25 }
+    expect { @pixel.blue = 255.25 }.not_to raise_error
     expect(@pixel.blue).to eq(255)
     expect { @pixel.blue = 'x' }.to raise_error(TypeError)
   end
 
   def test_alpha
-    assert_nothing_raised { @pixel.alpha = 123 }
+    expect { @pixel.alpha = 123 }.not_to raise_error
     expect(@pixel.alpha).to eq(123)
-    assert_nothing_raised { @pixel.alpha = 255.25 }
+    expect { @pixel.alpha = 255.25 }.not_to raise_error
     expect(@pixel.alpha).to eq(255)
     expect { @pixel.alpha = 'x' }.to raise_error(TypeError)
   end
 
   def test_cyan
-    assert_nothing_raised { @pixel.cyan = 123 }
+    expect { @pixel.cyan = 123 }.not_to raise_error
     expect(@pixel.cyan).to eq(123)
-    assert_nothing_raised { @pixel.cyan = 255.25 }
+    expect { @pixel.cyan = 255.25 }.not_to raise_error
     expect(@pixel.cyan).to eq(255)
     expect { @pixel.cyan = 'x' }.to raise_error(TypeError)
   end
 
   def test_magenta
-    assert_nothing_raised { @pixel.magenta = 123 }
+    expect { @pixel.magenta = 123 }.not_to raise_error
     expect(@pixel.magenta).to eq(123)
-    assert_nothing_raised { @pixel.magenta = 255.25 }
+    expect { @pixel.magenta = 255.25 }.not_to raise_error
     expect(@pixel.magenta).to eq(255)
     expect { @pixel.magenta = 'x' }.to raise_error(TypeError)
   end
 
   def test_yellow
-    assert_nothing_raised { @pixel.yellow = 123 }
+    expect { @pixel.yellow = 123 }.not_to raise_error
     expect(@pixel.yellow).to eq(123)
-    assert_nothing_raised { @pixel.yellow = 255.25 }
+    expect { @pixel.yellow = 255.25 }.not_to raise_error
     expect(@pixel.yellow).to eq(255)
     expect { @pixel.yellow = 'x' }.to raise_error(TypeError)
   end
 
   def test_black
-    assert_nothing_raised { @pixel.black = 123 }
+    expect { @pixel.black = 123 }.not_to raise_error
     expect(@pixel.black).to eq(123)
-    assert_nothing_raised { @pixel.black = 255.25 }
+    expect { @pixel.black = 255.25 }.not_to raise_error
     expect(@pixel.black).to eq(255)
     expect { @pixel.black = 'x' }.to raise_error(TypeError)
   end
@@ -105,7 +105,7 @@ class PixelUT < Minitest::Test
 
   def test_hash
     hash = nil
-    assert_nothing_raised { hash = @pixel.hash }
+    expect { hash = @pixel.hash }.not_to raise_error
     assert_not_nil(hash)
     expect(hash).to eq(1_385_502_079)
 
@@ -132,12 +132,12 @@ class PixelUT < Minitest::Test
   def test_fcmp
     red = Magick::Pixel.from_color('red')
     blue = Magick::Pixel.from_color('blue')
-    assert_nothing_raised { red.fcmp(red) }
+    expect { red.fcmp(red) }.not_to raise_error
     assert(red.fcmp(red))
     assert(!red.fcmp(blue))
 
-    assert_nothing_raised { red.fcmp(blue, 10) }
-    assert_nothing_raised { red.fcmp(blue, 10, Magick::RGBColorspace) }
+    expect { red.fcmp(blue, 10) }.not_to raise_error
+    expect { red.fcmp(blue, 10, Magick::RGBColorspace) }.not_to raise_error
     expect { red.fcmp(blue, 'x') }.to raise_error(TypeError)
     expect { red.fcmp(blue, 10, 'x') }.to raise_error(TypeError)
     expect { red.fcmp }.to raise_error(ArgumentError)
@@ -145,11 +145,11 @@ class PixelUT < Minitest::Test
   end
 
   def test_from_hsla
-    assert_nothing_raised { Magick::Pixel.from_hsla(127, 50, 50) }
-    assert_nothing_raised { Magick::Pixel.from_hsla(127, 50, 50, 0) }
-    assert_nothing_raised { Magick::Pixel.from_hsla('99%', '100%', '100%', '100%') }
-    assert_nothing_raised { Magick::Pixel.from_hsla(0, 0, 0, 0) }
-    assert_nothing_raised { Magick::Pixel.from_hsla(359, 255, 255, 1.0) }
+    expect { Magick::Pixel.from_hsla(127, 50, 50) }.not_to raise_error
+    expect { Magick::Pixel.from_hsla(127, 50, 50, 0) }.not_to raise_error
+    expect { Magick::Pixel.from_hsla('99%', '100%', '100%', '100%') }.not_to raise_error
+    expect { Magick::Pixel.from_hsla(0, 0, 0, 0) }.not_to raise_error
+    expect { Magick::Pixel.from_hsla(359, 255, 255, 1.0) }.not_to raise_error
     expect { Magick::Pixel.from_hsla([], 50, 50, 0) }.to raise_error(TypeError)
     expect { Magick::Pixel.from_hsla(127, [], 50, 0) }.to raise_error(TypeError)
     expect { Magick::Pixel.from_hsla(127, 50, [], 0) }.to raise_error(TypeError)
@@ -163,7 +163,7 @@ class PixelUT < Minitest::Test
     expect { Magick::Pixel.from_hsla(360, 0, 0) }.to raise_error(RangeError)
     expect { Magick::Pixel.from_hsla(0, 256, 0) }.to raise_error(RangeError)
     expect { Magick::Pixel.from_hsla(0, 0, 256) }.to raise_error(RangeError)
-    assert_nothing_raised { @pixel.to_hsla }
+    expect { @pixel.to_hsla }.not_to raise_error
 
     args = [200, 125.125, 250.5, 0.6]
     px = Magick::Pixel.from_hsla(*args)
@@ -231,17 +231,17 @@ class PixelUT < Minitest::Test
   end
 
   def test_to_color
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance) }
-    assert_nothing_raised { @pixel.to_color(Magick::SVGCompliance) }
-    assert_nothing_raised { @pixel.to_color(Magick::X11Compliance) }
-    assert_nothing_raised { @pixel.to_color(Magick::XPMCompliance) }
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, true) }
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false) }
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 8) }
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 16) }
+    expect { @pixel.to_color(Magick::AllCompliance) }.not_to raise_error
+    expect { @pixel.to_color(Magick::SVGCompliance) }.not_to raise_error
+    expect { @pixel.to_color(Magick::X11Compliance) }.not_to raise_error
+    expect { @pixel.to_color(Magick::XPMCompliance) }.not_to raise_error
+    expect { @pixel.to_color(Magick::AllCompliance, true) }.not_to raise_error
+    expect { @pixel.to_color(Magick::AllCompliance, false) }.not_to raise_error
+    expect { @pixel.to_color(Magick::AllCompliance, false, 8) }.not_to raise_error
+    expect { @pixel.to_color(Magick::AllCompliance, false, 16) }.not_to raise_error
     # test "hex" format
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 8, true) }
-    assert_nothing_raised { @pixel.to_color(Magick::AllCompliance, false, 16, true) }
+    expect { @pixel.to_color(Magick::AllCompliance, false, 8, true) }.not_to raise_error
+    expect { @pixel.to_color(Magick::AllCompliance, false, 16, true) }.not_to raise_error
 
     expect(@pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
     expect(@pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')

--- a/test/PolaroidOptions.rb
+++ b/test/PolaroidOptions.rb
@@ -7,14 +7,14 @@ class PolaroidOptionsUT < Minitest::Test
   end
 
   def test_shadow_color
-    assert_nothing_raised { @options.shadow_color = "gray50" }
+    expect { @options.shadow_color = "gray50" }.not_to raise_error
 
     @options.freeze
     expect { @options.shadow_color = "gray50" }.to raise_error(FreezeError)
   end
 
   def test_border_color
-    assert_nothing_raised { @options.border_color = "gray50" }
+    expect { @options.border_color = "gray50" }.not_to raise_error
 
     @options.freeze
     expect { @options.border_color = "gray50" }.to raise_error(FreezeError)

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -4,12 +4,12 @@ require 'minitest/autorun'
 class PreviewUT < Minitest::Test
   def test_preview
     hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    assert_nothing_raised do
+    expect do
       prev = hat.preview(Magick::RotatePreview)
       assert_instance_of(Magick::Image, prev)
-    end
+    end.not_to raise_error
     Magick::PreviewType.values do |type|
-      assert_nothing_raised { hat.preview(type) }
+      expect { hat.preview(type) }.not_to raise_error
     end
     expect { hat.preview(2) }.to raise_error(TypeError)
   end

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -10,7 +10,7 @@ class LibDrawUT < Minitest::Test
   def test_affine
     @draw.affine(10.5, 12, 15, 20, 22, 25)
     expect(@draw.inspect).to eq('affine 10.5,12,15,20,22,25')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.affine('x', 12, 15, 20, 22, 25) }.to raise_error(ArgumentError)
     expect { @draw.affine(10, 'x', 15, 20, 22, 25) }.to raise_error(ArgumentError)
@@ -24,7 +24,7 @@ class LibDrawUT < Minitest::Test
     Magick::PaintMethod.values do |method|
       draw = Magick::Draw.new
       draw.alpha(10, '20.5', method)
-      assert_nothing_raised { draw.draw(@img) }
+      expect { draw.draw(@img) }.not_to raise_error
     end
 
     expect { @draw.alpha(10, '20.5', 'xxx') }.to raise_error(ArgumentError)
@@ -35,7 +35,7 @@ class LibDrawUT < Minitest::Test
   def test_arc
     @draw.arc(100.5, 120.5, 200, 250, 20, 370)
     expect(@draw.inspect).to eq('arc 100.5,120.5 200,250 20,370')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.arc('x', 120.5, 200, 250, 20, 370) }.to raise_error(ArgumentError)
     expect { @draw.arc(100.5, 'x', 200, 250, 20, 370) }.to raise_error(ArgumentError)
@@ -48,7 +48,7 @@ class LibDrawUT < Minitest::Test
   def test_bezier
     @draw.bezier(10, '20', '20.5', 30, 40.5, 50)
     expect(@draw.inspect).to eq('bezier 10,20,20.5,30,40.5,50')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.bezier }.to raise_error(ArgumentError)
     expect { @draw.bezier(1) }.to raise_error(ArgumentError)
@@ -58,7 +58,7 @@ class LibDrawUT < Minitest::Test
   def test_circle
     @draw.circle(10, '20.5', 30, 40.5)
     expect(@draw.inspect).to eq('circle 10,20.5 30,40.5')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.circle('x', 20, 30, 40) }.to raise_error(ArgumentError)
     expect { @draw.circle(10, 'x', 30, 40) }.to raise_error(ArgumentError)
@@ -69,19 +69,19 @@ class LibDrawUT < Minitest::Test
   def test_clip_path
     @draw.clip_path('test')
     expect(@draw.inspect).to eq('clip-path test')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
   end
 
   def test_clip_rule
     draw = Magick::Draw.new
     draw.clip_rule('evenodd')
     expect(draw.inspect).to eq('clip-rule evenodd')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.clip_rule('nonzero')
     expect(draw.inspect).to eq('clip-rule nonzero')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.clip_rule('foo') }.to raise_error(ArgumentError)
   end
@@ -90,17 +90,17 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.clip_units('userspace')
     expect(draw.inspect).to eq('clip-units userspace')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.clip_units('userspaceonuse')
     expect(draw.inspect).to eq('clip-units userspaceonuse')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.clip_units('objectboundingbox')
     expect(draw.inspect).to eq('clip-units objectboundingbox')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.clip_units('foo') }.to raise_error(ArgumentError)
   end
@@ -109,27 +109,27 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::PointMethod)
     expect(draw.inspect).to eq('color 50.5,50,point')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::ReplaceMethod)
     expect(draw.inspect).to eq('color 50.5,50,replace')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::FloodfillMethod)
     expect(draw.inspect).to eq('color 50.5,50,floodfill')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::FillToBorderMethod)
     expect(draw.inspect).to eq('color 50.5,50,filltoborder')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.color(50.5, 50, Magick::ResetMethod)
     expect(draw.inspect).to eq('color 50.5,50,reset')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.color(10, 20, 'unknown') }.to raise_error(ArgumentError)
     expect { @draw.color('x', 20, Magick::PointMethod) }.to raise_error(ArgumentError)
@@ -141,42 +141,42 @@ class LibDrawUT < Minitest::Test
     draw.decorate(Magick::NoDecoration)
     expect(draw.inspect).to eq('decorate none')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.decorate(Magick::UnderlineDecoration)
     expect(draw.inspect).to eq('decorate underline')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.decorate(Magick::OverlineDecoration)
     expect(draw.inspect).to eq('decorate overline')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.decorate(Magick::OverlineDecoration)
     expect(draw.inspect).to eq('decorate overline')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     # draw = Magick::Draw.new
     # draw.decorate('tomato')
     # expect(draw.inspect).to eq('decorate "tomato"')
     # draw.text(50, 50, 'Hello world')
-    # assert_nothing_raised { draw.draw(@img) }
+    # expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_define_clip_path
-    assert_nothing_raised { @draw.define_clip_path('test') { @draw } }
+    expect { @draw.define_clip_path('test') { @draw } }.not_to raise_error
     expect(@draw.inspect).to eq("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs")
   end
 
   def test_ellipse
     @draw.ellipse(50.5, 30, 25, 25, 60, 120)
     expect(@draw.inspect).to eq('ellipse 50.5,30 25,25 60,120')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.ellipse('x', 20, 30, 40, 50, 60) }.to raise_error(ArgumentError)
     expect { @draw.ellipse(10, 'x', 30, 40, 50, 60) }.to raise_error(ArgumentError)
@@ -189,7 +189,7 @@ class LibDrawUT < Minitest::Test
   def test_encoding
     @draw.encoding('UTF-8')
     expect(@draw.inspect).to eq('encoding UTF-8')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
   end
 
   def test_fill
@@ -197,23 +197,23 @@ class LibDrawUT < Minitest::Test
     draw.fill('tomato')
     expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.fill_color('tomato')
     expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.fill_pattern('tomato')
     expect(draw.inspect).to eq('fill "tomato"')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     # draw = Magick::Draw.new
     # draw.fill_pattern('foo')
-    # assert_nothing_raised { draw.draw(@img) }
+    # expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_fill_opacity
@@ -221,19 +221,19 @@ class LibDrawUT < Minitest::Test
     draw.fill_opacity(0.5)
     expect(draw.inspect).to eq('fill-opacity 0.5')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.fill_opacity('50%')
     expect(draw.inspect).to eq('fill-opacity 50%')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
-    assert_nothing_raised { @draw.fill_opacity(0.0) }
-    assert_nothing_raised { @draw.fill_opacity(1.0) }
-    assert_nothing_raised { @draw.fill_opacity('0.0') }
-    assert_nothing_raised { @draw.fill_opacity('1.0') }
-    assert_nothing_raised { @draw.fill_opacity('20%') }
+    expect { @draw.fill_opacity(0.0) }.not_to raise_error
+    expect { @draw.fill_opacity(1.0) }.not_to raise_error
+    expect { @draw.fill_opacity('0.0') }.not_to raise_error
+    expect { @draw.fill_opacity('1.0') }.not_to raise_error
+    expect { @draw.fill_opacity('20%') }.not_to raise_error
 
     expect { @draw.fill_opacity(-0.01) }.to raise_error(ArgumentError)
     expect { @draw.fill_opacity(1.01) }.to raise_error(ArgumentError)
@@ -247,13 +247,13 @@ class LibDrawUT < Minitest::Test
     draw.fill_rule('evenodd')
     expect(draw.inspect).to eq('fill-rule evenodd')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.fill_rule('nonzero')
     expect(draw.inspect).to eq('fill-rule nonzero')
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.fill_rule('zero') }.to raise_error(ArgumentError)
   end
@@ -264,7 +264,7 @@ class LibDrawUT < Minitest::Test
     draw.font(font_name)
     expect(draw.inspect).to eq("font '#{font_name}'")
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_font_family
@@ -272,7 +272,7 @@ class LibDrawUT < Minitest::Test
     draw.font_family('sans-serif')
     expect(draw.inspect).to eq("font-family 'sans-serif'")
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_font_stretch
@@ -282,7 +282,7 @@ class LibDrawUT < Minitest::Test
       draw = Magick::Draw.new
       draw.font_stretch(stretch)
       draw.text(50, 50, 'Hello world')
-      assert_nothing_raised { draw.draw(@img) }
+      expect { draw.draw(@img) }.not_to raise_error
     end
 
     expect { @draw.font_stretch('xxx') }.to raise_error(ArgumentError)
@@ -293,19 +293,19 @@ class LibDrawUT < Minitest::Test
     draw.font_style(Magick::NormalStyle)
     expect(draw.inspect).to eq('font-style normal')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.font_style(Magick::ItalicStyle)
     expect(draw.inspect).to eq('font-style italic')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.font_style(Magick::ObliqueStyle)
     expect(draw.inspect).to eq('font-style oblique')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.font_style('xxx') }.to raise_error(ArgumentError)
   end
@@ -315,14 +315,14 @@ class LibDrawUT < Minitest::Test
       draw = Magick::Draw.new
       draw.font_weight(weight)
       draw.text(50, 50, 'Hello world')
-      assert_nothing_raised { draw.draw(@img) }
+      expect { draw.draw(@img) }.not_to raise_error
     end
 
     draw = Magick::Draw.new
     draw.font_weight(400)
     expect(draw.inspect).to eq('font-weight 400')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.font_weight('xxx') }.to raise_error(ArgumentError)
   end
@@ -334,7 +334,7 @@ class LibDrawUT < Minitest::Test
       draw = Magick::Draw.new
       draw.gravity(gravity)
       draw.circle(10, '20.5', 30, 40.5)
-      assert_nothing_raised { draw.draw(@img) }
+      expect { draw.draw(@img) }.not_to raise_error
     end
 
     expect { @draw.gravity('xxx') }.to raise_error(ArgumentError)
@@ -346,7 +346,7 @@ class LibDrawUT < Minitest::Test
 
       draw = Magick::Draw.new
       draw.image(composite, 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg")
-      assert_nothing_raised { draw.draw(@img) }
+      expect { draw.draw(@img) }.not_to raise_error
     end
 
     expect { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
@@ -360,12 +360,12 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.interline_spacing(40.5)
     expect(draw.inspect).to eq('interline-spacing 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.interline_spacing('40.5')
     expect(draw.inspect).to eq('interline-spacing 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.interline_spacing(Float::NAN) }.to raise_error(ArgumentError)
     expect { @draw.interline_spacing('nan') }.to raise_error(ArgumentError)
@@ -377,12 +377,12 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.interword_spacing(40.5)
     expect(draw.inspect).to eq('interword-spacing 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.interword_spacing('40.5')
     expect(draw.inspect).to eq('interword-spacing 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.interword_spacing(Float::NAN) }.to raise_error(ArgumentError)
     expect { @draw.interword_spacing('nan') }.to raise_error(ArgumentError)
@@ -394,12 +394,12 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.kerning(40.5)
     expect(draw.inspect).to eq('kerning 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.kerning('40.5')
     expect(draw.inspect).to eq('kerning 40.5')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.kerning(Float::NAN) }.to raise_error(ArgumentError)
     expect { @draw.kerning('nan') }.to raise_error(ArgumentError)
@@ -410,7 +410,7 @@ class LibDrawUT < Minitest::Test
   def test_line
     @draw.line(10, '20.5', 30, 40.5)
     expect(@draw.inspect).to eq('line 10,20.5 30,40.5')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.line('x', '20.5', 30, 40.5) }.to raise_error(ArgumentError)
     expect { @draw.line(10, 'x', 30, 40.5) }.to raise_error(ArgumentError)
@@ -421,13 +421,13 @@ class LibDrawUT < Minitest::Test
   def test_opacity
     @draw.opacity(0.8)
     expect(@draw.inspect).to eq('opacity 0.8')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
-    assert_nothing_raised { @draw.opacity(0.0) }
-    assert_nothing_raised { @draw.opacity(1.0) }
-    assert_nothing_raised { @draw.opacity('0.0') }
-    assert_nothing_raised { @draw.opacity('1.0') }
-    assert_nothing_raised { @draw.opacity('20%') }
+    expect { @draw.opacity(0.0) }.not_to raise_error
+    expect { @draw.opacity(1.0) }.not_to raise_error
+    expect { @draw.opacity('0.0') }.not_to raise_error
+    expect { @draw.opacity('1.0') }.not_to raise_error
+    expect { @draw.opacity('20%') }.not_to raise_error
 
     expect { @draw.opacity(-0.01) }.to raise_error(ArgumentError)
     expect { @draw.opacity(1.01) }.to raise_error(ArgumentError)
@@ -439,13 +439,13 @@ class LibDrawUT < Minitest::Test
   def test_path
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'")
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
   end
 
   def test_pattern
     @draw.pattern('hat', 0, 10.5, 20, '20') {}
     expect(@draw.inspect).to eq("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs")
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.pattern('hat', 'x', 0, 20, 20) {} }.to raise_error(ArgumentError)
     expect { @draw.pattern('hat', 0, 'x', 20, 20) {} }.to raise_error(ArgumentError)
@@ -456,7 +456,7 @@ class LibDrawUT < Minitest::Test
   def test_point
     @draw.point(10.5, '20')
     expect(@draw.inspect).to eq('point 10.5,20')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.point('x', 20) }.to raise_error(ArgumentError)
     expect { @draw.point(10, 'x') }.to raise_error(ArgumentError)
@@ -465,7 +465,7 @@ class LibDrawUT < Minitest::Test
   def test_pointsize
     @draw.pointsize(20.5)
     expect(@draw.inspect).to eq('font-size 20.5')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.pointsize('x') }.to raise_error(ArgumentError)
   end
@@ -473,7 +473,7 @@ class LibDrawUT < Minitest::Test
   def test_font_size
     @draw.font_size(20)
     expect(@draw.inspect).to eq('font-size 20')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.font_size('x') }.to raise_error(ArgumentError)
   end
@@ -481,7 +481,7 @@ class LibDrawUT < Minitest::Test
   def test_polygon
     @draw.polygon(0, '0.5', 8.5, 16, 16, 0, 0, 0)
     expect(@draw.inspect).to eq('polygon 0,0.5,8.5,16,16,0,0,0')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.polygon }.to raise_error(ArgumentError)
     expect { @draw.polygon(0) }.to raise_error(ArgumentError)
@@ -491,7 +491,7 @@ class LibDrawUT < Minitest::Test
   def test_polyline
     @draw.polyline(0, '0.5', 16.5, 16)
     expect(@draw.inspect).to eq('polyline 0,0.5,16.5,16')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.polyline }.to raise_error(ArgumentError)
     expect { @draw.polyline(0) }.to raise_error(ArgumentError)
@@ -501,7 +501,7 @@ class LibDrawUT < Minitest::Test
   def test_rectangle
     @draw.rectangle(10, '10', 100, 100)
     expect(@draw.inspect).to eq('rectangle 10,10 100,100')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.rectangle('x', 10, 20, 20) }.to raise_error(ArgumentError)
     expect { @draw.rectangle(10, 'x', 20, 20) }.to raise_error(ArgumentError)
@@ -513,7 +513,7 @@ class LibDrawUT < Minitest::Test
     @draw.rotate(45)
     expect(@draw.inspect).to eq('rotate 45')
     @draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.rotate('x') }.to raise_error(ArgumentError)
   end
@@ -521,7 +521,7 @@ class LibDrawUT < Minitest::Test
   def test_roundrectangle
     @draw.roundrectangle(10, '10', 100, 100, 20, 20)
     expect(@draw.inspect).to eq('roundrectangle 10,10,100,100,20,20')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }.to raise_error(ArgumentError)
     expect { @draw.roundrectangle(10, 'x', 100, 100, 20, 20) }.to raise_error(ArgumentError)
@@ -535,7 +535,7 @@ class LibDrawUT < Minitest::Test
     @draw.scale('0.5', 1.5)
     expect(@draw.inspect).to eq('scale 0.5,1.5')
     @draw.rectangle(10, '10', 100, 100)
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.scale('x', 1.5) }.to raise_error(ArgumentError)
     expect { @draw.scale(0.5, 'x') }.to raise_error(ArgumentError)
@@ -545,7 +545,7 @@ class LibDrawUT < Minitest::Test
     @draw.skewx(45)
     expect(@draw.inspect).to eq('skewX 45')
     @draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.skewx('x') }.to raise_error(ArgumentError)
   end
@@ -554,7 +554,7 @@ class LibDrawUT < Minitest::Test
     @draw.skewy(45)
     expect(@draw.inspect).to eq('skewY 45')
     @draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.skewy('x') }.to raise_error(ArgumentError)
   end
@@ -563,7 +563,7 @@ class LibDrawUT < Minitest::Test
     @draw.stroke('red')
     expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.stroke(100) }.to raise_error(ArgumentError)
   end
@@ -572,7 +572,7 @@ class LibDrawUT < Minitest::Test
     @draw.stroke_color('red')
     expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.stroke_color(100) }.to raise_error(ArgumentError)
   end
@@ -581,7 +581,7 @@ class LibDrawUT < Minitest::Test
     @draw.stroke_pattern('red')
     expect(@draw.inspect).to eq('stroke "red"')
     @draw.rectangle(10, '10', 100, 100)
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     # expect { @draw.stroke_pattern(100) }.to raise_error(ArgumentError)
   end
@@ -593,7 +593,7 @@ class LibDrawUT < Minitest::Test
     draw.stroke_pattern('red')
     draw.stroke_width(5)
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_antialias(false)
@@ -601,7 +601,7 @@ class LibDrawUT < Minitest::Test
     draw.stroke_pattern('red')
     draw.stroke_width(5)
     draw.circle(10, '20.5', 30, 40.5)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_stroke_dasharray
@@ -611,12 +611,12 @@ class LibDrawUT < Minitest::Test
     draw.stroke_pattern('red')
     draw.stroke_width(2)
     draw.rectangle(10, '10', 100, 100)
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_dasharray
     expect(draw.inspect).to eq('stroke-dasharray none')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_dasharray(-0.1) }.to raise_error(ArgumentError)
     expect { @draw.stroke_dasharray('x') }.to raise_error(ArgumentError)
@@ -625,7 +625,7 @@ class LibDrawUT < Minitest::Test
   def test_stroke_dashoffset
     @draw.stroke_dashoffset(10)
     expect(@draw.inspect).to eq('stroke-dashoffset 10')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_dashoffset('x') }.to raise_error(ArgumentError)
   end
@@ -634,17 +634,17 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.stroke_linecap('butt')
     expect(draw.inspect).to eq('stroke-linecap butt')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_linecap('round')
     expect(draw.inspect).to eq('stroke-linecap round')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_linecap('square')
     expect(draw.inspect).to eq('stroke-linecap square')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_linecap('foo') }.to raise_error(ArgumentError)
   end
@@ -653,17 +653,17 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.stroke_linejoin('round')
     expect(draw.inspect).to eq('stroke-linejoin round')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_linejoin('miter')
     expect(draw.inspect).to eq('stroke-linejoin miter')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.stroke_linejoin('bevel')
     expect(draw.inspect).to eq('stroke-linejoin bevel')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_linejoin('foo') }.to raise_error(ArgumentError)
   end
@@ -672,7 +672,7 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.stroke_miterlimit(1.0)
     expect(draw.inspect).to eq('stroke-miterlimit 1.0')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_miterlimit(0.9) }.to raise_error(ArgumentError)
     expect { @draw.stroke_miterlimit('foo') }.to raise_error(ArgumentError)
@@ -681,13 +681,13 @@ class LibDrawUT < Minitest::Test
   def test_stroke_opacity
     @draw.stroke_opacity(0.8)
     expect(@draw.inspect).to eq('stroke-opacity 0.8')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
-    assert_nothing_raised { @draw.stroke_opacity(0.0) }
-    assert_nothing_raised { @draw.stroke_opacity(1.0) }
-    assert_nothing_raised { @draw.stroke_opacity('0.0') }
-    assert_nothing_raised { @draw.stroke_opacity('1.0') }
-    assert_nothing_raised { @draw.stroke_opacity('20%') }
+    expect { @draw.stroke_opacity(0.0) }.not_to raise_error
+    expect { @draw.stroke_opacity(1.0) }.not_to raise_error
+    expect { @draw.stroke_opacity('0.0') }.not_to raise_error
+    expect { @draw.stroke_opacity('1.0') }.not_to raise_error
+    expect { @draw.stroke_opacity('20%') }.not_to raise_error
 
     expect { @draw.stroke_opacity(-0.01) }.to raise_error(ArgumentError)
     expect { @draw.stroke_opacity(1.01) }.to raise_error(ArgumentError)
@@ -699,7 +699,7 @@ class LibDrawUT < Minitest::Test
   def test_stroke_width
     @draw.stroke_width(2.5)
     expect(@draw.inspect).to eq('stroke-width 2.5')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.stroke_width('xxx') }.to raise_error(ArgumentError)
   end
@@ -708,27 +708,27 @@ class LibDrawUT < Minitest::Test
     draw = Magick::Draw.new
     draw.text(50, 50, 'Hello world')
     expect(draw.inspect).to eq("text 50,50 'Hello world'")
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello 'world'")
     expect(draw.inspect).to eq("text 50,50 \"Hello 'world'\"")
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text(50, 50, 'Hello "world"')
     expect(draw.inspect).to eq("text 50,50 'Hello \"world\"'")
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello 'world\"")
     expect(draw.inspect).to eq("text 50,50 {Hello 'world\"}")
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text(50, 50, "Hello {'world\"")
     expect(draw.inspect).to eq("text 50,50 {Hello {'world\"}")
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.text(50, 50, '') }.to raise_error(ArgumentError)
     expect { @draw.text('x', 50, 'Hello world') }.to raise_error(ArgumentError)
@@ -740,19 +740,19 @@ class LibDrawUT < Minitest::Test
     draw.text_align(Magick::LeftAlign)
     expect(draw.inspect).to eq('text-align left')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text_align(Magick::RightAlign)
     expect(draw.inspect).to eq('text-align right')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text_align(Magick::CenterAlign)
     expect(draw.inspect).to eq('text-align center')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.text_align('x') }.to raise_error(ArgumentError)
   end
@@ -762,19 +762,19 @@ class LibDrawUT < Minitest::Test
     draw.text_anchor(Magick::StartAnchor)
     expect(draw.inspect).to eq('text-anchor start')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text_anchor(Magick::MiddleAnchor)
     expect(draw.inspect).to eq('text-anchor middle')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text_anchor(Magick::EndAnchor)
     expect(draw.inspect).to eq('text-anchor end')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     expect { @draw.text_anchor('x') }.to raise_error(ArgumentError)
   end
@@ -784,26 +784,26 @@ class LibDrawUT < Minitest::Test
     draw.text_antialias(true)
     expect(draw.inspect).to eq('text-antialias 1')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
 
     draw = Magick::Draw.new
     draw.text_antialias(false)
     expect(draw.inspect).to eq('text-antialias 0')
     draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { draw.draw(@img) }
+    expect { draw.draw(@img) }.not_to raise_error
   end
 
   def test_text_undercolor
     @draw.text_undercolor('red')
     expect(@draw.inspect).to eq('text-undercolor "red"')
     @draw.text(50, 50, 'Hello world')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
   end
 
   def test_translate
     @draw.translate('200', 300)
     expect(@draw.inspect).to eq('translate 200,300')
-    assert_nothing_raised { @draw.draw(@img) }
+    expect { @draw.draw(@img) }.not_to raise_error
 
     expect { @draw.translate('x', 300) }.to raise_error(ArgumentError)
     expect { @draw.translate(200, 'x') }.to raise_error(ArgumentError)

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -30,10 +30,6 @@ end
 
 module Minitest
   module Assertions
-    def assert_nothing_raised
-      yield
-    end
-
     def assert_block
       assert(yield)
     end
@@ -55,17 +51,25 @@ module Minitest
       end
     end
 
+    def not_to(matcher)
+      case matcher
+      when :raise_error
+        @actual_block.call
+      else
+        raise ArgumentError, "no negated matcher: #{matcher.inspect}"
+      end
+    end
+
     def eq(expected)
       @expected = expected
       :eq
     end
 
-    def raise_error(expected)
+    def raise_error(expected = :__not_set__)
       @expected = expected
       :raise_error
     end
 
-    alias assert_nothing_thrown assert_nothing_raised
     alias assert_not_same refute_same
     alias assert_not_equal refute_equal
     alias assert_not_nil refute_nil

--- a/test/tmpnam_test.rb
+++ b/test/tmpnam_test.rb
@@ -17,7 +17,7 @@ class TmpnamTest < Minitest::Test
     info.texture = texture
 
     # now it exists
-    assert_nothing_raised { Magick._tmpnam_ }
+    expect { Magick._tmpnam_ }.not_to raise_error
     expect(Magick._tmpnam_).to eq(1)
 
     info.texture = texture


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/raise-error-matcher#expect-no-error-at-all