### PR TITLE
Replace `assert_instance_of` with RSpec style matcher

### DIFF
--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -179,7 +179,7 @@ class DrawUT < Minitest::Test
       @draw.annotate(img, 100, 100, 20, 20, 'Hello world 2') do |draw|
         yield_obj = draw
       end
-      assert_instance_of(Magick::Draw, yield_obj)
+      expect(yield_obj).to be_instance_of(Magick::Draw)
     end.not_to raise_error
 
     expect do
@@ -205,14 +205,14 @@ class DrawUT < Minitest::Test
     @draw.taint
     @draw.freeze
     dup = @draw.dup
-    assert_instance_of(Magick::Draw, dup)
+    expect(dup).to be_instance_of(Magick::Draw)
   end
 
   def test_clone
     @draw.taint
     @draw.freeze
     clone = @draw.clone
-    assert_instance_of(Magick::Draw, clone)
+    expect(clone).to be_instance_of(Magick::Draw)
   end
 
   def test_composite
@@ -321,7 +321,7 @@ class DrawUT < Minitest::Test
       Magick::Draw.new do |option|
         yield_obj = option
       end
-      assert_instance_of(Magick::Image::DrawOptions, yield_obj)
+      expect(yield_obj).to be_instance_of(Magick::Image::DrawOptions)
     end.not_to raise_error
   end
 

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -56,14 +56,14 @@ class EnumUT < Minitest::Test
   end
 
   def test_type_values
-    assert_instance_of(Array, Magick::AlignType.values)
+    expect(Magick::AlignType.values).to be_instance_of(Array)
 
     expect(Magick::AlignType.values[0].to_s).to eq('UndefinedAlign')
     expect(Magick::AlignType.values[0].to_i).to eq(0)
 
     Magick::AlignType.values do |enum|
       assert_kind_of(Magick::Enum, enum)
-      assert_instance_of(Magick::AlignType, enum)
+      expect(enum).to be_instance_of(Magick::AlignType)
     end
   end
 

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -3,8 +3,8 @@ require 'minitest/autorun'
 
 class GradientFillUT < Minitest::Test
   def test_new
-    assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000'))
-    assert_instance_of(Magick::GradientFill, Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red'))
+    expect(Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000')).to be_instance_of(Magick::GradientFill)
+    expect(Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red')).to be_instance_of(Magick::GradientFill)
 
     expect { Magick::GradientFill.new(0, 0, 0, 100, 'foo', '#000') }.to raise_error(ArgumentError)
     expect { Magick::GradientFill.new(0, 0, 0, 100, '#900', 'bar') }.to raise_error(ArgumentError)
@@ -76,7 +76,7 @@ end
 class TextureFillUT < Minitest::Test
   def test_new
     granite = Magick::Image.read('granite:').first
-    assert_instance_of(Magick::TextureFill, Magick::TextureFill.new(granite))
+    expect(Magick::TextureFill.new(granite)).to be_instance_of(Magick::TextureFill)
   end
 
   def test_fill

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -11,8 +11,8 @@ class Image1_UT < Minitest::Test
     blob = img.to_blob
     encoded = [blob].pack('m*')
     res = Magick::Image.read_inline(encoded)
-    assert_instance_of(Array, res)
-    assert_instance_of(Magick::Image, res[0])
+    expect(res).to be_instance_of(Array)
+    expect(res[0]).to be_instance_of(Magick::Image)
     expect(res[0]).to eq(img)
     expect { Magick::Image.read(nil) }.to raise_error(ArgumentError)
     expect { Magick::Image.read("") }.to raise_error(ArgumentError)
@@ -36,7 +36,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_blur
     expect do
       res = @img.adaptive_blur
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_blur(2) }.not_to raise_error
     expect { @img.adaptive_blur(3, 2) }.not_to raise_error
@@ -46,7 +46,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_blur_channel
     expect do
       res = @img.adaptive_blur_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_blur_channel(2) }.not_to raise_error
     expect { @img.adaptive_blur_channel(3, 2) }.not_to raise_error
@@ -58,7 +58,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_resize
     expect do
       res = @img.adaptive_resize(10, 10)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_resize(2) }.not_to raise_error
     expect { @img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
@@ -70,7 +70,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_sharpen
     expect do
       res = @img.adaptive_sharpen
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_sharpen(2) }.not_to raise_error
     expect { @img.adaptive_sharpen(3, 2) }.not_to raise_error
@@ -80,7 +80,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_sharpen_channel
     expect do
       res = @img.adaptive_sharpen_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_sharpen_channel(2) }.not_to raise_error
     expect { @img.adaptive_sharpen_channel(3, 2) }.not_to raise_error
@@ -92,7 +92,7 @@ class Image1_UT < Minitest::Test
   def test_adaptive_threshold
     expect do
       res = @img.adaptive_threshold
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.adaptive_threshold(2) }.not_to raise_error
     expect { @img.adaptive_threshold(2, 4) }.not_to raise_error
@@ -150,7 +150,7 @@ class Image1_UT < Minitest::Test
     expect { @img.affine_transform(affine) }.not_to raise_error
     expect { @img.affine_transform(0) }.to raise_error(TypeError)
     res = @img.affine_transform(affine)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   # test alpha backward compatibility. Image#alpha w/o arguments acts like alpha?
