### PR TITLE
Replace `assert_block` with RSpec style matcher

### DIFF
--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -341,9 +341,9 @@ class Image1_UT < Minitest::Test
   end
 
   def test_changed?
-    #        assert_block { !@img.changed? }
+    #        expect(@img.changed?).to be(false)
     #        @img.pixel_color(0,0,'red')
-    #        assert_block { @img.changed? }
+    #        expect(@img.changed?).to be(true)
   end
 
   def test_channel

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -909,9 +909,7 @@ class Image2_UT < Minitest::Test
       pixels = @img.get_pixels(0, 0, @img.columns, 1)
       expect(pixels).to be_instance_of(Array)
       expect(pixels.length).to eq(@img.columns)
-      assert_block do
-        pixels.all? { |p| p.is_a? Magick::Pixel }
-      end
+      expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
     end.not_to raise_error
     expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
     expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
@@ -1205,9 +1203,9 @@ class Image2_UT < Minitest::Test
   end
 
   def test_monochrome?
-    #       assert_block { @img.monochrome? }
+    #       expect(@img.monochrome?).to be(true)
     @img.pixel_color(0, 0, 'red')
-    assert_block { !@img.monochrome? }
+    expect(@img.monochrome?).to be(false)
   end
 
   def test_motion_blur
@@ -1307,10 +1305,10 @@ class Image2_UT < Minitest::Test
 
   def test_opaque?
     expect do
-      assert_block { @img.opaque? }
+      expect(@img.opaque?).to be(true)
     end.not_to raise_error
     @img.alpha(Magick::TransparentAlphaChannel)
-    assert_block { !@img.opaque? }
+    expect(@img.opaque?).to be(false)
   end
 
   def test_ordered_dither
@@ -1355,10 +1353,10 @@ class Image2_UT < Minitest::Test
   def test_palette?
     img = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     expect do
-      assert_block { !img.palette? }
+      expect(img.palette?).to be(false)
     end.not_to raise_error
     img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    assert_block { img.palette? }
+    expect(img.palette?).to be(true)
   end
 
   def test_pixel_color

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -262,8 +262,8 @@ class Image3_UT < Minitest::Test
 
   # Make sure the old name is still around
   def test_resize_to_fill_7
-    assert_block { @img.respond_to? :crop_resized }
-    assert_block { @img.respond_to? :crop_resized! }
+    expect(@img).to respond_to(:crop_resized)
+    expect(@img).to respond_to(:crop_resized!)
   end
 
   # 2nd argument defaults to the same value as the 1st argument

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -30,10 +30,6 @@ end
 
 module Minitest
   module Assertions
-    def assert_block
-      assert(yield)
-    end
-
     def expect(actual = :__not_set__, &actual_block)
       @actual = actual
       @actual_block = actual_block
@@ -56,6 +52,8 @@ module Minitest
         assert_match(@expected, @actual)
       when :raise_error
         assert_raises(@expected, &@actual_block)
+      when :respond_to
+        assert(@actual.respond_to?(@expected))
       else
         raise ArgumentError, "no matcher: #{matcher.inspect}"
       end
@@ -112,6 +110,11 @@ module Minitest
     def raise_error(expected = :__not_set__)
       @expected = expected
       :raise_error
+    end
+
+    def respond_to(expected)
+      @expected = expected
+      :respond_to
     end
 
     alias assert_not_nil refute_nil


### PR DESCRIPTION
This continues transitioning matcher styles to RSpec style, which should
greatly speed up the transition to RSpec.

In this case I replaced `assert_block` calls with a handful of other
matchers, mostly `to be(true)` and `to be(false)`. I also added a
`respond_to` matcher. There is an `all` matcher, but I didn't want to
get down the rabbit hole of trying to implement that, so I left the
`all?` with a `be(true)` matcher as well.

https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/respond-to-matcher
https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/all-matcher