### PR TITLE
Replace `assert_in_delta` with RSpec style matcher

### DIFF
--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -66,10 +66,10 @@ class Image_Attributes_UT < Minitest::Test
     expect(@img.bias).to be_instance_of(Float)
 
     expect { @img.bias = 0.1 }.not_to raise_error
-    assert_in_delta(Magick::QuantumRange * 0.1, @img.bias, 0.1)
+    expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.1)
 
     expect { @img.bias = '10%' }.not_to raise_error
-    assert_in_delta(Magick::QuantumRange * 0.10, @img.bias, 0.1)
+    expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.10)
 
     expect { @img.bias = [] }.to raise_error(TypeError)
     expect { @img.bias = 'x' }.to raise_error(ArgumentError)
@@ -323,7 +323,7 @@ class Image_Attributes_UT < Minitest::Test
     expect { @img.fuzz = 50 }.not_to raise_error
     expect(@img.fuzz).to eq(50.0)
     expect { @img.fuzz = '50%' }.not_to raise_error
-    assert_in_delta(Magick::QuantumRange * 0.50, @img.fuzz, 0.1)
+    expect(@img.fuzz).to be_within(0.1).of(Magick::QuantumRange * 0.50)
     expect { @img.fuzz = [] }.to raise_error(TypeError)
     expect { @img.fuzz = 'xxx' }.to raise_error(ArgumentError)
   end

--- a/test/Import_Export.rb
+++ b/test/Import_Export.rb
@@ -16,12 +16,12 @@ class ImportExportUT < Minitest::Test
 
   def import(pixels, type, expected = 0.0)
     diff = import_pixels(pixels, type)
-    assert_in_delta(expected, diff, 0.1)
+    expect(diff).to be_within(0.1).of(expected)
   end
 
   def fimport(pixels, type)
     diff = import_pixels(pixels, type)
-    assert_in_delta(0.0, diff, 50.0)
+    expect(diff).to be_within(50.0).of(0.0)
   end
 
   def test_import_export_float

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -168,10 +168,10 @@ class PixelUT < Minitest::Test
     args = [200, 125.125, 250.5, 0.6]
     px = Magick::Pixel.from_hsla(*args)
     hsla = px.to_hsla
-    assert_in_delta(args[0], hsla[0], 0.25, "expected #{args.inspect} got #{hsla.inspect}")
-    assert_in_delta(args[1], hsla[1], 0.25, "expected #{args.inspect} got #{hsla.inspect}")
-    assert_in_delta(args[2], hsla[2], 0.25, "expected #{args.inspect} got #{hsla.inspect}")
-    assert_in_delta(args[3], hsla[3], 0.005, "expected #{args.inspect} got #{hsla.inspect}")
+    expect(hsla[0]).to be_within(0.25).of(args[0])
+    expect(hsla[1]).to be_within(0.25).of(args[1])
+    expect(hsla[2]).to be_within(0.25).of(args[2])
+    expect(hsla[3]).to be_within(0.005).of(args[3])
 
     # test percentages
     args = ['20%', '20%', '20%', '20%']
@@ -181,10 +181,10 @@ class PixelUT < Minitest::Test
     px2 = Magick::Pixel.from_hsla(*args2)
     hsla2 = px2.to_hsla
 
-    assert_in_delta(hsla[0], hsla2[0], 0.25, "#{hsla.inspect} != #{hsla2.inspect} with args: #{args.inspect} and #{args2.inspect}")
-    assert_in_delta(hsla[1], hsla2[1], 0.25, "#{hsla.inspect} != #{hsla2.inspect} with args: #{args.inspect} and #{args2.inspect}")
-    assert_in_delta(hsla[2], hsla2[2], 0.25, "#{hsla.inspect} != #{hsla2.inspect} with args: #{args.inspect} and #{args2.inspect}")
-    assert_in_delta(hsla[3], hsla2[3], 0.005, "#{hsla.inspect} != #{hsla2.inspect} with args: #{args.inspect} and #{args2.inspect}")
+    expect(hsla2[0]).to be_within(0.25).of(hsla[0])
+    expect(hsla2[1]).to be_within(0.25).of(hsla[1])
+    expect(hsla2[2]).to be_within(0.25).of(hsla[2])
+    expect(hsla2[3]).to be_within(0.005).of(hsla[3])
   end
 
   def test_intensity

--- a/test/appearance/appearance_assertion.rb
+++ b/test/appearance/appearance_assertion.rb
@@ -6,6 +6,6 @@ module AppearanceAssertion
 
     expected = Magick::Image.read(path).first
     _, error = expected.compare_channel(image_object, Magick::MeanSquaredErrorMetric)
-    assert_in_delta(0.0, error, delta)
+    expect(error).to be_within(delta).of(0.0)
   end
 end

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -48,6 +48,8 @@ module Minitest
         assert_instance_of(@expected, @actual)
       when :be_kind_of
         assert_kind_of(@expected, @actual)
+      when :be_within
+        assert_in_delta(@expected, @actual, @delta)
       when :eq
         assert_equal(@expected, @actual)
       when :raise_error
@@ -81,6 +83,16 @@ module Minitest
     def be_kind_of(expected)
       @expected = expected
       :be_kind_of
+    end
+
+    def be_within(delta)
+      @delta = delta
+      self
+    end
+
+    def of(expected)
+      @expected = expected
+      :be_within
     end
 
     def eq(expected)


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

I removed the test descriptions for now. I think these can be made a
little more clear once the RSpec transition is completed.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/be-within-matcher