@@ -193,7 +193,7 @@ class Image1_UT < Minitest::Test
   def test_auto_gamma
     res = nil
     expect { res = @img.auto_gamma_channel }.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect { res = @img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
     expect { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
@@ -203,7 +203,7 @@ class Image1_UT < Minitest::Test
   def test_auto_level
     res = nil
     expect { res = @img.auto_level_channel }.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect { res = @img.auto_level_channel Magick::RedChannel }.not_to raise_error
     expect { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
@@ -216,7 +216,7 @@ class Image1_UT < Minitest::Test
         img = Magick::Image.new(10, 10)
         img.orientation = v
         res = img.auto_orient
-        assert_instance_of(Magick::Image, res)
+        expect(res).to be_instance_of(Magick::Image)
         assert_not_same(img, res)
       end.not_to raise_error
     end
@@ -238,7 +238,7 @@ class Image1_UT < Minitest::Test
     expect { @img.bilevel_channel(100, Magick::AllChannels) }.not_to raise_error
     expect { @img.bilevel_channel(100, 2) }.to raise_error(TypeError)
     res = @img.bilevel_channel(100)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   def test_blend
@@ -252,7 +252,7 @@ class Image1_UT < Minitest::Test
       expect { @img.blend(@img2, 0.25, 0.75, gravity, 10, 10) }.not_to raise_error
     end
 
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     expect { @img.blend(@img2, '25%') }.not_to raise_error
     expect { @img.blend(@img2, 0.25, 0.75) }.not_to raise_error
     expect { @img.blend(@img2, '25%', '75%') }.not_to raise_error
@@ -285,7 +285,7 @@ class Image1_UT < Minitest::Test
     expect { @img.blur_channel(1, 2, Magick::AllChannels) }.not_to raise_error
     expect { @img.blur_channel(1, 2, 2) }.to raise_error(TypeError)
     res = @img.blur_channel
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   def test_blur_image
@@ -294,7 +294,7 @@ class Image1_UT < Minitest::Test
     expect { @img.blur_image(1, 2) }.not_to raise_error
     expect { @img.blur_image(1, 2, 3) }.to raise_error(ArgumentError)
     res = @img.blur_image
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   def test_black_threshold
@@ -308,14 +308,14 @@ class Image1_UT < Minitest::Test
     expect { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
     expect { @img.black_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
     res = @img.black_threshold(50)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   def test_border
     expect { @img.border(2, 2, 'red') }.not_to raise_error
     expect { @img.border!(2, 2, 'red') }.not_to raise_error
     res = @img.border(2, 2, 'red')
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     @img.freeze
     expect { @img.border!(2, 2, 'red') }.to raise_error(FreezeError)
   end
@@ -351,7 +351,7 @@ class Image1_UT < Minitest::Test
       expect { @img.channel(channel) }.not_to raise_error
     end
 
-    assert_instance_of(Magick::Image, @img.channel(Magick::RedChannel))
+    expect(@img.channel(Magick::RedChannel)).to be_instance_of(Magick::Image)
     expect { @img.channel(2) }.to raise_error(TypeError)
   end
 
@@ -370,7 +370,7 @@ class Image1_UT < Minitest::Test
   def test_channel_extrema
     expect do
       res = @img.channel_extrema
-      assert_instance_of(Array, res)
+      expect(res).to be_instance_of(Array)
       expect(res.length).to eq(2)
       assert_kind_of(Integer, res[0])
       assert_kind_of(Integer, res[1])
@@ -387,10 +387,10 @@ class Image1_UT < Minitest::Test
   def test_channel_mean
     expect do
       res = @img.channel_mean
-      assert_instance_of(Array, res)
+      expect(res).to be_instance_of(Array)
       expect(res.length).to eq(2)
-      assert_instance_of(Float, res[0])
-      assert_instance_of(Float, res[1])
+      expect(res[0]).to be_instance_of(Float)
+      expect(res[1]).to be_instance_of(Float)
     end.not_to raise_error
     expect { @img.channel_mean(Magick::RedChannel) }.not_to raise_error
     expect { @img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
@@ -404,7 +404,7 @@ class Image1_UT < Minitest::Test
   def test_charcoal
     expect do
       res = @img.charcoal
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.charcoal(1.0) }.not_to raise_error
     expect { @img.charcoal(1.0, 2.0) }.not_to raise_error
@@ -414,14 +414,14 @@ class Image1_UT < Minitest::Test
   def test_chop
     expect do
       res = @img.chop(10, 10, 10, 10)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
   def test_clone
     expect do
       res = @img.clone
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       expect(@img).to eq(res)
     end.not_to raise_error
     res = @img.clone
@@ -448,7 +448,7 @@ class Image1_UT < Minitest::Test
     expect { @img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
     expect do
       res = @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, 'red')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
@@ -459,7 +459,7 @@ class Image1_UT < Minitest::Test
     expect { @img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
     expect do
       res = @img.color_floodfill(@img.columns / 2, @img.rows / 2, 'red')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { @img.color_floodfill(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
@@ -468,20 +468,20 @@ class Image1_UT < Minitest::Test
   def test_color_histogram
     expect do
       res = @img.color_histogram
-      assert_instance_of(Hash, res)
+      expect(res).to be_instance_of(Hash)
     end.not_to raise_error
     expect do
       @img.class_type = Magick::PseudoClass
       res = @img.color_histogram
       expect(@img.class_type).to eq(Magick::PseudoClass)
-      assert_instance_of(Hash, res)
+      expect(res).to be_instance_of(Hash)
     end.not_to raise_error
   end
 
   def test_colorize
     expect do
       res = @img.colorize(0.25, 0.25, 0.25, 'red')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
@@ -509,7 +509,7 @@ class Image1_UT < Minitest::Test
     expect { pc_img.colormap(-1) }.to raise_error(IndexError)
     expect { pc_img.colormap(ncolors - 1) }.not_to raise_error
     res = pc_img.colormap(0)
-    assert_instance_of(String, res)
+    expect(res).to be_instance_of(String)
 
     # test 'set' operation
     expect do
@@ -531,7 +531,7 @@ class Image1_UT < Minitest::Test
   def test_color_point
     expect do
       res = @img.color_point(0, 0, 'red')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
@@ -571,9 +571,9 @@ class Image1_UT < Minitest::Test
     expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }.to raise_error(TypeError)
 
     res = img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric)
-    assert_instance_of(Array, res)
-    assert_instance_of(Magick::Image, res[0])
-    assert_instance_of(Float, res[1])
+    expect(res).to be_instance_of(Array)
+    expect(res[0]).to be_instance_of(Magick::Image)
+    expect(res[1]).to be_instance_of(Float)
 
     img2.destroy!
     expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric) }.to raise_error(Magick::DestroyedImageError)

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -61,7 +61,7 @@ class Image2_UT < Minitest::Test
     img2.define('compose:args', '1x1')
     expect do
       res = img1.composite_affine(img2, affine)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -89,7 +89,7 @@ class Image2_UT < Minitest::Test
     fg = Magick::Image.new(50, 50) { self.background_color = 'black' }
     res = nil
     expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(bg, res)
     assert_not_same(fg, res)
     expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
@@ -108,7 +108,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = bg.composite_tiled(fg)
     end.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(bg, res)
     assert_not_same(fg, res)
     expect { bg.composite_tiled!(fg) }.not_to raise_error
@@ -138,7 +138,7 @@ class Image2_UT < Minitest::Test
   def test_contrast
     expect do
       res = @img.contrast
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.contrast(true) }.not_to raise_error
@@ -148,7 +148,7 @@ class Image2_UT < Minitest::Test
   def test_contrast_stretch_channel
     expect do
       res = @img.contrast_stretch_channel(25)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
@@ -167,7 +167,7 @@ class Image2_UT < Minitest::Test
     Magick::MorphologyMethod.values do |method|
       expect do
         res = @img.morphology(method, 2, kernel)
-        assert_instance_of(Magick::Image, res)
+        expect(res).to be_instance_of(Magick::Image)
         assert_not_same(@img, res)
       end.not_to raise_error
     end
@@ -183,7 +183,7 @@ class Image2_UT < Minitest::Test
     kernel = Magick::KernelInfo.new('Octagon')
     expect do
       res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -193,7 +193,7 @@ class Image2_UT < Minitest::Test
     order = 3
     expect do
       res = @img.convolve(order, kernel)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.convolve }.to raise_error(ArgumentError)
@@ -215,7 +215,7 @@ class Image2_UT < Minitest::Test
     order = 3
     expect do
       res = @img.convolve_channel(order, kernel, Magick::RedChannel)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -240,7 +240,7 @@ class Image2_UT < Minitest::Test
     expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
     expect do
       res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -276,7 +276,7 @@ class Image2_UT < Minitest::Test
   def test_cycle_colormap
     expect do
       res = @img.cycle_colormap(5)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
       expect(res.class_type).to eq(Magick::PseudoClass)
     end.not_to raise_error
@@ -288,11 +288,11 @@ class Image2_UT < Minitest::Test
       res = @img.encipher 'passphrase'
       res2 = res.decipher 'passphrase'
     end.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect(res.columns).to eq(@img.columns)
     expect(res.rows).to eq(@img.rows)
-    assert_instance_of(Magick::Image, res2)
+    expect(res2).to be_instance_of(Magick::Image)
     assert_not_same(@img, res2)
     expect(res2.columns).to eq(@img.columns)
     expect(res2.rows).to eq(@img.rows)
@@ -308,7 +308,7 @@ class Image2_UT < Minitest::Test
   def test_deskew
     expect do
       res = @img.deskew
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -322,7 +322,7 @@ class Image2_UT < Minitest::Test
   def test_despeckle
     expect do
       res = @img.despeckle
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -406,11 +406,11 @@ class Image2_UT < Minitest::Test
     img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
     expect do
       res = img1.difference(img2)
-      assert_instance_of(Array, res)
+      expect(res).to be_instance_of(Array)
       expect(res.length).to eq(3)
-      assert_instance_of(Float, res[0])
-      assert_instance_of(Float, res[1])
-      assert_instance_of(Float, res[2])
+      expect(res[0]).to be_instance_of(Float)
+      expect(res[1]).to be_instance_of(Float)
+      expect(res[2]).to be_instance_of(Float)
     end.not_to raise_error
 
     expect { img1.difference(2) }.to raise_error(NoMethodError)
@@ -422,7 +422,7 @@ class Image2_UT < Minitest::Test
     @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
     expect { @img.displace(@img2, 25) }.not_to raise_error
     res = @img.displace(@img2, 25)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect { @img.displace(@img2, 25, 25) }.not_to raise_error
     expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
@@ -481,7 +481,7 @@ class Image2_UT < Minitest::Test
   def test_distortion_channel
     expect do
       metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
-      assert_instance_of(Float, metric)
+      expect(metric).to be_instance_of(Float)
       expect(metric).to eq(0.0)
     end.not_to raise_error
     expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }.not_to raise_error
@@ -503,14 +503,14 @@ class Image2_UT < Minitest::Test
 
   def test__dump
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_instance_of(String, img._dump(10))
+    expect(img._dump(10)).to be_instance_of(String)
   end
 
   def test__load
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     res = img._dump(10)
 
-    assert_instance_of(Magick::Image, Magick::Image._load(res))
+    expect(Magick::Image._load(res)).to be_instance_of(Magick::Image)
   end
 
   def test_dup
@@ -540,7 +540,7 @@ class Image2_UT < Minitest::Test
   def test_edge
     expect do
       res = @img.edge
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.edge(2.0) }.not_to raise_error
@@ -551,7 +551,7 @@ class Image2_UT < Minitest::Test
   def test_emboss
     expect do
       res = @img.emboss
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.emboss(1.0) }.not_to raise_error
@@ -564,7 +564,7 @@ class Image2_UT < Minitest::Test
   def test_enhance
     expect do
       res = @img.enhance
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -572,7 +572,7 @@ class Image2_UT < Minitest::Test
   def test_equalize
     expect do
       res = @img.equalize
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -580,7 +580,7 @@ class Image2_UT < Minitest::Test
   def test_equalize_channel
     expect do
       res = @img.equalize_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.equalize_channel }.not_to raise_error
