### PR TITLE
Replace `assert_nil` with RSpec style matcher

### DIFF
--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -32,7 +32,7 @@ class EnumUT < Minitest::Test
     expect(enum1 <=> enum2).to eq(-1)
     expect(enum1 <=> enum4).to eq(0)
     expect(enum1 <=> enum3).to eq(1)
-    assert_nil(enum1 <=> 'x')
+    expect(enum1 <=> 'x').to be(nil)
   end
 
   def test_case_eq

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -30,7 +30,7 @@ class Image1_UT < Minitest::Test
     expect(img1 <=> img0).to eq(sig1 <=> sig0)
     expect(img0).to eq(img0)
     assert_not_equal(img0, img1)
-    assert_nil(img0 <=> nil)
+    expect(img0 <=> nil).to be(nil)
   end
 
   def test_adaptive_blur
@@ -177,8 +177,8 @@ class Image1_UT < Minitest::Test
 
   def test_aref
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_nil(img[nil])
-    assert_nil(img['label'])
+    expect(img[nil]).to be(nil)
+    expect(img['label']).to be(nil)
     assert_match(/^Creator: PolyView/, img[:comment])
   end
 
@@ -224,7 +224,7 @@ class Image1_UT < Minitest::Test
     expect do
       res = @img.auto_orient!
       # When not changed, returns nil
-      assert_nil(res)
+      expect(res).to be(nil)
     end.not_to raise_error
   end
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -526,7 +526,7 @@ class Image2_UT < Minitest::Test
   end
 
   def test_each_profile
-    assert_nil(@img.each_profile {})
+    expect(@img.each_profile {}).to be(nil)
 
     @img.iptc_profile = 'test profile'
     expect do
@@ -732,7 +732,7 @@ class Image2_UT < Minitest::Test
     end.not_to raise_error
 
     x = girl.find_similar_region(@img)
-    assert_nil(x)
+    expect(x).to be(nil)
 
     expect { girl.find_similar_region(region, 10, 10, 10) }.to raise_error(ArgumentError)
     expect { girl.find_similar_region(region, 10, 'x') }.to raise_error(TypeError)

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -324,7 +324,7 @@ class Image3_UT < Minitest::Test
     end.not_to raise_error
     expect do
       res = img.rotate(90, '<')
-      assert_nil(res)
+      expect(res).to be(nil)
     end.not_to raise_error
     expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
     expect { img.rotate(90, []) }.to raise_error(TypeError)

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -144,7 +144,7 @@ class ImageList1UT < Minitest::Test
     expect(@list[-1]).to be_instance_of(Magick::Image)
     expect(@list[0, 1]).to be_instance_of(Magick::ImageList)
     expect(@list[0..2]).to be_instance_of(Magick::ImageList)
-    assert_nil(@list[20])
+    expect(@list[20]).to be(nil)
   end
 
   def test_aset
@@ -242,7 +242,7 @@ class ImageList1UT < Minitest::Test
       expect(@list[7]).to be(img)
       expect(@list.cur_image).to be(cur)
       img = @list.at(10)
-      assert_nil(img)
+      expect(img).to be(nil)
       expect(@list.cur_image).to be(cur)
       img = @list.at(-1)
       expect(@list[9]).to be(img)
@@ -340,7 +340,7 @@ class ImageList1UT < Minitest::Test
     expect { @list.clear }.not_to raise_error
     expect(@list).to be_instance_of(Magick::ImageList)
     expect(@list.length).to eq(0)
-    assert_nil(@list.scene)
+    expect(@list.scene).to be(nil)
   end
 
   def test_collect
@@ -631,7 +631,7 @@ class ImageList1UT < Minitest::Test
     end.not_to raise_error
 
     # returns nil if no changes are made
-    assert_nil(@list.reject! { false })
+    expect(@list.reject! { false }).to be(nil)
   end
 
   def test_replace1
@@ -640,7 +640,7 @@ class ImageList1UT < Minitest::Test
       res = @list.replace([])
       expect(@list).to be(res)
       expect(@list.length).to eq(0)
-      assert_nil(@list.scene)
+      expect(@list.scene).to be(nil)
     end.not_to raise_error
 
     # Replace empty list with non-empty list
@@ -793,7 +793,7 @@ class ImageList1UT < Minitest::Test
 
   def test_uniq!
     expect do
