### PR TITLE
Add aligned malloc/free handler for Ruby 2.4+ 

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -100,7 +100,7 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS = %(-I"#{dir_paths[:include]}")
-        $LDFLAGS = %(-L"#{dir_paths[:lib]}")
+        $LDFLAGS = %(-L"#{dir_paths[:lib]}" -lucrt)
 
         have_library(im_version_at_least?('7.0.0') ? 'CORE_RL_MagickCore_' : 'CORE_RL_magick_')
 
@@ -112,7 +112,7 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS << %( -I"#{dir_paths[:include]}")
-        $LDFLAGS << %( -libpath:"#{dir_paths[:lib]}")
+        $LDFLAGS << %( -libpath:"#{dir_paths[:lib]}" -libpath:ucrt)
 
         $LOCAL_LIBS = im_version_at_least?('7.0.0') ? 'CORE_RL_MagickCore_.lib' : 'CORE_RL_magick_.lib'
 

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -100,7 +100,8 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS = %(-I"#{dir_paths[:include]}")
-        $LDFLAGS = %(-L"#{dir_paths[:lib]}" -lucrt)
+        $LDFLAGS = %(-L"#{dir_paths[:lib]}")
+        $LDFLAGS << ' -lucrt' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
 
         have_library(im_version_at_least?('7.0.0') ? 'CORE_RL_MagickCore_' : 'CORE_RL_magick_')
 
@@ -112,7 +113,8 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS << %( -I"#{dir_paths[:include]}")
-        $LDFLAGS << %( -libpath:"#{dir_paths[:lib]}" -libpath:ucrt)
+        $LDFLAGS << %( -libpath:"#{dir_paths[:lib]}")
+        $LDFLAGS << ' -libpath:ucrt' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
 
         $LOCAL_LIBS = im_version_at_least?('7.0.0') ? 'CORE_RL_MagickCore_.lib' : 'CORE_RL_magick_.lib'
 

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -325,8 +325,16 @@ END_MINGW
 
     def create_header_file
       [
+        'posix_memalign',
+        'memalign',
+        'malloc_usable_size',
+        'malloc_size',
+
+        'rb_gc_adjust_memory_usage', # Ruby 2.4.0
+
         'GetImageChannelEntropy', # 6.9.0-0
-        'SetImageGray' # 6.9.1-10
+        'SetImageGray', # 6.9.1-10
+        'SetMagickAlignedMemoryMethods' # 7.0.9-0
       ].each do |func|
         have_func(func, headers)
       end

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -18,6 +18,12 @@
 #if defined HAVE_RB_GC_ADJUST_MEMORY_USAGE && \
     (defined HAVE_POSIX_MEMALIGN || defined HAVE_MEMALIGN || defined _WIN32)
     #define USE_RM_ALIGNED_MALLOC 1
+
+    #if defined HAVE_MALLOC_USABLE_SIZE
+    #include <malloc.h>
+    #elif defined HAVE_MALLOC_SIZE
+    #include <malloc/malloc.h>
+    #endif
 #endif
 #endif
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -14,17 +14,16 @@
 #define MAIN                        // Define external variables
 #include "rmagick.h"
 
-#if defined HAVE_SETMAGICKALIGNEDMEMORYMETHODS
-#if defined HAVE_RB_GC_ADJUST_MEMORY_USAGE && \
-    (defined HAVE_POSIX_MEMALIGN || defined HAVE_MEMALIGN || defined _WIN32)
-    #define USE_RM_ALIGNED_MALLOC 1
+#if defined(HAVE_SETMAGICKALIGNEDMEMORYMETHODS) && defined(HAVE_RB_GC_ADJUST_MEMORY_USAGE)
+    #if defined(HAVE_POSIX_MEMALIGN) || defined(HAVE_MEMALIGN) || defined(_WIN32)
+        #define USE_RM_ALIGNED_MALLOC 1
 
-    #if defined HAVE_MALLOC_USABLE_SIZE
-    #include <malloc.h>
-    #elif defined HAVE_MALLOC_SIZE
-    #include <malloc/malloc.h>
+        #if defined(HAVE_MALLOC_USABLE_SIZE)
+            #include <malloc.h>
+        #elif defined(HAVE_MALLOC_SIZE)
+            #include <malloc/malloc.h>
+        #endif
     #endif