@@ -612,7 +612,7 @@ class Image2_UT < Minitest::Test
   def test_export_pixels
     expect do
       res = @img.export_pixels
-      assert_instance_of(Array, res)
+      expect(res).to be_instance_of(Array)
       expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
       res.each do |p|
         assert_kind_of(Integer, p)
@@ -638,7 +638,7 @@ class Image2_UT < Minitest::Test
   def test_export_pixels_to_str
     expect do
       res = @img.export_pixels_to_str
-      assert_instance_of(String, res)
+      expect(res).to be_instance_of(String)
       expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
     end.not_to raise_error
     expect { @img.export_pixels_to_str(0) }.not_to raise_error
@@ -685,7 +685,7 @@ class Image2_UT < Minitest::Test
   def test_extent
     expect { @img.extent(40, 40) }.not_to raise_error
     res = @img.extent(40, 40)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect(res.columns).to eq(40)
     expect(res.rows).to eq(40)
@@ -745,7 +745,7 @@ class Image2_UT < Minitest::Test
   def test_flip
     expect do
       res = @img.flip
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -760,7 +760,7 @@ class Image2_UT < Minitest::Test
   def test_flop
     expect do
       res = @img.flop
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -775,7 +775,7 @@ class Image2_UT < Minitest::Test
   def test_frame
     expect do
       res = @img.frame
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.frame(50) }.not_to raise_error
@@ -804,7 +804,7 @@ class Image2_UT < Minitest::Test
   def test_gamma_channel
     expect do
       res = @img.gamma_channel(0.8)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.gamma_channel }.to raise_error(ArgumentError)
@@ -854,7 +854,7 @@ class Image2_UT < Minitest::Test
     expect { @img.gamma_correct }.to raise_error(ArgumentError)
     expect do
       res = @img.gamma_correct(0.8)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
@@ -867,7 +867,7 @@ class Image2_UT < Minitest::Test
   def test_gaussian_blur
     expect do
       res = @img.gaussian_blur
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.gaussian_blur(0.0) }.not_to raise_error
@@ -880,7 +880,7 @@ class Image2_UT < Minitest::Test
   def test_gaussian_blur_channel
     expect do
       res = @img.gaussian_blur_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
@@ -893,21 +893,21 @@ class Image2_UT < Minitest::Test
   def test_get_exif_by_entry
     expect do
       res = @img.get_exif_by_entry
-      assert_instance_of(Array, res)
+      expect(res).to be_instance_of(Array)
     end.not_to raise_error
   end
 
   def test_get_exif_by_number
     expect do
       res = @img.get_exif_by_number
-      assert_instance_of(Hash, res)
+      expect(res).to be_instance_of(Hash)
     end.not_to raise_error
   end
 
   def test_get_pixels
     expect do
       pixels = @img.get_pixels(0, 0, @img.columns, 1)
-      assert_instance_of(Array, pixels)
+      expect(pixels).to be_instance_of(Array)
       expect(pixels.length).to eq(@img.columns)
       assert_block do
         pixels.all? { |p| p.is_a? Magick::Pixel }
@@ -934,7 +934,7 @@ class Image2_UT < Minitest::Test
   def test_implode
     expect do
       res = @img.implode(0.5)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
@@ -972,7 +972,7 @@ class Image2_UT < Minitest::Test
   def test_level
     expect do
       res = @img.level
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.level(0.0) }.not_to raise_error
@@ -1005,7 +1005,7 @@ class Image2_UT < Minitest::Test
     expect { @img.level_channel }.to raise_error(ArgumentError)
     expect do
       res = @img.level_channel(Magick::RedChannel)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -1025,7 +1025,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.level_colors
     end.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
 
     expect { @img.level_colors('black') }.not_to raise_error
@@ -1044,7 +1044,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.levelize_channel(0, Magick::QuantumRange)
     end.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
 
     expect { @img.levelize_channel(0) }.not_to raise_error
@@ -1083,7 +1083,7 @@ class Image2_UT < Minitest::Test
   def test_magnify
     expect do
       res = @img.magnify
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -1124,7 +1124,7 @@ class Image2_UT < Minitest::Test
   def test_matte_fill_to_border
     expect do
       res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
@@ -1135,7 +1135,7 @@ class Image2_UT < Minitest::Test
   def test_matte_floodfill
     expect do
       res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
@@ -1154,7 +1154,7 @@ class Image2_UT < Minitest::Test
   def test_matte_replace
     expect do
       res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -1169,7 +1169,7 @@ class Image2_UT < Minitest::Test
   def test_median_filter
     expect do
       res = @img.median_filter
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.median_filter(0.5) }.not_to raise_error
@@ -1180,7 +1180,7 @@ class Image2_UT < Minitest::Test
   def test_minify
     expect do
       res = @img.minify
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
 
@@ -1191,7 +1191,7 @@ class Image2_UT < Minitest::Test
   def test_modulate
     expect do
       res = @img.modulate
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.modulate(0.5) }.not_to raise_error
@@ -1213,7 +1213,7 @@ class Image2_UT < Minitest::Test
   def test_motion_blur
     expect do
       res = @img.motion_blur(1.0, 7.0, 180)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
@@ -1223,7 +1223,7 @@ class Image2_UT < Minitest::Test
   def test_negate
     expect do
       res = @img.negate
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.negate(true) }.not_to raise_error
@@ -1233,7 +1233,7 @@ class Image2_UT < Minitest::Test
   def test_negate_channel
     expect do
       res = @img.negate_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.negate_channel(true) }.not_to raise_error
@@ -1245,7 +1245,7 @@ class Image2_UT < Minitest::Test
   def test_normalize
     expect do
       res = @img.normalize
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
   end
@@ -1253,7 +1253,7 @@ class Image2_UT < Minitest::Test
   def test_normalize_channel
     expect do
       res = @img.normalize_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.normalize_channel(Magick::RedChannel) }.not_to raise_error
@@ -1264,7 +1264,7 @@ class Image2_UT < Minitest::Test
   def test_oil_paint
     expect do
       res = @img.oil_paint
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.oil_paint(2.0) }.not_to raise_error
@@ -1274,7 +1274,7 @@ class Image2_UT < Minitest::Test
   def test_opaque
     expect do
       res = @img.opaque('white', 'red')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
@@ -1288,7 +1288,7 @@ class Image2_UT < Minitest::Test
     res = nil
     expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
     assert_not_nil(res)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(res, @img)
     expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
     expect { @img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
@@ -1316,7 +1316,7 @@ class Image2_UT < Minitest::Test
   def test_ordered_dither
     expect do
       res = @img.ordered_dither
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.ordered_dither('3x3') }.not_to raise_error
@@ -1331,7 +1331,7 @@ class Image2_UT < Minitest::Test
     res = nil
     expect { res = @img.paint_transparent('red') }.not_to raise_error
     assert_not_nil(res)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(res, @img)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
@@ -1364,7 +1364,7 @@ class Image2_UT < Minitest::Test
   def test_pixel_color
     expect do
       res = @img.pixel_color(0, 0)
-      assert_instance_of(Magick::Pixel, res)
+      expect(res).to be_instance_of(Magick::Pixel)
     end.not_to raise_error
     res = @img.pixel_color(0, 0)
     expect(res.to_color).to eq(@img.background_color)
@@ -1389,7 +1389,7 @@ class Image2_UT < Minitest::Test
   def test_polaroid
     expect { @img.polaroid }.not_to raise_error
     expect { @img.polaroid(5) }.not_to raise_error
-    assert_instance_of(Magick::Image, @img.polaroid)
+    expect(@img.polaroid).to be_instance_of(Magick::Image)
     expect { @img.polaroid('x') }.to raise_error(TypeError)
     expect { @img.polaroid(5, 'x') }.to raise_error(ArgumentError)
   end
