### PR TITLE
Replace `assert_kind_of` with RSpec style matcher

### DIFF
--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -62,7 +62,7 @@ class EnumUT < Minitest::Test
     expect(Magick::AlignType.values[0].to_i).to eq(0)
 
     Magick::AlignType.values do |enum|
-      assert_kind_of(Magick::Enum, enum)
+      expect(enum).to be_kind_of(Magick::Enum)
       expect(enum).to be_instance_of(Magick::AlignType)
     end
   end

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -364,7 +364,7 @@ class Image1_UT < Minitest::Test
     expect { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
     expect { @img.channel_depth(Magick::GrayChannel) }.not_to raise_error
     expect { @img.channel_depth(2) }.to raise_error(TypeError)
-    assert_kind_of(Integer, @img.channel_depth(Magick::RedChannel))
+    expect(@img.channel_depth(Magick::RedChannel)).to be_kind_of(Integer)
   end
 
   def test_channel_extrema
@@ -372,8 +372,8 @@ class Image1_UT < Minitest::Test
       res = @img.channel_extrema
       expect(res).to be_instance_of(Array)
       expect(res.length).to eq(2)
-      assert_kind_of(Integer, res[0])
-      assert_kind_of(Integer, res[1])
+      expect(res[0]).to be_kind_of(Integer)
+      expect(res[1]).to be_kind_of(Integer)
     end.not_to raise_error
     expect { @img.channel_extrema(Magick::RedChannel) }.not_to raise_error
     expect { @img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -615,7 +615,7 @@ class Image2_UT < Minitest::Test
       expect(res).to be_instance_of(Array)
       expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
       res.each do |p|
-        assert_kind_of(Integer, p)
+        expect(p).to be_kind_of(Integer)
       end
     end.not_to raise_error
     expect { @img.export_pixels(0) }.not_to raise_error

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -86,7 +86,7 @@ class ImageList1UT < Minitest::Test
 
   def test_iterations
     expect { @list.iterations }.not_to raise_error
-    assert_kind_of(Integer, @list.iterations)
+    expect(@list.iterations).to be_kind_of(Integer)
     expect { @list.iterations = 20 }.not_to raise_error
     expect(@list.iterations).to eq(20)
     expect { @list.iterations = 'x' }.to raise_error(ArgumentError)

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -255,7 +255,7 @@ class ImageList2UT < Minitest::Test
       expect do
         res = @ilist.optimize_layers(method)
         expect(res).to be_instance_of(Magick::ImageList)
-        assert_kind_of(Integer, res.length)
+        expect(res.length).to be_kind_of(Integer)
       end.not_to raise_error
     end
 

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -162,7 +162,7 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.colors).to eq(0)
     img = @img.copy
     img.class_type = Magick::PseudoClass
-    assert_kind_of(Integer, img.colors)
+    expect(img.colors).to be_kind_of(Integer)
     expect { img.colors = 2 }.to raise_error(NoMethodError)
   end
 
@@ -431,7 +431,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_number_colors
     expect { @hat.number_colors }.not_to raise_error
-    assert_kind_of(Integer, @hat.number_colors)
+    expect(@hat.number_colors).to be_kind_of(Integer)
     expect { @hat.number_colors = 2 }.to raise_error(NoMethodError)
   end
 
@@ -545,7 +545,7 @@ class Image_Attributes_UT < Minitest::Test
 
   def test_total_colors
     expect { @hat.total_colors }.not_to raise_error
-    assert_kind_of(Integer, @hat.total_colors)
+    expect(@hat.total_colors).to be_kind_of(Integer)
     expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
   end
 

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -268,8 +268,8 @@ class InfoUT < Minitest::Test
     expect { @info.monitor = -> {} }.not_to raise_error
     monitor = proc do |mth, q, s|
       expect(mth).to eq('resize!')
-      assert_kind_of(Integer, q)
-      assert_kind_of(Integer, s)
+      expect(q).to be_kind_of(Integer)
+      expect(s).to be_kind_of(Integer)
       GC.start
       true
     end
@@ -287,7 +287,7 @@ class InfoUT < Minitest::Test
   end
 
   def test_number_scenes
-    assert_kind_of(Integer, @info.number_scenes)
+    expect(@info.number_scenes).to be_kind_of(Integer)
     expect { @info.number_scenes = 50 }.not_to raise_error
     expect(@info.number_scenes).to eq(50)
     expect { @info.number_scenes = nil }.to raise_error(TypeError)

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -78,7 +78,7 @@ class MagickUT < Minitest::Test
       expect(f.family).to be_instance_of(String)
       expect(f.style).to be_instance_of(Magick::StyleType) unless f.style.nil?
       expect(f.stretch).to be_instance_of(Magick::StretchType) unless f.stretch.nil?
-      assert_kind_of(Integer, f.weight)
+      expect(f.weight).to be_kind_of(Integer)
       expect(f.encoding).to be_instance_of(String) unless f.encoding.nil?
       expect(f.foundry).to be_instance_of(String) unless f.foundry.nil?
       expect(f.format).to be_instance_of(String) unless f.format.nil?
@@ -261,35 +261,35 @@ class MagickUT < Minitest::Test
     cur = new = nil
 
     expect { cur = Magick.limit_resource(:memory, 500) }.not_to raise_error
-    assert_kind_of(Integer, cur)
+    expect(cur).to be_kind_of(Integer)
     assert(cur > 1024**2)
     expect { new = Magick.limit_resource('memory') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:memory, cur)
 
     expect { cur = Magick.limit_resource(:map, 3500) }.not_to raise_error
-    assert_kind_of(Integer, cur)
+    expect(cur).to be_kind_of(Integer)
     assert(cur > 1024**2)
     expect { new = Magick.limit_resource('map') }.not_to raise_error
     expect(new).to eq(3500)
     Magick.limit_resource(:map, cur)
 
     expect { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }.not_to raise_error
-    assert_kind_of(Integer, cur)
+    expect(cur).to be_kind_of(Integer)
     assert(cur > 1024**2)
     expect { new = Magick.limit_resource('disk') }.not_to raise_error
     expect(new).to eq(3_221_225_472)
     Magick.limit_resource(:disk, cur)
 
     expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
-    assert_kind_of(Integer, cur)
+    expect(cur).to be_kind_of(Integer)
     assert(cur > 512)
     expect { new = Magick.limit_resource('file') }.not_to raise_error
     expect(new).to eq(500)
     Magick.limit_resource(:file, cur)
 
     expect { cur = Magick.limit_resource(:time, 300) }.not_to raise_error
-    assert_kind_of(Integer, cur)
+    expect(cur).to be_kind_of(Integer)
     assert(cur > 300)
     expect { new = Magick.limit_resource('time') }.not_to raise_error
     expect(new).to eq(300)

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -188,7 +188,7 @@ class PixelUT < Minitest::Test
   end
 
   def test_intensity
-    assert_kind_of(Integer, @pixel.intensity)
+    expect(@pixel.intensity).to be_kind_of(Integer)
   end
 
   def test_marshal

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -3,27 +3,27 @@ require 'minitest/autorun'
 
 class LibGeometryUT < Minitest::Test
   def test_constants
-    assert_kind_of(Magick::GeometryValue, Magick::PercentGeometry)
+    expect(Magick::PercentGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::PercentGeometry.to_s).to eq('PercentGeometry')
     expect(Magick::PercentGeometry.to_i).to eq(1)
 
-    assert_kind_of(Magick::GeometryValue, Magick::AspectGeometry)
+    expect(Magick::AspectGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::AspectGeometry.to_s).to eq('AspectGeometry')
     expect(Magick::AspectGeometry.to_i).to eq(2)
 
-    assert_kind_of(Magick::GeometryValue, Magick::LessGeometry)
+    expect(Magick::LessGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::LessGeometry.to_s).to eq('LessGeometry')
     expect(Magick::LessGeometry.to_i).to eq(3)
 
-    assert_kind_of(Magick::GeometryValue, Magick::GreaterGeometry)
+    expect(Magick::GreaterGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::GreaterGeometry.to_s).to eq('GreaterGeometry')
     expect(Magick::GreaterGeometry.to_i).to eq(4)
 
-    assert_kind_of(Magick::GeometryValue, Magick::AreaGeometry)
+    expect(Magick::AreaGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::AreaGeometry.to_s).to eq('AreaGeometry')
     expect(Magick::AreaGeometry.to_i).to eq(5)
 
-    assert_kind_of(Magick::GeometryValue, Magick::MinimumGeometry)
+    expect(Magick::MinimumGeometry).to be_kind_of(Magick::GeometryValue)
     expect(Magick::MinimumGeometry.to_s).to eq('MinimumGeometry')
     expect(Magick::MinimumGeometry.to_i).to eq(6)
   end

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -46,6 +46,8 @@ module Minitest
         assert_same(@expected, @actual)
       when :be_instance_of
         assert_instance_of(@expected, @actual)
+      when :be_kind_of
+        assert_kind_of(@expected, @actual)
       when :eq
         assert_equal(@expected, @actual)
       when :raise_error
@@ -74,6 +76,11 @@ module Minitest
     def be_instance_of(expected)
       @expected = expected
       :be_instance_of
+    end
+
+    def be_kind_of(expected)
+      @expected = expected
+      :be_kind_of
     end
 
     def eq(expected)


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/type-matchers#be-(a-)kind-of-matcher