### PR TITLE
Replace `assert_not_same` with RSpec style matcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ AllCops:
     - 'vendor/bundle/**/*'
     - '**/*\.spec'
 
+# this can be removed after finishing transition to RSpec
+Rails/RefuteMethods: { Enabled: false }
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -194,7 +194,7 @@ class Image1_UT < Minitest::Test
     res = nil
     expect { res = @img.auto_gamma_channel }.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect { res = @img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
     expect { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { @img.auto_gamma_channel(1) }.to raise_error(TypeError)
@@ -204,7 +204,7 @@ class Image1_UT < Minitest::Test
     res = nil
     expect { res = @img.auto_level_channel }.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect { res = @img.auto_level_channel Magick::RedChannel }.not_to raise_error
     expect { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { @img.auto_level_channel(1) }.to raise_error(TypeError)
@@ -217,7 +217,7 @@ class Image1_UT < Minitest::Test
         img.orientation = v
         res = img.auto_orient
         expect(res).to be_instance_of(Magick::Image)
-        assert_not_same(img, res)
+        expect(res).not_to be(img)
       end.not_to raise_error
     end
 
@@ -268,8 +268,8 @@ class Image1_UT < Minitest::Test
   end
 
   def test_blue_shift
-    assert_not_same(@img, @img.blue_shift)
-    assert_not_same(@img, @img.blue_shift(2.0))
+    expect(@img.blue_shift).not_to be(@img)
+    expect(@img.blue_shift(2.0)).not_to be(@img)
     expect { @img.blue_shift('x') }.to raise_error(TypeError)
     expect { @img.blue_shift(2, 2) }.to raise_error(ArgumentError)
   end
@@ -532,7 +532,7 @@ class Image1_UT < Minitest::Test
     expect do
       res = @img.color_point(0, 0, 'red')
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { @img.color_point(0, 0, pixel) }.not_to raise_error

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -17,14 +17,14 @@ class Image2_UT < Minitest::Test
       Magick::GravityType.values do |gravity|
         expect do
           res = img1.composite(img2, gravity, 5, 5, op)
-          assert_not_same(img1, res)
+          expect(res).not_to be(img1)
         end.not_to raise_error
       end
     end
 
     expect do
       res = img1.composite(img2, 5, 5, Magick::OverCompositeOp)
-      assert_not_same(img1, res)
+      expect(res).not_to be(img1)
     end.not_to raise_error
 
     expect { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
@@ -62,7 +62,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = img1.composite_affine(img2, affine)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -75,7 +75,7 @@ class Image2_UT < Minitest::Test
       Magick::GravityType.values do |gravity|
         expect do
           res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
-          assert_not_same(img1, res)
+          expect(res).not_to be(img1)
         end.not_to raise_error
       end
     end
@@ -90,8 +90,8 @@ class Image2_UT < Minitest::Test
     res = nil
     expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(bg, res)
-    assert_not_same(fg, res)
+    expect(res).not_to be(bg)
+    expect(res).not_to be(fg)
     expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
     expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
 
@@ -109,8 +109,8 @@ class Image2_UT < Minitest::Test
       res = bg.composite_tiled(fg)
     end.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(bg, res)
-    assert_not_same(fg, res)
+    expect(res).not_to be(bg)
+    expect(res).not_to be(fg)
     expect { bg.composite_tiled!(fg) }.not_to raise_error
     expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
     expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error
@@ -139,7 +139,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.contrast
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.contrast(true) }.not_to raise_error
     expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
@@ -149,7 +149,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.contrast_stretch_channel(25)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
     expect { @img.contrast_stretch_channel('10%') }.not_to raise_error
@@ -168,7 +168,7 @@ class Image2_UT < Minitest::Test
       expect do
         res = @img.morphology(method, 2, kernel)
         expect(res).to be_instance_of(Magick::Image)
-        assert_not_same(@img, res)
+        expect(res).not_to be(@img)
       end.not_to raise_error
     end
   end
@@ -184,7 +184,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -194,7 +194,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.convolve(order, kernel)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.convolve }.to raise_error(ArgumentError)
     expect { @img.convolve(0) }.to raise_error(ArgumentError)
@@ -216,7 +216,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.convolve_channel(order, kernel, Magick::RedChannel)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     expect { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
@@ -241,7 +241,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     # 3-argument form
@@ -277,7 +277,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.cycle_colormap(5)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
       expect(res.class_type).to eq(Magick::PseudoClass)
     end.not_to raise_error
   end
@@ -289,11 +289,11 @@ class Image2_UT < Minitest::Test
       res2 = res.decipher 'passphrase'
     end.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect(res.columns).to eq(@img.columns)
     expect(res.rows).to eq(@img.rows)
     expect(res2).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res2)
+    expect(res2).not_to be(@img)
     expect(res2.columns).to eq(@img.columns)
     expect(res2.rows).to eq(@img.rows)
     expect(res2).to eq(@img)
@@ -309,7 +309,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.deskew
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     expect { @img.deskew(0.10) }.not_to raise_error
@@ -323,7 +323,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.despeckle
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -423,7 +423,7 @@ class Image2_UT < Minitest::Test
     expect { @img.displace(@img2, 25) }.not_to raise_error
     res = @img.displace(@img2, 25)
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect { @img.displace(@img2, 25, 25) }.not_to raise_error
     expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
     expect { @img.displace(@img2, 25, 25, 10, 10) }.not_to raise_error
@@ -541,7 +541,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.edge
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.edge(2.0) }.not_to raise_error
     expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
@@ -552,7 +552,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.emboss
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.emboss(1.0) }.not_to raise_error
     expect { @img.emboss(1.0, 0.5) }.not_to raise_error