@@ -1397,7 +1397,7 @@ class Image2_UT < Minitest::Test
   def test_posterize
     expect do
       res = @img.posterize
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect { @img.posterize(5) }.not_to raise_error

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -28,7 +28,7 @@ class Image3_UT < Minitest::Test
   def test_quantize
     expect do
       res = @img.quantize
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     Magick::ColorspaceType.values do |cs|
@@ -50,7 +50,7 @@ class Image3_UT < Minitest::Test
   def test_quantum_operator
     expect do
       res = @img.quantum_operator(Magick::AddQuantumOperator, 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     Magick::QuantumExpressionOperator.values do |op|
       expect { @img.quantum_operator(op, 2) }.not_to raise_error
@@ -65,7 +65,7 @@ class Image3_UT < Minitest::Test
   def test_radial_blur
     expect do
       res = @img.radial_blur(30)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
@@ -73,7 +73,7 @@ class Image3_UT < Minitest::Test
     res = nil
     expect { res = @img.radial_blur_channel(30) }.not_to raise_error
     assert_not_nil(res)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
     expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
 
@@ -84,7 +84,7 @@ class Image3_UT < Minitest::Test
   def test_raise
     expect do
       res = @img.raise
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.raise(4) }.not_to raise_error
     expect { @img.raise(4, 4) }.not_to raise_error
@@ -97,7 +97,7 @@ class Image3_UT < Minitest::Test
   def test_random_threshold_channel
     expect do
       res = @img.random_threshold_channel('20%')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     threshold = Magick::Geometry.new(20)
     expect { @img.random_threshold_channel(threshold) }.not_to raise_error
@@ -116,7 +116,7 @@ class Image3_UT < Minitest::Test
   def test_reduce_noise
     expect do
       res = @img.reduce_noise(0)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.reduce_noise(4) }.not_to raise_error
   end
@@ -185,7 +185,7 @@ class Image3_UT < Minitest::Test
   def test_resize
     expect do
       res = @img.resize(2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.resize(50, 50) }.not_to raise_error
 
@@ -278,7 +278,7 @@ class Image3_UT < Minitest::Test
     res = nil
     expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
     assert_not_nil(res)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(img, res)
     expect(res.columns).to eq(40)
     expect(res.rows).to eq(50)
@@ -287,7 +287,7 @@ class Image3_UT < Minitest::Test
   def test_resize_to_fit2
     img = Magick::Image.new(200, 300)
     changed = img.resize_to_fit(100)
-    assert_instance_of(Magick::Image, changed)
+    expect(changed).to be_instance_of(Magick::Image)
     assert_not_same(img, changed)
     expect(changed.columns).to eq(67)
     expect(changed.rows).to eq(100)
@@ -297,7 +297,7 @@ class Image3_UT < Minitest::Test
     img = Magick::Image.new(200, 300)
     keep = img
     img.resize_to_fit!(100)
-    assert_instance_of(Magick::Image, img)
+    expect(img).to be_instance_of(Magick::Image)
     assert_same(img, keep)
     expect(img.columns).to eq(67)
     expect(img.rows).to eq(100)
@@ -306,21 +306,21 @@ class Image3_UT < Minitest::Test
   def test_roll
     expect do
       res = @img.roll(5, 5)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
   def test_rotate
     expect do
       res = @img.rotate(45)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.rotate(-45) }.not_to raise_error
 
     img = Magick::Image.new(100, 50)
     expect do
       res = img.rotate(90, '>')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       expect(res.columns).to eq(50)
       expect(res.rows).to eq(100)
     end.not_to raise_error
@@ -344,7 +344,7 @@ class Image3_UT < Minitest::Test
   def test_sample
     expect do
       res = @img.sample(10, 10)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.sample(2) }.not_to raise_error
     expect { @img.sample }.to raise_error(ArgumentError)
@@ -368,7 +368,7 @@ class Image3_UT < Minitest::Test
   def test_scale
     expect do
       res = @img.scale(10, 10)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.scale(2) }.not_to raise_error
     expect { @img.scale }.to raise_error(ArgumentError)
@@ -389,7 +389,7 @@ class Image3_UT < Minitest::Test
   def test_segment
     expect do
       res = @img.segment
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     # Don't test colorspaces that require PsuedoColor images
@@ -420,7 +420,7 @@ class Image3_UT < Minitest::Test
   def test_selective_blur_channel
     res = nil
     expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
     assert_not_same(@img, res)
     expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
 
@@ -434,15 +434,15 @@ class Image3_UT < Minitest::Test
   end
 
   def test_separate
-    assert_instance_of(Magick::ImageList, @img.separate)
-    assert_instance_of(Magick::ImageList, @img.separate(Magick::BlueChannel))
+    expect(@img.separate).to be_instance_of(Magick::ImageList)
+    expect(@img.separate(Magick::BlueChannel)).to be_instance_of(Magick::ImageList)
     expect { @img.separate('x') }.to raise_error(TypeError)
   end
 
   def test_sepiatone
     expect do
       res = @img.sepiatone
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
     expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
@@ -458,7 +458,7 @@ class Image3_UT < Minitest::Test
   def test_shade
     expect do
       res = @img.shade
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.shade(true) }.not_to raise_error
     expect { @img.shade(true, 30) }.not_to raise_error
@@ -471,7 +471,7 @@ class Image3_UT < Minitest::Test
   def test_shadow
     expect do
       res = @img.shadow
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.shadow(5) }.not_to raise_error
     expect { @img.shadow(5, 5) }.not_to raise_error
@@ -488,7 +488,7 @@ class Image3_UT < Minitest::Test
   def test_sharpen
     expect do
       res = @img.sharpen
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.sharpen(2.0) }.not_to raise_error
     expect { @img.sharpen(2.0, 1.0) }.not_to raise_error
@@ -500,7 +500,7 @@ class Image3_UT < Minitest::Test
   def test_sharpen_channel
     expect do
       res = @img.sharpen_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.sharpen_channel(2.0) }.not_to raise_error
     expect { @img.sharpen_channel(2.0, 1.0) }.not_to raise_error
@@ -514,7 +514,7 @@ class Image3_UT < Minitest::Test
   def test_shave
     expect do
       res = @img.shave(5, 5)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect do
       res = @img.shave!(5, 5)
@@ -527,14 +527,14 @@ class Image3_UT < Minitest::Test
   def test_shear
     expect do
       res = @img.shear(30, 30)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
   def test_sigmoidal_contrast_channel
     expect do
       res = @img.sigmoidal_contrast_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
     expect { @img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
@@ -549,7 +549,7 @@ class Image3_UT < Minitest::Test
   def test_signature
     expect do
       res = @img.signature
-      assert_instance_of(String, res)
+      expect(res).to be_instance_of(String)
     end.not_to raise_error
   end
 
@@ -567,7 +567,7 @@ class Image3_UT < Minitest::Test
   def test_solarize
     expect do
       res = @img.solarize
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.solarize(100) }.not_to raise_error
     expect { @img.solarize(-100) }.to raise_error(ArgumentError)
@@ -611,7 +611,7 @@ class Image3_UT < Minitest::Test
   def test_splice
     expect do
       res = @img.splice(0, 0, 2, 2)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
@@ -627,7 +627,7 @@ class Image3_UT < Minitest::Test
   def test_spread
     expect do
       res = @img.spread
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.spread(3.0) }.not_to raise_error
     expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
@@ -639,7 +639,7 @@ class Image3_UT < Minitest::Test
     watermark = Magick::Image.new(10, 10) { self.background_color = 'white' }
     expect do
       res = @img.stegano(watermark, 0)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     watermark.destroy!
@@ -649,7 +649,7 @@ class Image3_UT < Minitest::Test
   def test_stereo
     expect do
       res = @img.stereo(@img)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     img = Magick::Image.new(20, 20)
@@ -683,7 +683,7 @@ class Image3_UT < Minitest::Test
   def test_swirl
     expect do
       res = @img.swirl(30)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
@@ -691,7 +691,7 @@ class Image3_UT < Minitest::Test
     texture = Magick::Image.read('granite:').first
     expect do
       res = @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, texture)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
     expect { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }.to raise_error(ArgumentError)
@@ -708,7 +708,7 @@ class Image3_UT < Minitest::Test
     texture = Magick::Image.read('granite:').first
     expect do
       res = @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
     texture.destroy!
@@ -718,14 +718,14 @@ class Image3_UT < Minitest::Test
   def test_threshold
     expect do
       res = @img.threshold(100)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
   def test_thumbnail
     expect do
       res = @img.thumbnail(10, 10)
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.thumbnail(2) }.not_to raise_error
     expect { @img.thumbnail }.to raise_error(ArgumentError)
@@ -782,7 +782,7 @@ class Image3_UT < Minitest::Test
   def test_to_blob
     res = nil
     expect { res = @img.to_blob { self.format = 'miff' } }.not_to raise_error
-    assert_instance_of(String, res)
+    expect(res).to be_instance_of(String)
     restored = Magick::Image.from_blob(res)
     expect(restored[0]).to eq(@img)
   end
