### PR TITLE
Replace `assert_not_equal` with RSpec style matcher

### DIFF
--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -94,7 +94,7 @@ class EnumUT < Minitest::Test
     Magick::ColorspaceType.values do |value|
       next if value == Magick::SRGBColorspace
 
-      assert_not_equal(value, img.colorspace)
+      expect(img.colorspace).not_to eq(value)
     end
   end
 

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -29,7 +29,7 @@ class Image1_UT < Minitest::Test
     expect(img0 <=> img1).to eq(sig0 <=> sig1)
     expect(img1 <=> img0).to eq(sig1 <=> sig0)
     expect(img0).to eq(img0)
-    assert_not_equal(img0, img1)
+    expect(img1).not_to eq(img0)
     expect(img0 <=> nil).to be(nil)
   end
 

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -831,13 +831,13 @@ class ImageList1UT < Minitest::Test
     expect(list2.scene).to eq(@list.scene)
     expect(list2).to eq(@list)
     list2.scene = 0
-    assert_not_equal(@list, list2)
+    expect(list2).not_to eq(@list)
     list2 = @list.copy
     list2[9] = list2[0]
-    assert_not_equal(@list, list2)
+    expect(list2).not_to eq(@list)
     list2 = @list.copy
     list2 << @list[9]
-    assert_not_equal(@list, list2)
+    expect(list2).not_to eq(@list)
 
     expect { @list <=> 2 }.to raise_error(TypeError)
     list = Magick::ImageList.new

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -81,7 +81,7 @@ class ImageList2UT < Minitest::Test
     @ilist.taint
     @ilist.freeze
     ilist2 = @ilist.dup
-    assert_not_equal(@ilist.frozen?, ilist2.frozen?)
+    expect(ilist2.frozen?).not_to eq(@ilist.frozen?)
     expect(ilist2.tainted?).to eq(@ilist.tainted?)
   end
 

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -399,9 +399,9 @@ class Image_Attributes_UT < Minitest::Test
 
     hat = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
 
-    assert_not_equal(0.0, hat.mean_error_per_pixel)
-    assert_not_equal(0.0, hat.normalized_mean_error)
-    assert_not_equal(0.0, hat.normalized_maximum_error)
+    expect(hat.mean_error_per_pixel).not_to eq(0.0)
+    expect(hat.normalized_mean_error).not_to eq(0.0)
+    expect(hat.normalized_maximum_error).not_to eq(0.0)
     expect { hat.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
     expect { hat.normalized_mean_error = 1 }.to raise_error(NoMethodError)
     expect { hat.normalized_maximum_error = 1 }.to raise_error(NoMethodError)

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -82,7 +82,7 @@ class PixelUT < Minitest::Test
   def test_clone
     pixel = @pixel.clone
     assert_true(@pixel === pixel)
-    assert_not_equal(@pixel.object_id, pixel.object_id)
+    expect(pixel.object_id).not_to eq(@pixel.object_id)
 
     pixel = @pixel.taint.clone
     assert_true(pixel.tainted?)
@@ -94,7 +94,7 @@ class PixelUT < Minitest::Test
   def test_dup
     pixel = @pixel.dup
     assert_true(@pixel === pixel)
-    assert_not_equal(@pixel.object_id, pixel.object_id)
+    expect(pixel.object_id).not_to eq(@pixel.object_id)
 
     pixel = @pixel.taint.dup
     assert_true(pixel.tainted?)
@@ -118,7 +118,7 @@ class PixelUT < Minitest::Test
     # Pixel.hash sacrifices the last bit of the opacity channel
     p = Magick::Pixel.new(0, 0, 0, 72)
     p2 = Magick::Pixel.new(0, 0, 0, 73)
-    assert_not_equal(p, p2)
+    expect(p2).not_to eq(p)
     expect(p2.hash).to eq(p.hash)
   end
 

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -65,6 +65,8 @@ module Minitest
       case matcher
       when :be
         refute_same(@expected, @actual)
+      when :eq
+        refute_equal(@expected, @actual)
       when :raise_error
         @actual_block.call
       else
@@ -112,7 +114,6 @@ module Minitest
       :raise_error
     end
 
-    alias assert_not_equal refute_equal
     alias assert_not_nil refute_nil
     alias assert_true assert
     alias assert_false refute


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/equality-matchers#compare-using-eq-(==)