-      assert_nil(@list.uniq!)
+      expect(@list.uniq!).to be(nil)
     end.not_to raise_error
     @list[1] = @list[0]
     @list.scene = 7

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -151,7 +151,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_color_profile
     expect { @img.color_profile }.not_to raise_error
-    assert_nil(@img.color_profile)
+    expect(@img.color_profile).to be(nil)
     expect { @img.color_profile = @p }.not_to raise_error
     expect(@img.color_profile).to eq(@p)
     expect { @img.color_profile = 2 }.to raise_error(TypeError)
@@ -238,7 +238,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_directory
     expect { @img.directory }.not_to raise_error
-    assert_nil(@img.directory)
+    expect(@img.directory).to be(nil)
     expect { @img.directory = nil }.to raise_error(NoMethodError)
   end
 
@@ -303,7 +303,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_format
     expect { @img.format }.not_to raise_error
-    assert_nil(@img.format)
+    expect(@img.format).to be(nil)
     expect { @img.format = 'GIF' }.not_to raise_error
     expect { @img.format = 'JPG' }.not_to raise_error
     expect { @img.format = 'TIFF' }.not_to raise_error
@@ -339,7 +339,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_geometry
     expect { @img.geometry }.not_to raise_error
-    assert_nil(@img.geometry)
+    expect(@img.geometry).to be(nil)
     expect { @img.geometry = nil }.not_to raise_error
     expect { @img.geometry = '90x90' }.not_to raise_error
     expect(@img.geometry).to eq('90x90')
@@ -383,7 +383,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_iptc_profile
     expect { @img.iptc_profile }.not_to raise_error
-    assert_nil(@img.iptc_profile)
+    expect(@img.iptc_profile).to be(nil)
     expect { @img.iptc_profile = 'xxx' }.not_to raise_error
     expect(@img.iptc_profile).to eq('xxx')
     expect { @img.iptc_profile = 2 }.to raise_error(TypeError)
@@ -426,7 +426,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_montage
     expect { @img.montage }.not_to raise_error
-    assert_nil(@img.montage)
+    expect(@img.montage).to be(nil)
   end
 
   def test_number_colors

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -9,13 +9,13 @@ class InfoUT < Minitest::Test
   def test_options
     # 1-argument form
     expect { @info['fill'] }.not_to raise_error
-    assert_nil(@info['fill'])
+    expect(@info['fill']).to be(nil)
 
     expect { @info['fill'] = 'red' }.not_to raise_error
     expect(@info['fill']).to eq('red')
 
     expect { @info['fill'] = nil }.not_to raise_error
-    assert_nil(@info['fill'])
+    expect(@info['fill']).to be(nil)
 
     # 2-argument form
     expect { @info['tiff', 'bits-per-sample'] = 2 }.not_to raise_error
@@ -26,7 +26,7 @@ class InfoUT < Minitest::Test
     expect(@info['tiff', 'bits-per-sample']).to eq('4')
 
     expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