@@ -798,7 +798,7 @@ class Image3_UT < Minitest::Test
   def test_transparent
     expect do
       res = @img.transparent('white')
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     pixel = Magick::Pixel.new
     expect { @img.transparent(pixel) }.not_to raise_error
@@ -812,7 +812,7 @@ class Image3_UT < Minitest::Test
   end
 
   def test_transparent_chroma
-    assert_instance_of(Magick::Image, @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)))
+    expect(@img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange))).to be_instance_of(Magick::Image)
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }.not_to raise_error
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }.not_to raise_error
@@ -826,12 +826,12 @@ class Image3_UT < Minitest::Test
   def test_transpose
     expect do
       res = @img.transpose
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect do
       res = @img.transpose!
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_same(@img, res)
     end.not_to raise_error
   end
@@ -839,12 +839,12 @@ class Image3_UT < Minitest::Test
   def test_transverse
     expect do
       res = @img.transverse
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(@img, res)
     end.not_to raise_error
     expect do
       res = @img.transverse!
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_same(@img, res)
     end.not_to raise_error
   end
@@ -853,8 +853,8 @@ class Image3_UT < Minitest::Test
     # Can't use the default image because it's a solid color
     hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     expect do
-      assert_instance_of(Magick::Image, hat.trim)
-      assert_instance_of(Magick::Image, hat.trim(10))
+      expect(hat.trim).to be_instance_of(Magick::Image)
+      expect(hat.trim(10)).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
 
@@ -871,7 +871,7 @@ class Image3_UT < Minitest::Test
   def test_unique_colors
     expect do
       res = @img.unique_colors
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       expect(res.columns).to eq(1)
       expect(res.rows).to eq(1)
     end.not_to raise_error
@@ -880,7 +880,7 @@ class Image3_UT < Minitest::Test
   def test_unsharp_mask
     expect do
       res = @img.unsharp_mask
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     expect { @img.unsharp_mask(2.0) }.not_to raise_error
@@ -901,7 +901,7 @@ class Image3_UT < Minitest::Test
   def test_unsharp_mask_channel
     expect do
       res = @img.unsharp_mask_channel
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
 
     expect { @img.unsharp_mask_channel(2.0) }.not_to raise_error
@@ -921,10 +921,10 @@ class Image3_UT < Minitest::Test
   def test_view
     expect do
       res = @img.view(0, 0, 5, 5)
-      assert_instance_of(Magick::Image::View, res)
+      expect(res).to be_instance_of(Magick::Image::View)
     end.not_to raise_error
     expect do
-      @img.view(0, 0, 5, 5) { |v| assert_instance_of(Magick::Image::View, v) }
+      @img.view(0, 0, 5, 5) { |v| expect(v).to be_instance_of(Magick::Image::View) }
     end.not_to raise_error
     expect { @img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
     expect { @img.view(0, -1, 5, 5) }.to raise_error(RangeError)
@@ -937,7 +937,7 @@ class Image3_UT < Minitest::Test
   def test_vignette
     expect do
       res = @img.vignette
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
       assert_not_same(res, @img)
     end.not_to raise_error
     expect { @img.vignette(0) }.not_to raise_error
@@ -979,7 +979,7 @@ class Image3_UT < Minitest::Test
   def test_wave
     expect do
       res = @img.wave
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @img.wave(25) }.not_to raise_error
     expect { @img.wave(25, 200) }.not_to raise_error
@@ -989,7 +989,7 @@ class Image3_UT < Minitest::Test
   end
 
   def test_wet_floor
-    assert_instance_of(Magick::Image, @img.wet_floor)
+    expect(@img.wet_floor).to be_instance_of(Magick::Image)
     expect { @img.wet_floor(0.0) }.not_to raise_error
     expect { @img.wet_floor(0.5) }.not_to raise_error
     expect { @img.wet_floor(0.5, 10) }.not_to raise_error
@@ -1012,7 +1012,7 @@ class Image3_UT < Minitest::Test
     expect { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
     expect { @img.white_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
     res = @img.white_threshold(50)
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   # test write with #format= attribute

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -26,7 +26,7 @@ class ImageList1UT < Minitest::Test
     expect { list.combine }.not_to raise_error
 
     res = list.combine
-    assert_instance_of(Magick::Image, res)
+    expect(res).to be_instance_of(Magick::Image)
 
     list << alpha
     expect { list.combine }.not_to raise_error
@@ -140,10 +140,10 @@ class ImageList1UT < Minitest::Test
 
   def test_aref
     expect { @list[0] }.not_to raise_error
-    assert_instance_of(Magick::Image, @list[0])
-    assert_instance_of(Magick::Image, @list[-1])
-    assert_instance_of(Magick::ImageList, @list[0, 1])
-    assert_instance_of(Magick::ImageList, @list[0..2])
+    expect(@list[0]).to be_instance_of(Magick::Image)
+    expect(@list[-1]).to be_instance_of(Magick::Image)
+    expect(@list[0, 1]).to be_instance_of(Magick::ImageList)
+    expect(@list[0..2]).to be_instance_of(Magick::ImageList)
     assert_nil(@list[20])
   end
 
@@ -216,7 +216,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       res = @list & @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       expect(res.length).to eq(5)
@@ -228,7 +228,7 @@ class ImageList1UT < Minitest::Test
     @list.scene = 2
     expect do
       res = @list & @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.scene).to eq(4)
     end.not_to raise_error
 
@@ -255,7 +255,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       res = @list * 2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(20)
       assert_not_same(res, @list)
       assert_same(cur, res.cur_image)
@@ -269,7 +269,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       res = @list + @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(15)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
@@ -284,7 +284,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       res = @list - @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(5)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
@@ -296,7 +296,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       res = @list - @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(5)
       expect(res.scene).to eq(4)
     end.not_to raise_error
@@ -319,7 +319,7 @@ class ImageList1UT < Minitest::Test
       # The or of these two lists should be the same as @list
       # but not be the *same* list
       res = @list | @list2
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       assert_not_same(res, @list)
       assert_not_same(res, @list2)
       expect(@list).to eq(res)
@@ -328,7 +328,7 @@ class ImageList1UT < Minitest::Test
     # Try or'ing disjoint lists
     temp_list = Magick::ImageList.new(*FILES[10..14])
     res = @list | temp_list
-    assert_instance_of(Magick::ImageList, res)
+    expect(res).to be_instance_of(Magick::ImageList)
     expect(res.length).to eq(15)
     expect(res.scene).to eq(7)
 
@@ -338,7 +338,7 @@ class ImageList1UT < Minitest::Test
 
   def test_clear
     expect { @list.clear }.not_to raise_error
-    assert_instance_of(Magick::ImageList, @list)
+    expect(@list).to be_instance_of(Magick::ImageList)
     expect(@list.length).to eq(0)
     assert_nil(@list.scene)
   end
@@ -347,14 +347,14 @@ class ImageList1UT < Minitest::Test
     expect do
       scene = @list.scene
       res = @list.collect(&:negate)
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       assert_not_same(res, @list)
       expect(res.scene).to eq(scene)
     end.not_to raise_error
     expect do
       scene = @list.scene
       @list.collect!(&:negate)
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list.scene).to eq(scene)
     end.not_to raise_error
   end
@@ -368,7 +368,7 @@ class ImageList1UT < Minitest::Test
     expect do
       res = @list
       @list.compact!
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list).to eq(res)
       assert_same(res, @list)
     end.not_to raise_error
@@ -377,7 +377,7 @@ class ImageList1UT < Minitest::Test
   def test_concat
     expect do
       res = @list.concat(@list2)
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(15)
       assert_same(res[14], res.cur_image)
     end.not_to raise_error
@@ -424,7 +424,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       @list.delete_if { |img| File.basename(img.filename) =~ /5/ }
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
     end.not_to raise_error
@@ -432,7 +432,7 @@ class ImageList1UT < Minitest::Test
     # Delete the current image
     expect do
       @list.delete_if { |img| File.basename(img.filename) =~ /7/ }
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
     end.not_to raise_error
@@ -442,7 +442,7 @@ class ImageList1UT < Minitest::Test
   def test_enumerables
     expect { @list.detect { true } }.not_to raise_error
     expect do
-      @list.each_with_index { |img, _n| assert_instance_of(Magick::Image, img) }
+      @list.each_with_index { |img, _n| expect(img).to be_instance_of(Magick::Image) }
     end.not_to raise_error
     expect { @list.entries }.not_to raise_error
     expect { @list.include?(@list[0]) }.not_to raise_error
@@ -465,7 +465,7 @@ class ImageList1UT < Minitest::Test
     list = @list.copy
     img = list[0].copy
     expect do