@@ -565,7 +565,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.enhance
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -573,7 +573,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.equalize
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -581,7 +581,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.equalize_channel
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.equalize_channel }.not_to raise_error
     expect { @img.equalize_channel(Magick::RedChannel) }.not_to raise_error
@@ -600,7 +600,7 @@ class Image2_UT < Minitest::Test
     res = nil
     img = Magick::Image.new(200, 200)
     expect { res = @img.excerpt(20, 20, 50, 100) }.not_to raise_error
-    assert_not_same(img, res)
+    expect(res).not_to be(img)
     expect(res.columns).to eq(50)
     expect(res.rows).to eq(100)
 
@@ -686,7 +686,7 @@ class Image2_UT < Minitest::Test
     expect { @img.extent(40, 40) }.not_to raise_error
     res = @img.extent(40, 40)
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect(res.columns).to eq(40)
     expect(res.rows).to eq(40)
     expect { @img.extent(40, 40, 5) }.not_to raise_error
@@ -746,7 +746,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.flip
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -761,7 +761,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.flop
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -776,7 +776,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.frame
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.frame(50) }.not_to raise_error
     expect { @img.frame(50, 50) }.not_to raise_error
@@ -805,7 +805,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.gamma_channel(0.8)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.gamma_channel }.to raise_error(ArgumentError)
     expect { @img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
@@ -855,7 +855,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.gamma_correct(0.8)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
     expect { @img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
@@ -868,7 +868,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.gaussian_blur
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.gaussian_blur(0.0) }.not_to raise_error
     expect { @img.gaussian_blur(0.0, 3.0) }.not_to raise_error
@@ -881,7 +881,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.gaussian_blur_channel
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
     expect { @img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
@@ -935,7 +935,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.implode(0.5)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
   end
@@ -973,7 +973,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.level
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.level(0.0) }.not_to raise_error
     expect { @img.level(0.0, 1.0) }.not_to raise_error
@@ -1006,7 +1006,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.level_channel(Magick::RedChannel)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     expect { @img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
@@ -1026,7 +1026,7 @@ class Image2_UT < Minitest::Test
       res = @img.level_colors
     end.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
 
     expect { @img.level_colors('black') }.not_to raise_error
     expect { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }.not_to raise_error
@@ -1045,7 +1045,7 @@ class Image2_UT < Minitest::Test
       res = @img.levelize_channel(0, Magick::QuantumRange)
     end.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
 
     expect { @img.levelize_channel(0) }.not_to raise_error
     expect { @img.levelize_channel(0, Magick::QuantumRange) }.not_to raise_error
@@ -1084,7 +1084,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.magnify
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     res = @img.magnify!
@@ -1106,7 +1106,7 @@ class Image2_UT < Minitest::Test
     res = nil
     expect { res = @img.mask }.not_to raise_error
     assert_not_nil(res)
-    assert_not_same(cimg, res)
+    expect(res).not_to be(cimg)
     expect(res.columns).to eq(20)
     expect(res.rows).to eq(20)
 
@@ -1125,7 +1125,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
     expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
@@ -1136,7 +1136,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
 
@@ -1155,7 +1155,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -1170,7 +1170,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.median_filter
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.median_filter(0.5) }.not_to raise_error
     expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
@@ -1181,7 +1181,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.minify
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
 
     res = @img.minify!
@@ -1192,7 +1192,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.modulate
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.modulate(0.5) }.not_to raise_error
     expect { @img.modulate(0.5, 0.5) }.not_to raise_error
