### PR TITLE
Replace `assert_match` with RSpec style matcher

### DIFF
--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -201,26 +201,26 @@ class EnumUT < Minitest::Test
     error = expect do
       img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
     end.to raise_error(ArgumentError)
-    assert_match(/UndefinedPixel/, error.message)
+    expect(error.message).to match(/UndefinedPixel/)
   end
 
   def test_stretch_type_name
     Magick::StretchType.values do |stretch|
       font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, stretch, 400, nil, 'test foundry', 'test format')
-      assert_match(/stretch=#{stretch.to_s}/, font.to_s)
+      expect(font.to_s).to match(/stretch=#{stretch.to_s}/)
     end
 
     font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, nil, 400, nil, 'test foundry', 'test format')
-    assert_match(/stretch=UndefinedStretch/, font.to_s)
+    expect(font.to_s).to match(/stretch=UndefinedStretch/)
   end
 
   def test_style_type_name
     Magick::StyleType.values do |style|
       font = Magick::Font.new('Arial', 'font test', 'Arial family', style, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
-      assert_match(/style=#{style.to_s}/, font.to_s)
+      expect(font.to_s).to match(/style=#{style.to_s}/)
     end
 
     font = Magick::Font.new('Arial', 'font test', 'Arial family', nil, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
-    assert_match(/style=UndefinedStyle/, font.to_s)
+    expect(font.to_s).to match(/style=UndefinedStyle/)
   end
 end

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -179,7 +179,7 @@ class Image1_UT < Minitest::Test
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
     expect(img[nil]).to be(nil)
     expect(img['label']).to be(nil)
-    assert_match(/^Creator: PolyView/, img[:comment])
+    expect(img[:comment]).to match(/^Creator: PolyView/)
   end
 
   def test_aset

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -251,6 +251,6 @@ class PixelUT < Minitest::Test
   end
 
   def test_to_s
-    assert_match(/red=\d+, green=\d+, blue=\d+, alpha=\d+/, @pixel.to_s)
+    expect(@pixel.to_s).to match(/red=\d+, green=\d+, blue=\d+, alpha=\d+/)
   end
 end

--- a/test/Struct.rb
+++ b/test/Struct.rb
@@ -4,30 +4,30 @@ require 'minitest/autorun'
 class StructUT < Minitest::Test
   def test_chromaticity_to_s
     image = Magick::Image.new(10, 10)
-    assert_match(/red_primary=\(x=.+,y=.+\) green_primary=\(x=.+,y=.+\) blue_primary=\(x=.+,y=.+\) white_point=\(x=.+,y=.+\)/, image.chromaticity.to_s)
+    expect(image.chromaticity.to_s).to match(/red_primary=\(x=.+,y=.+\) green_primary=\(x=.+,y=.+\) blue_primary=\(x=.+,y=.+\) white_point=\(x=.+,y=.+\)/)
   end
 
   def test_export_color_info
     color = Magick.colors[0]
     expect(color).to be_instance_of(Magick::Color)
-    assert_match(/name=.+, compliance=.+, color.red=.+, color.green=.+, color.blue=.+, color.alpha=.+/, color.to_s)
+    expect(color.to_s).to match(/name=.+, compliance=.+, color.red=.+, color.green=.+, color.blue=.+, color.alpha=.+/)
   end
 
   def test_export_type_info
     font = Magick.fonts[0]
-    assert_match(/^name=.+, description=.+, family=.+, style=.+, stretch=.+, weight=.+, encoding=.*, foundry=.*, format=.*$/, font.to_s)
+    expect(font.to_s).to match(/^name=.+, description=.+, family=.+, style=.+, stretch=.+, weight=.+, encoding=.*, foundry=.*, format=.*$/)
   end
 
   def test_export_point_info
     draw = Magick::Draw.new
     metric = draw.get_type_metrics('ABCDEF')
-    assert_match(/^pixels_per_em=\(x=.+,y=.+\) ascent=.+ descent=.+ width=.+ height=.+ max_advance=.+ bounds.x1=.+ bounds.y1=.+ bounds.x2=.+ bounds.y2=.+ underline_position=.+ underline_thickness=.+$/, metric.to_s)
+    expect(metric.to_s).to match(/^pixels_per_em=\(x=.+,y=.+\) ascent=.+ descent=.+ width=.+ height=.+ max_advance=.+ bounds.x1=.+ bounds.y1=.+ bounds.x2=.+ bounds.y2=.+ underline_position=.+ underline_thickness=.+$/)
   end
 
   def test_primary_info_to_s
     chrom = Magick::Image.new(10, 10).chromaticity
     red_primary = chrom.red_primary
-    assert_match(/^x=.+, y=.+, z=.+$/, red_primary.to_s)
+    expect(red_primary.to_s).to match(/^x=.+, y=.+, z=.+$/)
   end
 
   def test_rectangle_info_to_s

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -6,12 +6,12 @@ class LibMagickUT < Minitest::Test
     expect(Magick.formats).to be_instance_of(Hash)
     Magick.formats.each do |f, v|
       expect(f).to be_instance_of(String)
-      assert_match(/[\*\+\srw]+/, v)
+      expect(v).to match(/[\*\+\srw]+/)
     end
 
     Magick.formats do |f, v|
       expect(f).to be_instance_of(String)
-      assert_match(/[\*\+\srw]+/, v)
+      expect(v).to match(/[\*\+\srw]+/)
     end
   end
 

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -52,6 +52,8 @@ module Minitest
         assert_in_delta(@expected, @actual, @delta)
       when :eq
         assert_equal(@expected, @actual)
+      when :match
+        assert_match(@expected, @actual)
       when :raise_error
         assert_raises(@expected, &@actual_block)
       else
@@ -88,6 +90,11 @@ module Minitest
     def be_within(delta)
       @delta = delta
       self
+    end
+
+    def match(expected)
+      @expected = expected
+      :match
     end
 
     def of(expected)


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/match-matcher