-      assert_instance_of(Magick::ImageList, list.fill(img))
+      expect(list.fill(img)).to be_instance_of(Magick::ImageList)
     end.not_to raise_error
     list.each { |el| assert_same(el, img) }
 
@@ -495,7 +495,7 @@ class ImageList1UT < Minitest::Test
   def find_all
     expect do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
     end.not_to raise_error
@@ -505,7 +505,7 @@ class ImageList1UT < Minitest::Test
     expect do
       @list.scene = 7
       cur = @list.cur_image
-      assert_instance_of(Magick::ImageList, @list.insert(1, @list[2]))
+      expect(@list.insert(1, @list[2])).to be_instance_of(Magick::ImageList)
       assert_same(cur, @list.cur_image)
       @list.insert(1, @list[2], @list[3], @list[4])
       assert_same(cur, @list.cur_image)
@@ -520,13 +520,13 @@ class ImageList1UT < Minitest::Test
     @list << img
     img2 = nil
     expect { img2 = @list.last }.not_to raise_error
-    assert_instance_of(Magick::Image, img2)
+    expect(img2).to be_instance_of(Magick::Image)
     expect(img).to eq(img2)
     img2 = Magick::Image.new(5, 5)
     @list << img2
     ilist = nil
     expect { ilist = @list.last(2) }.not_to raise_error
-    assert_instance_of(Magick::ImageList, ilist)
+    expect(ilist).to be_instance_of(Magick::ImageList)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(1)
     expect(ilist[0]).to eq(img)
@@ -538,7 +538,7 @@ class ImageList1UT < Minitest::Test
     expect do
       @list.__map__ { |_x| img }
     end.not_to raise_error
-    assert_instance_of(Magick::ImageList, @list)
+    expect(@list).to be_instance_of(Magick::ImageList)
     expect { @list.__map__ { 2 } }.to raise_error(ArgumentError)
   end
 
@@ -547,7 +547,7 @@ class ImageList1UT < Minitest::Test
     expect do
       @list.map! { img }
     end.not_to raise_error
-    assert_instance_of(Magick::ImageList, @list)
+    expect(@list).to be_instance_of(Magick::ImageList)
     expect { @list.map! { 2 } }.to raise_error(ArgumentError)
   end
 
@@ -560,10 +560,10 @@ class ImageList1UT < Minitest::Test
         (n & 1).zero?
       end
     end.not_to raise_error
-    assert_instance_of(Array, a)
+    expect(a).to be_instance_of(Array)
     expect(a.size).to eq(2)
-    assert_instance_of(Magick::ImageList, a[0])
-    assert_instance_of(Magick::ImageList, a[1])
+    expect(a[0]).to be_instance_of(Magick::ImageList)
+    expect(a[1]).to be_instance_of(Magick::ImageList)
     expect(a[0].scene).to eq(4)
     expect(a[0].length).to eq(5)
     expect(a[1].scene).to eq(4)
@@ -599,7 +599,7 @@ class ImageList1UT < Minitest::Test
     expect do
       res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
       expect(res.length).to eq(9)
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       assert_same(cur, res.cur_image)
     end.not_to raise_error
     assert_same(list, @list)
@@ -617,7 +617,7 @@ class ImageList1UT < Minitest::Test
     cur = @list.cur_image
     expect do
       @list.reject! { |img| File.basename(img.filename) =~ /5/ }
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list.length).to eq(9)
       assert_same(cur, @list.cur_image)
     end.not_to raise_error
@@ -625,7 +625,7 @@ class ImageList1UT < Minitest::Test
     # Delete the current image
     expect do
       @list.reject! { |img| File.basename(img.filename) =~ /7/ }
-      assert_instance_of(Magick::ImageList, @list)
+      expect(@list).to be_instance_of(Magick::ImageList)
       expect(@list.length).to eq(8)
       assert_same(@list[-1], @list.cur_image)
     end.not_to raise_error
@@ -700,7 +700,7 @@ class ImageList1UT < Minitest::Test
   # Just validate its existence
   def test_reverse_each
     expect do
-      @list.reverse_each { |img| assert_instance_of(Magick::Image, img) }
+      @list.reverse_each { |img| expect(img).to be_instance_of(Magick::Image) }
     end.not_to raise_error
   end
 
@@ -714,7 +714,7 @@ class ImageList1UT < Minitest::Test
   def test_select
     expect do
       res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(1)
       assert_same(res[0], @list[2])
     end.not_to raise_error
@@ -771,13 +771,13 @@ class ImageList1UT < Minitest::Test
   def test_to_a
     a = nil
     expect { a = @list.to_a }.not_to raise_error
-    assert_instance_of(Array, a)
+    expect(a).to be_instance_of(Array)
     expect(a.length).to eq(10)
   end
 
   def test_uniq
     expect { @list.uniq }.not_to raise_error
-    assert_instance_of(Magick::ImageList, @list.uniq)
+    expect(@list.uniq).to be_instance_of(Magick::ImageList)
     @list[1] = @list[0]
     @list.scene = 7
     list = @list.uniq
@@ -821,7 +821,7 @@ class ImageList1UT < Minitest::Test
   def test_values_at
     ilist = nil
     expect { ilist = @list.values_at(1, 3, 5) }.not_to raise_error
-    assert_instance_of(Magick::ImageList, ilist)
+    expect(ilist).to be_instance_of(Magick::ImageList)
     expect(ilist.length).to eq(3)
     expect(ilist.scene).to eq(2)
   end

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -11,11 +11,11 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
     expect do
       img = @ilist.append(true)
-      assert_instance_of(Magick::Image, img)
+      expect(img).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect do
       img = @ilist.append(false)
-      assert_instance_of(Magick::Image, img)
+      expect(img).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @ilist.append }.to raise_error(ArgumentError)
     expect { @ilist.append(true, 1) }.to raise_error(ArgumentError)
@@ -25,7 +25,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
     expect do
       img = @ilist.average
-      assert_instance_of(Magick::Image, img)
+      expect(img).to be_instance_of(Magick::Image)
     end.not_to raise_error
     expect { @ilist.average(1) }.to raise_error(ArgumentError)
   end
@@ -47,7 +47,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
     ilist = nil
     expect { ilist = @ilist.coalesce }.not_to raise_error
-    assert_instance_of(Magick::ImageList, ilist)
+    expect(ilist).to be_instance_of(Magick::ImageList)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(0)
   end
@@ -67,7 +67,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     ilist = nil
     expect { ilist = @ilist.deconstruct }.not_to raise_error
-    assert_instance_of(Magick::ImageList, ilist)
+    expect(ilist).to be_instance_of(Magick::ImageList)
     expect(ilist.length).to eq(2)
     expect(ilist.scene).to eq(0)
   end
@@ -89,7 +89,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     expect do
       img = @ilist.flatten_images
-      assert_instance_of(Magick::Image, img)
+      expect(img).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
@@ -97,7 +97,7 @@ class ImageList2UT < Minitest::Test
     hat = File.open(FLOWER_HAT, 'rb')
     blob = hat.read
     expect { @ilist.from_blob(blob) }.not_to raise_error
-    assert_instance_of(Magick::Image, @ilist[0])
+    expect(@ilist[0]).to be_instance_of(Magick::Image)
     expect(@ilist.scene).to eq(0)
 
     ilist2 = Magick::ImageList.new(FLOWER_HAT)
@@ -144,7 +144,7 @@ class ImageList2UT < Minitest::Test
         self.tile = Magick::Geometry.new(4, 9)
         self.title = 'sample'
       end
-      assert_instance_of(Magick::ImageList, montage)
+      expect(montage).to be_instance_of(Magick::ImageList)
       expect(ilist).to eq(@ilist)
 
       montage_image = montage.first
@@ -213,7 +213,7 @@ class ImageList2UT < Minitest::Test
     expect { @ilist.morph(-1) }.to raise_error(ArgumentError)
     expect do
       res = @ilist.morph(2)
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(4)
       expect(res.scene).to eq(0)
     end.not_to raise_error
@@ -223,7 +223,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     expect do
       res = @ilist.mosaic
-      assert_instance_of(Magick::Image, res)
+      expect(res).to be_instance_of(Magick::Image)
     end.not_to raise_error
   end
 
@@ -254,7 +254,7 @@ class ImageList2UT < Minitest::Test
 
       expect do
         res = @ilist.optimize_layers(method)
-        assert_instance_of(Magick::ImageList, res)
+        expect(res).to be_instance_of(Magick::ImageList)
         assert_kind_of(Integer, res.length)
       end.not_to raise_error
     end
@@ -281,7 +281,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     expect do
       res = @ilist.quantize