-#endif
 #endif
 
 /*----------------------------------------------------------------------------\
@@ -117,11 +116,11 @@ static void rm_free(void *ptr)
 static size_t
 rm_aligned_malloc_size(void *ptr)
 {
-#if defined HAVE_MALLOC_USABLE_SIZE
+#if defined(HAVE_MALLOC_USABLE_SIZE)
     return malloc_usable_size(ptr);
-#elif defined HAVE_MALLOC_SIZE
+#elif defined(HAVE_MALLOC_SIZE)
     return malloc_size(ptr);
-#elif defined _WIN32
+#elif defined(_WIN32)
     return _aligned_msize(ptr, 0, 0);
 #endif
 }
@@ -139,13 +138,13 @@ static void *rm_aligned_malloc(size_t size, size_t alignment)
 {
     void *res;
 
-#if defined HAVE_POSIX_MEMALIGN
+#if defined(HAVE_POSIX_MEMALIGN)
     if (posix_memalign(&res, alignment, size) != 0) {
         return NULL;
     }
-#elif defined HAVE_MEMALIGN
+#elif defined(HAVE_MEMALIGN)
     res = memalign(alignment, size);
-#elif defined _WIN32
+#elif defined(_WIN32)
     res = _aligned_malloc(size, alignment);
 #endif
 
@@ -169,9 +168,9 @@ static void rm_aligned_free(void *ptr)
     size_t size = rm_aligned_malloc_size(ptr);
     rb_gc_adjust_memory_usage(-size);
 
-#if defined HAVE_POSIX_MEMALIGN || defined HAVE_MEMALIGN
+#if defined(HAVE_POSIX_MEMALIGN) || defined(HAVE_MEMALIGN)
     free(ptr);
-#elif defined _WIN32
+#elif defined(_WIN32)
     _aligned_free(ptr);
 #endif
 }

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -137,6 +137,7 @@ rm_aligned_malloc_size(void *ptr)
 static void *rm_aligned_malloc(size_t size, size_t alignment)
 {
     void *res;
+    size_t allocated_size;
 
 #if defined(HAVE_POSIX_MEMALIGN)
     if (posix_memalign(&res, alignment, size) != 0) {
@@ -148,8 +149,8 @@ static void *rm_aligned_malloc(size_t size, size_t alignment)
     res = _aligned_malloc(size, alignment);
 #endif
 
-    size = rm_aligned_malloc_size(res);
-    rb_gc_adjust_memory_usage(size);
+    allocated_size = rm_aligned_malloc_size(res);
+    rb_gc_adjust_memory_usage(allocated_size);
     return res;
 }
 
@@ -165,8 +166,8 @@ static void *rm_aligned_malloc(size_t size, size_t alignment)
  */
 static void rm_aligned_free(void *ptr)
 {
-    size_t size = rm_aligned_malloc_size(ptr);
-    rb_gc_adjust_memory_usage(-size);
+    size_t allocated_size = rm_aligned_malloc_size(ptr);
+    rb_gc_adjust_memory_usage(-allocated_size);
 
 #if defined(HAVE_POSIX_MEMALIGN) || defined(HAVE_MEMALIGN)
     free(ptr);

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -105,6 +105,7 @@ static void rm_free(void *ptr)
 }
 
 
+
 #if USE_RM_ALIGNED_MALLOC
 
 static size_t
@@ -118,6 +119,7 @@ rm_aligned_malloc_size(void *ptr)
     return _aligned_msize(ptr, 0, 0);
 #endif
 }
+
 
 /**
  * Allocate aligned memory.
@@ -147,6 +149,8 @@ static void *rm_aligned_malloc(size_t size, size_t alignment)
 }
 
 
+
+
 /**
  * Free aligned memory.
  *
@@ -165,6 +169,7 @@ static void rm_aligned_free(void *ptr)
     _aligned_free(ptr);
 #endif
 }
+
 #endif
 
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -121,7 +121,11 @@ rm_aligned_malloc_size(void *ptr)
 #elif defined(HAVE_MALLOC_SIZE)
     return malloc_size(ptr);
 #elif defined(_WIN32)
-    return _aligned_msize(ptr, 0, 0);
+// Refered to https://github.com/ImageMagick/ImageMagick/blob/master/MagickCore/memory-private.h
+#define MAGICKCORE_SIZEOF_VOID_P 8
+#define CACHE_LINE_SIZE  (8 * MAGICKCORE_SIZEOF_VOID_P)
+
+    return _aligned_msize(ptr, CACHE_LINE_SIZE, 0);
 #endif
 }
 


### PR DESCRIPTION
This PR is yet another implementation that solves the same problem as #832.
#832 requires adding new API in Ruby, and it might not be merged.

So, this implements custom allocation handler using `rb_gc_adjust_memory_usage()` Ruby's API.
The API notify memory usage in RMagick/ImageMagick to Ruby GC and GC works properly. 

`rb_gc_adjust_memory_usage()` can be used since Ruby 2.4.
So this PR will support many platform than #832.