@@ -1214,7 +1214,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.motion_blur(1.0, 7.0, 180)
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
     expect { @img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
@@ -1224,7 +1224,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.negate
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.negate(true) }.not_to raise_error
     expect { @img.negate(true, 2) }.to raise_error(ArgumentError)
@@ -1234,7 +1234,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.negate_channel
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.negate_channel(true) }.not_to raise_error
     expect { @img.negate_channel(true, Magick::RedChannel) }.not_to raise_error
@@ -1246,7 +1246,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.normalize
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
   end
 
@@ -1254,7 +1254,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.normalize_channel
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.normalize_channel(Magick::RedChannel) }.not_to raise_error
     expect { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
@@ -1265,7 +1265,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.oil_paint
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.oil_paint(2.0) }.not_to raise_error
     expect { @img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
@@ -1275,7 +1275,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.opaque('white', 'red')
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
@@ -1289,7 +1289,7 @@ class Image2_UT < Minitest::Test
     expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
     assert_not_nil(res)
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(res, @img)
+    expect(@img).not_to be(res)
     expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
     expect { @img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
     expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }.not_to raise_error
@@ -1317,7 +1317,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.ordered_dither
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.ordered_dither('3x3') }.not_to raise_error
     expect { @img.ordered_dither(2) }.not_to raise_error
@@ -1332,7 +1332,7 @@ class Image2_UT < Minitest::Test
     expect { res = @img.paint_transparent('red') }.not_to raise_error
     assert_not_nil(res)
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(res, @img)
+    expect(@img).not_to be(res)
     expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
@@ -1398,7 +1398,7 @@ class Image2_UT < Minitest::Test
     expect do
       res = @img.posterize
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect { @img.posterize(5) }.not_to raise_error
     expect { @img.posterize(5, true) }.not_to raise_error

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -217,7 +217,7 @@ class Image3_UT < Minitest::Test
     changed = @img.resize_to_fill(@img.columns, @img.rows)
     expect(changed.columns).to eq(@img.columns)
     expect(changed.rows).to eq(@img.rows)
-    assert_not_same(changed, @img)
+    expect(@img).not_to be(changed)
   end
 
   def test_resize_to_fill_1
@@ -279,7 +279,7 @@ class Image3_UT < Minitest::Test
     expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
     assert_not_nil(res)
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(img, res)
+    expect(res).not_to be(img)
     expect(res.columns).to eq(40)
     expect(res.rows).to eq(50)
   end
@@ -288,7 +288,7 @@ class Image3_UT < Minitest::Test
     img = Magick::Image.new(200, 300)
     changed = img.resize_to_fit(100)
     expect(changed).to be_instance_of(Magick::Image)
-    assert_not_same(img, changed)
+    expect(changed).not_to be(img)
     expect(changed.columns).to eq(67)
     expect(changed.rows).to eq(100)
   end
@@ -419,7 +419,7 @@ class Image3_UT < Minitest::Test
     res = nil
     expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
     expect(res).to be_instance_of(Magick::Image)
-    assert_not_same(@img, res)
+    expect(res).not_to be(@img)
     expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
 
     expect { @img.selective_blur_channel(0, 1, 0.1) }.not_to raise_error
@@ -825,7 +825,7 @@ class Image3_UT < Minitest::Test
     expect do
       res = @img.transpose
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect do
       res = @img.transpose!
@@ -838,7 +838,7 @@ class Image3_UT < Minitest::Test
     expect do
       res = @img.transverse
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(@img, res)
+      expect(res).not_to be(@img)
     end.not_to raise_error
     expect do
       res = @img.transverse!