-      assert_instance_of(Magick::ImageList, res)
+      expect(res).to be_instance_of(Magick::ImageList)
       expect(res.scene).to eq(1)
     end.not_to raise_error
     expect { @ilist.quantize(128) }.not_to raise_error

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -63,7 +63,7 @@ class Image_Attributes_UT < Minitest::Test
   def test_bias
     expect { @img.bias }.not_to raise_error
     expect(@img.bias).to eq(0.0)
-    assert_instance_of(Float, @img.bias)
+    expect(@img.bias).to be_instance_of(Float)
 
     expect { @img.bias = 0.1 }.not_to raise_error
     assert_in_delta(Magick::QuantumRange * 0.1, @img.bias, 0.1)
@@ -117,7 +117,7 @@ class Image_Attributes_UT < Minitest::Test
   def test_chromaticity
     chrom = @img.chromaticity
     expect { @img.chromaticity }.not_to raise_error
-    assert_instance_of(Magick::Chromaticity, chrom)
+    expect(chrom).to be_instance_of(Magick::Chromaticity)
     expect(chrom.red_primary.x).to eq(0)
     expect(chrom.red_primary.y).to eq(0)
     expect(chrom.red_primary.z).to eq(0)
@@ -136,7 +136,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_class_type
     expect { @img.class_type }.not_to raise_error
-    assert_instance_of(Magick::ClassType, @img.class_type)
+    expect(@img.class_type).to be_instance_of(Magick::ClassType)
     expect(@img.class_type).to eq(Magick::DirectClass)
     expect { @img.class_type = Magick::PseudoClass }.not_to raise_error
     expect(@img.class_type).to eq(Magick::PseudoClass)
@@ -168,7 +168,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_colorspace
     expect { @img.colorspace }.not_to raise_error
-    assert_instance_of(Magick::ColorspaceType, @img.colorspace)
+    expect(@img.colorspace).to be_instance_of(Magick::ColorspaceType)
     expect(@img.colorspace).to eq(Magick::SRGBColorspace)
     img = @img.copy
 
@@ -189,7 +189,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_compose
     expect { @img.compose }.not_to raise_error
-    assert_instance_of(Magick::CompositeOperator, @img.compose)
+    expect(@img.compose).to be_instance_of(Magick::CompositeOperator)
     expect(@img.compose).to eq(Magick::OverCompositeOp)
     expect { @img.compose = 2 }.to raise_error(TypeError)
     expect { @img.compose = Magick::UndefinedCompositeOp }.not_to raise_error
@@ -203,7 +203,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_compression
     expect { @img.compression }.not_to raise_error
-    assert_instance_of(Magick::CompressionType, @img.compression)
+    expect(@img.compression).to be_instance_of(Magick::CompressionType)
     expect(@img.compression).to eq(Magick::UndefinedCompression)
     expect { @img.compression = Magick::BZipCompression }.not_to raise_error
     expect(@img.compression).to eq(Magick::BZipCompression)
@@ -244,7 +244,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_dispose
     expect { @img.dispose }.not_to raise_error
-    assert_instance_of(Magick::DisposeType, @img.dispose)
+    expect(@img.dispose).to be_instance_of(Magick::DisposeType)
     expect(@img.dispose).to eq(Magick::UndefinedDispose)
     expect { @img.dispose = Magick::NoneDispose }.not_to raise_error
     expect(@img.dispose).to eq(Magick::NoneDispose)
@@ -257,7 +257,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_endian
     expect { @img.endian }.not_to raise_error
-    assert_instance_of(Magick::EndianType, @img.endian)
+    expect(@img.endian).to be_instance_of(Magick::EndianType)
     expect(@img.endian).to eq(Magick::UndefinedEndian)
     expect { @img.endian = Magick::LSBEndian }.not_to raise_error
     expect(@img.endian).to eq(Magick::LSBEndian)
@@ -267,7 +267,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_extract_info
     expect { @img.extract_info }.not_to raise_error
-    assert_instance_of(Magick::Rectangle, @img.extract_info)
+    expect(@img.extract_info).to be_instance_of(Magick::Rectangle)
     ext = @img.extract_info
     expect(ext.x).to eq(0)
     expect(ext.y).to eq(0)
@@ -290,7 +290,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_filter
     expect { @img.filter }.not_to raise_error
-    assert_instance_of(Magick::FilterType, @img.filter)
+    expect(@img.filter).to be_instance_of(Magick::FilterType)
     expect(@img.filter).to eq(Magick::UndefinedFilter)
     expect { @img.filter = Magick::PointFilter }.not_to raise_error
     expect(@img.filter).to eq(Magick::PointFilter)
@@ -318,7 +318,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_fuzz
     expect { @img.fuzz }.not_to raise_error
-    assert_instance_of(Float, @img.fuzz)
+    expect(@img.fuzz).to be_instance_of(Float)
     expect(@img.fuzz).to eq(0.0)
     expect { @img.fuzz = 50 }.not_to raise_error
     expect(@img.fuzz).to eq(50.0)
@@ -330,7 +330,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_gamma
     expect { @img.gamma }.not_to raise_error
-    assert_instance_of(Float, @img.gamma)
+    expect(@img.gamma).to be_instance_of(Float)
     expect(@img.gamma).to eq(0.45454543828964233)
     expect { @img.gamma = 2.0 }.not_to raise_error
     expect(@img.gamma).to eq(2.0)
@@ -349,7 +349,7 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_gravity
-    assert_instance_of(Magick::GravityType, @img.gravity)
+    expect(@img.gravity).to be_instance_of(Magick::GravityType)
 
     Magick::GravityType.values do |gravity|
       expect { @img.gravity = gravity }.not_to raise_error
@@ -359,7 +359,7 @@ class Image_Attributes_UT < Minitest::Test
   end
 
   def test_image_type
-    assert_instance_of(Magick::ImageType, @img.image_type)
+    expect(@img.image_type).to be_instance_of(Magick::ImageType)
 
     Magick::ImageType.values do |image_type|
       expect { @img.image_type = image_type }.not_to raise_error
@@ -370,7 +370,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_interlace_type
     expect { @img.interlace }.not_to raise_error
-    assert_instance_of(Magick::InterlaceType, @img.interlace)
+    expect(@img.interlace).to be_instance_of(Magick::InterlaceType)
     expect(@img.interlace).to eq(Magick::NoInterlace)
     expect { @img.interlace = Magick::LineInterlace }.not_to raise_error
     expect(@img.interlace).to eq(Magick::LineInterlace)
@@ -445,7 +445,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_orientation
     expect { @img.orientation }.not_to raise_error
-    assert_instance_of(Magick::OrientationType, @img.orientation)
+    expect(@img.orientation).to be_instance_of(Magick::OrientationType)
     expect(@img.orientation).to eq(Magick::UndefinedOrientation)
     expect { @img.orientation = Magick::TopLeftOrientation }.not_to raise_error
     expect(@img.orientation).to eq(Magick::TopLeftOrientation)
@@ -474,7 +474,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_pixel_interpolation_method
     expect { @img.pixel_interpolation_method }.not_to raise_error
-    assert_instance_of(Magick::PixelInterpolateMethod, @img.pixel_interpolation_method)
+    expect(@img.pixel_interpolation_method).to be_instance_of(Magick::PixelInterpolateMethod)
     expect(@img.pixel_interpolation_method).to eq(Magick::UndefinedInterpolatePixel)
     expect { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }.not_to raise_error
     expect(@img.pixel_interpolation_method).to eq(Magick::AverageInterpolatePixel)
@@ -499,7 +499,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_rendering_intent
     expect { @img.rendering_intent }.not_to raise_error
-    assert_instance_of(Magick::RenderingIntent, @img.rendering_intent)
+    expect(@img.rendering_intent).to be_instance_of(Magick::RenderingIntent)
     expect(@img.rendering_intent).to eq(Magick::PerceptualIntent)
 
     Magick::RenderingIntent.values do |rendering_intent|
@@ -551,7 +551,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_units
     expect { @img.units }.not_to raise_error
-    assert_instance_of(Magick::ResolutionType, @img.units)
+    expect(@img.units).to be_instance_of(Magick::ResolutionType)
     expect(@img.units).to eq(Magick::UndefinedResolution)
     expect { @img.units = Magick::PixelsPerInchResolution }.not_to raise_error
     expect(@img.units).to eq(Magick::PixelsPerInchResolution)

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -13,7 +13,7 @@ class KernelInfoUT < Minitest::Test
       if kernel == Magick::UserDefinedKernel
         expect { Magick::KernelInfo.new(k) }.to raise_error(RuntimeError)
       else