-    assert_nil(@info['tiff', 'bits-per-sample'])
+    expect(@info['tiff', 'bits-per-sample']).to be(nil)
     expect { @info.undefine('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
 
@@ -53,14 +53,14 @@ class InfoUT < Minitest::Test
     expect { @info.attenuate = 5.25 }.not_to raise_error
     expect(@info.attenuate).to eq(5.25)
     expect { @info.attenuate = nil }.not_to raise_error
-    assert_nil(@info.attenuate)
+    expect(@info.attenuate).to be(nil)
   end
 
   def test_authenticate
     expect { @info.authenticate = 'string' }.not_to raise_error
     expect(@info.authenticate).to eq('string')
     expect { @info.authenticate = nil }.not_to raise_error
-    assert_nil(@info.authenticate)
+    expect(@info.authenticate).to be(nil)
     expect { @info.authenticate = '' }.not_to raise_error
     expect(@info.authenticate).to eq('')
   end
@@ -87,7 +87,7 @@ class InfoUT < Minitest::Test
     expect { @info.caption = 'string' }.not_to raise_error
     expect(@info.caption).to eq('string')
     expect { @info.caption = nil }.not_to raise_error
-    assert_nil(@info.caption)
+    expect(@info.caption).to be(nil)
     expect { Magick::Image.new(20, 20) { self.caption = 'string' } }.not_to raise_error
   end
 
@@ -130,7 +130,7 @@ class InfoUT < Minitest::Test
     expect { @info.density = Magick::Geometry.new(72, 72) }.not_to raise_error
     expect(@info.density).to eq('72x72')
     expect { @info.density = nil }.not_to raise_error
-    assert_nil(@info.density)
+    expect(@info.density).to be(nil)
     expect { @info.density = 'aaa' }.to raise_error(ArgumentError)
   end
 
@@ -138,7 +138,7 @@ class InfoUT < Minitest::Test
     expect { @info.delay = 60 }.not_to raise_error
     expect(@info.delay).to eq(60)
     expect { @info.delay = nil }.not_to raise_error
-    assert_nil(@info.delay)
+    expect(@info.delay).to be(nil)
     expect { @info.delay = '60' }.to raise_error(TypeError)
   end
 
@@ -177,7 +177,7 @@ class InfoUT < Minitest::Test
     expect { @info.extract = Magick::Geometry.new(100, 100) }.not_to raise_error
     expect(@info.extract).to eq('100x100')
     expect { @info.extract = nil }.not_to raise_error
-    assert_nil(@info.extract)
+    expect(@info.extract).to be(nil)
     expect { @info.extract = 'aaa' }.to raise_error(ArgumentError)
   end
 
@@ -190,13 +190,13 @@ class InfoUT < Minitest::Test
 
   def test_fill
     expect { @info.fill }.not_to raise_error
-    assert_nil(@info.fill)
+    expect(@info.fill).to be(nil)
 
     expect { @info.fill = 'white' }.not_to raise_error
     expect(@info.fill).to eq('white')
 
     expect { @info.fill = nil }.not_to raise_error
-    assert_nil(@info.fill)
+    expect(@info.fill).to be(nil)
 
     expect { @info.fill = 'xxx' }.to raise_error(ArgumentError)
   end
@@ -205,7 +205,7 @@ class InfoUT < Minitest::Test
     expect { @info.font = 'Arial' }.not_to raise_error
     expect(@info.font).to eq('Arial')
     expect { @info.font = nil }.not_to raise_error
-    assert_nil(@info.font)
+    expect(@info.font).to be(nil)
   end
 
   def test_format
@@ -251,7 +251,7 @@ class InfoUT < Minitest::Test
     expect { @info.label = 'string' }.not_to raise_error
     expect(@info.label).to eq('string')
     expect { @info.label = nil }.not_to raise_error
-    assert_nil(@info.label)
+    expect(@info.label).to be(nil)
   end
 
   def test_matte_color
@@ -308,7 +308,7 @@ class InfoUT < Minitest::Test
     expect { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }.not_to raise_error
     expect(@info.origin).to eq('+10+10')
     expect { @info.origin = nil }.not_to raise_error
-    assert_nil(@info.origin)
+    expect(@info.origin).to be(nil)
     expect { @info.origin = 'aaa' }.to raise_error(ArgumentError)
   end
 
@@ -316,7 +316,7 @@ class InfoUT < Minitest::Test
     expect { @info.page = '612x792>' }.not_to raise_error
     expect(@info.page).to eq('612x792>')
     expect { @info.page = nil }.not_to raise_error
-    assert_nil(@info.page)
+    expect(@info.page).to be(nil)
   end
 
   def test_pointsize
@@ -333,7 +333,7 @@ class InfoUT < Minitest::Test
     expect { @info.sampling_factor = '2x1' }.not_to raise_error
     expect(@info.sampling_factor).to eq('2x1')
     expect { @info.sampling_factor = nil }.not_to raise_error
-    assert_nil(@info.sampling_factor)
+    expect(@info.sampling_factor).to be(nil)
   end
 
   def test_scene
@@ -346,7 +346,7 @@ class InfoUT < Minitest::Test
     expect { @info.server_name = 'foo' }.not_to raise_error
     expect(@info.server_name).to eq('foo')
     expect { @info.server_name = nil }.not_to raise_error
-    assert_nil(@info.server_name)
+    expect(@info.server_name).to be(nil)
   end
 
   def test_size
@@ -355,19 +355,19 @@ class InfoUT < Minitest::Test
     expect { @info.size = Magick::Geometry.new(100, 200) }.not_to raise_error
     expect(@info.size).to eq('100x200')
     expect { @info.size = nil }.not_to raise_error
-    assert_nil(@info.size)
+    expect(@info.size).to be(nil)
     expect { @info.size = 'aaa' }.to raise_error(ArgumentError)
   end
 
   def test_stroke
     expect { @info.stroke }.not_to raise_error
-    assert_nil(@info.stroke)
+    expect(@info.stroke).to be(nil)
 
     expect { @info.stroke = 'white' }.not_to raise_error
     expect(@info.stroke).to eq('white')
 
     expect { @info.stroke = nil }.not_to raise_error
-    assert_nil(@info.stroke)
+    expect(@info.stroke).to be(nil)
 
     expect { @info.stroke = 'xxx' }.to raise_error(ArgumentError)
   end
@@ -378,7 +378,7 @@ class InfoUT < Minitest::Test
     expect { @info.stroke_width = 5.25 }.not_to raise_error
     expect(@info.stroke_width).to eq(5.25)
     expect { @info.stroke_width = nil }.not_to raise_error
-    assert_nil(@info.stroke_width)
+    expect(@info.stroke_width).to be(nil)
     expect { @info.stroke_width = 'xxx' }.to raise_error(TypeError)
   end
 
@@ -404,13 +404,13 @@ class InfoUT < Minitest::Test
 
   def test_undercolor
     expect { @info.undercolor }.not_to raise_error
-    assert_nil(@info.undercolor)
+    expect(@info.undercolor).to be(nil)
 
     expect { @info.undercolor = 'white' }.not_to raise_error
     expect(@info.undercolor).to eq('white')
 
     expect { @info.undercolor = nil }.not_to raise_error
-    assert_nil(@info.undercolor)
+    expect(@info.undercolor).to be(nil)
 
     expect { @info.undercolor = 'xxx' }.to raise_error(ArgumentError)
   end
@@ -426,7 +426,7 @@ class InfoUT < Minitest::Test
     expect { @info.view = 'string' }.not_to raise_error
     expect(@info.view).to eq('string')
     expect { @info.view = nil }.not_to raise_error
-    assert_nil(@info.view)
+    expect(@info.view).to be(nil)
     expect { @info.view = '' }.not_to raise_error
     expect(@info.view).to eq('')
   end

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -21,22 +21,22 @@ class KernelInfoUT < Minitest::Test
   end
 
   def test_unity_add
-    assert_nil(@kernel.unity_add(1.0))
-    assert_nil(@kernel.unity_add(12))
+    expect(@kernel.unity_add(1.0)).to be(nil)
+    expect(@kernel.unity_add(12)).to be(nil)
     expect { @kernel.unity_add('x') }.to raise_error(TypeError)
   end
 
   def test_scale
     Magick::GeometryFlags.values do |flag|
-      assert_nil(@kernel.scale(1.0, flag))
-      assert_nil(@kernel.scale(42, flag))
+      expect(@kernel.scale(1.0, flag)).to be(nil)
+      expect(@kernel.scale(42, flag)).to be(nil)
     end
     expect { @kernel.scale(42, 'x') }.to raise_error(ArgumentError)
     expect { @kernel.scale(42, Magick::BoldWeight) }.to raise_error(ArgumentError)
   end
 
   def test_scale_geometry
-    assert_nil(@kernel.scale_geometry('-set option:convolve:scale 1.0'))
+    expect(@kernel.scale_geometry('-set option:convolve:scale 1.0')).to be(nil)
     expect { @kernel.scale_geometry(42) }.to raise_error(TypeError)
   end
 

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -42,7 +42,7 @@ class LibGeometryUT < Minitest::Test
     expect(geometry.height).to eq(0)
     expect(geometry.x).to eq(0)
     expect(geometry.y).to eq(0)
-    assert_nil(geometry.flag)
+    expect(geometry.flag).to be(nil)
 
     geometry = Magick::Geometry.new(10, 20, 30, 40)
     expect(geometry.width).to eq(10)


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

In this case I decided to use `to be(nil)` rather than `to be_nil`. Both
are available in RSpec, and they are essentially equivalent. The reason
I chose `be(nil)` was to be syntactically consistent with `be(true)` and
`be(false)`, since there is no longer a `be_true` in RSpec, only a
`be_truthy` which is less strict about the return value. In this latter
case I prefer to avoid `be_truthy` and be more explicit about what is
expected, either via `be(true)` or `eq(something_more_specific)`.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/equality-matchers#compare-using-be-(equal?)
https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/be-matchers#be-nil-matcher