@@ -936,7 +936,7 @@ class Image3_UT < Minitest::Test
     expect do
       res = @img.vignette
       expect(res).to be_instance_of(Magick::Image)
-      assert_not_same(res, @img)
+      expect(@img).not_to be(res)
     end.not_to raise_error
     expect { @img.vignette(0) }.not_to raise_error
     expect { @img.vignette(0, 0) }.not_to raise_error

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -217,8 +217,8 @@ class ImageList1UT < Minitest::Test
     expect do
       res = @list & @list2
       expect(res).to be_instance_of(Magick::ImageList)
-      assert_not_same(res, @list)
-      assert_not_same(res, @list2)
+      expect(@list).not_to be(res)
+      expect(@list2).not_to be(res)
       expect(res.length).to eq(5)
       expect(res.scene).to eq(2)
       expect(res.cur_image).to be(cur)
@@ -257,7 +257,7 @@ class ImageList1UT < Minitest::Test
       res = @list * 2
       expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(20)
-      assert_not_same(res, @list)
+      expect(@list).not_to be(res)
       expect(res.cur_image).to be(cur)
     end.not_to raise_error
 
@@ -271,8 +271,8 @@ class ImageList1UT < Minitest::Test
       res = @list + @list2
       expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(15)
-      assert_not_same(res, @list)
-      assert_not_same(res, @list2)
+      expect(@list).not_to be(res)
+      expect(@list2).not_to be(res)
       expect(res.cur_image).to be(cur)
     end.not_to raise_error
 
@@ -286,8 +286,8 @@ class ImageList1UT < Minitest::Test
       res = @list - @list2
       expect(res).to be_instance_of(Magick::ImageList)
       expect(res.length).to eq(5)
-      assert_not_same(res, @list)
-      assert_not_same(res, @list2)
+      expect(@list).not_to be(res)
+      expect(@list2).not_to be(res)
       expect(res.cur_image).to be(cur)
     end.not_to raise_error
 
@@ -320,8 +320,8 @@ class ImageList1UT < Minitest::Test
       # but not be the *same* list
       res = @list | @list2
       expect(res).to be_instance_of(Magick::ImageList)
-      assert_not_same(res, @list)
-      assert_not_same(res, @list2)
+      expect(@list).not_to be(res)
+      expect(@list2).not_to be(res)
       expect(@list).to eq(res)
     end.not_to raise_error
 
@@ -348,7 +348,7 @@ class ImageList1UT < Minitest::Test
       scene = @list.scene
       res = @list.collect(&:negate)
       expect(res).to be_instance_of(Magick::ImageList)
-      assert_not_same(res, @list)
+      expect(@list).not_to be(res)
       expect(res.scene).to eq(scene)
     end.not_to raise_error
     expect do
@@ -362,7 +362,7 @@ class ImageList1UT < Minitest::Test
   def test_compact
     expect do
       res = @list.compact
-      assert_not_same(res, @list)
+      expect(@list).not_to be(res)
       expect(@list).to eq(res)
     end.not_to raise_error
     expect do

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -56,7 +56,7 @@ class ImageList2UT < Minitest::Test
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     @ilist.scene = 7
     ilist2 = @ilist.copy
-    assert_not_same(@ilist, ilist2)
+    expect(ilist2).not_to be(@ilist)
     expect(ilist2.scene).to eq(@ilist.scene)
     @ilist.each_with_index do |img, x|
       expect(ilist2[x]).to eq(img)

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -42,7 +42,7 @@ class KernelInfoUT < Minitest::Test
 
   def test_clone
     expect(@kernel.clone).to be_instance_of(Magick::KernelInfo)
-    assert_not_same(@kernel, @kernel.clone)
+    expect(@kernel.clone).not_to be(@kernel)
   end
 
   def test_builtin

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -57,6 +57,8 @@ module Minitest
 
     def not_to(matcher)
       case matcher
+      when :be
+        refute_same(@expected, @actual)
       when :raise_error
         @actual_block.call
       else
@@ -84,7 +86,6 @@ module Minitest
       :raise_error
     end
 
-    alias assert_not_same refute_same
     alias assert_not_equal refute_equal
     alias assert_not_nil refute_nil
     alias assert_true assert


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

I disabled the `Rails/RefuteMethods` rule as it wants us to use
`assert_not_same`.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/equality-matchers#compare-using-be-(equal?)