-        assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.new(k))
+        expect(Magick::KernelInfo.new(k)).to be_instance_of(Magick::KernelInfo)
       end
     end
     expect { Magick::KernelInfo.new('') }.to raise_error(RuntimeError)
@@ -41,16 +41,16 @@ class KernelInfoUT < Minitest::Test
   end
 
   def test_clone
-    assert_instance_of(Magick::KernelInfo, @kernel.clone)
+    expect(@kernel.clone).to be_instance_of(Magick::KernelInfo)
     assert_not_same(@kernel, @kernel.clone)
   end
 
   def test_builtin
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::UnityKernel, ''))
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::GaussianKernel, 'Gaussian:10,5'))
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::LoGKernel, 'LoG:10,5'))
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::DoGKernel, 'DoG:10,5'))
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::BlurKernel, 'Blur:10,5,1'))
-    assert_instance_of(Magick::KernelInfo, Magick::KernelInfo.builtin(Magick::CometKernel, 'Comet:10,5,1'))
+    expect(Magick::KernelInfo.builtin(Magick::UnityKernel, '')).to be_instance_of(Magick::KernelInfo)
+    expect(Magick::KernelInfo.builtin(Magick::GaussianKernel, 'Gaussian:10,5')).to be_instance_of(Magick::KernelInfo)
+    expect(Magick::KernelInfo.builtin(Magick::LoGKernel, 'LoG:10,5')).to be_instance_of(Magick::KernelInfo)
+    expect(Magick::KernelInfo.builtin(Magick::DoGKernel, 'DoG:10,5')).to be_instance_of(Magick::KernelInfo)
+    expect(Magick::KernelInfo.builtin(Magick::BlurKernel, 'Blur:10,5,1')).to be_instance_of(Magick::KernelInfo)
+    expect(Magick::KernelInfo.builtin(Magick::CometKernel, 'Comet:10,5,1')).to be_instance_of(Magick::KernelInfo)
   end
 end

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -29,14 +29,14 @@ class MagickUT < Minitest::Test
   def test_colors
     res = nil
     expect { res = Magick.colors }.not_to raise_error
-    assert_instance_of(Array, res)
+    expect(res).to be_instance_of(Array)
     res.each do |c|
-      assert_instance_of(Magick::Color, c)
-      assert_instance_of(String, c.name)
-      assert_instance_of(Magick::ComplianceType, c.compliance) unless c.compliance.nil?
-      assert_instance_of(Magick::Pixel, c.color)
+      expect(c).to be_instance_of(Magick::Color)
+      expect(c.name).to be_instance_of(String)
+      expect(c.compliance).to be_instance_of(Magick::ComplianceType) unless c.compliance.nil?
+      expect(c.color).to be_instance_of(Magick::Pixel)
     end
-    Magick.colors { |c| assert_instance_of(Magick::Color, c) }
+    Magick.colors { |c| expect(c).to be_instance_of(Magick::Color) }
   end
 
   # Test a few of the @@enumerator arrays in the Enum subclasses.
@@ -46,44 +46,44 @@ class MagickUT < Minitest::Test
     expect do
       ary = Magick::AlphaChannelOption.enumerators
     end.not_to raise_error
-    assert_instance_of(Array, ary)
+    expect(ary).to be_instance_of(Array)
 
     expect do
       ary = Magick::AlignType.enumerators
     end.not_to raise_error
-    assert_instance_of(Array, ary)
+    expect(ary).to be_instance_of(Array)
     expect(ary.length).to eq(4)
 
     expect do
       ary = Magick::AnchorType.enumerators
     end.not_to raise_error
-    assert_instance_of(Array, ary)
+    expect(ary).to be_instance_of(Array)
     expect(ary.length).to eq(3)
   end
 
   def test_features
     res = nil
     expect { res = Magick::Magick_features }.not_to raise_error
-    assert_instance_of(String, res)
+    expect(res).to be_instance_of(String)
   end
 
   def test_fonts
     res = nil
     expect { res = Magick.fonts }.not_to raise_error
-    assert_instance_of(Array, res)
+    expect(res).to be_instance_of(Array)
     res.each do |f|
-      assert_instance_of(Magick::Font, f)
-      assert_instance_of(String, f.name)
-      assert_instance_of(String, f.description) unless f.description.nil?
-      assert_instance_of(String, f.family)
-      assert_instance_of(Magick::StyleType, f.style) unless f.style.nil?
-      assert_instance_of(Magick::StretchType, f.stretch) unless f.stretch.nil?
+      expect(f).to be_instance_of(Magick::Font)
+      expect(f.name).to be_instance_of(String)
+      expect(f.description).to be_instance_of(String) unless f.description.nil?
+      expect(f.family).to be_instance_of(String)
+      expect(f.style).to be_instance_of(Magick::StyleType) unless f.style.nil?
+      expect(f.stretch).to be_instance_of(Magick::StretchType) unless f.stretch.nil?
       assert_kind_of(Integer, f.weight)
-      assert_instance_of(String, f.encoding) unless f.encoding.nil?
-      assert_instance_of(String, f.foundry) unless f.foundry.nil?
-      assert_instance_of(String, f.format) unless f.format.nil?
+      expect(f.encoding).to be_instance_of(String) unless f.encoding.nil?
+      expect(f.foundry).to be_instance_of(String) unless f.foundry.nil?
+      expect(f.format).to be_instance_of(String) unless f.format.nil?
     end
-    Magick.fonts { |f| assert_instance_of(Magick::Font, f) }
+    Magick.fonts { |f| expect(f).to be_instance_of(Magick::Font) }
   end
 
   def test_geometry
@@ -241,7 +241,7 @@ class MagickUT < Minitest::Test
   end
 
   def test_init_formats
-    assert_instance_of(Hash, Magick.init_formats)
+    expect(Magick.init_formats).to be_instance_of(Hash)
   end
 
   def test_opaque_alpha

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -6,7 +6,7 @@ class PreviewUT < Minitest::Test
     hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     expect do
       prev = hat.preview(Magick::RotatePreview)
-      assert_instance_of(Magick::Image, prev)
+      expect(prev).to be_instance_of(Magick::Image)
     end.not_to raise_error
     Magick::PreviewType.values do |type|
       expect { hat.preview(type) }.not_to raise_error

--- a/test/Struct.rb
+++ b/test/Struct.rb
@@ -9,7 +9,7 @@ class StructUT < Minitest::Test
 
   def test_export_color_info
     color = Magick.colors[0]
-    assert_instance_of(Magick::Color, color)
+    expect(color).to be_instance_of(Magick::Color)
     assert_match(/name=.+, compliance=.+, color.red=.+, color.green=.+, color.blue=.+, color.alpha=.+/, color.to_s)
   end
 

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -3,14 +3,14 @@ require 'minitest/autorun'
 
 class LibMagickUT < Minitest::Test
   def test_formats
-    assert_instance_of(Hash, Magick.formats)
+    expect(Magick.formats).to be_instance_of(Hash)
     Magick.formats.each do |f, v|
-      assert_instance_of(String, f)
+      expect(f).to be_instance_of(String)
       assert_match(/[\*\+\srw]+/, v)
     end
 
     Magick.formats do |f, v|
-      assert_instance_of(String, f)
+      expect(f).to be_instance_of(String)
       assert_match(/[\*\+\srw]+/, v)
     end
   end
@@ -18,16 +18,16 @@ class LibMagickUT < Minitest::Test
   def test_trace_proc
     Magick.trace_proc = proc do |which, description, id, method|
       assert(which == :c)
-      assert_instance_of(String, description)
-      assert_instance_of(String, id)
+      expect(description).to be_instance_of(String)
+      expect(id).to be_instance_of(String)
       expect(method).to eq(:initialize)
     end
     img = Magick::Image.new(20, 20)
 
     Magick.trace_proc = proc do |which, description, id, method|
       assert(which == :d)
-      assert_instance_of(String, description)
-      assert_instance_of(String, id)
+      expect(description).to be_instance_of(String)
+      expect(id).to be_instance_of(String)
       expect(method).to eq(:"destroy!")
     end
     img.destroy!

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -42,6 +42,8 @@ module Minitest
 
     def to(matcher)
       case matcher
+      when :be_instance_of
+        assert_instance_of(@expected, @actual)
       when :eq
         assert_equal(@expected, @actual)
       when :raise_error
@@ -58,6 +60,11 @@ module Minitest
       else
         raise ArgumentError, "no negated matcher: #{matcher.inspect}"
       end
+    end
+
+    def be_instance_of(expected)
+      @expected = expected
+      :be_instance_of
     end
 
     def eq(expected)


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/type-matchers#be-(an-)instance-of-matcher