### PR TITLE
RSpec: convert all tests to minitest spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,10 @@ AllCops:
     - 'vendor/bundle/**/*'
     - '**/*\.spec'
 
-# this can be removed after finishing transition to RSpec
+# these can be removed after finishing transition to RSpec
+Metrics/BlockLength: { Exclude: [test/**/*.rb] }
 Rails/RefuteMethods: { Enabled: false }
+RSpec/FilePath: { Enabled: false }
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }

--- a/test/Draw.rb
+++ b/test/Draw.rb
@@ -1,348 +1,422 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class DrawUT < Minitest::Test
-  def setup
+describe Magick::Draw do
+  before do
     @draw = Magick::Draw.new
   end
 
-  def test_affine
-    expect do
-      @draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
-    end.not_to raise_error
-    expect { @draw.affine = [1, 2, 3, 4, 5, 6] }.to raise_error(TypeError)
-  end
-
-  def test_align
-    Magick::AlignType.values do |align|
-      expect { @draw.align = align }.not_to raise_error
+  describe '#affine' do
+    it 'works' do
+      expect do
+        @draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
+      end.not_to raise_error
+      expect { @draw.affine = [1, 2, 3, 4, 5, 6] }.to raise_error(TypeError)
     end
   end
 
-  def test_decorate
-    Magick::DecorationType.values do |decoration|
-      expect { @draw.decorate = decoration }.not_to raise_error
-    end
-  end
-
-  def test_density
-    expect { @draw.density = '90x90' }.not_to raise_error
-    expect { @draw.density = 'x90' }.not_to raise_error
-    expect { @draw.density = '90' }.not_to raise_error
-    expect { @draw.density = 2 }.to raise_error(TypeError)
-  end
-
-  def test_encoding
-    expect { @draw.encoding = 'AdobeCustom' }.not_to raise_error
-    expect { @draw.encoding = 2 }.to raise_error(TypeError)
-  end
-
-  def test_fill
-    expect { @draw.fill = 'white' }.not_to raise_error
-    expect { @draw.fill = Magick::Pixel.from_color('white') }.not_to raise_error
-    expect { @draw.fill = 2 }.to raise_error(TypeError)
-  end
-
-  def test_fill_pattern
-    expect { @draw.fill_pattern = nil }.not_to raise_error
-    expect do
-      img1 = Magick::Image.new(10, 10)
-      img2 = Magick::Image.new(20, 20)
-
-      @draw.fill_pattern = img1
-      @draw.fill_pattern = img2
-    end.not_to raise_error
-
-    expect { @draw.fill_pattern = 'x' }.to raise_error(NoMethodError)
-  end
-
-  def test_font
-    expect { @draw.font = 'Arial-Bold' }.not_to raise_error
-    expect { @draw.font = 2 }.to raise_error(TypeError)
-  end
-
-  def test_font_family
-    expect { @draw.font_family = 'Arial' }.not_to raise_error
-    expect { @draw.font_family = 2 }.to raise_error(TypeError)
-  end
-
-  def test_font_stretch
-    Magick::StretchType.values do |stretch|
-      expect { @draw.font_stretch = stretch }.not_to raise_error
-    end
-
-    expect { @draw.font_stretch = 2 }.to raise_error(TypeError)
-  end
-
-  def test_font_style
-    Magick::StyleType.values do |style|
-      expect { @draw.font_style = style }.not_to raise_error
-    end
-
-    expect { @draw.font_style = 2 }.to raise_error(TypeError)
-  end
-
-  def test_font_weight
-    Magick::WeightType.values do |weight|
-      expect { @draw.font_weight = weight }.not_to raise_error
-    end
-
-    expect { @draw.font_weight = 99 }.to raise_error(ArgumentError)
-    expect { @draw.font_weight = 901 }.to raise_error(ArgumentError)
-  end
-
-  def test_gravity
-    Magick::GravityType.values do |gravity|
-      expect { @draw.gravity = gravity }.not_to raise_error
-    end
-
-    expect { @draw.gravity = 2 }.to raise_error(TypeError)
-  end
-
-  def test_interline_spacing
-    expect { @draw.interline_spacing = 2 }.not_to raise_error
-    expect { @draw.interline_spacing = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_interword_spacing
-    expect { @draw.interword_spacing = 2 }.not_to raise_error
-    expect { @draw.interword_spacing = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_kerning
-    expect { @draw.kerning = 2 }.not_to raise_error
-    expect { @draw.kerning = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_pointsize
-    expect { @draw.pointsize = 2 }.not_to raise_error
-    expect { @draw.pointsize = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_rotation
-    expect { @draw.rotation = 15 }.not_to raise_error
-    expect { @draw.rotation = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_stroke
-    expect { @draw.stroke = Magick::Pixel.from_color('white') }.not_to raise_error
-    expect { @draw.stroke = 'white' }.not_to raise_error
-    expect { @draw.stroke = 2 }.to raise_error(TypeError)
-  end
-
-  def test_stroke_pattern
-    expect { @draw.stroke_pattern = nil }.not_to raise_error
-    expect do
-      img1 = Magick::Image.new(10, 10)
-      img2 = Magick::Image.new(20, 20)
-
-      @draw.stroke_pattern = img1
-      @draw.stroke_pattern = img2
-    end.not_to raise_error
-
-    expect { @draw.stroke_pattern = 'x' }.to raise_error(NoMethodError)
-  end
-
-  def test_stroke_width
-    expect { @draw.stroke_width = 15 }.not_to raise_error
-    expect { @draw.stroke_width = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_text_antialias
-    expect { @draw.text_antialias = true }.not_to raise_error
-    expect { @draw.text_antialias = false }.not_to raise_error
-  end
-
-  def test_tile
-    expect { @draw.tile = nil }.not_to raise_error
-    expect do
-      img1 = Magick::Image.new(10, 10)
-      img2 = Magick::Image.new(20, 20)
-
-      @draw.tile = img1
-      @draw.tile = img2
-    end.not_to raise_error
-  end
-
-  def test_undercolor
-    expect { @draw.undercolor = Magick::Pixel.from_color('white') }.not_to raise_error
-    expect { @draw.undercolor = 'white' }.not_to raise_error
-    expect { @draw.undercolor = 2 }.to raise_error(TypeError)
-  end
-
-  def test_annotate
-    expect do
-      img = Magick::Image.new(10, 10)
-      @draw.annotate(img, 0, 0, 0, 20, 'Hello world')
-
-      yield_obj = nil
-      @draw.annotate(img, 100, 100, 20, 20, 'Hello world 2') do |draw|
-        yield_obj = draw
+  describe '#align' do
+    it 'works' do
+      Magick::AlignType.values do |align|
+        expect { @draw.align = align }.not_to raise_error
       end
-      expect(yield_obj).to be_instance_of(Magick::Draw)
-    end.not_to raise_error
-
-    expect do
-      img = Magick::Image.new(10, 10)
-      @draw.annotate(img, 0, 0, 0, 20, nil)
-    end.to raise_error(TypeError)
-
-    expect { @draw.annotate('x', 0, 0, 0, 20, 'Hello world') }.to raise_error(NoMethodError)
+    end
   end
 
-  def test_annotate_stack_buffer_overflow
-    expect do
-      if 1.size == 8
-        # 64-bit environment can use larger value for Integer and it can causes stack buffer overflow.
+  describe '#decorate' do
+    it 'works' do
+      Magick::DecorationType.values do |decoration|
+        expect { @draw.decorate = decoration }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#density' do
+    it 'works' do
+      expect { @draw.density = '90x90' }.not_to raise_error
+      expect { @draw.density = 'x90' }.not_to raise_error
+      expect { @draw.density = '90' }.not_to raise_error
+      expect { @draw.density = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#encoding' do
+    it 'works' do
+      expect { @draw.encoding = 'AdobeCustom' }.not_to raise_error
+      expect { @draw.encoding = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#fill' do
+    it 'works' do
+      expect { @draw.fill = 'white' }.not_to raise_error
+      expect { @draw.fill = Magick::Pixel.from_color('white') }.not_to raise_error
+      expect { @draw.fill = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#fill_pattern' do
+    it 'works' do
+      expect { @draw.fill_pattern = nil }.not_to raise_error
+      expect do
+        img1 = Magick::Image.new(10, 10)
+        img2 = Magick::Image.new(20, 20)
+
+        @draw.fill_pattern = img1
+        @draw.fill_pattern = img2
+      end.not_to raise_error
+
+      expect { @draw.fill_pattern = 'x' }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#font' do
+    it 'works' do
+      expect { @draw.font = 'Arial-Bold' }.not_to raise_error
+      expect { @draw.font = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#font_family' do
+    it 'works' do
+      expect { @draw.font_family = 'Arial' }.not_to raise_error
+      expect { @draw.font_family = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#font_stretch' do
+    it 'works' do
+      Magick::StretchType.values do |stretch|
+        expect { @draw.font_stretch = stretch }.not_to raise_error
+      end
+
+      expect { @draw.font_stretch = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#font_style' do
+    it 'works' do
+      Magick::StyleType.values do |style|
+        expect { @draw.font_style = style }.not_to raise_error
+      end
+
+      expect { @draw.font_style = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#font_weight' do
+    it 'works' do
+      Magick::WeightType.values do |weight|
+        expect { @draw.font_weight = weight }.not_to raise_error
+      end
+
+      expect { @draw.font_weight = 99 }.to raise_error(ArgumentError)
+      expect { @draw.font_weight = 901 }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#gravity' do
+    it 'works' do
+      Magick::GravityType.values do |gravity|
+        expect { @draw.gravity = gravity }.not_to raise_error
+      end
+
+      expect { @draw.gravity = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#interline_spacing' do
+    it 'works' do
+      expect { @draw.interline_spacing = 2 }.not_to raise_error
+      expect { @draw.interline_spacing = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#interword_spacing' do
+    it 'works' do
+      expect { @draw.interword_spacing = 2 }.not_to raise_error
+      expect { @draw.interword_spacing = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#kerning' do
+    it 'works' do
+      expect { @draw.kerning = 2 }.not_to raise_error
+      expect { @draw.kerning = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#pointsize' do
+    it 'works' do
+      expect { @draw.pointsize = 2 }.not_to raise_error
+      expect { @draw.pointsize = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#rotation' do
+    it 'works' do
+      expect { @draw.rotation = 15 }.not_to raise_error
+      expect { @draw.rotation = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#stroke' do
+    it 'works' do
+      expect { @draw.stroke = Magick::Pixel.from_color('white') }.not_to raise_error
+      expect { @draw.stroke = 'white' }.not_to raise_error
+      expect { @draw.stroke = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#stroke_pattern' do
+    it 'works' do
+      expect { @draw.stroke_pattern = nil }.not_to raise_error
+      expect do
+        img1 = Magick::Image.new(10, 10)
+        img2 = Magick::Image.new(20, 20)
+
+        @draw.stroke_pattern = img1
+        @draw.stroke_pattern = img2
+      end.not_to raise_error
+
+      expect { @draw.stroke_pattern = 'x' }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#stroke_width' do
+    it 'works' do
+      expect { @draw.stroke_width = 15 }.not_to raise_error
+      expect { @draw.stroke_width = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#text_antialias' do
+    it 'works' do
+      expect { @draw.text_antialias = true }.not_to raise_error
+      expect { @draw.text_antialias = false }.not_to raise_error
+    end
+  end
+
+  describe '#tile' do
+    it 'works' do
+      expect { @draw.tile = nil }.not_to raise_error
+      expect do
+        img1 = Magick::Image.new(10, 10)
+        img2 = Magick::Image.new(20, 20)
+
+        @draw.tile = img1
+        @draw.tile = img2
+      end.not_to raise_error
+    end
+  end
+
+  describe '#undercolor' do
+    it 'works' do
+      expect { @draw.undercolor = Magick::Pixel.from_color('white') }.not_to raise_error
+      expect { @draw.undercolor = 'white' }.not_to raise_error
+      expect { @draw.undercolor = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#annotate' do
+    it 'works' do
+      expect do
         img = Magick::Image.new(10, 10)
-        @draw.annotate(img, 2**63, 2**63, 2**62, 2**62, 'Hello world')
-      end
-    end.not_to raise_error
-  end
+        @draw.annotate(img, 0, 0, 0, 20, 'Hello world')
 
-  def test_dup
-    @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    @draw.taint
-    @draw.freeze
-    dup = @draw.dup
-    expect(dup).to be_instance_of(Magick::Draw)
-  end
+        yield_obj = nil
+        @draw.annotate(img, 100, 100, 20, 20, 'Hello world 2') do |draw|
+          yield_obj = draw
+        end
+        expect(yield_obj).to be_instance_of(Magick::Draw)
+      end.not_to raise_error
 
-  def test_clone
-    @draw.taint
-    @draw.freeze
-    clone = @draw.clone
-    expect(clone).to be_instance_of(Magick::Draw)
-  end
+      expect do
+        img = Magick::Image.new(10, 10)
+        @draw.annotate(img, 0, 0, 0, 20, nil)
+      end.to raise_error(TypeError)
 
-  def test_composite
-    img = Magick::Image.new(10, 10)
-    expect { @draw.composite(0, 0, 10, 10, img) }.not_to raise_error
-
-    Magick::CompositeOperator.values do |op|
-      expect { @draw.composite(0, 0, 10, 10, img, op) }.not_to raise_error
+      expect { @draw.annotate('x', 0, 0, 0, 20, 'Hello world') }.to raise_error(NoMethodError)
     end
-
-    expect { @draw.composite('x', 0, 10, 10, img) }.to raise_error(TypeError)
-    expect { @draw.composite(0, 'y', 10, 10, img) }.to raise_error(TypeError)
-    expect { @draw.composite(0, 0, 'w', 10, img) }.to raise_error(TypeError)
-    expect { @draw.composite(0, 0, 10, 'h', img) }.to raise_error(TypeError)
-    expect { @draw.composite(0, 0, 10, 10, img, Magick::CenterAlign) }.to raise_error(TypeError)
-    expect { @draw.composite(0, 0, 10, 10, 'image') }.to raise_error(NoMethodError)
-    expect { @draw.composite(0, 0, 10, 10) }.to raise_error(ArgumentError)
-    expect { @draw.composite(0, 0, 10, 10, img, Magick::ModulusAddCompositeOp, 'x') }.to raise_error(ArgumentError)
   end
 
-  def test_draw
-    draw = @draw.dup
-
-    img = Magick::Image.new(10, 10)
-    @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    expect { @draw.draw(img) }.not_to raise_error
-
-    expect { draw.draw(img) }.to raise_error(ArgumentError)
-    expect { draw.draw('x') }.to raise_error(NoMethodError)
-  end
-
-  def test_get_type_metrics
-    img = Magick::Image.new(10, 10)
-    expect { @draw.get_type_metrics('ABCDEF') }.not_to raise_error
-    expect { @draw.get_type_metrics(img, 'ABCDEF') }.not_to raise_error
-
-    expect { @draw.get_type_metrics }.to raise_error(ArgumentError)
-    expect { @draw.get_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
-    expect { @draw.get_type_metrics(img, '') }.to raise_error(ArgumentError)
-    expect { @draw.get_type_metrics('x', 'ABCDEF') }.to raise_error(NoMethodError)
-  end
-
-  def test_get_multiline_type_metrics
-    img = Magick::Image.new(10, 10)
-    expect { @draw.get_multiline_type_metrics('ABCDEF') }.not_to raise_error
-    expect { @draw.get_multiline_type_metrics(img, 'ABCDEF') }.not_to raise_error
-
-    expect { @draw.get_multiline_type_metrics }.to raise_error(ArgumentError)
-    expect { @draw.get_multiline_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
-    expect { @draw.get_multiline_type_metrics(img, '') }.to raise_error(ArgumentError)
-  end
-
-  def test_inspect
-    expect(@draw.inspect).to eq('(no primitives defined)')
-
-    @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    @draw.fill('yellow')
-    expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'\nfill \"yellow\"")
-  end
-
-  def test_marshal
-    draw = @draw.dup
-    draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
-    draw.decorate = Magick::LineThroughDecoration
-    draw.encoding = 'AdobeCustom'
-    draw.gravity = Magick::CenterGravity
-    draw.fill = Magick::Pixel.from_color('red')
-    draw.fill_pattern = Magick::Image.new(10, 10) { self.format = 'miff' }
-    draw.stroke = Magick::Pixel.from_color('blue')
-    draw.stroke_width = 5
-    draw.text_antialias = true
-    draw.font = 'Arial-Bold'
-    draw.font_family = 'arial'
-    draw.font_style = Magick::ItalicStyle
-    draw.font_stretch = Magick::CondensedStretch
-    draw.font_weight = Magick::BoldWeight
-    draw.pointsize = 12
-    draw.density = '72x72'
-    draw.align = Magick::CenterAlign
-    draw.undercolor = Magick::Pixel.from_color('green')
-    draw.kerning = 10.5
-    draw.interword_spacing = 3.75
-
-    draw.circle(20, 25, 20, 28)
-
-    dumped = nil
-    expect { dumped = draw.marshal_dump }.not_to raise_error
-
-    draw2 = @draw.dup
-    expect do
-      draw2.marshal_load(dumped)
-    end.not_to raise_error
-    expect(draw2.inspect).to eq(draw.inspect)
-  end
-
-  def test_primitive
-    expect { @draw.primitive('ABCDEF') }.not_to raise_error
-    expect { @draw.primitive('12345') }.not_to raise_error
-    expect { @draw.primitive(nil) }.to raise_error(TypeError)
-  end
-
-  def test_draw_options
-    expect do
-      yield_obj = nil
-
-      Magick::Draw.new do |option|
-        yield_obj = option
-      end
-      expect(yield_obj).to be_instance_of(Magick::Image::DrawOptions)
-    end.not_to raise_error
-  end
-
-  def test_issue_604
-    points = [0, 0, 1, 1, 2, 2]
-
-    pr = Magick::Draw.new
-
-    pr.define_clip_path('example') do
-      pr.polygon(*points)
+  describe '#annotate_stack_buffer_overflow' do
+    it 'works' do
+      expect do
+        if 1.size == 8
+          # 64-bit environment can use larger value for Integer and it can causes stack buffer overflow.
+          img = Magick::Image.new(10, 10)
+          @draw.annotate(img, 2**63, 2**63, 2**62, 2**62, 'Hello world')
+        end
+      end.not_to raise_error
     end
+  end
 
-    pr.push
-    pr.clip_path('example')
+  describe '#dup' do
+    it 'works' do
+      @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
+      @draw.taint
+      @draw.freeze
+      dup = @draw.dup
+      expect(dup).to be_instance_of(Magick::Draw)
+    end
+  end
 
-    composite = Magick::Image.new(10, 10)
-    pr.composite(0, 0, 10, 10, composite)
+  describe '#clone' do
+    it 'works' do
+      @draw.taint
+      @draw.freeze
+      clone = @draw.clone
+      expect(clone).to be_instance_of(Magick::Draw)
+    end
+  end
 
-    pr.pop
+  describe '#composite' do
+    it 'works' do
+      img = Magick::Image.new(10, 10)
+      expect { @draw.composite(0, 0, 10, 10, img) }.not_to raise_error
 
-    canvas = Magick::Image.new(10, 10)
-    pr.draw(canvas)
+      Magick::CompositeOperator.values do |op|
+        expect { @draw.composite(0, 0, 10, 10, img, op) }.not_to raise_error
+      end
+
+      expect { @draw.composite('x', 0, 10, 10, img) }.to raise_error(TypeError)
+      expect { @draw.composite(0, 'y', 10, 10, img) }.to raise_error(TypeError)
+      expect { @draw.composite(0, 0, 'w', 10, img) }.to raise_error(TypeError)
+      expect { @draw.composite(0, 0, 10, 'h', img) }.to raise_error(TypeError)
+      expect { @draw.composite(0, 0, 10, 10, img, Magick::CenterAlign) }.to raise_error(TypeError)
+      expect { @draw.composite(0, 0, 10, 10, 'image') }.to raise_error(NoMethodError)
+      expect { @draw.composite(0, 0, 10, 10) }.to raise_error(ArgumentError)
+      expect { @draw.composite(0, 0, 10, 10, img, Magick::ModulusAddCompositeOp, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#draw' do
+    it 'works' do
+      draw = @draw.dup
+
+      img = Magick::Image.new(10, 10)
+      @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
+      expect { @draw.draw(img) }.not_to raise_error
+
+      expect { draw.draw(img) }.to raise_error(ArgumentError)
+      expect { draw.draw('x') }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#get_type_metrics' do
+    it 'works' do
+      img = Magick::Image.new(10, 10)
+      expect { @draw.get_type_metrics('ABCDEF') }.not_to raise_error
+      expect { @draw.get_type_metrics(img, 'ABCDEF') }.not_to raise_error
+
+      expect { @draw.get_type_metrics }.to raise_error(ArgumentError)
+      expect { @draw.get_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
+      expect { @draw.get_type_metrics(img, '') }.to raise_error(ArgumentError)
+      expect { @draw.get_type_metrics('x', 'ABCDEF') }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#get_multiline_type_metrics' do
+    it 'works' do
+      img = Magick::Image.new(10, 10)
+      expect { @draw.get_multiline_type_metrics('ABCDEF') }.not_to raise_error
+      expect { @draw.get_multiline_type_metrics(img, 'ABCDEF') }.not_to raise_error
+
+      expect { @draw.get_multiline_type_metrics }.to raise_error(ArgumentError)
+      expect { @draw.get_multiline_type_metrics(img, 'ABCDEF', 20) }.to raise_error(ArgumentError)
+      expect { @draw.get_multiline_type_metrics(img, '') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#inspect' do
+    it 'works' do
+      expect(@draw.inspect).to eq('(no primitives defined)')
+
+      @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
+      @draw.fill('yellow')
+      expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'\nfill \"yellow\"")
+    end
+  end
+
+  describe '#marshal' do
+    it 'works' do
+      draw = @draw.dup
+      draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
+      draw.decorate = Magick::LineThroughDecoration
+      draw.encoding = 'AdobeCustom'
+      draw.gravity = Magick::CenterGravity
+      draw.fill = Magick::Pixel.from_color('red')
+      draw.fill_pattern = Magick::Image.new(10, 10) { self.format = 'miff' }
+      draw.stroke = Magick::Pixel.from_color('blue')
+      draw.stroke_width = 5
+      draw.text_antialias = true
+      draw.font = 'Arial-Bold'
+      draw.font_family = 'arial'
+      draw.font_style = Magick::ItalicStyle
+      draw.font_stretch = Magick::CondensedStretch
+      draw.font_weight = Magick::BoldWeight
+      draw.pointsize = 12
+      draw.density = '72x72'
+      draw.align = Magick::CenterAlign
+      draw.undercolor = Magick::Pixel.from_color('green')
+      draw.kerning = 10.5
+      draw.interword_spacing = 3.75
+
+      draw.circle(20, 25, 20, 28)
+
+      dumped = nil
+      expect { dumped = draw.marshal_dump }.not_to raise_error
+
+      draw2 = @draw.dup
+      expect do
+        draw2.marshal_load(dumped)
+      end.not_to raise_error
+      expect(draw2.inspect).to eq(draw.inspect)
+    end
+  end
+
+  describe '#primitive' do
+    it 'works' do
+      expect { @draw.primitive('ABCDEF') }.not_to raise_error
+      expect { @draw.primitive('12345') }.not_to raise_error
+      expect { @draw.primitive(nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#draw_options' do
+    it 'works' do
+      expect do
+        yield_obj = nil
+
+        Magick::Draw.new do |option|
+          yield_obj = option
+        end
+        expect(yield_obj).to be_instance_of(Magick::Image::DrawOptions)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#issue_604' do
+    it 'works' do
+      points = [0, 0, 1, 1, 2, 2]
+
+      pr = Magick::Draw.new
+
+      pr.define_clip_path('example') do
+        pr.polygon(*points)
+      end
+
+      pr.push
+      pr.clip_path('example')
+
+      composite = Magick::Image.new(10, 10)
+      pr.composite(0, 0, 10, 10, composite)
+
+      pr.pop
+
+      canvas = Magick::Image.new(10, 10)
+      pr.draw(canvas)
+    end
   end
 end

--- a/test/Enum.rb
+++ b/test/Enum.rb
@@ -1,226 +1,278 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class EnumUT < Minitest::Test
-  def test_new
-    expect { Magick::Enum.new(:foo, 42) }.not_to raise_error
-    expect { Magick::Enum.new('foo', 42) }.not_to raise_error
+describe Magick::Enum do
+  describe '#new' do
+    it 'works' do
+      expect { Magick::Enum.new(:foo, 42) }.not_to raise_error
+      expect { Magick::Enum.new('foo', 42) }.not_to raise_error
 
-    expect { Magick::Enum.new(Object.new, 42) }.to raise_error(TypeError)
-    expect { Magick::Enum.new(:foo, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_to_s
-    enum = Magick::Enum.new(:foo, 42)
-    expect(enum.to_s).to eq('foo')
-
-    enum = Magick::Enum.new('foo', 42)
-    expect(enum.to_s).to eq('foo')
-  end
-
-  def test_to_i
-    enum = Magick::Enum.new(:foo, 42)
-    expect(enum.to_i).to eq(42)
-  end
-
-  def test_spaceship
-    enum1 = Magick::Enum.new(:foo, 42)
-    enum2 = Magick::Enum.new(:foo, 56)
-    enum3 = Magick::Enum.new(:foo, 36)
-    enum4 = Magick::Enum.new(:foo, 42)
-
-    expect(enum1 <=> enum2).to eq(-1)
-    expect(enum1 <=> enum4).to eq(0)
-    expect(enum1 <=> enum3).to eq(1)
-    expect(enum1 <=> 'x').to be(nil)
-  end
-
-  def test_case_eq
-    enum1 = Magick::Enum.new(:foo, 42)
-    enum2 = Magick::Enum.new(:foo, 56)
-
-    expect(enum1 === enum1).to be(true)
-    expect(enum1 === enum2).to be(false)
-    expect(enum1 === 'x').to be(false)
-  end
-
-  def test_bitwise_or
-    enum1 = Magick::Enum.new(:foo, 42)
-    enum2 = Magick::Enum.new(:bar, 56)
-
-    enum = enum1 | enum2
-    expect(enum.to_i).to eq(58)
-    expect(enum.to_s).to eq('foo|bar')
-
-    expect { enum1 | 'x' }.to raise_error(ArgumentError)
-  end
-
-  def test_type_values
-    expect(Magick::AlignType.values).to be_instance_of(Array)
-
-    expect(Magick::AlignType.values[0].to_s).to eq('UndefinedAlign')
-    expect(Magick::AlignType.values[0].to_i).to eq(0)
-
-    Magick::AlignType.values do |enum|
-      expect(enum).to be_kind_of(Magick::Enum)
-      expect(enum).to be_instance_of(Magick::AlignType)
+      expect { Magick::Enum.new(Object.new, 42) }.to raise_error(TypeError)
+      expect { Magick::Enum.new(:foo, 'x') }.to raise_error(TypeError)
     end
   end
 
-  def test_type_inspect
-    expect(Magick::AlignType.values[0].inspect).to eq('UndefinedAlign=0')
-  end
+  describe '#to_s' do
+    it 'works' do
+      enum = Magick::Enum.new(:foo, 42)
+      expect(enum.to_s).to eq('foo')
 
-  def test_using_compose_does_not_cause_endless_loop
-    img = Magick::Image.new(10, 10)
-    Magick::CompositeOperator.values do |op|
-      img.compose = op
-      expect(img.compose).to eq(op)
+      enum = Magick::Enum.new('foo', 42)
+      expect(enum.to_s).to eq('foo')
     end
   end
 
-  def test_using_class_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::ClassType.values do |value|
-      next if value == Magick::UndefinedClass
-
-      img.class_type = value
-      expect(img.class_type).to eq(value)
+  describe '#to_i' do
+    it 'works' do
+      enum = Magick::Enum.new(:foo, 42)
+      expect(enum.to_i).to eq(42)
     end
   end
 
-  def test_using_colorspace_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::ColorspaceType.values do |value|
-      next if value == Magick::SRGBColorspace
+  describe '#spaceship' do
+    it 'works' do
+      enum1 = Magick::Enum.new(:foo, 42)
+      enum2 = Magick::Enum.new(:foo, 56)
+      enum3 = Magick::Enum.new(:foo, 36)
+      enum4 = Magick::Enum.new(:foo, 42)
 
-      expect(img.colorspace).not_to eq(value)
+      expect(enum1 <=> enum2).to eq(-1)
+      expect(enum1 <=> enum4).to eq(0)
+      expect(enum1 <=> enum3).to eq(1)
+      expect(enum1 <=> 'x').to be(nil)
     end
   end
 
-  def test_using_compression_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::CompressionType.values do |value|
-      img.compression = value
-      expect(img.compression).to eq(value)
+  describe '#case_eq' do
+    it 'works' do
+      enum1 = Magick::Enum.new(:foo, 42)
+      enum2 = Magick::Enum.new(:foo, 56)
+
+      expect(enum1 === enum1).to be(true)
+      expect(enum1 === enum2).to be(false)
+      expect(enum1 === 'x').to be(false)
     end
   end
 
-  def test_using_dispose_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::DisposeType.values do |value|
-      img.dispose = value
-      expect(img.dispose).to eq(value)
+  describe '#bitwise_or' do
+    it 'works' do
+      enum1 = Magick::Enum.new(:foo, 42)
+      enum2 = Magick::Enum.new(:bar, 56)
+
+      enum = enum1 | enum2
+      expect(enum.to_i).to eq(58)
+      expect(enum.to_s).to eq('foo|bar')
+
+      expect { enum1 | 'x' }.to raise_error(ArgumentError)
     end
   end
 
-  def test_using_endian_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::EndianType.values do |value|
-      img.endian = value
-      expect(img.endian).to eq(value)
+  describe '#type_values' do
+    it 'works' do
+      expect(Magick::AlignType.values).to be_instance_of(Array)
+
+      expect(Magick::AlignType.values[0].to_s).to eq('UndefinedAlign')
+      expect(Magick::AlignType.values[0].to_i).to eq(0)
+
+      Magick::AlignType.values do |enum|
+        expect(enum).to be_kind_of(Magick::Enum)
+        expect(enum).to be_instance_of(Magick::AlignType)
+      end
     end
   end
 
-  def test_using_filter_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::FilterType.values do |value|
-      img.filter = value
-      expect(img.filter).to eq(value)
+  describe '#type_inspect' do
+    it 'works' do
+      expect(Magick::AlignType.values[0].inspect).to eq('UndefinedAlign=0')
     end
   end
 
-  def test_using_gravity_type_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::GravityType.values do |value|
-      img.gravity = value
-      expect(img.gravity).to eq(value)
+  describe '#using_compose_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(10, 10)
+      Magick::CompositeOperator.values do |op|
+        img.compose = op
+        expect(img.compose).to eq(op)
+      end
     end
   end
 
-  def test_using_image_type_does_not_cause_endless_loop
-    info = Magick::Image::Info.new
-    Magick::ImageType.values do |value|
-      info.image_type = value
-      expect(info.image_type).to eq(value)
+  describe '#using_class_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::ClassType.values do |value|
+        next if value == Magick::UndefinedClass
+
+        img.class_type = value
+        expect(img.class_type).to eq(value)
+      end
     end
   end
 
-  def test_using_orientation_type_does_not_cause_endless_loop
-    info = Magick::Image::Info.new
-    Magick::OrientationType.values do |value|
-      info.orientation = value
-      expect(info.orientation).to eq(value)
+  describe '#using_colorspace_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::ColorspaceType.values do |value|
+        next if value == Magick::SRGBColorspace
+
+        expect(img.colorspace).not_to eq(value)
+      end
     end
   end
 
-  def test_using_interlace_type_does_not_cause_endless_loop
-    info = Magick::Image::Info.new
-    Magick::InterlaceType.values do |value|
-      info.interlace = value
-      expect(info.interlace).to eq(value)
+  describe '#using_compression_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::CompressionType.values do |value|
+        img.compression = value
+        expect(img.compression).to eq(value)
+      end
     end
   end
 
-  def test_using_pixel_interpolation_method_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::PixelInterpolateMethod.values do |value|
-      img.pixel_interpolation_method = value
-      expect(img.pixel_interpolation_method).to eq(value)
+  describe '#using_dispose_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::DisposeType.values do |value|
+        img.dispose = value
+        expect(img.dispose).to eq(value)
+      end
     end
   end
 
-  def test_using_rendering_intent_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::RenderingIntent.values do |value|
-      img.rendering_intent = value
-      expect(img.rendering_intent).to eq(value)
+  describe '#using_endian_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::EndianType.values do |value|
+        img.endian = value
+        expect(img.endian).to eq(value)
+      end
     end
   end
 
-  def test_using_resolution_type_does_not_cause_endless_loop
-    info = Magick::Image::Info.new
-    Magick::ResolutionType.values do |value|
-      info.units = value
-      expect(info.units).to eq(value)
+  describe '#using_filter_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::FilterType.values do |value|
+        img.filter = value
+        expect(img.filter).to eq(value)
+      end
     end
   end
 
-  def test_using_virtual_pixel_method_does_not_cause_endless_loop
-    img = Magick::Image.new(1, 1)
-    Magick::VirtualPixelMethod.values do |value|
-      img.virtual_pixel_method = value
-      expect(img.virtual_pixel_method).to eq(value)
+  describe '#using_gravity_type_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::GravityType.values do |value|
+        img.gravity = value
+        expect(img.gravity).to eq(value)
+      end
     end
   end
 
-  def test_storage_type_name
-    img = Magick::Image.new(20, 20)
-    pixels = img.export_pixels(0, 0, 20, 20, 'RGB').pack('D*')
-
-    error = expect do
-      img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
-    end.to raise_error(ArgumentError)
-    expect(error.message).to match(/UndefinedPixel/)
+  describe '#using_image_type_does_not_cause_endless_loop' do
+    it 'works' do
+      info = Magick::Image::Info.new
+      Magick::ImageType.values do |value|
+        info.image_type = value
+        expect(info.image_type).to eq(value)
+      end
+    end
   end
 
-  def test_stretch_type_name
-    Magick::StretchType.values do |stretch|
-      font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, stretch, 400, nil, 'test foundry', 'test format')
-      expect(font.to_s).to match(/stretch=#{stretch.to_s}/)
+  describe '#using_orientation_type_does_not_cause_endless_loop' do
+    it 'works' do
+      info = Magick::Image::Info.new
+      Magick::OrientationType.values do |value|
+        info.orientation = value
+        expect(info.orientation).to eq(value)
+      end
     end
-
-    font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, nil, 400, nil, 'test foundry', 'test format')
-    expect(font.to_s).to match(/stretch=UndefinedStretch/)
   end
 
-  def test_style_type_name
-    Magick::StyleType.values do |style|
-      font = Magick::Font.new('Arial', 'font test', 'Arial family', style, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
-      expect(font.to_s).to match(/style=#{style.to_s}/)
+  describe '#using_interlace_type_does_not_cause_endless_loop' do
+    it 'works' do
+      info = Magick::Image::Info.new
+      Magick::InterlaceType.values do |value|
+        info.interlace = value
+        expect(info.interlace).to eq(value)
+      end
     end
+  end
 
-    font = Magick::Font.new('Arial', 'font test', 'Arial family', nil, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
-    expect(font.to_s).to match(/style=UndefinedStyle/)
+  describe '#using_pixel_interpolation_method_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::PixelInterpolateMethod.values do |value|
+        img.pixel_interpolation_method = value
+        expect(img.pixel_interpolation_method).to eq(value)
+      end
+    end
+  end
+
+  describe '#using_rendering_intent_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::RenderingIntent.values do |value|
+        img.rendering_intent = value
+        expect(img.rendering_intent).to eq(value)
+      end
+    end
+  end
+
+  describe '#using_resolution_type_does_not_cause_endless_loop' do
+    it 'works' do
+      info = Magick::Image::Info.new
+      Magick::ResolutionType.values do |value|
+        info.units = value
+        expect(info.units).to eq(value)
+      end
+    end
+  end
+
+  describe '#using_virtual_pixel_method_does_not_cause_endless_loop' do
+    it 'works' do
+      img = Magick::Image.new(1, 1)
+      Magick::VirtualPixelMethod.values do |value|
+        img.virtual_pixel_method = value
+        expect(img.virtual_pixel_method).to eq(value)
+      end
+    end
+  end
+
+  describe '#storage_type_name' do
+    it 'works' do
+      img = Magick::Image.new(20, 20)
+      pixels = img.export_pixels(0, 0, 20, 20, 'RGB').pack('D*')
+
+      error = expect do
+        img.import_pixels(0, 0, 20, 20, 'RGB', pixels, Magick::UndefinedPixel)
+      end.to raise_error(ArgumentError)
+      expect(error.message).to match(/UndefinedPixel/)
+    end
+  end
+
+  describe '#stretch_type_name' do
+    it 'works' do
+      Magick::StretchType.values do |stretch|
+        font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, stretch, 400, nil, 'test foundry', 'test format')
+        expect(font.to_s).to match(/stretch=#{stretch.to_s}/)
+      end
+
+      font = Magick::Font.new('Arial', 'font test', 'Arial family', Magick::NormalStyle, nil, 400, nil, 'test foundry', 'test format')
+      expect(font.to_s).to match(/stretch=UndefinedStretch/)
+    end
+  end
+
+  describe '#style_type_name' do
+    it 'works' do
+      Magick::StyleType.values do |style|
+        font = Magick::Font.new('Arial', 'font test', 'Arial family', style, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
+        expect(font.to_s).to match(/style=#{style.to_s}/)
+      end
+
+      font = Magick::Font.new('Arial', 'font test', 'Arial family', nil, Magick::NormalStretch, 400, nil, 'test foundry', 'test format')
+      expect(font.to_s).to match(/style=UndefinedStyle/)
+    end
   end
 end

--- a/test/Fill.rb
+++ b/test/Fill.rb
@@ -1,90 +1,98 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class GradientFillUT < Minitest::Test
-  def test_new
-    expect(Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000')).to be_instance_of(Magick::GradientFill)
-    expect(Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red')).to be_instance_of(Magick::GradientFill)
+describe Magick::GradientFill do
+  describe '#new' do
+    it 'works' do
+      expect(Magick::GradientFill.new(0, 0, 0, 100, '#900', '#000')).to be_instance_of(Magick::GradientFill)
+      expect(Magick::GradientFill.new(0, 0, 0, 100, 'white', 'red')).to be_instance_of(Magick::GradientFill)
 
-    expect { Magick::GradientFill.new(0, 0, 0, 100, 'foo', '#000') }.to raise_error(ArgumentError)
-    expect { Magick::GradientFill.new(0, 0, 0, 100, '#900', 'bar') }.to raise_error(ArgumentError)
-    expect { Magick::GradientFill.new('x1', 0, 0, 100, '#900', '#000') }.to raise_error(TypeError)
-    expect { Magick::GradientFill.new(0, 'y1', 0, 100, '#900', '#000') }.to raise_error(TypeError)
-    expect { Magick::GradientFill.new(0, 0, 'x2', 100, '#900', '#000') }.to raise_error(TypeError)
-    expect { Magick::GradientFill.new(0, 0, 0, 'y2', '#900', '#000') }.to raise_error(TypeError)
+      expect { Magick::GradientFill.new(0, 0, 0, 100, 'foo', '#000') }.to raise_error(ArgumentError)
+      expect { Magick::GradientFill.new(0, 0, 0, 100, '#900', 'bar') }.to raise_error(ArgumentError)
+      expect { Magick::GradientFill.new('x1', 0, 0, 100, '#900', '#000') }.to raise_error(TypeError)
+      expect { Magick::GradientFill.new(0, 'y1', 0, 100, '#900', '#000') }.to raise_error(TypeError)
+      expect { Magick::GradientFill.new(0, 0, 'x2', 100, '#900', '#000') }.to raise_error(TypeError)
+      expect { Magick::GradientFill.new(0, 0, 0, 'y2', '#900', '#000') }.to raise_error(TypeError)
+    end
   end
 
-  def test_fill
-    img = Magick::Image.new(10, 10)
+  describe '#fill' do
+    it 'works' do
+      img = Magick::Image.new(10, 10)
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 0, 0, 0, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 0, 0, 0, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 0, 0, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 0, 0, 10, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 0, 10, 0, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 0, 10, 0, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 0, 10, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 0, 10, 10, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 0, 5, 20, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 0, 5, 20, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(-10, 0, -10, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(-10, 0, -10, 10, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, -10, 10, -10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, -10, 10, -10, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, -10, 10, -20, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, -10, 10, -20, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
 
-    expect do
-      gradient = Magick::GradientFill.new(0, 100, 100, 200, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+      expect do
+        gradient = Magick::GradientFill.new(0, 100, 100, 200, '#900', '#000')
+        obj = gradient.fill(img)
+        expect(obj).to eq(gradient)
+      end.not_to raise_error
+    end
   end
 end
 
-class TextureFillUT < Minitest::Test
-  def test_new
-    granite = Magick::Image.read('granite:').first
-    expect(Magick::TextureFill.new(granite)).to be_instance_of(Magick::TextureFill)
+describe Magick::TextureFill do
+  describe '#new' do
+    it 'works' do
+      granite = Magick::Image.read('granite:').first
+      expect(Magick::TextureFill.new(granite)).to be_instance_of(Magick::TextureFill)
+    end
   end
 
-  def test_fill
-    granite = Magick::Image.read('granite:').first
-    texture = Magick::TextureFill.new(granite)
+  describe '#fill' do
+    it 'works' do
+      granite = Magick::Image.read('granite:').first
+      texture = Magick::TextureFill.new(granite)
 
-    img = Magick::Image.new(10, 10)
-    obj = texture.fill(img)
-    expect(obj).to eq(texture)
+      img = Magick::Image.new(10, 10)
+      obj = texture.fill(img)
+      expect(obj).to eq(texture)
+    end
   end
 end

--- a/test/Image1.rb
+++ b/test/Image1.rb
@@ -1,582 +1,674 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class Image1_UT < Minitest::Test
-  def setup
+describe Magick::Image do
+  before do
     @img = Magick::Image.new(20, 20)
   end
 
-  def test_read_inline
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    blob = img.to_blob
-    encoded = [blob].pack('m*')
-    res = Magick::Image.read_inline(encoded)
-    expect(res).to be_instance_of(Array)
-    expect(res[0]).to be_instance_of(Magick::Image)
-    expect(res[0]).to eq(img)
-    expect { Magick::Image.read(nil) }.to raise_error(ArgumentError)
-    expect { Magick::Image.read("") }.to raise_error(ArgumentError)
-  end
-
-  def test_spaceship
-    img0 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    sig0 = img0.signature
-    sig1 = img1.signature
-    # since <=> is based on the signature, the images should
-    # have the same relationship to each other as their
-    # signatures have to each other.
-    expect(img0 <=> img1).to eq(sig0 <=> sig1)
-    expect(img1 <=> img0).to eq(sig1 <=> sig0)
-    expect(img0).to eq(img0)
-    expect(img1).not_to eq(img0)
-    expect(img0 <=> nil).to be(nil)
-  end
-
-  def test_adaptive_blur
-    expect do
-      res = @img.adaptive_blur
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_blur(2) }.not_to raise_error
-    expect { @img.adaptive_blur(3, 2) }.not_to raise_error
-    expect { @img.adaptive_blur(3, 2, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_adaptive_blur_channel
-    expect do
-      res = @img.adaptive_blur_channel
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_blur_channel(2) }.not_to raise_error
-    expect { @img.adaptive_blur_channel(3, 2) }.not_to raise_error
-    expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel) }.not_to raise_error
-    expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.adaptive_blur_channel(3, 2, 2) }.to raise_error(TypeError)
-  end
-
-  def test_adaptive_resize
-    expect do
-      res = @img.adaptive_resize(10, 10)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_resize(2) }.not_to raise_error
-    expect { @img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
-    expect { @img.adaptive_resize(10, 10, 10) }.to raise_error(ArgumentError)
-    expect { @img.adaptive_resize }.to raise_error(ArgumentError)
-    expect { @img.adaptive_resize(Float::MAX) }.to raise_error(RangeError)
-  end
-
-  def test_adaptive_sharpen
-    expect do
-      res = @img.adaptive_sharpen
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_sharpen(2) }.not_to raise_error
-    expect { @img.adaptive_sharpen(3, 2) }.not_to raise_error
-    expect { @img.adaptive_sharpen(3, 2, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_adaptive_sharpen_channel
-    expect do
-      res = @img.adaptive_sharpen_channel
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_sharpen_channel(2) }.not_to raise_error
-    expect { @img.adaptive_sharpen_channel(3, 2) }.not_to raise_error
-    expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }.not_to raise_error
-    expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.adaptive_sharpen_channel(3, 2, 2) }.to raise_error(TypeError)
-  end
-
-  def test_adaptive_threshold
-    expect do
-      res = @img.adaptive_threshold
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.adaptive_threshold(2) }.not_to raise_error
-    expect { @img.adaptive_threshold(2, 4) }.not_to raise_error
-    expect { @img.adaptive_threshold(2, 4, 1) }.not_to raise_error
-    expect { @img.adaptive_threshold(2, 4, 1, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_add_compose_mask
-    mask = Magick::Image.new(20, 20)
-    expect { @img.add_compose_mask(mask) }.not_to raise_error
-    expect { @img.delete_compose_mask }.not_to raise_error
-    expect { @img.add_compose_mask(mask) }.not_to raise_error
-    expect { @img.add_compose_mask(mask) }.not_to raise_error
-    expect { @img.delete_compose_mask }.not_to raise_error
-    expect { @img.delete_compose_mask }.not_to raise_error
-
-    mask = Magick::Image.new(10, 10)
-    expect { @img.add_compose_mask(mask) }.to raise_error(ArgumentError)
-  end
-
-  def test_add_noise
-    Magick::NoiseType.values do |noise|
-      expect { @img.add_noise(noise) }.not_to raise_error
+  describe "#read_inline" do
+    it "works" do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      blob = img.to_blob
+      encoded = [blob].pack('m*')
+      res = Magick::Image.read_inline(encoded)
+      expect(res).to be_instance_of(Array)
+      expect(res[0]).to be_instance_of(Magick::Image)
+      expect(res[0]).to eq(img)
+      expect { Magick::Image.read(nil) }.to raise_error(ArgumentError)
+      expect { Magick::Image.read("") }.to raise_error(ArgumentError)
     end
-    expect { @img.add_noise(0) }.to raise_error(TypeError)
   end
 
-  def test_add_noise_channel
-    expect { @img.add_noise_channel(Magick::UniformNoise) }.not_to raise_error
-    expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel) }.not_to raise_error
-    expect { @img.add_noise_channel(Magick::GaussianNoise, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.add_noise_channel(Magick::ImpulseNoise, Magick::GreenChannel) }.not_to raise_error
-    expect { @img.add_noise_channel(Magick::LaplacianNoise, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
-    expect { @img.add_noise_channel(Magick::PoissonNoise, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel) }.not_to raise_error
-
-    # Not a NoiseType
-    expect { @img.add_noise_channel(1) }.to raise_error(TypeError)
-    # Not a ChannelType
-    expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel, 1) }.to raise_error(TypeError)
-    # Too few arguments
-    expect { @img.add_noise_channel }.to raise_error(ArgumentError)
+  describe "#spaceship" do
+    it "works" do
+      img0 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      sig0 = img0.signature
+      sig1 = img1.signature
+      # since <=> is based on the signature, the images should
+      # have the same relationship to each other as their
+      # signatures have to each other.
+      expect(img0 <=> img1).to eq(sig0 <=> sig1)
+      expect(img1 <=> img0).to eq(sig1 <=> sig0)
+      expect(img0).to eq(img0)
+      expect(img1).not_to eq(img0)
+      expect(img0 <=> nil).to be(nil)
+    end
   end
 
-  def test_add_delete_profile
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect { img.add_profile(File.join(__dir__, 'cmyk.icm')) }.not_to raise_error
-    # expect { img.add_profile(File.join(__dir__, 'srgb.icm')) }.to raise_error(Magick::ImageMagickError)
-
-    img.each_profile { |name, _value| expect(name).to eq('icc') }
-    expect { img.delete_profile('icc') }.not_to raise_error
+  describe "#adaptive_blur" do
+    it "works" do
+      expect do
+        res = @img.adaptive_blur
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_blur(2) }.not_to raise_error
+      expect { @img.adaptive_blur(3, 2) }.not_to raise_error
+      expect { @img.adaptive_blur(3, 2, 2) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_affine_matrix
-    affine = Magick::AffineMatrix.new(1, Math::PI / 6, Math::PI / 6, 1, 0, 0)
-    expect { @img.affine_transform(affine) }.not_to raise_error
-    expect { @img.affine_transform(0) }.to raise_error(TypeError)
-    res = @img.affine_transform(affine)
-    expect(res).to be_instance_of(Magick::Image)
+  describe "#adaptive_blur_channel" do
+    it "works" do
+      expect do
+        res = @img.adaptive_blur_channel
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_blur_channel(2) }.not_to raise_error
+      expect { @img.adaptive_blur_channel(3, 2) }.not_to raise_error
+      expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel) }.not_to raise_error
+      expect { @img.adaptive_blur_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.adaptive_blur_channel(3, 2, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#adaptive_resize" do
+    it "works" do
+      expect do
+        res = @img.adaptive_resize(10, 10)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_resize(2) }.not_to raise_error
+      expect { @img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
+      expect { @img.adaptive_resize(10, 10, 10) }.to raise_error(ArgumentError)
+      expect { @img.adaptive_resize }.to raise_error(ArgumentError)
+      expect { @img.adaptive_resize(Float::MAX) }.to raise_error(RangeError)
+    end
+  end
+
+  describe "#adaptive_sharpen" do
+    it "works" do
+      expect do
+        res = @img.adaptive_sharpen
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_sharpen(2) }.not_to raise_error
+      expect { @img.adaptive_sharpen(3, 2) }.not_to raise_error
+      expect { @img.adaptive_sharpen(3, 2, 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#adaptive_sharpen_channel" do
+    it "works" do
+      expect do
+        res = @img.adaptive_sharpen_channel
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_sharpen_channel(2) }.not_to raise_error
+      expect { @img.adaptive_sharpen_channel(3, 2) }.not_to raise_error
+      expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }.not_to raise_error
+      expect { @img.adaptive_sharpen_channel(3, 2, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.adaptive_sharpen_channel(3, 2, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#adaptive_threshold" do
+    it "works" do
+      expect do
+        res = @img.adaptive_threshold
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.adaptive_threshold(2) }.not_to raise_error
+      expect { @img.adaptive_threshold(2, 4) }.not_to raise_error
+      expect { @img.adaptive_threshold(2, 4, 1) }.not_to raise_error
+      expect { @img.adaptive_threshold(2, 4, 1, 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#add_compose_mask" do
+    it "works" do
+      mask = Magick::Image.new(20, 20)
+      expect { @img.add_compose_mask(mask) }.not_to raise_error
+      expect { @img.delete_compose_mask }.not_to raise_error
+      expect { @img.add_compose_mask(mask) }.not_to raise_error
+      expect { @img.add_compose_mask(mask) }.not_to raise_error
+      expect { @img.delete_compose_mask }.not_to raise_error
+      expect { @img.delete_compose_mask }.not_to raise_error
+
+      mask = Magick::Image.new(10, 10)
+      expect { @img.add_compose_mask(mask) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#add_noise" do
+    it "works" do
+      Magick::NoiseType.values do |noise|
+        expect { @img.add_noise(noise) }.not_to raise_error
+      end
+      expect { @img.add_noise(0) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#add_noise_channel" do
+    it "works" do
+      expect { @img.add_noise_channel(Magick::UniformNoise) }.not_to raise_error
+      expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel) }.not_to raise_error
+      expect { @img.add_noise_channel(Magick::GaussianNoise, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.add_noise_channel(Magick::ImpulseNoise, Magick::GreenChannel) }.not_to raise_error
+      expect { @img.add_noise_channel(Magick::LaplacianNoise, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+      expect { @img.add_noise_channel(Magick::PoissonNoise, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel) }.not_to raise_error
+
+      # Not a NoiseType
+      expect { @img.add_noise_channel(1) }.to raise_error(TypeError)
+      # Not a ChannelType
+      expect { @img.add_noise_channel(Magick::UniformNoise, Magick::RedChannel, 1) }.to raise_error(TypeError)
+      # Too few arguments
+      expect { @img.add_noise_channel }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#add_delete_profile" do
+    it "works" do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect { img.add_profile(File.join(__dir__, 'cmyk.icm')) }.not_to raise_error
+      # expect { img.add_profile(File.join(__dir__, 'srgb.icm')) }.to raise_error(Magick::ImageMagickError)
+
+      img.each_profile { |name, _value| expect(name).to eq('icc') }
+      expect { img.delete_profile('icc') }.not_to raise_error
+    end
+  end
+
+  describe "#affine_matrix" do
+    it "works" do
+      affine = Magick::AffineMatrix.new(1, Math::PI / 6, Math::PI / 6, 1, 0, 0)
+      expect { @img.affine_transform(affine) }.not_to raise_error
+      expect { @img.affine_transform(0) }.to raise_error(TypeError)
+      res = @img.affine_transform(affine)
+      expect(res).to be_instance_of(Magick::Image)
+    end
   end
 
   # test alpha backward compatibility. Image#alpha w/o arguments acts like alpha?
-  def test_alpha_compat
-    expect { @img.alpha }.not_to raise_error
-    expect(@img.alpha).to be(false)
-    expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
-    expect(@img.alpha).to be(true)
-  end
-
-  def test_alpha
-    expect { @img.alpha? }.not_to raise_error
-    expect(@img.alpha?).to be(false)
-    expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
-    expect(@img.alpha?).to be(true)
-    expect { @img.alpha Magick::DeactivateAlphaChannel }.not_to raise_error
-    expect(@img.alpha?).to be(false)
-    expect { @img.alpha Magick::OpaqueAlphaChannel }.not_to raise_error
-    expect { @img.alpha Magick::SetAlphaChannel }.not_to raise_error
-    expect { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }.to raise_error(ArgumentError)
-    @img.freeze
-    expect { @img.alpha Magick::SetAlphaChannel }.to raise_error(FreezeError)
-  end
-
-  def test_aref
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect(img[nil]).to be(nil)
-    expect(img['label']).to be(nil)
-    expect(img[:comment]).to match(/^Creator: PolyView/)
-  end
-
-  def test_aset
-    @img['label'] = 'foobarbaz'
-    @img[:comment] = 'Hello world'
-    expect(@img['label']).to eq('foobarbaz')
-    expect(@img['comment']).to eq('Hello world')
-    expect { @img[nil] = 'foobarbaz' }.not_to raise_error
-  end
-
-  def test_auto_gamma
-    res = nil
-    expect { res = @img.auto_gamma_channel }.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect { res = @img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
-    expect { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
-    expect { @img.auto_gamma_channel(1) }.to raise_error(TypeError)
-  end
-
-  def test_auto_level
-    res = nil
-    expect { res = @img.auto_level_channel }.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect { res = @img.auto_level_channel Magick::RedChannel }.not_to raise_error
-    expect { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
-    expect { @img.auto_level_channel(1) }.to raise_error(TypeError)
-  end
-
-  def test_auto_orient
-    Magick::OrientationType.values.each do |v|
-      expect do
-        img = Magick::Image.new(10, 10)
-        img.orientation = v
-        res = img.auto_orient
-        expect(res).to be_instance_of(Magick::Image)
-        expect(res).not_to be(img)
-      end.not_to raise_error
+  describe "#alpha_compat" do
+    it "works" do
+      expect { @img.alpha }.not_to raise_error
+      expect(@img.alpha).to be(false)
+      expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
+      expect(@img.alpha).to be(true)
     end
-
-    expect do
-      res = @img.auto_orient!
-      # When not changed, returns nil
-      expect(res).to be(nil)
-    end.not_to raise_error
   end
 
-  def test_bilevel_channel
-    expect { @img.bilevel_channel }.to raise_error(ArgumentError)
-    expect { @img.bilevel_channel(100) }.not_to raise_error
-    expect { @img.bilevel_channel(100, Magick::RedChannel) }.not_to raise_error
-    expect { @img.bilevel_channel(100, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
-    expect { @img.bilevel_channel(100, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
-    expect { @img.bilevel_channel(100, Magick::GrayChannel) }.not_to raise_error
-    expect { @img.bilevel_channel(100, Magick::AllChannels) }.not_to raise_error
-    expect { @img.bilevel_channel(100, 2) }.to raise_error(TypeError)
-    res = @img.bilevel_channel(100)
-    expect(res).to be_instance_of(Magick::Image)
-  end
-
-  def test_blend
-    @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    expect { @img.blend(@img2, 0.25) }.not_to raise_error
-    res = @img.blend(@img2, 0.25)
-
-    Magick::GravityType.values do |gravity|
-      expect { @img.blend(@img2, 0.25, 0.75, gravity) }.not_to raise_error
-      expect { @img.blend(@img2, 0.25, 0.75, gravity, 10) }.not_to raise_error
-      expect { @img.blend(@img2, 0.25, 0.75, gravity, 10, 10) }.not_to raise_error
+  describe "#alpha" do
+    it "works" do
+      expect { @img.alpha? }.not_to raise_error
+      expect(@img.alpha?).to be(false)
+      expect { @img.alpha Magick::ActivateAlphaChannel }.not_to raise_error
+      expect(@img.alpha?).to be(true)
+      expect { @img.alpha Magick::DeactivateAlphaChannel }.not_to raise_error
+      expect(@img.alpha?).to be(false)
+      expect { @img.alpha Magick::OpaqueAlphaChannel }.not_to raise_error
+      expect { @img.alpha Magick::SetAlphaChannel }.not_to raise_error
+      expect { @img.alpha Magick::SetAlphaChannel, Magick::OpaqueAlphaChannel }.to raise_error(ArgumentError)
+      @img.freeze
+      expect { @img.alpha Magick::SetAlphaChannel }.to raise_error(FreezeError)
     end
-
-    expect(res).to be_instance_of(Magick::Image)
-    expect { @img.blend(@img2, '25%') }.not_to raise_error
-    expect { @img.blend(@img2, 0.25, 0.75) }.not_to raise_error
-    expect { @img.blend(@img2, '25%', '75%') }.not_to raise_error
-    expect { @img.blend }.to raise_error(ArgumentError)
-    expect { @img.blend(@img2, 'x') }.to raise_error(ArgumentError)
-    expect { @img.blend(@img2, 0.25, []) }.to raise_error(TypeError)
-    expect { @img.blend(@img2, 0.25, 0.75, 'x') }.to raise_error(TypeError)
-    expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
-    expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
-
-    @img2.destroy!
-    expect { @img.blend(@img2, '25%') }.to raise_error(Magick::DestroyedImageError)
   end
 
-  def test_blue_shift
-    expect(@img.blue_shift).not_to be(@img)
-    expect(@img.blue_shift(2.0)).not_to be(@img)
-    expect { @img.blue_shift('x') }.to raise_error(TypeError)
-    expect { @img.blue_shift(2, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_blur_channel
-    expect { @img.blur_channel }.not_to raise_error
-    expect { @img.blur_channel(1) }.not_to raise_error
-    expect { @img.blur_channel(1, 2) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, Magick::RedChannel) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, Magick::GrayChannel) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, Magick::AllChannels) }.not_to raise_error
-    expect { @img.blur_channel(1, 2, 2) }.to raise_error(TypeError)
-    res = @img.blur_channel
-    expect(res).to be_instance_of(Magick::Image)
-  end
-
-  def test_blur_image
-    expect { @img.blur_image }.not_to raise_error
-    expect { @img.blur_image(1) }.not_to raise_error
-    expect { @img.blur_image(1, 2) }.not_to raise_error
-    expect { @img.blur_image(1, 2, 3) }.to raise_error(ArgumentError)
-    res = @img.blur_image
-    expect(res).to be_instance_of(Magick::Image)
-  end
-
-  def test_black_threshold
-    expect { @img.black_threshold }.to raise_error(ArgumentError)
-    expect { @img.black_threshold(50) }.not_to raise_error
-    expect { @img.black_threshold(50, 50) }.not_to raise_error
-    expect { @img.black_threshold(50, 50, 50) }.not_to raise_error
-    expect { @img.black_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
-    expect { @img.black_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
-    expect { @img.black_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
-    expect { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
-    expect { @img.black_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
-    res = @img.black_threshold(50)
-    expect(res).to be_instance_of(Magick::Image)
-  end
-
-  def test_border
-    expect { @img.border(2, 2, 'red') }.not_to raise_error
-    expect { @img.border!(2, 2, 'red') }.not_to raise_error
-    res = @img.border(2, 2, 'red')
-    expect(res).to be_instance_of(Magick::Image)
-    @img.freeze
-    expect { @img.border!(2, 2, 'red') }.to raise_error(FreezeError)
-  end
-
-  def test_capture
-    # expect { Magick::Image.capture }.not_to raise_error
-    # expect { Magick::Image.capture(true) }.not_to raise_error
-    # expect { Magick::Image.capture(true, true) }.not_to raise_error
-    # expect { Magick::Image.capture(true, true, true) }.not_to raise_error
-    # expect { Magick::Image.capture(true, true, true, true) }.not_to raise_error
-    # expect { Magick::Image.capture(true, true, true, true, true) }.not_to raise_error
-    expect { Magick::Image.capture(true, true, true, true, true, true) }.to raise_error(ArgumentError)
-  end
-
-  def test_change_geometry
-    expect { @img.change_geometry('sss') }.to raise_error(ArgumentError)
-    expect { @img.change_geometry('100x100') }.to raise_error(LocalJumpError)
-    expect do
-      res = @img.change_geometry('100x100') { 1 }
-      expect(res).to eq(1)
-    end.not_to raise_error
-    expect { @img.change_geometry([]) }.to raise_error(ArgumentError)
-  end
-
-  def test_changed?
-    #        expect(@img.changed?).to be(false)
-    #        @img.pixel_color(0,0,'red')
-    #        expect(@img.changed?).to be(true)
-  end
-
-  def test_channel
-    Magick::ChannelType.values do |channel|
-      expect { @img.channel(channel) }.not_to raise_error
+  describe "#aref" do
+    it "works" do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect(img[nil]).to be(nil)
+      expect(img['label']).to be(nil)
+      expect(img[:comment]).to match(/^Creator: PolyView/)
     end
-
-    expect(@img.channel(Magick::RedChannel)).to be_instance_of(Magick::Image)
-    expect { @img.channel(2) }.to raise_error(TypeError)
   end
 
-  def test_channel_depth
-    expect { @img.channel_depth }.not_to raise_error
-    expect { @img.channel_depth(Magick::RedChannel) }.not_to raise_error
-    expect { @img.channel_depth(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.channel_depth(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
-    expect { @img.channel_depth(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
-    expect { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
-    expect { @img.channel_depth(Magick::GrayChannel) }.not_to raise_error
-    expect { @img.channel_depth(2) }.to raise_error(TypeError)
-    expect(@img.channel_depth(Magick::RedChannel)).to be_kind_of(Integer)
+  describe "#aset" do
+    it "works" do
+      @img['label'] = 'foobarbaz'
+      @img[:comment] = 'Hello world'
+      expect(@img['label']).to eq('foobarbaz')
+      expect(@img['comment']).to eq('Hello world')
+      expect { @img[nil] = 'foobarbaz' }.not_to raise_error
+    end
   end
 
-  def test_channel_extrema
-    expect do
-      res = @img.channel_extrema
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(2)
-      expect(res[0]).to be_kind_of(Integer)
-      expect(res[1]).to be_kind_of(Integer)
-    end.not_to raise_error
-    expect { @img.channel_extrema(Magick::RedChannel) }.not_to raise_error
-    expect { @img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.channel_extrema(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
-    expect { @img.channel_extrema(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
-    expect { @img.channel_extrema(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
-    expect { @img.channel_extrema(Magick::GrayChannel) }.not_to raise_error
-    expect { @img.channel_extrema(2) }.to raise_error(TypeError)
-  end
-
-  def test_channel_mean
-    expect do
-      res = @img.channel_mean
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(2)
-      expect(res[0]).to be_instance_of(Float)
-      expect(res[1]).to be_instance_of(Float)
-    end.not_to raise_error
-    expect { @img.channel_mean(Magick::RedChannel) }.not_to raise_error
-    expect { @img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.channel_mean(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
-    expect { @img.channel_mean(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
-    expect { @img.channel_mean(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
-    expect { @img.channel_mean(Magick::GrayChannel) }.not_to raise_error
-    expect { @img.channel_mean(2) }.to raise_error(TypeError)
-  end
-
-  def test_charcoal
-    expect do
-      res = @img.charcoal
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.charcoal(1.0) }.not_to raise_error
-    expect { @img.charcoal(1.0, 2.0) }.not_to raise_error
-    expect { @img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
-  end
-
-  def test_chop
-    expect do
-      res = @img.chop(10, 10, 10, 10)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_clone
-    expect do
-      res = @img.clone
-      expect(res).to be_instance_of(Magick::Image)
-      expect(@img).to eq(res)
-    end.not_to raise_error
-    res = @img.clone
-    expect(@img.frozen?).to eq(res.frozen?)
-    @img.freeze
-    res = @img.clone
-    expect(@img.frozen?).to eq(res.frozen?)
-  end
-
-  def test_clut_channel
-    img = Magick::Image.new(20, 20) { self.colorspace = Magick::GRAYColorspace }
-    clut = Magick::Image.new(20, 1) { self.background_color = 'red' }
-    res = nil
-    expect { res = img.clut_channel(clut) }.not_to raise_error
-    expect(res).to be(img)
-    expect { img.clut_channel(clut, Magick::RedChannel) }.not_to raise_error
-    expect { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { img.clut_channel }.to raise_error(ArgumentError)
-    expect { img.clut_channel(clut, 1, Magick::RedChannel) }.to raise_error(ArgumentError)
-  end
-
-  def test_color_fill_to_border
-    expect { @img.color_fill_to_border(-1, 1, 'red') }.to raise_error(ArgumentError)
-    expect { @img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
-    expect do
-      res = @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, 'red')
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
-  end
-
-  def test_color_floodfill
-    expect { @img.color_floodfill(-1, 1, 'red') }.to raise_error(ArgumentError)
-    expect { @img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
-    expect do
-      res = @img.color_floodfill(@img.columns / 2, @img.rows / 2, 'red')
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.color_floodfill(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
-  end
-
-  def test_color_histogram
-    expect do
-      res = @img.color_histogram
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
-    expect do
-      @img.class_type = Magick::PseudoClass
-      res = @img.color_histogram
-      expect(@img.class_type).to eq(Magick::PseudoClass)
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
-  end
-
-  def test_colorize
-    expect do
-      res = @img.colorize(0.25, 0.25, 0.25, 'red')
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.colorize(0.25, 0.25, 0.25, pixel) }.not_to raise_error
-    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, pixel) }.not_to raise_error
-    expect { @img.colorize }.to raise_error(ArgumentError)
-    expect { @img.colorize(0.25) }.to raise_error(ArgumentError)
-    expect { @img.colorize(0.25, 0.25) }.to raise_error(ArgumentError)
-    expect { @img.colorize(0.25, 0.25, 0.25) }.to raise_error(ArgumentError)
-    expect { @img.colorize(0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
-    # last argument must be a color name or pixel
-    expect { @img.colorize(0.25, 0.25, 0.25, 0.25) }.to raise_error(TypeError)
-    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
-    expect { @img.colorize(0.25, 0.25, 0.25, 0.25, [2]) }.to raise_error(TypeError)
-  end
-
-  def test_colormap
-    # IndexError b/c @img is DirectClass
-    expect { @img.colormap(0) }.to raise_error(IndexError)
-    # Read PseudoClass image
-    pc_img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect { pc_img.colormap(0) }.not_to raise_error
-    ncolors = pc_img.colors
-    expect { pc_img.colormap(ncolors + 1) }.to raise_error(IndexError)
-    expect { pc_img.colormap(-1) }.to raise_error(IndexError)
-    expect { pc_img.colormap(ncolors - 1) }.not_to raise_error
-    res = pc_img.colormap(0)
-    expect(res).to be_instance_of(String)
-
-    # test 'set' operation
-    expect do
-      old_color = pc_img.colormap(0)
-      res = pc_img.colormap(0, 'red')
-      expect(res).to eq(old_color)
-      res = pc_img.colormap(0)
-      expect(res).to eq('red')
-    end.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { pc_img.colormap(0, pixel) }.not_to raise_error
-    expect { pc_img.colormap }.to raise_error(ArgumentError)
-    expect { pc_img.colormap(0, pixel, Magick::BlackChannel) }.to raise_error(ArgumentError)
-    expect { pc_img.colormap(0, [2]) }.to raise_error(TypeError)
-    pc_img.freeze
-    expect { pc_img.colormap(0, 'red') }.to raise_error(FreezeError)
-  end
-
-  def test_color_point
-    expect do
-      res = @img.color_point(0, 0, 'red')
+  describe "#auto_gamma" do
+    it "works" do
+      res = nil
+      expect { res = @img.auto_gamma_channel }.not_to raise_error
       expect(res).to be_instance_of(Magick::Image)
       expect(res).not_to be(@img)
-    end.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.color_point(0, 0, pixel) }.not_to raise_error
-  end
-
-  def test_color_reset!
-    expect do
-      res = @img.color_reset!('red')
-      expect(res).to be(@img)
-    end.not_to raise_error
-    pixel = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.color_reset!(pixel) }.not_to raise_error
-    expect { @img.color_reset!([2]) }.to raise_error(TypeError)
-    expect { @img.color_reset!('x') }.to raise_error(ArgumentError)
-    @img.freeze
-    expect { @img.color_reset!('red') }.to raise_error(FreezeError)
-  end
-
-  def test_compare_channel
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-
-    Magick::MetricType.values do |metric|
-      expect { img1.compare_channel(img2, metric) }.not_to raise_error
+      expect { res = @img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
+      expect { res = @img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+      expect { @img.auto_gamma_channel(1) }.to raise_error(TypeError)
     end
-    expect { img1.compare_channel(img2, 2) }.to raise_error(TypeError)
-    expect { img1.compare_channel }.to raise_error(ArgumentError)
+  end
 
-    ilist = Magick::ImageList.new
-    ilist << img2
-    expect { img1.compare_channel(ilist, Magick::MeanAbsoluteErrorMetric) }.not_to raise_error
+  describe "#auto_level" do
+    it "works" do
+      res = nil
+      expect { res = @img.auto_level_channel }.not_to raise_error
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+      expect { res = @img.auto_level_channel Magick::RedChannel }.not_to raise_error
+      expect { res = @img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+      expect { @img.auto_level_channel(1) }.to raise_error(TypeError)
+    end
+  end
 
-    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel) }.not_to raise_error
-    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, 2) }.to raise_error(TypeError)
-    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }.to raise_error(TypeError)
+  describe "#auto_orient" do
+    it "works" do
+      Magick::OrientationType.values.each do |v|
+        expect do
+          img = Magick::Image.new(10, 10)
+          img.orientation = v
+          res = img.auto_orient
+          expect(res).to be_instance_of(Magick::Image)
+          expect(res).not_to be(img)
+        end.not_to raise_error
+      end
 
-    res = img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric)
-    expect(res).to be_instance_of(Array)
-    expect(res[0]).to be_instance_of(Magick::Image)
-    expect(res[1]).to be_instance_of(Float)
+      expect do
+        res = @img.auto_orient!
+        # When not changed, returns nil
+        expect(res).to be(nil)
+      end.not_to raise_error
+    end
+  end
 
-    img2.destroy!
-    expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric) }.to raise_error(Magick::DestroyedImageError)
+  describe "#bilevel_channel" do
+    it "works" do
+      expect { @img.bilevel_channel }.to raise_error(ArgumentError)
+      expect { @img.bilevel_channel(100) }.not_to raise_error
+      expect { @img.bilevel_channel(100, Magick::RedChannel) }.not_to raise_error
+      expect { @img.bilevel_channel(100, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+      expect { @img.bilevel_channel(100, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
+      expect { @img.bilevel_channel(100, Magick::GrayChannel) }.not_to raise_error
+      expect { @img.bilevel_channel(100, Magick::AllChannels) }.not_to raise_error
+      expect { @img.bilevel_channel(100, 2) }.to raise_error(TypeError)
+      res = @img.bilevel_channel(100)
+      expect(res).to be_instance_of(Magick::Image)
+    end
+  end
+
+  describe "#blend" do
+    it "works" do
+      @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
+      expect { @img.blend(@img2, 0.25) }.not_to raise_error
+      res = @img.blend(@img2, 0.25)
+
+      Magick::GravityType.values do |gravity|
+        expect { @img.blend(@img2, 0.25, 0.75, gravity) }.not_to raise_error
+        expect { @img.blend(@img2, 0.25, 0.75, gravity, 10) }.not_to raise_error
+        expect { @img.blend(@img2, 0.25, 0.75, gravity, 10, 10) }.not_to raise_error
+      end
+
+      expect(res).to be_instance_of(Magick::Image)
+      expect { @img.blend(@img2, '25%') }.not_to raise_error
+      expect { @img.blend(@img2, 0.25, 0.75) }.not_to raise_error
+      expect { @img.blend(@img2, '25%', '75%') }.not_to raise_error
+      expect { @img.blend }.to raise_error(ArgumentError)
+      expect { @img.blend(@img2, 'x') }.to raise_error(ArgumentError)
+      expect { @img.blend(@img2, 0.25, []) }.to raise_error(TypeError)
+      expect { @img.blend(@img2, 0.25, 0.75, 'x') }.to raise_error(TypeError)
+      expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
+      expect { @img.blend(@img2, 0.25, 0.75, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
+
+      @img2.destroy!
+      expect { @img.blend(@img2, '25%') }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe "#blue_shift" do
+    it "works" do
+      expect(@img.blue_shift).not_to be(@img)
+      expect(@img.blue_shift(2.0)).not_to be(@img)
+      expect { @img.blue_shift('x') }.to raise_error(TypeError)
+      expect { @img.blue_shift(2, 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#blur_channel" do
+    it "works" do
+      expect { @img.blur_channel }.not_to raise_error
+      expect { @img.blur_channel(1) }.not_to raise_error
+      expect { @img.blur_channel(1, 2) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, Magick::RedChannel) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, Magick::CyanChannel, Magick::MagentaChannel, Magick::YellowChannel, Magick::BlackChannel) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, Magick::GrayChannel) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, Magick::AllChannels) }.not_to raise_error
+      expect { @img.blur_channel(1, 2, 2) }.to raise_error(TypeError)
+      res = @img.blur_channel
+      expect(res).to be_instance_of(Magick::Image)
+    end
+  end
+
+  describe "#blur_image" do
+    it "works" do
+      expect { @img.blur_image }.not_to raise_error
+      expect { @img.blur_image(1) }.not_to raise_error
+      expect { @img.blur_image(1, 2) }.not_to raise_error
+      expect { @img.blur_image(1, 2, 3) }.to raise_error(ArgumentError)
+      res = @img.blur_image
+      expect(res).to be_instance_of(Magick::Image)
+    end
+  end
+
+  describe "#black_threshold" do
+    it "works" do
+      expect { @img.black_threshold }.to raise_error(ArgumentError)
+      expect { @img.black_threshold(50) }.not_to raise_error
+      expect { @img.black_threshold(50, 50) }.not_to raise_error
+      expect { @img.black_threshold(50, 50, 50) }.not_to raise_error
+      expect { @img.black_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
+      expect { @img.black_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
+      expect { @img.black_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
+      expect { @img.black_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
+      expect { @img.black_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
+      res = @img.black_threshold(50)
+      expect(res).to be_instance_of(Magick::Image)
+    end
+  end
+
+  describe "#border" do
+    it "works" do
+      expect { @img.border(2, 2, 'red') }.not_to raise_error
+      expect { @img.border!(2, 2, 'red') }.not_to raise_error
+      res = @img.border(2, 2, 'red')
+      expect(res).to be_instance_of(Magick::Image)
+      @img.freeze
+      expect { @img.border!(2, 2, 'red') }.to raise_error(FreezeError)
+    end
+  end
+
+  describe "#capture" do
+    it "works" do
+      # expect { Magick::Image.capture }.not_to raise_error
+      # expect { Magick::Image.capture(true) }.not_to raise_error
+      # expect { Magick::Image.capture(true, true) }.not_to raise_error
+      # expect { Magick::Image.capture(true, true, true) }.not_to raise_error
+      # expect { Magick::Image.capture(true, true, true, true) }.not_to raise_error
+      # expect { Magick::Image.capture(true, true, true, true, true) }.not_to raise_error
+      expect { Magick::Image.capture(true, true, true, true, true, true) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#change_geometry" do
+    it "works" do
+      expect { @img.change_geometry('sss') }.to raise_error(ArgumentError)
+      expect { @img.change_geometry('100x100') }.to raise_error(LocalJumpError)
+      expect do
+        res = @img.change_geometry('100x100') { 1 }
+        expect(res).to eq(1)
+      end.not_to raise_error
+      expect { @img.change_geometry([]) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#changed?" do
+    it "works" do
+      #        expect(@img.changed?).to be(false)
+      #        @img.pixel_color(0,0,'red')
+      #        expect(@img.changed?).to be(true)
+    end
+  end
+
+  describe "#channel" do
+    it "works" do
+      Magick::ChannelType.values do |channel|
+        expect { @img.channel(channel) }.not_to raise_error
+      end
+
+      expect(@img.channel(Magick::RedChannel)).to be_instance_of(Magick::Image)
+      expect { @img.channel(2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#channel_depth" do
+    it "works" do
+      expect { @img.channel_depth }.not_to raise_error
+      expect { @img.channel_depth(Magick::RedChannel) }.not_to raise_error
+      expect { @img.channel_depth(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.channel_depth(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+      expect { @img.channel_depth(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+      expect { @img.channel_depth(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+      expect { @img.channel_depth(Magick::GrayChannel) }.not_to raise_error
+      expect { @img.channel_depth(2) }.to raise_error(TypeError)
+      expect(@img.channel_depth(Magick::RedChannel)).to be_kind_of(Integer)
+    end
+  end
+
+  describe "#channel_extrema" do
+    it "works" do
+      expect do
+        res = @img.channel_extrema
+        expect(res).to be_instance_of(Array)
+        expect(res.length).to eq(2)
+        expect(res[0]).to be_kind_of(Integer)
+        expect(res[1]).to be_kind_of(Integer)
+      end.not_to raise_error
+      expect { @img.channel_extrema(Magick::RedChannel) }.not_to raise_error
+      expect { @img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.channel_extrema(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+      expect { @img.channel_extrema(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+      expect { @img.channel_extrema(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+      expect { @img.channel_extrema(Magick::GrayChannel) }.not_to raise_error
+      expect { @img.channel_extrema(2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#channel_mean" do
+    it "works" do
+      expect do
+        res = @img.channel_mean
+        expect(res).to be_instance_of(Array)
+        expect(res.length).to eq(2)
+        expect(res[0]).to be_instance_of(Float)
+        expect(res[1]).to be_instance_of(Float)
+      end.not_to raise_error
+      expect { @img.channel_mean(Magick::RedChannel) }.not_to raise_error
+      expect { @img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.channel_mean(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error
+      expect { @img.channel_mean(Magick::MagentaChannel, Magick::CyanChannel) }.not_to raise_error
+      expect { @img.channel_mean(Magick::CyanChannel, Magick::BlackChannel) }.not_to raise_error
+      expect { @img.channel_mean(Magick::GrayChannel) }.not_to raise_error
+      expect { @img.channel_mean(2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#charcoal" do
+    it "works" do
+      expect do
+        res = @img.charcoal
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.charcoal(1.0) }.not_to raise_error
+      expect { @img.charcoal(1.0, 2.0) }.not_to raise_error
+      expect { @img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#chop" do
+    it "works" do
+      expect do
+        res = @img.chop(10, 10, 10, 10)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
+  end
+
+  describe "#clone" do
+    it "works" do
+      expect do
+        res = @img.clone
+        expect(res).to be_instance_of(Magick::Image)
+        expect(@img).to eq(res)
+      end.not_to raise_error
+      res = @img.clone
+      expect(@img.frozen?).to eq(res.frozen?)
+      @img.freeze
+      res = @img.clone
+      expect(@img.frozen?).to eq(res.frozen?)
+    end
+  end
+
+  describe "#clut_channel" do
+    it "works" do
+      img = Magick::Image.new(20, 20) { self.colorspace = Magick::GRAYColorspace }
+      clut = Magick::Image.new(20, 1) { self.background_color = 'red' }
+      res = nil
+      expect { res = img.clut_channel(clut) }.not_to raise_error
+      expect(res).to be(img)
+      expect { img.clut_channel(clut, Magick::RedChannel) }.not_to raise_error
+      expect { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { img.clut_channel }.to raise_error(ArgumentError)
+      expect { img.clut_channel(clut, 1, Magick::RedChannel) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#color_fill_to_border" do
+    it "works" do
+      expect { @img.color_fill_to_border(-1, 1, 'red') }.to raise_error(ArgumentError)
+      expect { @img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
+      expect do
+        res = @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, 'red')
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.color_fill_to_border(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
+    end
+  end
+
+  describe "#color_floodfill" do
+    it "works" do
+      expect { @img.color_floodfill(-1, 1, 'red') }.to raise_error(ArgumentError)
+      expect { @img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
+      expect do
+        res = @img.color_floodfill(@img.columns / 2, @img.rows / 2, 'red')
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.color_floodfill(@img.columns / 2, @img.rows / 2, pixel) }.not_to raise_error
+    end
+  end
+
+  describe "#color_histogram" do
+    it "works" do
+      expect do
+        res = @img.color_histogram
+        expect(res).to be_instance_of(Hash)
+      end.not_to raise_error
+      expect do
+        @img.class_type = Magick::PseudoClass
+        res = @img.color_histogram
+        expect(@img.class_type).to eq(Magick::PseudoClass)
+        expect(res).to be_instance_of(Hash)
+      end.not_to raise_error
+    end
+  end
+
+  describe "#colorize" do
+    it "works" do
+      expect do
+        res = @img.colorize(0.25, 0.25, 0.25, 'red')
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.colorize(0.25, 0.25, 0.25, pixel) }.not_to raise_error
+      expect { @img.colorize(0.25, 0.25, 0.25, 0.25, pixel) }.not_to raise_error
+      expect { @img.colorize }.to raise_error(ArgumentError)
+      expect { @img.colorize(0.25) }.to raise_error(ArgumentError)
+      expect { @img.colorize(0.25, 0.25) }.to raise_error(ArgumentError)
+      expect { @img.colorize(0.25, 0.25, 0.25) }.to raise_error(ArgumentError)
+      expect { @img.colorize(0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
+      # last argument must be a color name or pixel
+      expect { @img.colorize(0.25, 0.25, 0.25, 0.25) }.to raise_error(TypeError)
+      expect { @img.colorize(0.25, 0.25, 0.25, 0.25, 'X') }.to raise_error(ArgumentError)
+      expect { @img.colorize(0.25, 0.25, 0.25, 0.25, [2]) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#colormap" do
+    it "works" do
+      # IndexError b/c @img is DirectClass
+      expect { @img.colormap(0) }.to raise_error(IndexError)
+      # Read PseudoClass image
+      pc_img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect { pc_img.colormap(0) }.not_to raise_error
+      ncolors = pc_img.colors
+      expect { pc_img.colormap(ncolors + 1) }.to raise_error(IndexError)
+      expect { pc_img.colormap(-1) }.to raise_error(IndexError)
+      expect { pc_img.colormap(ncolors - 1) }.not_to raise_error
+      res = pc_img.colormap(0)
+      expect(res).to be_instance_of(String)
+
+      # test 'set' operation
+      expect do
+        old_color = pc_img.colormap(0)
+        res = pc_img.colormap(0, 'red')
+        expect(res).to eq(old_color)
+        res = pc_img.colormap(0)
+        expect(res).to eq('red')
+      end.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { pc_img.colormap(0, pixel) }.not_to raise_error
+      expect { pc_img.colormap }.to raise_error(ArgumentError)
+      expect { pc_img.colormap(0, pixel, Magick::BlackChannel) }.to raise_error(ArgumentError)
+      expect { pc_img.colormap(0, [2]) }.to raise_error(TypeError)
+      pc_img.freeze
+      expect { pc_img.colormap(0, 'red') }.to raise_error(FreezeError)
+    end
+  end
+
+  describe "#color_point" do
+    it "works" do
+      expect do
+        res = @img.color_point(0, 0, 'red')
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.color_point(0, 0, pixel) }.not_to raise_error
+    end
+  end
+
+  describe "#color_reset!" do
+    it "works" do
+      expect do
+        res = @img.color_reset!('red')
+        expect(res).to be(@img)
+      end.not_to raise_error
+      pixel = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.color_reset!(pixel) }.not_to raise_error
+      expect { @img.color_reset!([2]) }.to raise_error(TypeError)
+      expect { @img.color_reset!('x') }.to raise_error(ArgumentError)
+      @img.freeze
+      expect { @img.color_reset!('red') }.to raise_error(FreezeError)
+    end
+  end
+
+  describe "#compare_channel" do
+    it "works" do
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+
+      Magick::MetricType.values do |metric|
+        expect { img1.compare_channel(img2, metric) }.not_to raise_error
+      end
+      expect { img1.compare_channel(img2, 2) }.to raise_error(TypeError)
+      expect { img1.compare_channel }.to raise_error(ArgumentError)
+
+      ilist = Magick::ImageList.new
+      ilist << img2
+      expect { img1.compare_channel(ilist, Magick::MeanAbsoluteErrorMetric) }.not_to raise_error
+
+      expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel) }.not_to raise_error
+      expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, 2) }.to raise_error(TypeError)
+      expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric, Magick::RedChannel, 2) }.to raise_error(TypeError)
+
+      res = img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric)
+      expect(res).to be_instance_of(Array)
+      expect(res[0]).to be_instance_of(Magick::Image)
+      expect(res[1]).to be_instance_of(Float)
+
+      img2.destroy!
+      expect { img1.compare_channel(img2, Magick::MeanAbsoluteErrorMetric) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 end
 

--- a/test/Image2.rb
+++ b/test/Image2.rb
@@ -3,1404 +3,1592 @@ require 'minitest/autorun'
 
 # TODO: improve exif tests - need a benchmark image with EXIF data
 
-class Image2_UT < Minitest::Test
-  def setup
+describe Magick::Image do
+  before do
     @img = Magick::Image.new(20, 20)
   end
 
-  def test_composite
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    img1.define('compose:args', '1x1')
-    img2.define('compose:args', '1x1')
-    Magick::CompositeOperator.values do |op|
-      Magick::GravityType.values do |gravity|
-        expect do
-          res = img1.composite(img2, gravity, 5, 5, op)
-          expect(res).not_to be(img1)
-        end.not_to raise_error
+  describe '#composite' do
+    it 'works' do
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      img1.define('compose:args', '1x1')
+      img2.define('compose:args', '1x1')
+      Magick::CompositeOperator.values do |op|
+        Magick::GravityType.values do |gravity|
+          expect do
+            res = img1.composite(img2, gravity, 5, 5, op)
+            expect(res).not_to be(img1)
+          end.not_to raise_error
+        end
       end
-    end
 
-    expect do
-      res = img1.composite(img2, 5, 5, Magick::OverCompositeOp)
-      expect(res).not_to be(img1)
-    end.not_to raise_error
-
-    expect { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
-    expect { img1.composite(img2, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
-    expect { img1.composite(img2, Magick::NorthWestGravity, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
-    expect { img1.composite(img2, Magick::NorthWestGravity, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
-
-    img1.freeze
-    expect { img1.composite(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.not_to raise_error
-  end
-
-  def test_composite!
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    img1.define('compose:args', '1x1')
-    img2.define('compose:args', '1x1')
-    Magick::CompositeOperator.values do |op|
-      Magick::GravityType.values do |gravity|
-        expect do
-          res = img1.composite!(img2, gravity, op)
-          expect(res).to be(img1)
-        end.not_to raise_error
-      end
-    end
-    img1.freeze
-    expect { img1.composite!(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.to raise_error(FreezeError)
-  end
-
-  def test_composite_affine
-    affine = Magick::AffineMatrix.new(1, 0, 1, 0, 0, 0)
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    img1.define('compose:args', '1x1')
-    img2.define('compose:args', '1x1')
-    expect do
-      res = img1.composite_affine(img2, affine)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_composite_channel
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    img1.define('compose:args', '1x1')
-    img2.define('compose:args', '1x1')
-    Magick::CompositeOperator.values do |op|
-      Magick::GravityType.values do |gravity|
-        expect do
-          res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
-          expect(res).not_to be(img1)
-        end.not_to raise_error
-      end
-    end
-
-    expect { img1.composite_channel(img2, Magick::NorthWestGravity) }.to raise_error(ArgumentError)
-    expect { img1.composite_channel(img2, Magick::NorthWestGravity, 5, 5, Magick::OverCompositeOp, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_composite_mathematics
-    bg = Magick::Image.new(50, 50)
-    fg = Magick::Image.new(50, 50) { self.background_color = 'black' }
-    res = nil
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(bg)
-    expect(res).not_to be(fg)
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
-
-    # too few arguments
-    expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)
-    # too many arguments
-    expect { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_composite_tiled
-    bg = Magick::Image.new(200, 200)
-    fg = Magick::Image.new(50, 100) { self.background_color = 'black' }
-    res = nil
-    expect do
-      res = bg.composite_tiled(fg)
-    end.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(bg)
-    expect(res).not_to be(fg)
-    expect { bg.composite_tiled!(fg) }.not_to raise_error
-    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
-    expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error
-    expect { bg.composite_tiled(fg, Magick::RedChannel) }.not_to raise_error
-    expect { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
-
-    expect { bg.composite_tiled }.to raise_error(ArgumentError)
-    expect { bg.composite_tiled(fg, 'x') }.to raise_error(TypeError)
-    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp, Magick::RedChannel, 'x') }.to raise_error(TypeError)
-
-    fg.destroy!
-    expect { bg.composite_tiled(fg) }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_compress_colormap!
-    # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
-    expect(@img.class_type).to eq(Magick::DirectClass)
-    expect { @img.compress_colormap! }.not_to raise_error
-    # expect(@img.class_type).to eq(Magick::PseudoClass)
-    @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect(@img.class_type).to eq(Magick::PseudoClass)
-    expect { @img.compress_colormap! }.not_to raise_error
-  end
-
-  def test_contrast
-    expect do
-      res = @img.contrast
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.contrast(true) }.not_to raise_error
-    expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_contrast_stretch_channel
-    expect do
-      res = @img.contrast_stretch_channel(25)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
-    expect { @img.contrast_stretch_channel('10%') }.not_to raise_error
-    expect { @img.contrast_stretch_channel('10%', '50%') }.not_to raise_error
-    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }.not_to raise_error
-    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
-    expect { @img.contrast_stretch_channel(25, 50, 'x') }.to raise_error(TypeError)
-    expect { @img.contrast_stretch_channel }.to raise_error(ArgumentError)
-    expect { @img.contrast_stretch_channel('x') }.to raise_error(ArgumentError)
-    expect { @img.contrast_stretch_channel(25, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_morphology
-    kernel = Magick::KernelInfo.new('Octagon')
-    Magick::MorphologyMethod.values do |method|
       expect do
-        res = @img.morphology(method, 2, kernel)
+        res = img1.composite(img2, 5, 5, Magick::OverCompositeOp)
+        expect(res).not_to be(img1)
+      end.not_to raise_error
+
+      expect { img1.composite(img2, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
+      expect { img1.composite(img2, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
+      expect { img1.composite(img2, Magick::NorthWestGravity, 'x', 5, Magick::OverCompositeOp) }.to raise_error(TypeError)
+      expect { img1.composite(img2, Magick::NorthWestGravity, 5, 'y', Magick::OverCompositeOp) }.to raise_error(TypeError)
+
+      img1.freeze
+      expect { img1.composite(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.not_to raise_error
+    end
+  end
+
+  describe '#composite!' do
+    it 'works' do
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      img1.define('compose:args', '1x1')
+      img2.define('compose:args', '1x1')
+      Magick::CompositeOperator.values do |op|
+        Magick::GravityType.values do |gravity|
+          expect do
+            res = img1.composite!(img2, gravity, op)
+            expect(res).to be(img1)
+          end.not_to raise_error
+        end
+      end
+      img1.freeze
+      expect { img1.composite!(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#composite_affine' do
+    it 'works' do
+      affine = Magick::AffineMatrix.new(1, 0, 1, 0, 0, 0)
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      img1.define('compose:args', '1x1')
+      img2.define('compose:args', '1x1')
+      expect do
+        res = img1.composite_affine(img2, affine)
         expect(res).to be_instance_of(Magick::Image)
         expect(res).not_to be(@img)
       end.not_to raise_error
     end
   end
 
-  def test_morphology_channel
-    expect { @img.morphology_channel }.to raise_error(ArgumentError)
-    expect { @img.morphology_channel(Magick::RedChannel) }.to raise_error(ArgumentError)
-    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }.to raise_error(ArgumentError)
-    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }.to raise_error(ArgumentError)
-    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
+  describe '#composite_channel' do
+    it 'works' do
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      img1.define('compose:args', '1x1')
+      img2.define('compose:args', '1x1')
+      Magick::CompositeOperator.values do |op|
+        Magick::GravityType.values do |gravity|
+          expect do
+            res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
+            expect(res).not_to be(img1)
+          end.not_to raise_error
+        end
+      end
 
-    kernel = Magick::KernelInfo.new('Octagon')
-    expect do
-      res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+      expect { img1.composite_channel(img2, Magick::NorthWestGravity) }.to raise_error(ArgumentError)
+      expect { img1.composite_channel(img2, Magick::NorthWestGravity, 5, 5, Magick::OverCompositeOp, 'x') }.to raise_error(TypeError)
+    end
   end
 
-  def test_convolve
-    kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-    order = 3
-    expect do
-      res = @img.convolve(order, kernel)
+  describe '#composite_mathematics' do
+    it 'works' do
+      bg = Magick::Image.new(50, 50)
+      fg = Magick::Image.new(50, 50) { self.background_color = 'black' }
+      res = nil
+      expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
       expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.convolve }.to raise_error(ArgumentError)
-    expect { @img.convolve(0) }.to raise_error(ArgumentError)
-    expect { @img.convolve(-1) }.to raise_error(ArgumentError)
-    expect { @img.convolve(order) }.to raise_error(ArgumentError)
-    expect { @img.convolve(5, kernel) }.to raise_error(IndexError)
-    expect { @img.convolve(order, 'x') }.to raise_error(IndexError)
-    expect { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }.to raise_error(TypeError)
-    expect { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }.to raise_error(ArgumentError)
+      expect(res).not_to be(bg)
+      expect(res).not_to be(fg)
+      expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
+      expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
+
+      # too few arguments
+      expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)
+      # too many arguments
+      expect { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0, 'x') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_convolve_channel
-    expect { @img.convolve_channel }.to raise_error(ArgumentError)
-    expect { @img.convolve_channel(0) }.to raise_error(ArgumentError)
-    expect { @img.convolve_channel(-1) }.to raise_error(ArgumentError)
-    expect { @img.convolve_channel(3) }.to raise_error(ArgumentError)
-    kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-    order = 3
-    expect do
-      res = @img.convolve_channel(order, kernel, Magick::RedChannel)
+  describe '#composite_tiled' do
+    it 'works' do
+      bg = Magick::Image.new(200, 200)
+      fg = Magick::Image.new(50, 100) { self.background_color = 'black' }
+      res = nil
+      expect do
+        res = bg.composite_tiled(fg)
+      end.not_to raise_error
       expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+      expect(res).not_to be(bg)
+      expect(res).not_to be(fg)
+      expect { bg.composite_tiled!(fg) }.not_to raise_error
+      expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
+      expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error
+      expect { bg.composite_tiled(fg, Magick::RedChannel) }.not_to raise_error
+      expect { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
 
-    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
-    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
+      expect { bg.composite_tiled }.to raise_error(ArgumentError)
+      expect { bg.composite_tiled(fg, 'x') }.to raise_error(TypeError)
+      expect { bg.composite_tiled(fg, Magick::AtopCompositeOp, Magick::RedChannel, 'x') }.to raise_error(TypeError)
+
+      fg.destroy!
+      expect { bg.composite_tiled(fg) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test_copy
-    expect do
+  describe '#compress_colormap!' do
+    it 'works' do
+      # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
+      expect(@img.class_type).to eq(Magick::DirectClass)
+      expect { @img.compress_colormap! }.not_to raise_error
+      # expect(@img.class_type).to eq(Magick::PseudoClass)
+      @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect(@img.class_type).to eq(Magick::PseudoClass)
+      expect { @img.compress_colormap! }.not_to raise_error
+    end
+  end
+
+  describe '#contrast' do
+    it 'works' do
+      expect do
+        res = @img.contrast
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.contrast(true) }.not_to raise_error
+      expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#contrast_stretch_channel' do
+    it 'works' do
+      expect do
+        res = @img.contrast_stretch_channel(25)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
+      expect { @img.contrast_stretch_channel('10%') }.not_to raise_error
+      expect { @img.contrast_stretch_channel('10%', '50%') }.not_to raise_error
+      expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }.not_to raise_error
+      expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+      expect { @img.contrast_stretch_channel(25, 50, 'x') }.to raise_error(TypeError)
+      expect { @img.contrast_stretch_channel }.to raise_error(ArgumentError)
+      expect { @img.contrast_stretch_channel('x') }.to raise_error(ArgumentError)
+      expect { @img.contrast_stretch_channel(25, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#morphology' do
+    it 'works' do
+      kernel = Magick::KernelInfo.new('Octagon')
+      Magick::MorphologyMethod.values do |method|
+        expect do
+          res = @img.morphology(method, 2, kernel)
+          expect(res).to be_instance_of(Magick::Image)
+          expect(res).not_to be(@img)
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe '#morphology_channel' do
+    it 'works' do
+      expect { @img.morphology_channel }.to raise_error(ArgumentError)
+      expect { @img.morphology_channel(Magick::RedChannel) }.to raise_error(ArgumentError)
+      expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }.to raise_error(ArgumentError)
+      expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }.to raise_error(ArgumentError)
+      expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
+
+      kernel = Magick::KernelInfo.new('Octagon')
+      expect do
+        res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#convolve' do
+    it 'works' do
+      kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      order = 3
+      expect do
+        res = @img.convolve(order, kernel)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.convolve }.to raise_error(ArgumentError)
+      expect { @img.convolve(0) }.to raise_error(ArgumentError)
+      expect { @img.convolve(-1) }.to raise_error(ArgumentError)
+      expect { @img.convolve(order) }.to raise_error(ArgumentError)
+      expect { @img.convolve(5, kernel) }.to raise_error(IndexError)
+      expect { @img.convolve(order, 'x') }.to raise_error(IndexError)
+      expect { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }.to raise_error(TypeError)
+      expect { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#convolve_channel' do
+    it 'works' do
+      expect { @img.convolve_channel }.to raise_error(ArgumentError)
+      expect { @img.convolve_channel(0) }.to raise_error(ArgumentError)
+      expect { @img.convolve_channel(-1) }.to raise_error(ArgumentError)
+      expect { @img.convolve_channel(3) }.to raise_error(ArgumentError)
+      kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      order = 3
+      expect do
+        res = @img.convolve_channel(order, kernel, Magick::RedChannel)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+
+      expect { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
+      expect { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#copy' do
+    it 'works' do
+      expect do
+        ditto = @img.copy
+        expect(ditto).to eq(@img)
+      end.not_to raise_error
       ditto = @img.copy
-      expect(ditto).to eq(@img)
-    end.not_to raise_error
-    ditto = @img.copy
-    expect(ditto.tainted?).to eq(@img.tainted?)
-    @img.taint
-    ditto = @img.copy
-    expect(ditto.tainted?).to eq(@img.tainted?)
-  end
-
-  def test_crop
-    expect { @img.crop }.to raise_error(ArgumentError)
-    expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
-    expect do
-      res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-
-    # 3-argument form
-    Magick::GravityType.values do |grav|
-      expect { @img.crop(grav, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+      expect(ditto.tainted?).to eq(@img.tainted?)
+      @img.taint
+      ditto = @img.copy
+      expect(ditto.tainted?).to eq(@img.tainted?)
     end
-    expect { @img.crop(2, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
-    expect { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+  end
 
-    # 4-argument form
-    expect { @img.crop(0, 0, @img.columns / 2, 'x') }.to raise_error(TypeError)
-    expect { @img.crop(0, 0, 'x', @img.rows / 2) }.to raise_error(TypeError)
-    expect { @img.crop(0, 'x', @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
-    expect { @img.crop('x', 0, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
-    expect { @img.crop(0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+  describe '#crop' do
+    it 'works' do
+      expect { @img.crop }.to raise_error(ArgumentError)
+      expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
+      expect do
+        res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
 
-    # 5-argument form
-    Magick::GravityType.values do |grav|
-      expect { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+      # 3-argument form
+      Magick::GravityType.values do |grav|
+        expect { @img.crop(grav, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+      end
+      expect { @img.crop(2, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+      expect { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+
+      # 4-argument form
+      expect { @img.crop(0, 0, @img.columns / 2, 'x') }.to raise_error(TypeError)
+      expect { @img.crop(0, 0, 'x', @img.rows / 2) }.to raise_error(TypeError)
+      expect { @img.crop(0, 'x', @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+      expect { @img.crop('x', 0, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+      expect { @img.crop(0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+
+      # 5-argument form
+      Magick::GravityType.values do |grav|
+        expect { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+      end
+
+      expect { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(ArgumentError)
     end
-
-    expect { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(ArgumentError)
   end
 
-  def test_crop!
-    expect do
-      res = @img.crop!(0, 0, @img.columns / 2, @img.rows / 2)
-      expect(res).to be(@img)
-    end.not_to raise_error
+  describe '#crop!' do
+    it 'works' do
+      expect do
+        res = @img.crop!(0, 0, @img.columns / 2, @img.rows / 2)
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
   end
 
-  def test_cycle_colormap
-    expect do
-      res = @img.cycle_colormap(5)
+  describe '#cycle_colormap' do
+    it 'works' do
+      expect do
+        res = @img.cycle_colormap(5)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+        expect(res.class_type).to eq(Magick::PseudoClass)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#decipher # tests encipher, too.' do
+    it 'works' do
+      res = res2 = nil
+      expect do
+        res = @img.encipher 'passphrase'
+        res2 = res.decipher 'passphrase'
+      end.not_to raise_error
       expect(res).to be_instance_of(Magick::Image)
       expect(res).not_to be(@img)
-      expect(res.class_type).to eq(Magick::PseudoClass)
-    end.not_to raise_error
+      expect(res.columns).to eq(@img.columns)
+      expect(res.rows).to eq(@img.rows)
+      expect(res2).to be_instance_of(Magick::Image)
+      expect(res2).not_to be(@img)
+      expect(res2.columns).to eq(@img.columns)
+      expect(res2.rows).to eq(@img.rows)
+      expect(res2).to eq(@img)
+    end
   end
 
-  def test_decipher # tests encipher, too.
-    res = res2 = nil
-    expect do
-      res = @img.encipher 'passphrase'
-      res2 = res.decipher 'passphrase'
-    end.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect(res.columns).to eq(@img.columns)
-    expect(res.rows).to eq(@img.rows)
-    expect(res2).to be_instance_of(Magick::Image)
-    expect(res2).not_to be(@img)
-    expect(res2.columns).to eq(@img.columns)
-    expect(res2.rows).to eq(@img.rows)
-    expect(res2).to eq(@img)
+  describe '#define' do
+    it 'works' do
+      expect { @img.define('deskew:auto-crop', 40) }.not_to raise_error
+      expect { @img.undefine('deskew:auto-crop') }.not_to raise_error
+      expect { @img.define('deskew:auto-crop', nil) }.not_to raise_error
+    end
   end
 
-  def test_define
-    expect { @img.define('deskew:auto-crop', 40) }.not_to raise_error
-    expect { @img.undefine('deskew:auto-crop') }.not_to raise_error
-    expect { @img.define('deskew:auto-crop', nil) }.not_to raise_error
+  describe '#deskew' do
+    it 'works' do
+      expect do
+        res = @img.deskew
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+
+      expect { @img.deskew(0.10) }.not_to raise_error
+      expect { @img.deskew('95%') }.not_to raise_error
+      expect { @img.deskew('x') }.to raise_error(ArgumentError)
+      expect { @img.deskew(0.40, 'x') }.to raise_error(TypeError)
+      expect { @img.deskew(0.40, 20, [1]) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_deskew
-    expect do
-      res = @img.deskew
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-
-    expect { @img.deskew(0.10) }.not_to raise_error
-    expect { @img.deskew('95%') }.not_to raise_error
-    expect { @img.deskew('x') }.to raise_error(ArgumentError)
-    expect { @img.deskew(0.40, 'x') }.to raise_error(TypeError)
-    expect { @img.deskew(0.40, 20, [1]) }.to raise_error(ArgumentError)
-  end
-
-  def test_despeckle
-    expect do
-      res = @img.despeckle
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#despeckle' do
+    it 'works' do
+      expect do
+        res = @img.despeckle
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
   end
 
   # ensure methods detect destroyed images
-  def test_destroy
-    methods = Magick::Image.instance_methods(false).sort
-    methods -= %i[__display__ destroy! destroyed? inspect cur_image marshal_load]
+  describe '#destroy' do
+    it 'works' do
+      methods = Magick::Image.instance_methods(false).sort
+      methods -= %i[__display__ destroy! destroyed? inspect cur_image marshal_load]
 
-    expect(@img.destroyed?).to eq(false)
-    @img.destroy!
-    expect(@img.destroyed?).to eq(true)
-    expect { @img.check_destroyed }.to raise_error(Magick::DestroyedImageError)
+      expect(@img.destroyed?).to eq(false)
+      @img.destroy!
+      expect(@img.destroyed?).to eq(true)
+      expect { @img.check_destroyed }.to raise_error(Magick::DestroyedImageError)
 
-    methods.each do |method|
-      arity = @img.method(method).arity
-      method = method.to_s
+      methods.each do |method|
+        arity = @img.method(method).arity
+        method = method.to_s
 
-      if method == '[]='
-        expect { @img['foo'] = 1 }.to raise_error(Magick::DestroyedImageError)
-      elsif method == 'difference'
-        other = Magick::Image.new(20, 20)
-        expect { @img.difference(other) }.to raise_error(Magick::DestroyedImageError)
-      elsif method == 'channel_entropy' && IM_VERSION < Gem::Version.new('6.9')
-        expect { @img.channel_entropy }.to raise_error(NotImplementedError)
-      elsif method == 'get_iptc_dataset'
-        expect { @img.get_iptc_dataset('x') }.to raise_error(Magick::DestroyedImageError)
-      elsif method == 'profile!'
-        expect { @img.profile!('x', 'y') }.to raise_error(Magick::DestroyedImageError)
-      elsif /=\Z/.match(method)
-        expect { @img.send(method, 1) }.to raise_error(Magick::DestroyedImageError)
-      elsif arity.zero?
-        expect { @img.send(method) }.to raise_error(Magick::DestroyedImageError)
-      elsif arity < 0
-        args = (1..-arity).to_a
-        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
-      elsif arity > 0
-        args = (1..arity).to_a
-        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
-      else
-        # Don't know how to test!
-        flunk("don't know how to test method #{method}")
+        if method == '[]='
+          expect { @img['foo'] = 1 }.to raise_error(Magick::DestroyedImageError)
+        elsif method == 'difference'
+          other = Magick::Image.new(20, 20)
+          expect { @img.difference(other) }.to raise_error(Magick::DestroyedImageError)
+        elsif method == 'channel_entropy' && IM_VERSION < Gem::Version.new('6.9')
+          expect { @img.channel_entropy }.to raise_error(NotImplementedError)
+        elsif method == 'get_iptc_dataset'
+          expect { @img.get_iptc_dataset('x') }.to raise_error(Magick::DestroyedImageError)
+        elsif method == 'profile!'
+          expect { @img.profile!('x', 'y') }.to raise_error(Magick::DestroyedImageError)
+        elsif /=\Z/.match(method)
+          expect { @img.send(method, 1) }.to raise_error(Magick::DestroyedImageError)
+        elsif arity.zero?
+          expect { @img.send(method) }.to raise_error(Magick::DestroyedImageError)
+        elsif arity < 0
+          args = (1..-arity).to_a
+          expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
+        elsif arity > 0
+          args = (1..arity).to_a
+          expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
+        else
+          # Don't know how to test!
+          flunk("don't know how to test method #{method}")
+        end
       end
     end
   end
 
   # ensure destroy! works
-  def test_destroy2
-    images = {}
-    GC.disable
+  describe '#destroy2' do
+    it 'works' do
+      images = {}
+      GC.disable
 
-    Magick.trace_proc = proc do |which, id, addr, method|
-      m = id.split(/ /)
-      name = File.basename m[0]
+      Magick.trace_proc = proc do |which, id, addr, method|
+        m = id.split(/ /)
+        name = File.basename m[0]
 
-      expect(%i[c d]).to include(which)
-      expect(method).to eq(:destroy!) if which == :d
+        expect(%i[c d]).to include(which)
+        expect(method).to eq(:destroy!) if which == :d
 
-      if which == :c
-        expect(images).not_to have_key(addr)
-        images[addr] = name
-      else
-        expect(images).to have_key(addr)
-        expect(images[addr]).to eq(name)
+        if which == :c
+          expect(images).not_to have_key(addr)
+          images[addr] = name
+        else
+          expect(images).to have_key(addr)
+          expect(images[addr]).to eq(name)
+        end
       end
+
+      unmapped = Magick::ImageList.new(IMAGES_DIR + '/Hot_Air_Balloons.jpg', IMAGES_DIR + '/Violin.jpg', IMAGES_DIR + '/Polynesia.jpg')
+      map = Magick::ImageList.new 'netscape:'
+      mapped = unmapped.remap map
+      unmapped.each(&:destroy!)
+      map.destroy!
+      mapped.each(&:destroy!)
     end
 
-    unmapped = Magick::ImageList.new(IMAGES_DIR + '/Hot_Air_Balloons.jpg', IMAGES_DIR + '/Violin.jpg', IMAGES_DIR + '/Polynesia.jpg')
-    map = Magick::ImageList.new 'netscape:'
-    mapped = unmapped.remap map
-    unmapped.each(&:destroy!)
-    map.destroy!
-    mapped.each(&:destroy!)
-  ensure
-    GC.enable
-    Magick.trace_proc = nil
+    after do
+      GC.enable
+      Magick.trace_proc = nil
+    end
   end
 
-  def test_difference
-    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-    expect do
-      res = img1.difference(img2)
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(3)
-      expect(res[0]).to be_instance_of(Float)
-      expect(res[1]).to be_instance_of(Float)
-      expect(res[2]).to be_instance_of(Float)
-    end.not_to raise_error
+  describe '#difference' do
+    it 'works' do
+      img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      expect do
+        res = img1.difference(img2)
+        expect(res).to be_instance_of(Array)
+        expect(res.length).to eq(3)
+        expect(res[0]).to be_instance_of(Float)
+        expect(res[1]).to be_instance_of(Float)
+        expect(res[2]).to be_instance_of(Float)
+      end.not_to raise_error
 
-    expect { img1.difference(2) }.to raise_error(NoMethodError)
-    img2.destroy!
-    expect { img1.difference(img2) }.to raise_error(Magick::DestroyedImageError)
+      expect { img1.difference(2) }.to raise_error(NoMethodError)
+      img2.destroy!
+      expect { img1.difference(img2) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test_displace
-    @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    expect { @img.displace(@img2, 25) }.not_to raise_error
-    res = @img.displace(@img2, 25)
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect { @img.displace(@img2, 25, 25) }.not_to raise_error
-    expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
-    expect { @img.displace(@img2, 25, 25, 10, 10) }.not_to raise_error
-    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity) }.not_to raise_error
-    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }.not_to raise_error
-    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }.not_to raise_error
-    expect { @img.displace }.to raise_error(ArgumentError)
-    expect { @img.displace(@img2, 'x') }.to raise_error(TypeError)
-    expect { @img.displace(@img2, 25, []) }.to raise_error(TypeError)
-    expect { @img.displace(@img2, 25, 25, 'x') }.to raise_error(TypeError)
-    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
-    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
+  describe '#displace' do
+    it 'works' do
+      @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
+      expect { @img.displace(@img2, 25) }.not_to raise_error
+      res = @img.displace(@img2, 25)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+      expect { @img.displace(@img2, 25, 25) }.not_to raise_error
+      expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
+      expect { @img.displace(@img2, 25, 25, 10, 10) }.not_to raise_error
+      expect { @img.displace(@img2, 25, 25, Magick::CenterGravity) }.not_to raise_error
+      expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }.not_to raise_error
+      expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }.not_to raise_error
+      expect { @img.displace }.to raise_error(ArgumentError)
+      expect { @img.displace(@img2, 'x') }.to raise_error(TypeError)
+      expect { @img.displace(@img2, 25, []) }.to raise_error(TypeError)
+      expect { @img.displace(@img2, 25, 25, 'x') }.to raise_error(TypeError)
+      expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
+      expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
 
-    @img2.destroy!
-    expect { @img.displace(@img2, 25, 25) }.to raise_error(Magick::DestroyedImageError)
+      @img2.destroy!
+      expect { @img.displace(@img2, 25, 25) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test_dissolve
-    src = Magick::Image.new(@img.columns, @img.rows)
-    src_list = Magick::ImageList.new
-    src_list << src.copy
-    expect { @img.dissolve(src, 0.50) }.not_to raise_error
-    expect { @img.dissolve(src_list, 0.50) }.not_to raise_error
-    expect { @img.dissolve(src, '50%') }.not_to raise_error
-    expect { @img.dissolve(src, 0.50, 0.10) }.not_to raise_error
-    expect { @img.dissolve(src, 0.50, 0.10, 10) }.not_to raise_error
-    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity) }.not_to raise_error
-    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10) }.not_to raise_error
-    expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
+  describe '#dissolve' do
+    it 'works' do
+      src = Magick::Image.new(@img.columns, @img.rows)
+      src_list = Magick::ImageList.new
+      src_list << src.copy
+      expect { @img.dissolve(src, 0.50) }.not_to raise_error
+      expect { @img.dissolve(src_list, 0.50) }.not_to raise_error
+      expect { @img.dissolve(src, '50%') }.not_to raise_error
+      expect { @img.dissolve(src, 0.50, 0.10) }.not_to raise_error
+      expect { @img.dissolve(src, 0.50, 0.10, 10) }.not_to raise_error
+      expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity) }.not_to raise_error
+      expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10) }.not_to raise_error
+      expect { @img.dissolve(src, 0.50, 0.10, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
 
-    expect { @img.dissolve }.to raise_error(ArgumentError)
-    expect { @img.dissolve(src, 'x') }.to raise_error(ArgumentError)
-    expect { @img.dissolve(src, 0.50, 'x') }.to raise_error(ArgumentError)
-    expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
-    expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
+      expect { @img.dissolve }.to raise_error(ArgumentError)
+      expect { @img.dissolve(src, 'x') }.to raise_error(ArgumentError)
+      expect { @img.dissolve(src, 0.50, 'x') }.to raise_error(ArgumentError)
+      expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
+      expect { @img.dissolve(src, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
 
-    src.destroy!
-    expect { @img.dissolve(src, 0.50) }.to raise_error(Magick::DestroyedImageError)
+      src.destroy!
+      expect { @img.dissolve(src, 0.50) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test_distort
-    @img = Magick::Image.new(200, 200)
-    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 35]) }.not_to raise_error
-    expect { @img.distort(Magick::AffineProjectionDistortion, [1, 0, 0, 1, 0, 0]) }.not_to raise_error
-    expect { @img.distort(Magick::BilinearDistortion, [7, 40, 4, 30, 4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
-    expect { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
-    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }.not_to raise_error
-    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }.not_to raise_error
-    expect { @img.distort }.to raise_error(ArgumentError)
-    expect { @img.distort(Magick::AffineDistortion) }.to raise_error(ArgumentError)
-    expect { @img.distort(1, [1]) }.to raise_error(TypeError)
-    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 'x']) }.to raise_error(TypeError)
+  describe '#distort' do
+    it 'works' do
+      @img = Magick::Image.new(200, 200)
+      expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 35]) }.not_to raise_error
+      expect { @img.distort(Magick::AffineProjectionDistortion, [1, 0, 0, 1, 0, 0]) }.not_to raise_error
+      expect { @img.distort(Magick::BilinearDistortion, [7, 40, 4, 30, 4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+      expect { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+      expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }.not_to raise_error
+      expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }.not_to raise_error
+      expect { @img.distort }.to raise_error(ArgumentError)
+      expect { @img.distort(Magick::AffineDistortion) }.to raise_error(ArgumentError)
+      expect { @img.distort(1, [1]) }.to raise_error(TypeError)
+      expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 'x']) }.to raise_error(TypeError)
+    end
   end
 
-  def test_distortion_channel
-    expect do
-      metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
-      expect(metric).to be_instance_of(Float)
-      expect(metric).to eq(0.0)
-    end.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }.not_to raise_error
-    expect { @img.distortion_channel(@img, 2) }.to raise_error(TypeError)
-    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }.to raise_error(TypeError)
-    expect { @img.distortion_channel }.to raise_error(ArgumentError)
-    expect { @img.distortion_channel(@img) }.to raise_error(ArgumentError)
+  describe '#distortion_channel' do
+    it 'works' do
+      expect do
+        metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
+        expect(metric).to be_instance_of(Float)
+        expect(metric).to eq(0.0)
+      end.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }.not_to raise_error
+      expect { @img.distortion_channel(@img, 2) }.to raise_error(TypeError)
+      expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }.to raise_error(TypeError)
+      expect { @img.distortion_channel }.to raise_error(ArgumentError)
+      expect { @img.distortion_channel(@img) }.to raise_error(ArgumentError)
 
-    img = Magick::Image.new(20, 20)
-    img.destroy!
-    expect { @img.distortion_channel(img, Magick::MeanSquaredErrorMetric) }.to raise_error(Magick::DestroyedImageError)
+      img = Magick::Image.new(20, 20)
+      img.destroy!
+      expect { @img.distortion_channel(img, Magick::MeanSquaredErrorMetric) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test__dump
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect(img._dump(10)).to be_instance_of(String)
+  describe '#_dump' do
+    it 'works' do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect(img._dump(10)).to be_instance_of(String)
+    end
   end
 
-  def test__load
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    res = img._dump(10)
+  describe '#_load' do
+    it 'works' do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      res = img._dump(10)
 
-    expect(Magick::Image._load(res)).to be_instance_of(Magick::Image)
+      expect(Magick::Image._load(res)).to be_instance_of(Magick::Image)
+    end
   end
 
-  def test_dup
-    expect do
+  describe '#dup' do
+    it 'works' do
+      expect do
+        ditto = @img.dup
+        expect(ditto).to eq(@img)
+      end.not_to raise_error
       ditto = @img.dup
-      expect(ditto).to eq(@img)
-    end.not_to raise_error
-    ditto = @img.dup
-    expect(ditto.tainted?).to eq(@img.tainted?)
-    @img.taint
-    ditto = @img.dup
-    expect(ditto.tainted?).to eq(@img.tainted?)
+      expect(ditto.tainted?).to eq(@img.tainted?)
+      @img.taint
+      ditto = @img.dup
+      expect(ditto.tainted?).to eq(@img.tainted?)
+    end
   end
 
-  def test_each_profile
-    expect(@img.each_profile {}).to be(nil)
+  describe '#each_profile' do
+    it 'works' do
+      expect(@img.each_profile {}).to be(nil)
 
-    @img.iptc_profile = 'test profile'
-    expect do
-      @img.each_profile do |name, value|
-        expect(name).to eq('iptc')
-        expect(value).to eq('test profile')
-      end
-    end.not_to raise_error
+      @img.iptc_profile = 'test profile'
+      expect do
+        @img.each_profile do |name, value|
+          expect(name).to eq('iptc')
+          expect(value).to eq('test profile')
+        end
+      end.not_to raise_error
+    end
   end
 
-  def test_edge
-    expect do
-      res = @img.edge
+  describe '#edge' do
+    it 'works' do
+      expect do
+        res = @img.edge
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.edge(2.0) }.not_to raise_error
+      expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
+      expect { @img.edge('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#emboss' do
+    it 'works' do
+      expect do
+        res = @img.emboss
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.emboss(1.0) }.not_to raise_error
+      expect { @img.emboss(1.0, 0.5) }.not_to raise_error
+      expect { @img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)
+      expect { @img.emboss(1.0, 'x') }.to raise_error(TypeError)
+      expect { @img.emboss('x', 1.0) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#enhance' do
+    it 'works' do
+      expect do
+        res = @img.enhance
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#equalize' do
+    it 'works' do
+      expect do
+        res = @img.equalize
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#equalize_channel' do
+    it 'works' do
+      expect do
+        res = @img.equalize_channel
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.equalize_channel }.not_to raise_error
+      expect { @img.equalize_channel(Magick::RedChannel) }.not_to raise_error
+      expect { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.equalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#erase!' do
+    it 'works' do
+      expect do
+        res = @img.erase!
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#excerpt' do
+    it 'works' do
+      res = nil
+      img = Magick::Image.new(200, 200)
+      expect { res = @img.excerpt(20, 20, 50, 100) }.not_to raise_error
+      expect(res).not_to be(img)
+      expect(res.columns).to eq(50)
+      expect(res.rows).to eq(100)
+
+      expect { img.excerpt!(20, 20, 50, 100) }.not_to raise_error
+      expect(img.columns).to eq(50)
+      expect(img.rows).to eq(100)
+    end
+  end
+
+  describe '#export_pixels' do
+    it 'works' do
+      expect do
+        res = @img.export_pixels
+        expect(res).to be_instance_of(Array)
+        expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
+        res.each do |p|
+          expect(p).to be_kind_of(Integer)
+        end
+      end.not_to raise_error
+      expect { @img.export_pixels(0) }.not_to raise_error
+      expect { @img.export_pixels(0, 0) }.not_to raise_error
+      expect { @img.export_pixels(0, 0, 10) }.not_to raise_error
+      expect { @img.export_pixels(0, 0, 10, 10) }.not_to raise_error
+      expect do
+        res = @img.export_pixels(0, 0, 10, 10, 'RGBA')
+        expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels(0, 0, 10, 10, 'I')
+        expect(res.length).to eq(10 * 10 * 'I'.length)
+      end.not_to raise_error
+
+      # too many arguments
+      expect { @img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#export_pixels_to_str' do
+    it 'works' do
+      expect do
+        res = @img.export_pixels_to_str
+        expect(res).to be_instance_of(String)
+        expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
+      end.not_to raise_error
+      expect { @img.export_pixels_to_str(0) }.not_to raise_error
+      expect { @img.export_pixels_to_str(0, 0) }.not_to raise_error
+      expect { @img.export_pixels_to_str(0, 0, 10) }.not_to raise_error
+      expect { @img.export_pixels_to_str(0, 0, 10, 10) }.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
+        expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I')
+        expect(res.length).to eq(10 * 10 * 'I'.length)
+      end.not_to raise_error
+
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
+        expect(res.length).to eq(10 * 10 * 1)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
+        expect(res.length).to eq(10 * 10 * 2)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
+        expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
+        expect(res.length).to eq(10 * 10 * 4)
+      end.not_to raise_error
+      expect do
+        res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
+        expect(res.length).to eq(10 * 10 * 8)
+      end.not_to raise_error
+      expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }.not_to raise_error
+
+      # too many arguments
+      expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }.to raise_error(ArgumentError)
+      # last arg s/b StorageType
+      expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#extent' do
+    it 'works' do
+      expect { @img.extent(40, 40) }.not_to raise_error
+      res = @img.extent(40, 40)
       expect(res).to be_instance_of(Magick::Image)
       expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.edge(2.0) }.not_to raise_error
-    expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
-    expect { @img.edge('x') }.to raise_error(TypeError)
+      expect(res.columns).to eq(40)
+      expect(res.rows).to eq(40)
+      expect { @img.extent(40, 40, 5) }.not_to raise_error
+      expect { @img.extent(40, 40, 5, 5) }.not_to raise_error
+      expect { @img.extent(-40) }.to raise_error(ArgumentError)
+      expect { @img.extent(-40, 40) }.to raise_error(ArgumentError)
+      expect { @img.extent(40, -40) }.to raise_error(ArgumentError)
+      expect { @img.extent(40, 40, 5, 5, 0) }.to raise_error(ArgumentError)
+      expect { @img.extent(0, 0, 5, 5) }.to raise_error(ArgumentError)
+      expect { @img.extent('x', 40) }.to raise_error(TypeError)
+      expect { @img.extent(40, 'x') }.to raise_error(TypeError)
+      expect { @img.extent(40, 40, 'x') }.to raise_error(TypeError)
+      expect { @img.extent(40, 40, 5, 'x') }.to raise_error(TypeError)
+    end
   end
 
-  def test_emboss
-    expect do
-      res = @img.emboss
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.emboss(1.0) }.not_to raise_error
-    expect { @img.emboss(1.0, 0.5) }.not_to raise_error
-    expect { @img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)
-    expect { @img.emboss(1.0, 'x') }.to raise_error(TypeError)
-    expect { @img.emboss('x', 1.0) }.to raise_error(TypeError)
+  describe '#find_similar_region' do
+    it 'works' do
+      girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      region = girl.crop(10, 10, 50, 50)
+      expect do
+        x, y = girl.find_similar_region(region)
+        expect(x).not_to be(nil)
+        expect(y).not_to be(nil)
+        expect(x).to eq(10)
+        expect(y).to eq(10)
+      end.not_to raise_error
+      expect do
+        x, y = girl.find_similar_region(region, 0)
+        expect(x).to eq(10)
+        expect(y).to eq(10)
+      end.not_to raise_error
+      expect do
+        x, y = girl.find_similar_region(region, 0, 0)
+        expect(x).to eq(10)
+        expect(y).to eq(10)
+      end.not_to raise_error
+
+      list = Magick::ImageList.new
+      list << region
+      expect do
+        x, y = girl.find_similar_region(list, 0, 0)
+        expect(x).to eq(10)
+        expect(y).to eq(10)
+      end.not_to raise_error
+
+      x = girl.find_similar_region(@img)
+      expect(x).to be(nil)
+
+      expect { girl.find_similar_region(region, 10, 10, 10) }.to raise_error(ArgumentError)
+      expect { girl.find_similar_region(region, 10, 'x') }.to raise_error(TypeError)
+      expect { girl.find_similar_region(region, 'x') }.to raise_error(TypeError)
+
+      region.destroy!
+      expect { girl.find_similar_region(region) }.to raise_error(Magick::DestroyedImageError)
+    end
   end
 
-  def test_enhance
-    expect do
-      res = @img.enhance
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#flip' do
+    it 'works' do
+      expect do
+        res = @img.flip
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
   end
 
-  def test_equalize
-    expect do
-      res = @img.equalize
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#flip!' do
+    it 'works' do
+      expect do
+        res = @img.flip!
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
   end
 
-  def test_equalize_channel
-    expect do
-      res = @img.equalize_channel
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.equalize_channel }.not_to raise_error
-    expect { @img.equalize_channel(Magick::RedChannel) }.not_to raise_error
-    expect { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.equalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
+  describe '#flop' do
+    it 'works' do
+      expect do
+        res = @img.flop
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
   end
 
-  def test_erase!
-    expect do
-      res = @img.erase!
-      expect(res).to be(@img)
-    end.not_to raise_error
+  describe '#flop!' do
+    it 'works' do
+      expect do
+        res = @img.flop!
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
   end
 
-  def test_excerpt
-    res = nil
-    img = Magick::Image.new(200, 200)
-    expect { res = @img.excerpt(20, 20, 50, 100) }.not_to raise_error
-    expect(res).not_to be(img)
-    expect(res.columns).to eq(50)
-    expect(res.rows).to eq(100)
-
-    expect { img.excerpt!(20, 20, 50, 100) }.not_to raise_error
-    expect(img.columns).to eq(50)
-    expect(img.rows).to eq(100)
+  describe '#frame' do
+    it 'works' do
+      expect do
+        res = @img.frame
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.frame(50) }.not_to raise_error
+      expect { @img.frame(50, 50) }.not_to raise_error
+      expect { @img.frame(50, 50, 25) }.not_to raise_error
+      expect { @img.frame(50, 50, 25, 25) }.not_to raise_error
+      expect { @img.frame(50, 50, 25, 25, 6) }.not_to raise_error
+      expect { @img.frame(50, 50, 25, 25, 6, 6) }.not_to raise_error
+      expect { @img.frame(50, 50, 25, 25, 6, 6, 'red') }.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.frame(50, 50, 25, 25, 6, 6, red) }.not_to raise_error
+      expect { @img.frame(50, 50, 25, 25, 6, 6, 2) }.to raise_error(TypeError)
+      expect { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_export_pixels
-    expect do
-      res = @img.export_pixels
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
-      res.each do |p|
-        expect(p).to be_kind_of(Integer)
-      end
-    end.not_to raise_error
-    expect { @img.export_pixels(0) }.not_to raise_error
-    expect { @img.export_pixels(0, 0) }.not_to raise_error
-    expect { @img.export_pixels(0, 0, 10) }.not_to raise_error
-    expect { @img.export_pixels(0, 0, 10, 10) }.not_to raise_error
-    expect do
-      res = @img.export_pixels(0, 0, 10, 10, 'RGBA')
-      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels(0, 0, 10, 10, 'I')
-      expect(res.length).to eq(10 * 10 * 'I'.length)
-    end.not_to raise_error
-
-    # too many arguments
-    expect { @img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
+  describe '#fx' do
+    it 'works' do
+      expect { @img.fx('1/2') }.not_to raise_error
+      expect { @img.fx('1/2', Magick::BlueChannel) }.not_to raise_error
+      expect { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }.not_to raise_error
+      expect { @img.fx }.to raise_error(ArgumentError)
+      expect { @img.fx(Magick::BlueChannel) }.to raise_error(ArgumentError)
+      expect { @img.fx(1) }.to raise_error(TypeError)
+      expect { @img.fx('1/2', 1) }.to raise_error(TypeError)
+    end
   end
 
-  def test_export_pixels_to_str
-    expect do
-      res = @img.export_pixels_to_str
-      expect(res).to be_instance_of(String)
-      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
-    end.not_to raise_error
-    expect { @img.export_pixels_to_str(0) }.not_to raise_error
-    expect { @img.export_pixels_to_str(0, 0) }.not_to raise_error
-    expect { @img.export_pixels_to_str(0, 0, 10) }.not_to raise_error
-    expect { @img.export_pixels_to_str(0, 0, 10, 10) }.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
-      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I')
-      expect(res.length).to eq(10 * 10 * 'I'.length)
-    end.not_to raise_error
-
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
-      expect(res.length).to eq(10 * 10 * 1)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
-      expect(res.length).to eq(10 * 10 * 2)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
-      expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
-      expect(res.length).to eq(10 * 10 * 4)
-    end.not_to raise_error
-    expect do
-      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
-      expect(res.length).to eq(10 * 10 * 8)
-    end.not_to raise_error
-    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }.not_to raise_error
-
-    # too many arguments
-    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }.to raise_error(ArgumentError)
-    # last arg s/b StorageType
-    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }.to raise_error(TypeError)
+  describe '#gamma_channel' do
+    it 'works' do
+      expect do
+        res = @img.gamma_channel(0.8)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.gamma_channel }.to raise_error(ArgumentError)
+      expect { @img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
+      expect { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.gamma_channel(0.8, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
   end
 
-  def test_extent
-    expect { @img.extent(40, 40) }.not_to raise_error
-    res = @img.extent(40, 40)
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect(res.columns).to eq(40)
-    expect(res.rows).to eq(40)
-    expect { @img.extent(40, 40, 5) }.not_to raise_error
-    expect { @img.extent(40, 40, 5, 5) }.not_to raise_error
-    expect { @img.extent(-40) }.to raise_error(ArgumentError)
-    expect { @img.extent(-40, 40) }.to raise_error(ArgumentError)
-    expect { @img.extent(40, -40) }.to raise_error(ArgumentError)
-    expect { @img.extent(40, 40, 5, 5, 0) }.to raise_error(ArgumentError)
-    expect { @img.extent(0, 0, 5, 5) }.to raise_error(ArgumentError)
-    expect { @img.extent('x', 40) }.to raise_error(TypeError)
-    expect { @img.extent(40, 'x') }.to raise_error(TypeError)
-    expect { @img.extent(40, 40, 'x') }.to raise_error(TypeError)
-    expect { @img.extent(40, 40, 5, 'x') }.to raise_error(TypeError)
+  describe '#function_channel' do
+    it 'works' do
+      img = Magick::Image.read('gradient:') { self.size = '20x600' }
+      img = img.first
+      img.rotate!(90)
+      expect { img.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error
+      expect { img.function_channel Magick::PolynomialFunction, 4, -1.5 }.not_to raise_error
+      expect { img.function_channel Magick::PolynomialFunction, 4, -4, 1 }.not_to raise_error
+      expect { img.function_channel Magick::PolynomialFunction, -25, 53, -36, 8.3, 0.2 }.not_to raise_error
+
+      expect { img.function_channel Magick::SinusoidFunction, 1 }.not_to raise_error
+      expect { img.function_channel Magick::SinusoidFunction, 1, 90 }.not_to raise_error
+      expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75 }.not_to raise_error
+
+      expect { img.function_channel Magick::ArcsinFunction, 1 }.not_to raise_error
+      expect { img.function_channel Magick::ArcsinFunction, 0.5 }.not_to raise_error
+      expect { img.function_channel Magick::ArcsinFunction, 0.4, 0.7 }.not_to raise_error
+      expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5 }.not_to raise_error
+
+      expect { img.function_channel Magick::ArctanFunction, 1 }.not_to raise_error
+      expect { img.function_channel Magick::ArctanFunction, 10, 0.7 }.not_to raise_error
+      expect { img.function_channel Magick::ArctanFunction, 5, 0.7, 1.2 }.not_to raise_error
+      expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75 }.not_to raise_error
+
+      # with channel args
+      expect { img.function_channel Magick::PolynomialFunction, 0.33, Magick::RedChannel }.not_to raise_error
+      expect { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+
+      # invalid args
+      expect { img.function_channel }.to raise_error(ArgumentError)
+      expect { img.function_channel 1 }.to raise_error(TypeError)
+      expect { img.function_channel Magick::PolynomialFunction }.to raise_error(ArgumentError)
+      expect { img.function_channel Magick::PolynomialFunction, [] }.to raise_error(TypeError)
+      expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75, 0.1 }.to raise_error(ArgumentError)
+      expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5, 0.1 }.to raise_error(ArgumentError)
+      expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75, 0.1 }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_find_similar_region
-    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    region = girl.crop(10, 10, 50, 50)
-    expect do
-      x, y = girl.find_similar_region(region)
-      expect(x).not_to be(nil)
-      expect(y).not_to be(nil)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-    expect do
-      x, y = girl.find_similar_region(region, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-    expect do
-      x, y = girl.find_similar_region(region, 0, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-
-    list = Magick::ImageList.new
-    list << region
-    expect do
-      x, y = girl.find_similar_region(list, 0, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-
-    x = girl.find_similar_region(@img)
-    expect(x).to be(nil)
-
-    expect { girl.find_similar_region(region, 10, 10, 10) }.to raise_error(ArgumentError)
-    expect { girl.find_similar_region(region, 10, 'x') }.to raise_error(TypeError)
-    expect { girl.find_similar_region(region, 'x') }.to raise_error(TypeError)
-
-    region.destroy!
-    expect { girl.find_similar_region(region) }.to raise_error(Magick::DestroyedImageError)
+  describe '#gramma_correct' do
+    it 'works' do
+      expect { @img.gamma_correct }.to raise_error(ArgumentError)
+      expect do
+        res = @img.gamma_correct(0.8)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
+      expect { @img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
+      expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }.not_to raise_error
+      # too many arguments
+      expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_flip
-    expect do
-      res = @img.flip
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#gaussian_blur' do
+    it 'works' do
+      expect do
+        res = @img.gaussian_blur
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.gaussian_blur(0.0) }.not_to raise_error
+      expect { @img.gaussian_blur(0.0, 3.0) }.not_to raise_error
+      # sigma must be != 0.0
+      expect { @img.gaussian_blur(1.0, 0.0) }.to raise_error(ArgumentError)
+      expect { @img.gaussian_blur(1.0, 3.0, 2) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_flip!
-    expect do
-      res = @img.flip!
-      expect(res).to be(@img)
-    end.not_to raise_error
+  describe '#gaussian_blur_channel' do
+    it 'works' do
+      expect do
+        res = @img.gaussian_blur_channel
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
+      expect { @img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
+      expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }.not_to raise_error
+      expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
   end
 
-  def test_flop
-    expect do
-      res = @img.flop
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#get_exif_by_entry' do
+    it 'works' do
+      expect do
+        res = @img.get_exif_by_entry
+        expect(res).to be_instance_of(Array)
+      end.not_to raise_error
+    end
   end
 
-  def test_flop!
-    expect do
-      res = @img.flop!
-      expect(res).to be(@img)
-    end.not_to raise_error
+  describe '#get_exif_by_number' do
+    it 'works' do
+      expect do
+        res = @img.get_exif_by_number
+        expect(res).to be_instance_of(Hash)
+      end.not_to raise_error
+    end
   end
 
-  def test_frame
-    expect do
-      res = @img.frame
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.frame(50) }.not_to raise_error
-    expect { @img.frame(50, 50) }.not_to raise_error
-    expect { @img.frame(50, 50, 25) }.not_to raise_error
-    expect { @img.frame(50, 50, 25, 25) }.not_to raise_error
-    expect { @img.frame(50, 50, 25, 25, 6) }.not_to raise_error
-    expect { @img.frame(50, 50, 25, 25, 6, 6) }.not_to raise_error
-    expect { @img.frame(50, 50, 25, 25, 6, 6, 'red') }.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.frame(50, 50, 25, 25, 6, 6, red) }.not_to raise_error
-    expect { @img.frame(50, 50, 25, 25, 6, 6, 2) }.to raise_error(TypeError)
-    expect { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }.to raise_error(ArgumentError)
+  describe '#get_pixels' do
+    it 'works' do
+      expect do
+        pixels = @img.get_pixels(0, 0, @img.columns, 1)
+        expect(pixels).to be_instance_of(Array)
+        expect(pixels.length).to eq(@img.columns)
+        expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
+      end.not_to raise_error
+      expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
+      expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
+      expect { @img.get_pixels(0,  0, @img.columns + 1, 1) }.to raise_error(RangeError)
+      expect { @img.get_pixels(0,  0, @img.columns, @img.rows + 1) }.to raise_error(RangeError)
+    end
   end
 
-  def test_fx
-    expect { @img.fx('1/2') }.not_to raise_error
-    expect { @img.fx('1/2', Magick::BlueChannel) }.not_to raise_error
-    expect { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }.not_to raise_error
-    expect { @img.fx }.to raise_error(ArgumentError)
-    expect { @img.fx(Magick::BlueChannel) }.to raise_error(ArgumentError)
-    expect { @img.fx(1) }.to raise_error(TypeError)
-    expect { @img.fx('1/2', 1) }.to raise_error(TypeError)
+  describe '#gray?' do
+    it 'works' do
+      gray = Magick::Image.new(20, 20) { self.background_color = 'gray50' }
+      expect(gray.gray?).to be(true)
+      red = Magick::Image.new(20, 20) { self.background_color = 'red' }
+      expect(red.gray?).to be(false)
+    end
   end
 
-  def test_gamma_channel
-    expect do
-      res = @img.gamma_channel(0.8)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.gamma_channel }.to raise_error(ArgumentError)
-    expect { @img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
-    expect { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.gamma_channel(0.8, Magick::RedChannel, 2) }.to raise_error(TypeError)
+  describe '#histogram?' do
+    it 'works' do
+      expect { @img.histogram? }.not_to raise_error
+      expect(@img.histogram?).to be(true)
+    end
   end
 
-  def test_function_channel
-    img = Magick::Image.read('gradient:') { self.size = '20x600' }
-    img = img.first
-    img.rotate!(90)
-    expect { img.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error
-    expect { img.function_channel Magick::PolynomialFunction, 4, -1.5 }.not_to raise_error
-    expect { img.function_channel Magick::PolynomialFunction, 4, -4, 1 }.not_to raise_error
-    expect { img.function_channel Magick::PolynomialFunction, -25, 53, -36, 8.3, 0.2 }.not_to raise_error
-
-    expect { img.function_channel Magick::SinusoidFunction, 1 }.not_to raise_error
-    expect { img.function_channel Magick::SinusoidFunction, 1, 90 }.not_to raise_error
-    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75 }.not_to raise_error
-
-    expect { img.function_channel Magick::ArcsinFunction, 1 }.not_to raise_error
-    expect { img.function_channel Magick::ArcsinFunction, 0.5 }.not_to raise_error
-    expect { img.function_channel Magick::ArcsinFunction, 0.4, 0.7 }.not_to raise_error
-    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5 }.not_to raise_error
-
-    expect { img.function_channel Magick::ArctanFunction, 1 }.not_to raise_error
-    expect { img.function_channel Magick::ArctanFunction, 10, 0.7 }.not_to raise_error
-    expect { img.function_channel Magick::ArctanFunction, 5, 0.7, 1.2 }.not_to raise_error
-    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75 }.not_to raise_error
-
-    # with channel args
-    expect { img.function_channel Magick::PolynomialFunction, 0.33, Magick::RedChannel }.not_to raise_error
-    expect { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
-
-    # invalid args
-    expect { img.function_channel }.to raise_error(ArgumentError)
-    expect { img.function_channel 1 }.to raise_error(TypeError)
-    expect { img.function_channel Magick::PolynomialFunction }.to raise_error(ArgumentError)
-    expect { img.function_channel Magick::PolynomialFunction, [] }.to raise_error(TypeError)
-    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75, 0.1 }.to raise_error(ArgumentError)
-    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5, 0.1 }.to raise_error(ArgumentError)
-    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75, 0.1 }.to raise_error(ArgumentError)
+  describe '#implode' do
+    it 'works' do
+      expect do
+        res = @img.implode(0.5)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_gramma_correct
-    expect { @img.gamma_correct }.to raise_error(ArgumentError)
-    expect do
-      res = @img.gamma_correct(0.8)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
-    expect { @img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
-    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }.not_to raise_error
-    # too many arguments
-    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }.to raise_error(ArgumentError)
+  describe '#import_pixels' do
+    it 'works' do
+      pixels = @img.export_pixels(0, 0, @img.columns, 1, 'RGB')
+      expect do
+        res = @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      expect { @img.import_pixels }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0, @img.columns) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0, @img.columns, 1) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB') }.to raise_error(ArgumentError)
+      expect { @img.import_pixels('x', 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+      expect { @img.import_pixels(0, 'x', @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+      expect { @img.import_pixels(0, 0, 'x', 1, 'RGB', pixels) }.to raise_error(TypeError)
+      expect { @img.import_pixels(0, 0, @img.columns, 'x', 'RGB', pixels) }.to raise_error(TypeError)
+      expect { @img.import_pixels(0, 0, @img.columns, 1, [2], pixels) }.to raise_error(TypeError)
+      expect { @img.import_pixels(-1, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, -1, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0, -1, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+      expect { @img.import_pixels(0, 0, @img.columns, -1, 'RGB', pixels) }.to raise_error(ArgumentError)
+
+      # pixel array is too small
+      expect { @img.import_pixels(0, 0, @img.columns, 2, 'RGB', pixels) }.to raise_error(ArgumentError)
+      # pixel array doesn't contain a multiple of the map length
+      pixels.shift
+      expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_gaussian_blur
-    expect do
-      res = @img.gaussian_blur
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.gaussian_blur(0.0) }.not_to raise_error
-    expect { @img.gaussian_blur(0.0, 3.0) }.not_to raise_error
-    # sigma must be != 0.0
-    expect { @img.gaussian_blur(1.0, 0.0) }.to raise_error(ArgumentError)
-    expect { @img.gaussian_blur(1.0, 3.0, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_gaussian_blur_channel
-    expect do
-      res = @img.gaussian_blur_channel
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
-    expect { @img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
-    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }.not_to raise_error
-    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
-  end
-
-  def test_get_exif_by_entry
-    expect do
-      res = @img.get_exif_by_entry
-      expect(res).to be_instance_of(Array)
-    end.not_to raise_error
-  end
-
-  def test_get_exif_by_number
-    expect do
-      res = @img.get_exif_by_number
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
-  end
-
-  def test_get_pixels
-    expect do
-      pixels = @img.get_pixels(0, 0, @img.columns, 1)
-      expect(pixels).to be_instance_of(Array)
-      expect(pixels.length).to eq(@img.columns)
-      expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
-    end.not_to raise_error
-    expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
-    expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
-    expect { @img.get_pixels(0,  0, @img.columns + 1, 1) }.to raise_error(RangeError)
-    expect { @img.get_pixels(0,  0, @img.columns, @img.rows + 1) }.to raise_error(RangeError)
-  end
-
-  def test_gray?
-    gray = Magick::Image.new(20, 20) { self.background_color = 'gray50' }
-    expect(gray.gray?).to be(true)
-    red = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    expect(red.gray?).to be(false)
-  end
-
-  def test_histogram?
-    expect { @img.histogram? }.not_to raise_error
-    expect(@img.histogram?).to be(true)
-  end
-
-  def test_implode
-    expect do
-      res = @img.implode(0.5)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
-  end
-
-  def test_import_pixels
-    pixels = @img.export_pixels(0, 0, @img.columns, 1, 'RGB')
-    expect do
-      res = @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    expect { @img.import_pixels }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0, @img.columns) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0, @img.columns, 1) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB') }.to raise_error(ArgumentError)
-    expect { @img.import_pixels('x', 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
-    expect { @img.import_pixels(0, 'x', @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
-    expect { @img.import_pixels(0, 0, 'x', 1, 'RGB', pixels) }.to raise_error(TypeError)
-    expect { @img.import_pixels(0, 0, @img.columns, 'x', 'RGB', pixels) }.to raise_error(TypeError)
-    expect { @img.import_pixels(0, 0, @img.columns, 1, [2], pixels) }.to raise_error(TypeError)
-    expect { @img.import_pixels(-1, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, -1, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0, -1, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
-    expect { @img.import_pixels(0, 0, @img.columns, -1, 'RGB', pixels) }.to raise_error(ArgumentError)
-
-    # pixel array is too small
-    expect { @img.import_pixels(0, 0, @img.columns, 2, 'RGB', pixels) }.to raise_error(ArgumentError)
-    # pixel array doesn't contain a multiple of the map length
-    pixels.shift
-    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
-  end
-
-  def test_level
-    expect do
-      res = @img.level
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.level(0.0) }.not_to raise_error
-    expect { @img.level(0.0, 1.0) }.not_to raise_error
-    expect { @img.level(0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
-    expect { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
-    expect { @img.level('x') }.to raise_error(ArgumentError)
-    expect { @img.level(0.0, 'x') }.to raise_error(ArgumentError)
-    expect { @img.level(0.0, 1.0, 'x') }.to raise_error(ArgumentError)
+  describe '#level' do
+    it 'works' do
+      expect do
+        res = @img.level
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.level(0.0) }.not_to raise_error
+      expect { @img.level(0.0, 1.0) }.not_to raise_error
+      expect { @img.level(0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
+      expect { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+      expect { @img.level('x') }.to raise_error(ArgumentError)
+      expect { @img.level(0.0, 'x') }.to raise_error(ArgumentError)
+      expect { @img.level(0.0, 1.0, 'x') }.to raise_error(ArgumentError)
+    end
   end
 
   # Ensure that #level properly swaps old-style arg list
-  def test_level2
-    img1 = @img.level(10, 2, 200)
-    img2 = @img.level(10, 200, 2)
-    expect(img1).to eq(img2)
+  describe '#level2' do
+    it 'works' do
+      img1 = @img.level(10, 2, 200)
+      img2 = @img.level(10, 200, 2)
+      expect(img1).to eq(img2)
 
-    # Ensure that level2 uses new arg order
-    img1 = @img.level2(10, 200, 2)
-    expect(img1).to eq(img2)
+      # Ensure that level2 uses new arg order
+      img1 = @img.level2(10, 200, 2)
+      expect(img1).to eq(img2)
 
-    expect { @img.level2 }.not_to raise_error
-    expect { @img.level2(10) }.not_to raise_error
-    expect { @img.level2(10, 10) }.not_to raise_error
-    expect { @img.level2(10, 10, 10) }.not_to raise_error
-    expect { @img.level2(10, 10, 10, 10) }.to raise_error(ArgumentError)
+      expect { @img.level2 }.not_to raise_error
+      expect { @img.level2(10) }.not_to raise_error
+      expect { @img.level2(10, 10) }.not_to raise_error
+      expect { @img.level2(10, 10, 10) }.not_to raise_error
+      expect { @img.level2(10, 10, 10, 10) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_level_channel
-    expect { @img.level_channel }.to raise_error(ArgumentError)
-    expect do
-      res = @img.level_channel(Magick::RedChannel)
+  describe '#level_channel' do
+    it 'works' do
+      expect { @img.level_channel }.to raise_error(ArgumentError)
+      expect do
+        res = @img.level_channel(Magick::RedChannel)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+
+      expect { @img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
+      expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }.not_to raise_error
+      expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
+
+      expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+      expect { @img.level_channel(2) }.to raise_error(TypeError)
+      expect { @img.level_channel(Magick::RedChannel, 'x') }.to raise_error(TypeError)
+      expect { @img.level_channel(Magick::RedChannel, 0.0, 'x') }.to raise_error(TypeError)
+      expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#level_colors' do
+    it 'works' do
+      res = nil
+      expect do
+        res = @img.level_colors
+      end.not_to raise_error
       expect(res).to be_instance_of(Magick::Image)
       expect(res).not_to be(@img)
-    end.not_to raise_error
 
-    expect { @img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
-    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }.not_to raise_error
-    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
+      expect { @img.level_colors('black') }.not_to raise_error
+      expect { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }.not_to raise_error
+      expect { @img.level_colors(Magick::Pixel.new(0, 0, 0), Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange, Magick::QuantumRange)) }.not_to raise_error
+      expect { @img.level_colors('black', 'white') }.not_to raise_error
+      expect { @img.level_colors('black', 'white', false) }.not_to raise_error
 
-    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
-    expect { @img.level_channel(2) }.to raise_error(TypeError)
-    expect { @img.level_channel(Magick::RedChannel, 'x') }.to raise_error(TypeError)
-    expect { @img.level_channel(Magick::RedChannel, 0.0, 'x') }.to raise_error(TypeError)
-    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, 'x') }.to raise_error(TypeError)
+      expect { @img.level_colors('black', 'white', false, 1) }.to raise_error(TypeError)
+      expect { @img.level_colors([]) }.to raise_error(TypeError)
+      expect { @img.level_colors('xxx') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_level_colors
-    res = nil
-    expect do
-      res = @img.level_colors
-    end.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
+  describe '#levelize_channel' do
+    it 'works' do
+      res = nil
+      expect do
+        res = @img.levelize_channel(0, Magick::QuantumRange)
+      end.not_to raise_error
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
 
-    expect { @img.level_colors('black') }.not_to raise_error
-    expect { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }.not_to raise_error
-    expect { @img.level_colors(Magick::Pixel.new(0, 0, 0), Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange, Magick::QuantumRange)) }.not_to raise_error
-    expect { @img.level_colors('black', 'white') }.not_to raise_error
-    expect { @img.level_colors('black', 'white', false) }.not_to raise_error
+      expect { @img.levelize_channel(0) }.not_to raise_error
+      expect { @img.levelize_channel(0, Magick::QuantumRange) }.not_to raise_error
+      expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5) }.not_to raise_error
+      expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }.not_to raise_error
+      expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
 
-    expect { @img.level_colors('black', 'white', false, 1) }.to raise_error(TypeError)
-    expect { @img.level_colors([]) }.to raise_error(TypeError)
-    expect { @img.level_colors('xxx') }.to raise_error(ArgumentError)
+      expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }.to raise_error(TypeError)
+      expect { @img.levelize_channel }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_levelize_channel
-    res = nil
-    expect do
-      res = @img.levelize_channel(0, Magick::QuantumRange)
-    end.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-
-    expect { @img.levelize_channel(0) }.not_to raise_error
-    expect { @img.levelize_channel(0, Magick::QuantumRange) }.not_to raise_error
-    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5) }.not_to raise_error
-    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }.not_to raise_error
-    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-
-    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }.to raise_error(TypeError)
-    expect { @img.levelize_channel }.to raise_error(ArgumentError)
-  end
-
-  #     def test_liquid_rescale
-  #       begin
-  #         @img.liquid_rescale(15,15)
-  #       rescue NotImplementedError
-  #         puts "liquid_rescale not implemented."
-  #         return
-  #       end
+  #     describe "#liquid_rescale" do
+  #       it "works" do
+  #         begin
+  #           @img.liquid_rescale(15,15)
+  #         rescue NotImplementedError
+  #           puts "liquid_rescale not implemented."
+  #           return
+  #         end
   #
-  #       res = nil
-  #       expect do
-  #         res = @img.liquid_rescale(15, 15)
-  #       end.not_to raise_error
-  #       expect(res.columns).to eq(15)
-  #       expect(res.rows).to eq(15)
-  #       expect { @img.liquid_rescale(15, 15, 0, 0) }.not_to raise_error
-  #       expect { @img.liquid_rescale(15) }.to raise_error(ArgumentError)
-  #       expect { @img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)
-  #       expect { @img.liquid_rescale([], 15) }.to raise_error(TypeError)
-  #       expect { @img.liquid_rescale(15, []) }.to raise_error(TypeError)
-  #       expect { @img.liquid_rescale(15, 15, []) }.to raise_error(TypeError)
-  #       expect { @img.liquid_rescale(15, 15, 0, []) }.to raise_error(TypeError)
+  #         res = nil
+  #         expect do
+  #           res = @img.liquid_rescale(15, 15)
+  #         end.not_to raise_error
+  #         expect(res.columns).to eq(15)
+  #         expect(res.rows).to eq(15)
+  #         expect { @img.liquid_rescale(15, 15, 0, 0) }.not_to raise_error
+  #         expect { @img.liquid_rescale(15) }.to raise_error(ArgumentError)
+  #         expect { @img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)
+  #         expect { @img.liquid_rescale([], 15) }.to raise_error(TypeError)
+  #         expect { @img.liquid_rescale(15, []) }.to raise_error(TypeError)
+  #         expect { @img.liquid_rescale(15, 15, []) }.to raise_error(TypeError)
+  #         expect { @img.liquid_rescale(15, 15, 0, []) }.to raise_error(TypeError)
+  #       end
   #     end
 
-  def test_magnify
-    expect do
-      res = @img.magnify
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+  describe '#magnify' do
+    it 'works' do
+      expect do
+        res = @img.magnify
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
 
-    res = @img.magnify!
-    expect(res).to be(@img)
-  end
-
-  def test_marshal
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    d = nil
-    img2 = nil
-    expect { d = Marshal.dump(img) }.not_to raise_error
-    expect { img2 = Marshal.load(d) }.not_to raise_error
-    expect(img2).to eq(img)
-  end
-
-  def test_mask
-    cimg = Magick::Image.new(10, 10)
-    expect { @img.mask(cimg) }.not_to raise_error
-    res = nil
-    expect { res = @img.mask }.not_to raise_error
-    expect(res).not_to be(nil)
-    expect(res).not_to be(cimg)
-    expect(res.columns).to eq(20)
-    expect(res.rows).to eq(20)
-
-    expect { @img.mask(cimg, 'x') }.to raise_error(ArgumentError)
-    # mask expects an Image and calls `cur_image'
-    expect { @img.mask = 2 }.to raise_error(NoMethodError)
-
-    img = @img.copy.freeze
-    expect { img.mask cimg }.to raise_error(FreezeError)
-
-    @img.destroy!
-    expect { @img.mask cimg }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_matte_fill_to_border
-    expect do
-      res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
-    expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
-    expect { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
-  end
-
-  def test_matte_floodfill
-    expect do
-      res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
-
-    Magick::PaintMethod.values do |method|
-      next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
-
-      expect { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
-    end
-    expect { @img.matte_floodfill(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
-    expect { @img.matte_floodfill(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
-    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-  end
-
-  def test_matte_replace
-    expect do
-      res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_matte_reset!
-    expect do
-      res = @img.matte_reset!
+      res = @img.magnify!
       expect(res).to be(@img)
-    end.not_to raise_error
+    end
   end
 
-  def test_median_filter
-    expect do
-      res = @img.median_filter
+  describe '#marshal' do
+    it 'works' do
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      d = nil
+      img2 = nil
+      expect { d = Marshal.dump(img) }.not_to raise_error
+      expect { img2 = Marshal.load(d) }.not_to raise_error
+      expect(img2).to eq(img)
+    end
+  end
+
+  describe '#mask' do
+    it 'works' do
+      cimg = Magick::Image.new(10, 10)
+      expect { @img.mask(cimg) }.not_to raise_error
+      res = nil
+      expect { res = @img.mask }.not_to raise_error
+      expect(res).not_to be(nil)
+      expect(res).not_to be(cimg)
+      expect(res.columns).to eq(20)
+      expect(res.rows).to eq(20)
+
+      expect { @img.mask(cimg, 'x') }.to raise_error(ArgumentError)
+      # mask expects an Image and calls `cur_image'
+      expect { @img.mask = 2 }.to raise_error(NoMethodError)
+
+      img = @img.copy.freeze
+      expect { img.mask cimg }.to raise_error(FreezeError)
+
+      @img.destroy!
+      expect { @img.mask cimg }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe '#matte_fill_to_border' do
+    it 'works' do
+      expect do
+        res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
+      expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+      expect { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#matte_floodfill' do
+    it 'works' do
+      expect do
+        res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
+
+      Magick::PaintMethod.values do |method|
+        next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
+
+        expect { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
+      end
+      expect { @img.matte_floodfill(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+      expect { @img.matte_floodfill(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
+      expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#matte_replace' do
+    it 'works' do
+      expect do
+        res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#matte_reset!' do
+    it 'works' do
+      expect do
+        res = @img.matte_reset!
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#median_filter' do
+    it 'works' do
+      expect do
+        res = @img.median_filter
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.median_filter(0.5) }.not_to raise_error
+      expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
+      expect { @img.median_filter('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#minify' do
+    it 'works' do
+      expect do
+        res = @img.minify
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+
+      res = @img.minify!
+      expect(res).to be(@img)
+    end
+  end
+
+  describe '#modulate' do
+    it 'works' do
+      expect do
+        res = @img.modulate
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.modulate(0.5) }.not_to raise_error
+      expect { @img.modulate(0.5, 0.5) }.not_to raise_error
+      expect { @img.modulate(0.5, 0.5, 0.5) }.not_to raise_error
+      expect { @img.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
+      expect { @img.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
+      expect { @img.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
+      expect { @img.modulate(0.5, 'x', 0.5) }.to raise_error(TypeError)
+      expect { @img.modulate(0.5, 0.5, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#monochrome?' do
+    it 'works' do
+      #       expect(@img.monochrome?).to be(true)
+      @img.pixel_color(0, 0, 'red')
+      expect(@img.monochrome?).to be(false)
+    end
+  end
+
+  describe '#motion_blur' do
+    it 'works' do
+      expect do
+        res = @img.motion_blur(1.0, 7.0, 180)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
+      expect { @img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
+    end
+  end
+
+  describe '#negate' do
+    it 'works' do
+      expect do
+        res = @img.negate
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.negate(true) }.not_to raise_error
+      expect { @img.negate(true, 2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#negate_channel' do
+    it 'works' do
+      expect do
+        res = @img.negate_channel
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.negate_channel(true) }.not_to raise_error
+      expect { @img.negate_channel(true, Magick::RedChannel) }.not_to raise_error
+      expect { @img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.negate_channel(true, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#normalize' do
+    it 'works' do
+      expect do
+        res = @img.normalize
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#normalize_channel' do
+    it 'works' do
+      expect do
+        res = @img.normalize_channel
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.normalize_channel(Magick::RedChannel) }.not_to raise_error
+      expect { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.normalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#oil_paint' do
+    it 'works' do
+      expect do
+        res = @img.oil_paint
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.oil_paint(2.0) }.not_to raise_error
+      expect { @img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#opaque' do
+    it 'works' do
+      expect do
+        res = @img.opaque('white', 'red')
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
+      expect { @img.opaque(red, blue) }.not_to raise_error
+      expect { @img.opaque(red, 2) }.to raise_error(TypeError)
+      expect { @img.opaque(2, blue) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#opaque_channel' do
+    it 'works' do
+      res = nil
+      expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
+      expect(res).not_to be(nil)
       expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.median_filter(0.5) }.not_to raise_error
-    expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
-    expect { @img.median_filter('x') }.to raise_error(TypeError)
+      expect(@img).not_to be(res)
+      expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
+      expect { @img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
+      expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }.not_to raise_error
+      expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+      expect do
+        @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel)
+      end.not_to raise_error
+
+      expect { @img.opaque_channel('red', 'blue', true, 50, 50) }.to raise_error(TypeError)
+      expect { @img.opaque_channel('red', 'blue', true, []) }.to raise_error(TypeError)
+      expect { @img.opaque_channel('red') }.to raise_error(ArgumentError)
+      expect { @img.opaque_channel('red', 'blue', true, -0.1) }.to raise_error(ArgumentError)
+      expect { @img.opaque_channel('red', []) }.to raise_error(TypeError)
+    end
   end
 
-  def test_minify
-    expect do
-      res = @img.minify
+  describe '#opaque?' do
+    it 'works' do
+      expect do
+        expect(@img.opaque?).to be(true)
+      end.not_to raise_error
+      @img.alpha(Magick::TransparentAlphaChannel)
+      expect(@img.opaque?).to be(false)
+    end
+  end
+
+  describe '#ordered_dither' do
+    it 'works' do
+      expect do
+        res = @img.ordered_dither
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.ordered_dither('3x3') }.not_to raise_error
+      expect { @img.ordered_dither(2) }.not_to raise_error
+      expect { @img.ordered_dither(3) }.not_to raise_error
+      expect { @img.ordered_dither(4) }.not_to raise_error
+      expect { @img.ordered_dither(5) }.to raise_error(ArgumentError)
+      expect { @img.ordered_dither(2, 1) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#paint_transparent' do
+    it 'works' do
+      res = nil
+      expect { res = @img.paint_transparent('red') }.not_to raise_error
+      expect(res).not_to be(nil)
       expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
+      expect(@img).not_to be(res)
+      expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', Magick::TransparentAlpha, true, 50) }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
 
-    res = @img.minify!
-    expect(res).to be(@img)
+      # Too many arguments
+      expect { @img.paint_transparent('red', true, 50, 50, 50) }.to raise_error(ArgumentError)
+      # Not enough
+      expect { @img.paint_transparent }.to raise_error(ArgumentError)
+      expect { @img.paint_transparent('red', true, [], alpha: Magick::TransparentAlpha) }.to raise_error(TypeError)
+      expect { @img.paint_transparent(50) }.to raise_error(TypeError)
+    end
   end
 
-  def test_modulate
-    expect do
-      res = @img.modulate
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.modulate(0.5) }.not_to raise_error
-    expect { @img.modulate(0.5, 0.5) }.not_to raise_error
-    expect { @img.modulate(0.5, 0.5, 0.5) }.not_to raise_error
-    expect { @img.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
-    expect { @img.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
-    expect { @img.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
-    expect { @img.modulate(0.5, 'x', 0.5) }.to raise_error(TypeError)
-    expect { @img.modulate(0.5, 0.5, 'x') }.to raise_error(TypeError)
+  describe '#palette?' do
+    it 'works' do
+      img = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      expect do
+        expect(img.palette?).to be(false)
+      end.not_to raise_error
+      img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      expect(img.palette?).to be(true)
+    end
   end
 
-  def test_monochrome?
-    #       expect(@img.monochrome?).to be(true)
-    @img.pixel_color(0, 0, 'red')
-    expect(@img.monochrome?).to be(false)
-  end
-
-  def test_motion_blur
-    expect do
-      res = @img.motion_blur(1.0, 7.0, 180)
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
-    expect { @img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
-  end
-
-  def test_negate
-    expect do
-      res = @img.negate
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.negate(true) }.not_to raise_error
-    expect { @img.negate(true, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_negate_channel
-    expect do
-      res = @img.negate_channel
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.negate_channel(true) }.not_to raise_error
-    expect { @img.negate_channel(true, Magick::RedChannel) }.not_to raise_error
-    expect { @img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.negate_channel(true, Magick::RedChannel, 2) }.to raise_error(TypeError)
-  end
-
-  def test_normalize
-    expect do
-      res = @img.normalize
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_normalize_channel
-    expect do
-      res = @img.normalize_channel
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.normalize_channel(Magick::RedChannel) }.not_to raise_error
-    expect { @img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.normalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
-  end
-
-  def test_oil_paint
-    expect do
-      res = @img.oil_paint
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.oil_paint(2.0) }.not_to raise_error
-    expect { @img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
-  end
-
-  def test_opaque
-    expect do
-      res = @img.opaque('white', 'red')
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
-    expect { @img.opaque(red, blue) }.not_to raise_error
-    expect { @img.opaque(red, 2) }.to raise_error(TypeError)
-    expect { @img.opaque(2, blue) }.to raise_error(TypeError)
-  end
-
-  def test_opaque_channel
-    res = nil
-    expect { res = @img.opaque_channel('white', 'red') }.not_to raise_error
-    expect(res).not_to be(nil)
-    expect(res).to be_instance_of(Magick::Image)
-    expect(@img).not_to be(res)
-    expect { @img.opaque_channel('red', 'blue', true) }.not_to raise_error
-    expect { @img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
-    expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }.not_to raise_error
-    expect { @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
-    expect do
-      @img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel, Magick::GreenChannel, Magick::BlueChannel)
-    end.not_to raise_error
-
-    expect { @img.opaque_channel('red', 'blue', true, 50, 50) }.to raise_error(TypeError)
-    expect { @img.opaque_channel('red', 'blue', true, []) }.to raise_error(TypeError)
-    expect { @img.opaque_channel('red') }.to raise_error(ArgumentError)
-    expect { @img.opaque_channel('red', 'blue', true, -0.1) }.to raise_error(ArgumentError)
-    expect { @img.opaque_channel('red', []) }.to raise_error(TypeError)
-  end
-
-  def test_opaque?
-    expect do
-      expect(@img.opaque?).to be(true)
-    end.not_to raise_error
-    @img.alpha(Magick::TransparentAlphaChannel)
-    expect(@img.opaque?).to be(false)
-  end
-
-  def test_ordered_dither
-    expect do
-      res = @img.ordered_dither
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.ordered_dither('3x3') }.not_to raise_error
-    expect { @img.ordered_dither(2) }.not_to raise_error
-    expect { @img.ordered_dither(3) }.not_to raise_error
-    expect { @img.ordered_dither(4) }.not_to raise_error
-    expect { @img.ordered_dither(5) }.to raise_error(ArgumentError)
-    expect { @img.ordered_dither(2, 1) }.to raise_error(ArgumentError)
-  end
-
-  def test_paint_transparent
-    res = nil
-    expect { res = @img.paint_transparent('red') }.not_to raise_error
-    expect(res).not_to be(nil)
-    expect(res).to be_instance_of(Magick::Image)
-    expect(@img).not_to be(res)
-    expect { @img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.paint_transparent('red', true, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', true, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', Magick::TransparentAlpha, true, 50) }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', true, 50, alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.paint_transparent('red', true, 50, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-
-    # Too many arguments
-    expect { @img.paint_transparent('red', true, 50, 50, 50) }.to raise_error(ArgumentError)
-    # Not enough
-    expect { @img.paint_transparent }.to raise_error(ArgumentError)
-    expect { @img.paint_transparent('red', true, [], alpha: Magick::TransparentAlpha) }.to raise_error(TypeError)
-    expect { @img.paint_transparent(50) }.to raise_error(TypeError)
-  end
-
-  def test_palette?
-    img = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      expect(img.palette?).to be(false)
-    end.not_to raise_error
-    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-    expect(img.palette?).to be(true)
-  end
-
-  def test_pixel_color
-    expect do
+  describe '#pixel_color' do
+    it 'works' do
+      expect do
+        res = @img.pixel_color(0, 0)
+        expect(res).to be_instance_of(Magick::Pixel)
+      end.not_to raise_error
       res = @img.pixel_color(0, 0)
-      expect(res).to be_instance_of(Magick::Pixel)
-    end.not_to raise_error
-    res = @img.pixel_color(0, 0)
-    expect(res.to_color).to eq(@img.background_color)
-    res = @img.pixel_color(0, 0, 'red')
-    expect(res.to_color).to eq('white')
-    res = @img.pixel_color(0, 0)
-    expect(res.to_color).to eq('red')
-
-    blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
-    expect { @img.pixel_color(0, 0, blue) }.not_to raise_error
-    # If args are out-of-bounds return the background color
-    img = Magick::Image.new(10, 10) { self.background_color = 'blue' }
-    expect(img.pixel_color(50, 50).to_color).to eq('blue')
-
-    expect do
-      @img.class_type = Magick::PseudoClass
+      expect(res.to_color).to eq(@img.background_color)
       res = @img.pixel_color(0, 0, 'red')
-      expect(res.to_color).to eq('blue')
-    end.not_to raise_error
+      expect(res.to_color).to eq('white')
+      res = @img.pixel_color(0, 0)
+      expect(res.to_color).to eq('red')
+
+      blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
+      expect { @img.pixel_color(0, 0, blue) }.not_to raise_error
+      # If args are out-of-bounds return the background color
+      img = Magick::Image.new(10, 10) { self.background_color = 'blue' }
+      expect(img.pixel_color(50, 50).to_color).to eq('blue')
+
+      expect do
+        @img.class_type = Magick::PseudoClass
+        res = @img.pixel_color(0, 0, 'red')
+        expect(res.to_color).to eq('blue')
+      end.not_to raise_error
+    end
   end
 
-  def test_polaroid
-    expect { @img.polaroid }.not_to raise_error
-    expect { @img.polaroid(5) }.not_to raise_error
-    expect(@img.polaroid).to be_instance_of(Magick::Image)
-    expect { @img.polaroid('x') }.to raise_error(TypeError)
-    expect { @img.polaroid(5, 'x') }.to raise_error(ArgumentError)
+  describe '#polaroid' do
+    it 'works' do
+      expect { @img.polaroid }.not_to raise_error
+      expect { @img.polaroid(5) }.not_to raise_error
+      expect(@img.polaroid).to be_instance_of(Magick::Image)
+      expect { @img.polaroid('x') }.to raise_error(TypeError)
+      expect { @img.polaroid(5, 'x') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_posterize
-    expect do
-      res = @img.posterize
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect { @img.posterize(5) }.not_to raise_error
-    expect { @img.posterize(5, true) }.not_to raise_error
-    expect { @img.posterize(5, true, 'x') }.to raise_error(ArgumentError)
+  describe '#posterize' do
+    it 'works' do
+      expect do
+        res = @img.posterize
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect { @img.posterize(5) }.not_to raise_error
+      expect { @img.posterize(5, true) }.not_to raise_error
+      expect { @img.posterize(5, true, 'x') }.to raise_error(ArgumentError)
+    end
   end
 end
 

--- a/test/Image3.rb
+++ b/test/Image3.rb
@@ -2,1075 +2,1233 @@ require 'rmagick'
 require 'minitest/autorun'
 require 'fileutils'
 
-class Image3_UT < Minitest::Test
-  def setup
+describe Magick::Image do
+  before do
     @img = Magick::Image.new(20, 20)
     @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
-  def test_profile!
-    expect do
-      res = @img.profile!('*', nil)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    expect { @img.profile!('icc', @p) }.not_to raise_error
-    expect { @img.profile!('iptc', 'xxx') }.not_to raise_error
-    expect { @img.profile!('icc', nil) }.not_to raise_error
-    expect { @img.profile!('iptc', nil) }.not_to raise_error
+  describe '#profile!' do
+    it 'works' do
+      expect do
+        res = @img.profile!('*', nil)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      expect { @img.profile!('icc', @p) }.not_to raise_error
+      expect { @img.profile!('iptc', 'xxx') }.not_to raise_error
+      expect { @img.profile!('icc', nil) }.not_to raise_error
+      expect { @img.profile!('iptc', nil) }.not_to raise_error
 
-    expect { @img.profile!('test', 'foobarbaz') }.to raise_error(ArgumentError)
+      expect { @img.profile!('test', 'foobarbaz') }.to raise_error(ArgumentError)
 
-    @img.freeze
-    expect { @img.profile!('icc', 'xxx') }.to raise_error(FreezeError)
-    expect { @img.profile!('*', nil) }.to raise_error(FreezeError)
-  end
-
-  def test_quantize
-    expect do
-      res = @img.quantize
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    Magick::ColorspaceType.values do |cs|
-      expect { @img.quantize(256, cs) }.not_to raise_error
+      @img.freeze
+      expect { @img.profile!('icc', 'xxx') }.to raise_error(FreezeError)
+      expect { @img.profile!('*', nil) }.to raise_error(FreezeError)
     end
-    expect { @img.quantize(256, Magick::RGBColorspace, false) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, true) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, true, 2) }.not_to raise_error
-    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }.not_to raise_error
-    expect { @img.quantize('x') }.to raise_error(TypeError)
-    expect { @img.quantize(16, 2) }.to raise_error(TypeError)
-    expect { @img.quantize(16, Magick::RGBColorspace, false, 'x') }.to raise_error(TypeError)
-    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true, true) }.to raise_error(ArgumentError)
   end
 
-  def test_quantum_operator
-    expect do
-      res = @img.quantum_operator(Magick::AddQuantumOperator, 2)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    Magick::QuantumExpressionOperator.values do |op|
-      expect { @img.quantum_operator(op, 2) }.not_to raise_error
+  describe '#quantize' do
+    it 'works' do
+      expect do
+        res = @img.quantize
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      Magick::ColorspaceType.values do |cs|
+        expect { @img.quantize(256, cs) }.not_to raise_error
+      end
+      expect { @img.quantize(256, Magick::RGBColorspace, false) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, true) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, true, 2) }.not_to raise_error
+      expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }.not_to raise_error
+      expect { @img.quantize('x') }.to raise_error(TypeError)
+      expect { @img.quantize(16, 2) }.to raise_error(TypeError)
+      expect { @img.quantize(16, Magick::RGBColorspace, false, 'x') }.to raise_error(TypeError)
+      expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true, true) }.to raise_error(ArgumentError)
     end
-    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }.not_to raise_error
-    expect { @img.quantum_operator(2, 2) }.to raise_error(TypeError)
-    expect { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }.to raise_error(TypeError)
-    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }.to raise_error(TypeError)
-    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel, 2) }.to raise_error(ArgumentError)
   end
 
-  def test_radial_blur
-    expect do
-      res = @img.radial_blur(30)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_radial_blur_channel
-    res = nil
-    expect { res = @img.radial_blur_channel(30) }.not_to raise_error
-    expect(res).not_to be(nil)
-    expect(res).to be_instance_of(Magick::Image)
-    expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
-    expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-
-    expect { @img.radial_blur_channel }.to raise_error(ArgumentError)
-    expect { @img.radial_blur_channel(30, 2) }.to raise_error(TypeError)
-  end
-
-  def test_raise
-    expect do
-      res = @img.raise
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.raise(4) }.not_to raise_error
-    expect { @img.raise(4, 4) }.not_to raise_error
-    expect { @img.raise(4, 4, false) }.not_to raise_error
-    expect { @img.raise('x') }.to raise_error(TypeError)
-    expect { @img.raise(2, 'x') }.to raise_error(TypeError)
-    expect { @img.raise(4, 4, false, 2) }.to raise_error(ArgumentError)
-  end
-
-  def test_random_threshold_channel
-    expect do
-      res = @img.random_threshold_channel('20%')
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    threshold = Magick::Geometry.new(20)
-    expect { @img.random_threshold_channel(threshold) }.not_to raise_error
-    expect { @img.random_threshold_channel(threshold, Magick::RedChannel) }.not_to raise_error
-    expect { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.random_threshold_channel }.to raise_error(ArgumentError)
-    expect { @img.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
-  end
-
-  def test_recolor
-    expect { @img.recolor([1, 1, 2, 1]) }.not_to raise_error
-    expect { @img.recolor('x') }.to raise_error(TypeError)
-    expect { @img.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
-  end
-
-  def test_reduce_noise
-    expect do
-      res = @img.reduce_noise(0)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.reduce_noise(4) }.not_to raise_error
-  end
-
-  def test_remap
-    remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    expect { @img.remap(remap_image) }.not_to raise_error
-    expect { @img.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
-    expect { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
-    expect { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
-
-    expect { @img.remap }.to raise_error(ArgumentError)
-    expect { @img.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
-    expect { @img.remap(remap_image, 1) }.to raise_error(TypeError)
-  end
-
-  def test_resample
-    @img.x_resolution = 72
-    @img.y_resolution = 72
-    expect { @img.resample }.not_to raise_error
-    expect { @img.resample(100) }.not_to raise_error
-    expect { @img.resample(100, 100) }.not_to raise_error
-
-    @img.x_resolution = 0
-    @img.y_resolution = 0
-    expect { @img.resample }.not_to raise_error
-    expect { @img.resample(100) }.not_to raise_error
-    expect { @img.resample(100, 100) }.not_to raise_error
-
-    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect(girl.x_resolution).to eq(240.0)
-    expect(girl.y_resolution).to eq(240.0)
-    res = girl.resample(120, 120)
-    expect(res.columns).to eq(100)
-    expect(res.rows).to eq(125)
-    expect(res.x_resolution).to eq(120.0)
-    expect(res.y_resolution).to eq(120.0)
-    expect(girl.columns).to eq(200)
-    expect(girl.rows).to eq(250)
-    expect(girl.x_resolution).to eq(240.0)
-    expect(girl.y_resolution).to eq(240.0)
-
-    Magick::FilterType.values do |filter|
-      expect { @img.resample(50, 50, filter) }.not_to raise_error
+  describe '#quantum_operator' do
+    it 'works' do
+      expect do
+        res = @img.quantum_operator(Magick::AddQuantumOperator, 2)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      Magick::QuantumExpressionOperator.values do |op|
+        expect { @img.quantum_operator(op, 2) }.not_to raise_error
+      end
+      expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }.not_to raise_error
+      expect { @img.quantum_operator(2, 2) }.to raise_error(TypeError)
+      expect { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }.to raise_error(TypeError)
+      expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }.to raise_error(TypeError)
+      expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel, 2) }.to raise_error(ArgumentError)
     end
-    expect { @img.resample(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
-
-    expect { @img.resample('x') }.to raise_error(TypeError)
-    expect { @img.resample(100, 'x') }.to raise_error(TypeError)
-    expect { @img.resample(50, 50, 2) }.to raise_error(TypeError)
-    expect { @img.resample(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
-    expect { @img.resample(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
-    expect { @img.resample(-100) }.to raise_error(ArgumentError)
-    expect { @img.resample(100, -100) }.to raise_error(ArgumentError)
   end
 
-  def test_resample!
-    expect do
-      res = @img.resample!(50)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.resample!(50) }.to raise_error(FreezeError)
-  end
-
-  def test_resize
-    expect do
-      res = @img.resize(2)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.resize(50, 50) }.not_to raise_error
-
-    Magick::FilterType.values do |filter|
-      expect { @img.resize(50, 50, filter) }.not_to raise_error
+  describe '#radial_blur' do
+    it 'works' do
+      expect do
+        res = @img.radial_blur(30)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
     end
-    expect { @img.resize(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
-    expect { @img.resize('x') }.to raise_error(TypeError)
-    expect { @img.resize(50, 'x') }.to raise_error(TypeError)
-    expect { @img.resize(50, 50, 2) }.to raise_error(TypeError)
-    expect { @img.resize(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
-    expect { @img.resize(-1.0) }.to raise_error(ArgumentError)
-    expect { @img.resize(0, 50) }.to raise_error(ArgumentError)
-    expect { @img.resize(50, 0) }.to raise_error(ArgumentError)
-    expect { @img.resize(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
-    expect { @img.resize }.to raise_error(ArgumentError)
   end
 
-  def test_resize!
-    expect do
-      res = @img.resize!(2)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.resize!(0.50) }.to raise_error(FreezeError)
+  describe '#radial_blur_channel' do
+    it 'works' do
+      res = nil
+      expect { res = @img.radial_blur_channel(30) }.not_to raise_error
+      expect(res).not_to be(nil)
+      expect(res).to be_instance_of(Magick::Image)
+      expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
+      expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+
+      expect { @img.radial_blur_channel }.to raise_error(ArgumentError)
+      expect { @img.radial_blur_channel(30, 2) }.to raise_error(TypeError)
+    end
   end
 
-  def test_resize_to_fill_0
-    changed = @img.resize_to_fill(@img.columns, @img.rows)
-    expect(changed.columns).to eq(@img.columns)
-    expect(changed.rows).to eq(@img.rows)
-    expect(@img).not_to be(changed)
+  describe '#raise' do
+    it 'works' do
+      expect do
+        res = @img.raise
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.raise(4) }.not_to raise_error
+      expect { @img.raise(4, 4) }.not_to raise_error
+      expect { @img.raise(4, 4, false) }.not_to raise_error
+      expect { @img.raise('x') }.to raise_error(TypeError)
+      expect { @img.raise(2, 'x') }.to raise_error(TypeError)
+      expect { @img.raise(4, 4, false, 2) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_resize_to_fill_1
-    @img = Magick::Image.new(200, 250)
-    @img.resize_to_fill!(100, 100)
-    expect(@img.columns).to eq(100)
-    expect(@img.rows).to eq(100)
+  describe '#random_threshold_channel' do
+    it 'works' do
+      expect do
+        res = @img.random_threshold_channel('20%')
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      threshold = Magick::Geometry.new(20)
+      expect { @img.random_threshold_channel(threshold) }.not_to raise_error
+      expect { @img.random_threshold_channel(threshold, Magick::RedChannel) }.not_to raise_error
+      expect { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.random_threshold_channel }.to raise_error(ArgumentError)
+      expect { @img.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
+    end
   end
 
-  def test_resize_to_fill_2
-    @img = Magick::Image.new(200, 250)
-    changed = @img.resize_to_fill(300, 100)
-    expect(changed.columns).to eq(300)
-    expect(changed.rows).to eq(100)
+  describe '#recolor' do
+    it 'works' do
+      expect { @img.recolor([1, 1, 2, 1]) }.not_to raise_error
+      expect { @img.recolor('x') }.to raise_error(TypeError)
+      expect { @img.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
+    end
   end
 
-  def test_resize_to_fill_3
-    @img = Magick::Image.new(200, 250)
-    changed = @img.resize_to_fill(100, 300)
-    expect(changed.columns).to eq(100)
-    expect(changed.rows).to eq(300)
+  describe '#reduce_noise' do
+    it 'works' do
+      expect do
+        res = @img.reduce_noise(0)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.reduce_noise(4) }.not_to raise_error
+    end
   end
 
-  def test_resize_to_fill_4
-    @img = Magick::Image.new(200, 250)
-    changed = @img.resize_to_fill(300, 350)
-    expect(changed.columns).to eq(300)
-    expect(changed.rows).to eq(350)
+  describe '#remap' do
+    it 'works' do
+      remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
+      expect { @img.remap(remap_image) }.not_to raise_error
+      expect { @img.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
+      expect { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
+      expect { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+
+      expect { @img.remap }.to raise_error(ArgumentError)
+      expect { @img.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
+      expect { @img.remap(remap_image, 1) }.to raise_error(TypeError)
+    end
   end
 
-  def test_resize_to_fill_5
-    changed = @img.resize_to_fill(20, 400)
-    expect(changed.columns).to eq(20)
-    expect(changed.rows).to eq(400)
+  describe '#resample' do
+    it 'works' do
+      @img.x_resolution = 72
+      @img.y_resolution = 72
+      expect { @img.resample }.not_to raise_error
+      expect { @img.resample(100) }.not_to raise_error
+      expect { @img.resample(100, 100) }.not_to raise_error
+
+      @img.x_resolution = 0
+      @img.y_resolution = 0
+      expect { @img.resample }.not_to raise_error
+      expect { @img.resample(100) }.not_to raise_error
+      expect { @img.resample(100, 100) }.not_to raise_error
+
+      girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      expect(girl.x_resolution).to eq(240.0)
+      expect(girl.y_resolution).to eq(240.0)
+      res = girl.resample(120, 120)
+      expect(res.columns).to eq(100)
+      expect(res.rows).to eq(125)
+      expect(res.x_resolution).to eq(120.0)
+      expect(res.y_resolution).to eq(120.0)
+      expect(girl.columns).to eq(200)
+      expect(girl.rows).to eq(250)
+      expect(girl.x_resolution).to eq(240.0)
+      expect(girl.y_resolution).to eq(240.0)
+
+      Magick::FilterType.values do |filter|
+        expect { @img.resample(50, 50, filter) }.not_to raise_error
+      end
+      expect { @img.resample(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
+
+      expect { @img.resample('x') }.to raise_error(TypeError)
+      expect { @img.resample(100, 'x') }.to raise_error(TypeError)
+      expect { @img.resample(50, 50, 2) }.to raise_error(TypeError)
+      expect { @img.resample(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+      expect { @img.resample(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+      expect { @img.resample(-100) }.to raise_error(ArgumentError)
+      expect { @img.resample(100, -100) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_resize_to_fill_6
-    changed = @img.resize_to_fill(3000, 400)
-    expect(changed.columns).to eq(3000)
-    expect(changed.rows).to eq(400)
+  describe '#resample!' do
+    it 'works' do
+      expect do
+        res = @img.resample!(50)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.resample!(50) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#resize' do
+    it 'works' do
+      expect do
+        res = @img.resize(2)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.resize(50, 50) }.not_to raise_error
+
+      Magick::FilterType.values do |filter|
+        expect { @img.resize(50, 50, filter) }.not_to raise_error
+      end
+      expect { @img.resize(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
+      expect { @img.resize('x') }.to raise_error(TypeError)
+      expect { @img.resize(50, 'x') }.to raise_error(TypeError)
+      expect { @img.resize(50, 50, 2) }.to raise_error(TypeError)
+      expect { @img.resize(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+      expect { @img.resize(-1.0) }.to raise_error(ArgumentError)
+      expect { @img.resize(0, 50) }.to raise_error(ArgumentError)
+      expect { @img.resize(50, 0) }.to raise_error(ArgumentError)
+      expect { @img.resize(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+      expect { @img.resize }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#resize!' do
+    it 'works' do
+      expect do
+        res = @img.resize!(2)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.resize!(0.50) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#resize_to_fill_0' do
+    it 'works' do
+      changed = @img.resize_to_fill(@img.columns, @img.rows)
+      expect(changed.columns).to eq(@img.columns)
+      expect(changed.rows).to eq(@img.rows)
+      expect(@img).not_to be(changed)
+    end
+  end
+
+  describe '#resize_to_fill_1' do
+    it 'works' do
+      @img = Magick::Image.new(200, 250)
+      @img.resize_to_fill!(100, 100)
+      expect(@img.columns).to eq(100)
+      expect(@img.rows).to eq(100)
+    end
+  end
+
+  describe '#resize_to_fill_2' do
+    it 'works' do
+      @img = Magick::Image.new(200, 250)
+      changed = @img.resize_to_fill(300, 100)
+      expect(changed.columns).to eq(300)
+      expect(changed.rows).to eq(100)
+    end
+  end
+
+  describe '#resize_to_fill_3' do
+    it 'works' do
+      @img = Magick::Image.new(200, 250)
+      changed = @img.resize_to_fill(100, 300)
+      expect(changed.columns).to eq(100)
+      expect(changed.rows).to eq(300)
+    end
+  end
+
+  describe '#resize_to_fill_4' do
+    it 'works' do
+      @img = Magick::Image.new(200, 250)
+      changed = @img.resize_to_fill(300, 350)
+      expect(changed.columns).to eq(300)
+      expect(changed.rows).to eq(350)
+    end
+  end
+
+  describe '#resize_to_fill_5' do
+    it 'works' do
+      changed = @img.resize_to_fill(20, 400)
+      expect(changed.columns).to eq(20)
+      expect(changed.rows).to eq(400)
+    end
+  end
+
+  describe '#resize_to_fill_6' do
+    it 'works' do
+      changed = @img.resize_to_fill(3000, 400)
+      expect(changed.columns).to eq(3000)
+      expect(changed.rows).to eq(400)
+    end
   end
 
   # Make sure the old name is still around
-  def test_resize_to_fill_7
-    expect(@img).to respond_to(:crop_resized)
-    expect(@img).to respond_to(:crop_resized!)
+  describe '#resize_to_fill_7' do
+    it 'works' do
+      expect(@img).to respond_to(:crop_resized)
+      expect(@img).to respond_to(:crop_resized!)
+    end
   end
 
   # 2nd argument defaults to the same value as the 1st argument
-  def test_resize_to_fill_8
-    changed = @img.resize_to_fill(100)
-    expect(changed.columns).to eq(100)
-    expect(changed.rows).to eq(100)
-  end
-
-  def test_resize_to_fit
-    img = Magick::Image.new(200, 250)
-    res = nil
-    expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
-    expect(res).not_to be(nil)
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(img)
-    expect(res.columns).to eq(40)
-    expect(res.rows).to eq(50)
-  end
-
-  def test_resize_to_fit2
-    img = Magick::Image.new(200, 300)
-    changed = img.resize_to_fit(100)
-    expect(changed).to be_instance_of(Magick::Image)
-    expect(changed).not_to be(img)
-    expect(changed.columns).to eq(67)
-    expect(changed.rows).to eq(100)
-  end
-
-  def test_resize_to_fit3
-    img = Magick::Image.new(200, 300)
-    img.resize_to_fit!(100)
-    expect(img).to be_instance_of(Magick::Image)
-    expect(img.columns).to eq(67)
-    expect(img.rows).to eq(100)
-  end
-
-  def test_roll
-    expect do
-      res = @img.roll(5, 5)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_rotate
-    expect do
-      res = @img.rotate(45)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.rotate(-45) }.not_to raise_error
-
-    img = Magick::Image.new(100, 50)
-    expect do
-      res = img.rotate(90, '>')
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res.columns).to eq(50)
-      expect(res.rows).to eq(100)
-    end.not_to raise_error
-    expect do
-      res = img.rotate(90, '<')
-      expect(res).to be(nil)
-    end.not_to raise_error
-    expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
-    expect { img.rotate(90, []) }.to raise_error(TypeError)
-  end
-
-  def test_rotate!
-    expect do
-      res = @img.rotate!(45)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.rotate!(45) }.to raise_error(FreezeError)
-  end
-
-  def test_sample
-    expect do
-      res = @img.sample(10, 10)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.sample(2) }.not_to raise_error
-    expect { @img.sample }.to raise_error(ArgumentError)
-    expect { @img.sample(0) }.to raise_error(ArgumentError)
-    expect { @img.sample(0, 25) }.to raise_error(ArgumentError)
-    expect { @img.sample(25, 0) }.to raise_error(ArgumentError)
-    expect { @img.sample(25, 25, 25) }.to raise_error(ArgumentError)
-    expect { @img.sample('x') }.to raise_error(TypeError)
-    expect { @img.sample(10, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_sample!
-    expect do
-      res = @img.sample!(2)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.sample!(0.50) }.to raise_error(FreezeError)
-  end
-
-  def test_scale
-    expect do
-      res = @img.scale(10, 10)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.scale(2) }.not_to raise_error
-    expect { @img.scale }.to raise_error(ArgumentError)
-    expect { @img.scale(25, 25, 25) }.to raise_error(ArgumentError)
-    expect { @img.scale('x') }.to raise_error(TypeError)
-    expect { @img.scale(10, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_scale!
-    expect do
-      res = @img.scale!(2)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.scale!(0.50) }.to raise_error(FreezeError)
-  end
-
-  def test_segment
-    expect do
-      res = @img.segment
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    # Don't test colorspaces that require PsuedoColor images
-    (Magick::ColorspaceType.values - [Magick::OHTAColorspace,
-                                      Magick::LabColorspace,
-                                      Magick::XYZColorspace,
-                                      Magick::YCbCrColorspace,
-                                      Magick::YCCColorspace,
-                                      Magick::YIQColorspace,
-                                      Magick::YPbPrColorspace,
-                                      Magick::YUVColorspace,
-                                      Magick::Rec601YCbCrColorspace,
-                                      Magick::Rec709YCbCrColorspace,
-                                      Magick::LogColorspace]).each do |cs|
-      expect { @img.segment(cs) }.not_to raise_error
-    end
-
-    expect { @img.segment(Magick::RGBColorspace, 2.0) }.not_to raise_error
-    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }.not_to raise_error
-    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }.not_to raise_error
-
-    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }.to raise_error(ArgumentError)
-    expect { @img.segment(2) }.to raise_error(TypeError)
-    expect { @img.segment(Magick::RGBColorspace, 'x') }.to raise_error(TypeError)
-    expect { @img.segment(Magick::RGBColorspace, 2.0, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_selective_blur_channel
-    res = nil
-    expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
-    expect(res).to be_instance_of(Magick::Image)
-    expect(res).not_to be(@img)
-    expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
-
-    expect { @img.selective_blur_channel(0, 1, 0.1) }.not_to raise_error
-    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }.not_to raise_error
-    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }.not_to raise_error
-
-    expect { @img.selective_blur_channel(0, 1) }.to raise_error(ArgumentError)
-    expect { @img.selective_blur_channel(0, 1, 0.1, '10%') }.to raise_error(TypeError)
-  end
-
-  def test_separate
-    expect(@img.separate).to be_instance_of(Magick::ImageList)
-    expect(@img.separate(Magick::BlueChannel)).to be_instance_of(Magick::ImageList)
-    expect { @img.separate('x') }.to raise_error(TypeError)
-  end
-
-  def test_sepiatone
-    expect do
-      res = @img.sepiatone
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
-    expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
-    expect { @img.sepiatone('x') }.to raise_error(TypeError)
-  end
-
-  def test_set_channel_depth
-    Magick::ChannelType.values do |ch|
-      expect { @img.set_channel_depth(ch, 8) }.not_to raise_error
+  describe '#resize_to_fill_8' do
+    it 'works' do
+      changed = @img.resize_to_fill(100)
+      expect(changed.columns).to eq(100)
+      expect(changed.rows).to eq(100)
     end
   end
 
-  def test_shade
-    expect do
-      res = @img.shade
+  describe '#resize_to_fit' do
+    it 'works' do
+      img = Magick::Image.new(200, 250)
+      res = nil
+      expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
+      expect(res).not_to be(nil)
       expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.shade(true) }.not_to raise_error
-    expect { @img.shade(true, 30) }.not_to raise_error
-    expect { @img.shade(true, 30, 30) }.not_to raise_error
-    expect { @img.shade(true, 30, 30, 2) }.to raise_error(ArgumentError)
-    expect { @img.shade(true, 'x') }.to raise_error(TypeError)
-    expect { @img.shade(true, 30, 'x') }.to raise_error(TypeError)
+      expect(res).not_to be(img)
+      expect(res.columns).to eq(40)
+      expect(res.rows).to eq(50)
+    end
   end
 
-  def test_shadow
-    expect do
-      res = @img.shadow
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.shadow(5) }.not_to raise_error
-    expect { @img.shadow(5, 5) }.not_to raise_error
-    expect { @img.shadow(5, 5, 3.0) }.not_to raise_error
-    expect { @img.shadow(5, 5, 3.0, 0.50) }.not_to raise_error
-    expect { @img.shadow(5, 5, 3.0, '50%') }.not_to raise_error
-    expect { @img.shadow(5, 5, 3.0, 0.50, 2) }.to raise_error(ArgumentError)
-    expect { @img.shadow('x') }.to raise_error(TypeError)
-    expect { @img.shadow(5, 'x') }.to raise_error(TypeError)
-    expect { @img.shadow(5, 5, 'x') }.to raise_error(TypeError)
-    expect { @img.shadow(5, 5, 3.0, 'x') }.to raise_error(ArgumentError)
+  describe '#resize_to_fit2' do
+    it 'works' do
+      img = Magick::Image.new(200, 300)
+      changed = img.resize_to_fit(100)
+      expect(changed).to be_instance_of(Magick::Image)
+      expect(changed).not_to be(img)
+      expect(changed.columns).to eq(67)
+      expect(changed.rows).to eq(100)
+    end
   end
 
-  def test_sharpen
-    expect do
-      res = @img.sharpen
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.sharpen(2.0) }.not_to raise_error
-    expect { @img.sharpen(2.0, 1.0) }.not_to raise_error
-    expect { @img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)
-    expect { @img.sharpen('x') }.to raise_error(TypeError)
-    expect { @img.sharpen(2.0, 'x') }.to raise_error(TypeError)
+  describe '#resize_to_fit3' do
+    it 'works' do
+      img = Magick::Image.new(200, 300)
+      img.resize_to_fit!(100)
+      expect(img).to be_instance_of(Magick::Image)
+      expect(img.columns).to eq(67)
+      expect(img.rows).to eq(100)
+    end
   end
 
-  def test_sharpen_channel
-    expect do
-      res = @img.sharpen_channel
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.sharpen_channel(2.0) }.not_to raise_error
-    expect { @img.sharpen_channel(2.0, 1.0) }.not_to raise_error
-    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }.not_to raise_error
-    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
-    expect { @img.sharpen_channel('x') }.to raise_error(TypeError)
-    expect { @img.sharpen_channel(2.0, 'x') }.to raise_error(TypeError)
+  describe '#roll' do
+    it 'works' do
+      expect do
+        res = @img.roll(5, 5)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
   end
 
-  def test_shave
-    expect do
-      res = @img.shave(5, 5)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect do
-      res = @img.shave!(5, 5)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.shave!(2, 2) }.to raise_error(FreezeError)
+  describe '#rotate' do
+    it 'works' do
+      expect do
+        res = @img.rotate(45)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.rotate(-45) }.not_to raise_error
+
+      img = Magick::Image.new(100, 50)
+      expect do
+        res = img.rotate(90, '>')
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res.columns).to eq(50)
+        expect(res.rows).to eq(100)
+      end.not_to raise_error
+      expect do
+        res = img.rotate(90, '<')
+        expect(res).to be(nil)
+      end.not_to raise_error
+      expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
+      expect { img.rotate(90, []) }.to raise_error(TypeError)
+    end
   end
 
-  def test_shear
-    expect do
-      res = @img.shear(30, 30)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
+  describe '#rotate!' do
+    it 'works' do
+      expect do
+        res = @img.rotate!(45)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.rotate!(45) }.to raise_error(FreezeError)
+    end
   end
 
-  def test_sigmoidal_contrast_channel
-    expect do
-      res = @img.sigmoidal_contrast_channel
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }.to raise_error(TypeError)
-    expect { @img.sigmoidal_contrast_channel('x') }.to raise_error(TypeError)
-    expect { @img.sigmoidal_contrast_channel(3.0, 'x') }.to raise_error(TypeError)
+  describe '#sample' do
+    it 'works' do
+      expect do
+        res = @img.sample(10, 10)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.sample(2) }.not_to raise_error
+      expect { @img.sample }.to raise_error(ArgumentError)
+      expect { @img.sample(0) }.to raise_error(ArgumentError)
+      expect { @img.sample(0, 25) }.to raise_error(ArgumentError)
+      expect { @img.sample(25, 0) }.to raise_error(ArgumentError)
+      expect { @img.sample(25, 25, 25) }.to raise_error(ArgumentError)
+      expect { @img.sample('x') }.to raise_error(TypeError)
+      expect { @img.sample(10, 'x') }.to raise_error(TypeError)
+    end
   end
 
-  def test_signature
-    expect do
-      res = @img.signature
+  describe '#sample!' do
+    it 'works' do
+      expect do
+        res = @img.sample!(2)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.sample!(0.50) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#scale' do
+    it 'works' do
+      expect do
+        res = @img.scale(10, 10)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.scale(2) }.not_to raise_error
+      expect { @img.scale }.to raise_error(ArgumentError)
+      expect { @img.scale(25, 25, 25) }.to raise_error(ArgumentError)
+      expect { @img.scale('x') }.to raise_error(TypeError)
+      expect { @img.scale(10, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#scale!' do
+    it 'works' do
+      expect do
+        res = @img.scale!(2)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.scale!(0.50) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#segment' do
+    it 'works' do
+      expect do
+        res = @img.segment
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      # Don't test colorspaces that require PsuedoColor images
+      (Magick::ColorspaceType.values - [Magick::OHTAColorspace,
+                                        Magick::LabColorspace,
+                                        Magick::XYZColorspace,
+                                        Magick::YCbCrColorspace,
+                                        Magick::YCCColorspace,
+                                        Magick::YIQColorspace,
+                                        Magick::YPbPrColorspace,
+                                        Magick::YUVColorspace,
+                                        Magick::Rec601YCbCrColorspace,
+                                        Magick::Rec709YCbCrColorspace,
+                                        Magick::LogColorspace]).each do |cs|
+                                          expect { @img.segment(cs) }.not_to raise_error
+                                        end
+
+      expect { @img.segment(Magick::RGBColorspace, 2.0) }.not_to raise_error
+      expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }.not_to raise_error
+      expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }.not_to raise_error
+
+      expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }.to raise_error(ArgumentError)
+      expect { @img.segment(2) }.to raise_error(TypeError)
+      expect { @img.segment(Magick::RGBColorspace, 'x') }.to raise_error(TypeError)
+      expect { @img.segment(Magick::RGBColorspace, 2.0, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#selective_blur_channel' do
+    it 'works' do
+      res = nil
+      expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+      expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
+
+      expect { @img.selective_blur_channel(0, 1, 0.1) }.not_to raise_error
+      expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }.not_to raise_error
+      expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }.not_to raise_error
+
+      expect { @img.selective_blur_channel(0, 1) }.to raise_error(ArgumentError)
+      expect { @img.selective_blur_channel(0, 1, 0.1, '10%') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#separate' do
+    it 'works' do
+      expect(@img.separate).to be_instance_of(Magick::ImageList)
+      expect(@img.separate(Magick::BlueChannel)).to be_instance_of(Magick::ImageList)
+      expect { @img.separate('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#sepiatone' do
+    it 'works' do
+      expect do
+        res = @img.sepiatone
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
+      expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+      expect { @img.sepiatone('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#set_channel_depth' do
+    it 'works' do
+      Magick::ChannelType.values do |ch|
+        expect { @img.set_channel_depth(ch, 8) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#shade' do
+    it 'works' do
+      expect do
+        res = @img.shade
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.shade(true) }.not_to raise_error
+      expect { @img.shade(true, 30) }.not_to raise_error
+      expect { @img.shade(true, 30, 30) }.not_to raise_error
+      expect { @img.shade(true, 30, 30, 2) }.to raise_error(ArgumentError)
+      expect { @img.shade(true, 'x') }.to raise_error(TypeError)
+      expect { @img.shade(true, 30, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#shadow' do
+    it 'works' do
+      expect do
+        res = @img.shadow
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.shadow(5) }.not_to raise_error
+      expect { @img.shadow(5, 5) }.not_to raise_error
+      expect { @img.shadow(5, 5, 3.0) }.not_to raise_error
+      expect { @img.shadow(5, 5, 3.0, 0.50) }.not_to raise_error
+      expect { @img.shadow(5, 5, 3.0, '50%') }.not_to raise_error
+      expect { @img.shadow(5, 5, 3.0, 0.50, 2) }.to raise_error(ArgumentError)
+      expect { @img.shadow('x') }.to raise_error(TypeError)
+      expect { @img.shadow(5, 'x') }.to raise_error(TypeError)
+      expect { @img.shadow(5, 5, 'x') }.to raise_error(TypeError)
+      expect { @img.shadow(5, 5, 3.0, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#sharpen' do
+    it 'works' do
+      expect do
+        res = @img.sharpen
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.sharpen(2.0) }.not_to raise_error
+      expect { @img.sharpen(2.0, 1.0) }.not_to raise_error
+      expect { @img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)
+      expect { @img.sharpen('x') }.to raise_error(TypeError)
+      expect { @img.sharpen(2.0, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#sharpen_channel' do
+    it 'works' do
+      expect do
+        res = @img.sharpen_channel
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.sharpen_channel(2.0) }.not_to raise_error
+      expect { @img.sharpen_channel(2.0, 1.0) }.not_to raise_error
+      expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }.not_to raise_error
+      expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
+      expect { @img.sharpen_channel('x') }.to raise_error(TypeError)
+      expect { @img.sharpen_channel(2.0, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#shave' do
+    it 'works' do
+      expect do
+        res = @img.shave(5, 5)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect do
+        res = @img.shave!(5, 5)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.shave!(2, 2) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#shear' do
+    it 'works' do
+      expect do
+        res = @img.shear(30, 30)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#sigmoidal_contrast_channel' do
+    it 'works' do
+      expect do
+        res = @img.sigmoidal_contrast_channel
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }.to raise_error(TypeError)
+      expect { @img.sigmoidal_contrast_channel('x') }.to raise_error(TypeError)
+      expect { @img.sigmoidal_contrast_channel(3.0, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#signature' do
+    it 'works' do
+      expect do
+        res = @img.signature
+        expect(res).to be_instance_of(String)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#sketch' do
+    it 'works' do
+      expect { @img.sketch }.not_to raise_error
+      expect { @img.sketch(0) }.not_to raise_error
+      expect { @img.sketch(0, 1) }.not_to raise_error
+      expect { @img.sketch(0, 1, 0) }.not_to raise_error
+      expect { @img.sketch(0, 1, 0, 1) }.to raise_error(ArgumentError)
+      expect { @img.sketch('x') }.to raise_error(TypeError)
+      expect { @img.sketch(0, 'x') }.to raise_error(TypeError)
+      expect { @img.sketch(0, 1, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#solarize' do
+    it 'works' do
+      expect do
+        res = @img.solarize
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.solarize(100) }.not_to raise_error
+      expect { @img.solarize(-100) }.to raise_error(ArgumentError)
+      expect { @img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)
+      expect { @img.solarize(100, 2) }.to raise_error(ArgumentError)
+      expect { @img.solarize('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#sparse_color' do
+    it 'works' do
+      img = Magick::Image.new(100, 100)
+      args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
+      # ensure good calls work
+      Magick::SparseColorMethod.values do |v|
+        next if v == Magick::UndefinedColorInterpolate
+
+        expect { img.sparse_color(v, *args) }.not_to raise_error
+      end
+      args << Magick::RedChannel
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+      args << Magick::GreenChannel
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+      args << Magick::BlueChannel
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+
+      # bad calls
+      args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
+      # invalid method
+      expect { img.sparse_color(1, *args) }.to raise_error(TypeError)
+      # missing arguments
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate) }.to raise_error(ArgumentError)
+      args << 10 # too many arguments
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
+      args.shift
+      args.shift # too few
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
+
+      args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, '20', 'yellow']
+      expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#splice' do
+    it 'works' do
+      expect do
+        res = @img.splice(0, 0, 2, 2)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @img.splice(0, 0, 2, 2, red) }.not_to raise_error
+      expect { @img.splice(0, 0, 2, 2, red, 'x') }.to raise_error(ArgumentError)
+      expect { @img.splice([], 0, 2, 2, red) }.to raise_error(TypeError)
+      expect { @img.splice(0, 'x', 2, 2, red) }.to raise_error(TypeError)
+      expect { @img.splice(0, 0, 'x', 2, red) }.to raise_error(TypeError)
+      expect { @img.splice(0, 0, 2, [], red) }.to raise_error(TypeError)
+      expect { @img.splice(0, 0, 2, 2, /m/) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#spread' do
+    it 'works' do
+      expect do
+        res = @img.spread
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.spread(3.0) }.not_to raise_error
+      expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
+      expect { @img.spread('x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#stegano' do
+    it 'works' do
+      @img = Magick::Image.new(100, 100) { self.background_color = 'black' }
+      watermark = Magick::Image.new(10, 10) { self.background_color = 'white' }
+      expect do
+        res = @img.stegano(watermark, 0)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      watermark.destroy!
+      expect { @img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe '#stereo' do
+    it 'works' do
+      expect do
+        res = @img.stereo(@img)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      img = Magick::Image.new(20, 20)
+      img.destroy!
+      expect { @img.stereo(img) }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe '#store_pixels' do
+    it 'works' do
+      pixels = @img.get_pixels(0, 0, @img.columns, 1)
+      expect do
+        res = @img.store_pixels(0, 0, @img.columns, 1, pixels)
+        expect(res).to be(@img)
+      end.not_to raise_error
+
+      pixels[0] = 'x'
+      expect { @img.store_pixels(0, 0, @img.columns, 1, pixels) }.to raise_error(TypeError)
+      expect { @img.store_pixels(-1, 0, @img.columns, 1, pixels) }.to raise_error(RangeError)
+      expect { @img.store_pixels(0, -1, @img.columns, 1, pixels) }.to raise_error(RangeError)
+      expect { @img.store_pixels(0, 0, 1 + @img.columns, 1, pixels) }.to raise_error(RangeError)
+      expect { @img.store_pixels(-1, 0, 1, 1 + @img.rows, pixels) }.to raise_error(RangeError)
+      expect { @img.store_pixels(0, 0, @img.columns, 1, ['x']) }.to raise_error(IndexError)
+    end
+  end
+
+  describe '#strip!' do
+    it 'works' do
+      expect do
+        res = @img.strip!
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#swirl' do
+    it 'works' do
+      expect do
+        res = @img.swirl(30)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#texture_fill_to_border' do
+    it 'works' do
+      texture = Magick::Image.read('granite:').first
+      expect do
+        res = @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, texture)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
+      expect { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }.to raise_error(ArgumentError)
+      expect { @img.texture_fill_to_border(@img.columns, @img.rows * 2, texture) }.to raise_error(ArgumentError)
+
+      Magick::PaintMethod.values do |method|
+        next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
+
+        expect { @img.texture_flood_fill('blue', texture, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#texture_floodfill' do
+    it 'works' do
+      texture = Magick::Image.read('granite:').first
+      expect do
+        res = @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
+      texture.destroy!
+      expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture) }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe '#threshold' do
+    it 'works' do
+      expect do
+        res = @img.threshold(100)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#thumbnail' do
+    it 'works' do
+      expect do
+        res = @img.thumbnail(10, 10)
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.thumbnail(2) }.not_to raise_error
+      expect { @img.thumbnail }.to raise_error(ArgumentError)
+      expect { @img.thumbnail(-1.0) }.to raise_error(ArgumentError)
+      expect { @img.thumbnail(0, 25) }.to raise_error(ArgumentError)
+      expect { @img.thumbnail(25, 0) }.to raise_error(ArgumentError)
+      expect { @img.thumbnail(25, 25, 25) }.to raise_error(ArgumentError)
+      expect { @img.thumbnail('x') }.to raise_error(TypeError)
+      expect { @img.thumbnail(10, 'x') }.to raise_error(TypeError)
+
+      girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      new_img = girl.thumbnail(200, 200)
+      expect(new_img.columns).to eq(160)
+      expect(new_img.rows).to eq(200)
+
+      new_img = girl.thumbnail(2)
+      expect(new_img.columns).to eq(400)
+      expect(new_img.rows).to eq(500)
+    end
+  end
+
+  describe '#thumbnail!' do
+    it 'works' do
+      expect do
+        res = @img.thumbnail!(2)
+        expect(res).to be(@img)
+      end.not_to raise_error
+      @img.freeze
+      expect { @img.thumbnail!(0.50) }.to raise_error(FreezeError)
+    end
+  end
+
+  describe '#tint' do
+    it 'works' do
+      expect do
+        pixels = @img.get_pixels(0, 0, 1, 1)
+        @img.tint(pixels[0], 1.0)
+      end.not_to raise_error
+      expect { @img.tint('red', 1.0) }.not_to raise_error
+      expect { @img.tint('red', 1.0, 1.0) }.not_to raise_error
+      expect { @img.tint('red', 1.0, 1.0, 1.0) }.not_to raise_error
+      expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0) }.not_to raise_error
+      expect { @img.tint }.to raise_error(ArgumentError)
+      expect { @img.tint('red') }.to raise_error(ArgumentError)
+      expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint('x', 1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint('red', -1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint('red', 1.0, -1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint('red', 1.0, 1.0, -1.0, 1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint('red', 1.0, 1.0, 1.0, -1.0) }.to raise_error(ArgumentError)
+      expect { @img.tint(1.0, 1.0) }.to raise_error(TypeError)
+      expect { @img.tint('red', 'green') }.to raise_error(TypeError)
+      expect { @img.tint('red', 1.0, 'green') }.to raise_error(TypeError)
+      expect { @img.tint('red', 1.0, 1.0, 'green') }.to raise_error(TypeError)
+      expect { @img.tint('red', 1.0, 1.0, 1.0, 'green') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#to_blob' do
+    it 'works' do
+      res = nil
+      expect { res = @img.to_blob { self.format = 'miff' } }.not_to raise_error
       expect(res).to be_instance_of(String)
-    end.not_to raise_error
-  end
-
-  def test_sketch
-    expect { @img.sketch }.not_to raise_error
-    expect { @img.sketch(0) }.not_to raise_error
-    expect { @img.sketch(0, 1) }.not_to raise_error
-    expect { @img.sketch(0, 1, 0) }.not_to raise_error
-    expect { @img.sketch(0, 1, 0, 1) }.to raise_error(ArgumentError)
-    expect { @img.sketch('x') }.to raise_error(TypeError)
-    expect { @img.sketch(0, 'x') }.to raise_error(TypeError)
-    expect { @img.sketch(0, 1, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_solarize
-    expect do
-      res = @img.solarize
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.solarize(100) }.not_to raise_error
-    expect { @img.solarize(-100) }.to raise_error(ArgumentError)
-    expect { @img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)
-    expect { @img.solarize(100, 2) }.to raise_error(ArgumentError)
-    expect { @img.solarize('x') }.to raise_error(TypeError)
-  end
-
-  def test_sparse_color
-    img = Magick::Image.new(100, 100)
-    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
-    # ensure good calls work
-    Magick::SparseColorMethod.values do |v|
-      next if v == Magick::UndefinedColorInterpolate
-
-      expect { img.sparse_color(v, *args) }.not_to raise_error
-    end
-    args << Magick::RedChannel
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
-    args << Magick::GreenChannel
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
-    args << Magick::BlueChannel
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
-
-    # bad calls
-    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
-    # invalid method
-    expect { img.sparse_color(1, *args) }.to raise_error(TypeError)
-    # missing arguments
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate) }.to raise_error(ArgumentError)
-    args << 10 # too many arguments
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
-    args.shift
-    args.shift # too few
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
-
-    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, '20', 'yellow']
-    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(TypeError)
-  end
-
-  def test_splice
-    expect do
-      res = @img.splice(0, 0, 2, 2)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @img.splice(0, 0, 2, 2, red) }.not_to raise_error
-    expect { @img.splice(0, 0, 2, 2, red, 'x') }.to raise_error(ArgumentError)
-    expect { @img.splice([], 0, 2, 2, red) }.to raise_error(TypeError)
-    expect { @img.splice(0, 'x', 2, 2, red) }.to raise_error(TypeError)
-    expect { @img.splice(0, 0, 'x', 2, red) }.to raise_error(TypeError)
-    expect { @img.splice(0, 0, 2, [], red) }.to raise_error(TypeError)
-    expect { @img.splice(0, 0, 2, 2, /m/) }.to raise_error(TypeError)
-  end
-
-  def test_spread
-    expect do
-      res = @img.spread
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.spread(3.0) }.not_to raise_error
-    expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
-    expect { @img.spread('x') }.to raise_error(TypeError)
-  end
-
-  def test_stegano
-    @img = Magick::Image.new(100, 100) { self.background_color = 'black' }
-    watermark = Magick::Image.new(10, 10) { self.background_color = 'white' }
-    expect do
-      res = @img.stegano(watermark, 0)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    watermark.destroy!
-    expect { @img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_stereo
-    expect do
-      res = @img.stereo(@img)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    img = Magick::Image.new(20, 20)
-    img.destroy!
-    expect { @img.stereo(img) }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_store_pixels
-    pixels = @img.get_pixels(0, 0, @img.columns, 1)
-    expect do
-      res = @img.store_pixels(0, 0, @img.columns, 1, pixels)
-      expect(res).to be(@img)
-    end.not_to raise_error
-
-    pixels[0] = 'x'
-    expect { @img.store_pixels(0, 0, @img.columns, 1, pixels) }.to raise_error(TypeError)
-    expect { @img.store_pixels(-1, 0, @img.columns, 1, pixels) }.to raise_error(RangeError)
-    expect { @img.store_pixels(0, -1, @img.columns, 1, pixels) }.to raise_error(RangeError)
-    expect { @img.store_pixels(0, 0, 1 + @img.columns, 1, pixels) }.to raise_error(RangeError)
-    expect { @img.store_pixels(-1, 0, 1, 1 + @img.rows, pixels) }.to raise_error(RangeError)
-    expect { @img.store_pixels(0, 0, @img.columns, 1, ['x']) }.to raise_error(IndexError)
-  end
-
-  def test_strip!
-    expect do
-      res = @img.strip!
-      expect(res).to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_swirl
-    expect do
-      res = @img.swirl(30)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_texture_fill_to_border
-    texture = Magick::Image.read('granite:').first
-    expect do
-      res = @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, texture)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.texture_fill_to_border(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
-    expect { @img.texture_fill_to_border(@img.columns * 2, @img.rows, texture) }.to raise_error(ArgumentError)
-    expect { @img.texture_fill_to_border(@img.columns, @img.rows * 2, texture) }.to raise_error(ArgumentError)
-
-    Magick::PaintMethod.values do |method|
-      next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
-
-      expect { @img.texture_flood_fill('blue', texture, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
+      restored = Magick::Image.from_blob(res)
+      expect(restored[0]).to eq(@img)
     end
   end
 
-  def test_texture_floodfill
-    texture = Magick::Image.read('granite:').first
-    expect do
-      res = @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture)
+  describe '#to_color' do
+    it 'works' do
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect do
+        res = @img.to_color(red)
+        expect(res).to eq('red')
+      end.not_to raise_error
+    end
+  end
+
+  describe '#transparent' do
+    it 'works' do
+      expect do
+        res = @img.transparent('white')
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      pixel = Magick::Pixel.new
+      expect { @img.transparent(pixel) }.not_to raise_error
+      expect { @img.transparent('white', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent('white', alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.transparent('white', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent('white', Magick::TransparentAlpha, 2) }.to raise_error(ArgumentError)
+      expect { @img.transparent('white', Magick::QuantumRange / 2) }.to raise_error(ArgumentError)
+      expect { @img.transparent(2) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#transparent_chroma' do
+    it 'works' do
+      expect(@img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange))).to be_instance_of(Magick::Image)
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }.not_to raise_error
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), true, alpha: Magick::TransparentAlpha) }.not_to raise_error
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+      expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#transpose' do
+    it 'works' do
+      expect do
+        res = @img.transpose
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect do
+        res = @img.transpose!
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#transverse' do
+    it 'works' do
+      expect do
+        res = @img.transverse
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+      expect do
+        res = @img.transverse!
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).to be(@img)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#trim' do
+    it 'works' do
+      # Can't use the default image because it's a solid color
+      hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      expect do
+        expect(hat.trim).to be_instance_of(Magick::Image)
+        expect(hat.trim(10)).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
+
+      expect do
+        res = hat.trim!
+        expect(res).to be(hat)
+
+        res = hat.trim!(10)
+        expect(res).to be(hat)
+      end.not_to raise_error
+      expect { hat.trim!(10, 10) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#unique_colors' do
+    it 'works' do
+      expect do
+        res = @img.unique_colors
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res.columns).to eq(1)
+        expect(res.rows).to eq(1)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#unsharp_mask' do
+    it 'works' do
+      expect do
+        res = @img.unsharp_mask
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      expect { @img.unsharp_mask(2.0) }.not_to raise_error
+      expect { @img.unsharp_mask(2.0, 1.0) }.not_to raise_error
+      expect { @img.unsharp_mask(2.0, 1.0, 0.50) }.not_to raise_error
+      expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
+      expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(ArgumentError)
+      expect { @img.unsharp_mask(-2.0, 1.0, 0.50, 0.10) }.to raise_error(ArgumentError)
+      expect { @img.unsharp_mask(2.0, 0.0, 0.50, 0.10) }.to raise_error(ArgumentError)
+      expect { @img.unsharp_mask(2.0, 1.0, 0.0, 0.10) }.to raise_error(ArgumentError)
+      expect { @img.unsharp_mask(2.0, 1.0, 0.01, -0.10) }.to raise_error(ArgumentError)
+      expect { @img.unsharp_mask('x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask(2.0, 'x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask(2.0, 1.0, 'x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#unsharp_mask_channel' do
+    it 'works' do
+      expect do
+        res = @img.unsharp_mask_channel
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+
+      expect { @img.unsharp_mask_channel(2.0) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, 2) }.to raise_error(TypeError)
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(TypeError)
+      expect { @img.unsharp_mask_channel('x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask_channel(2.0, 'x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 'x') }.to raise_error(TypeError)
+      expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#view' do
+    it 'works' do
+      expect do
+        res = @img.view(0, 0, 5, 5)
+        expect(res).to be_instance_of(Magick::Image::View)
+      end.not_to raise_error
+      expect do
+        @img.view(0, 0, 5, 5) { |v| expect(v).to be_instance_of(Magick::Image::View) }
+      end.not_to raise_error
+      expect { @img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
+      expect { @img.view(0, -1, 5, 5) }.to raise_error(RangeError)
+      expect { @img.view(1, 0, @img.columns, 5) }.to raise_error(RangeError)
+      expect { @img.view(0, 1, 5, @img.rows) }.to raise_error(RangeError)
+      expect { @img.view(0, 0, 0, 1) }.to raise_error(ArgumentError)
+      expect { @img.view(0, 0, 1, 0) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#vignette' do
+    it 'works' do
+      expect do
+        res = @img.vignette
+        expect(res).to be_instance_of(Magick::Image)
+        expect(@img).not_to be(res)
+      end.not_to raise_error
+      expect { @img.vignette(0) }.not_to raise_error
+      expect { @img.vignette(0, 0) }.not_to raise_error
+      expect { @img.vignette(0, 0, 0) }.not_to raise_error
+      expect { @img.vignette(0, 0, 0, 1) }.not_to raise_error
+      # too many arguments
+      expect { @img.vignette(0, 0, 0, 1, 1) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#watermark' do
+    it 'works' do
+      mark = Magick::Image.new(5, 5)
+      mark_list = Magick::ImageList.new
+      mark_list << mark.copy
+      expect { @img.watermark(mark) }.not_to raise_error
+      expect { @img.watermark(mark_list) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50) }.not_to raise_error
+      expect { @img.watermark(mark, '50%') }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, '50%') }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50, 10) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50, 10, 10) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10) }.not_to raise_error
+      expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
+
+      expect { @img.watermark }.to raise_error(ArgumentError)
+      expect { @img.watermark(mark, 'x') }.to raise_error(ArgumentError)
+      expect { @img.watermark(mark, 0.50, 'x') }.to raise_error(ArgumentError)
+      expect { @img.watermark(mark, 0.50, '1500%') }.to raise_error(ArgumentError)
+      expect { @img.watermark(mark, 0.50, 0.50, 'x') }.to raise_error(TypeError)
+      expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
+      expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
+
+      mark.destroy!
+      expect { @img.watermark(mark) }.to raise_error(Magick::DestroyedImageError)
+    end
+  end
+
+  describe '#wave' do
+    it 'works' do
+      expect do
+        res = @img.wave
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @img.wave(25) }.not_to raise_error
+      expect { @img.wave(25, 200) }.not_to raise_error
+      expect { @img.wave(25, 200, 2) }.to raise_error(ArgumentError)
+      expect { @img.wave('x') }.to raise_error(TypeError)
+      expect { @img.wave(25, 'x') }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#wet_floor' do
+    it 'works' do
+      expect(@img.wet_floor).to be_instance_of(Magick::Image)
+      expect { @img.wet_floor(0.0) }.not_to raise_error
+      expect { @img.wet_floor(0.5) }.not_to raise_error
+      expect { @img.wet_floor(0.5, 10) }.not_to raise_error
+      expect { @img.wet_floor(0.5, 0.0) }.not_to raise_error
+
+      expect { @img.wet_floor(2.0) }.to raise_error(ArgumentError)
+      expect { @img.wet_floor(-2.0) }.to raise_error(ArgumentError)
+      expect { @img.wet_floor(0.5, -1.0) }.to raise_error(ArgumentError)
+      expect { @img.wet_floor(0.5, 10, 0.5) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#white_threshold' do
+    it 'works' do
+      expect { @img.white_threshold }.to raise_error(ArgumentError)
+      expect { @img.white_threshold(50) }.not_to raise_error
+      expect { @img.white_threshold(50, 50) }.not_to raise_error
+      expect { @img.white_threshold(50, 50, 50) }.not_to raise_error
+      expect { @img.white_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
+      expect { @img.white_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
+      expect { @img.white_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
+      expect { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
+      expect { @img.white_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
+      res = @img.white_threshold(50)
       expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, 'x') }.to raise_error(NoMethodError)
-    texture.destroy!
-    expect { @img.texture_floodfill(@img.columns / 2, @img.rows / 2, texture) }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_threshold
-    expect do
-      res = @img.threshold(100)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_thumbnail
-    expect do
-      res = @img.thumbnail(10, 10)
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.thumbnail(2) }.not_to raise_error
-    expect { @img.thumbnail }.to raise_error(ArgumentError)
-    expect { @img.thumbnail(-1.0) }.to raise_error(ArgumentError)
-    expect { @img.thumbnail(0, 25) }.to raise_error(ArgumentError)
-    expect { @img.thumbnail(25, 0) }.to raise_error(ArgumentError)
-    expect { @img.thumbnail(25, 25, 25) }.to raise_error(ArgumentError)
-    expect { @img.thumbnail('x') }.to raise_error(TypeError)
-    expect { @img.thumbnail(10, 'x') }.to raise_error(TypeError)
-
-    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    new_img = girl.thumbnail(200, 200)
-    expect(new_img.columns).to eq(160)
-    expect(new_img.rows).to eq(200)
-
-    new_img = girl.thumbnail(2)
-    expect(new_img.columns).to eq(400)
-    expect(new_img.rows).to eq(500)
-  end
-
-  def test_thumbnail!
-    expect do
-      res = @img.thumbnail!(2)
-      expect(res).to be(@img)
-    end.not_to raise_error
-    @img.freeze
-    expect { @img.thumbnail!(0.50) }.to raise_error(FreezeError)
-  end
-
-  def test_tint
-    expect do
-      pixels = @img.get_pixels(0, 0, 1, 1)
-      @img.tint(pixels[0], 1.0)
-    end.not_to raise_error
-    expect { @img.tint('red', 1.0) }.not_to raise_error
-    expect { @img.tint('red', 1.0, 1.0) }.not_to raise_error
-    expect { @img.tint('red', 1.0, 1.0, 1.0) }.not_to raise_error
-    expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0) }.not_to raise_error
-    expect { @img.tint }.to raise_error(ArgumentError)
-    expect { @img.tint('red') }.to raise_error(ArgumentError)
-    expect { @img.tint('red', 1.0, 1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint('x', 1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint('red', -1.0, 1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint('red', 1.0, -1.0, 1.0, 1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint('red', 1.0, 1.0, -1.0, 1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint('red', 1.0, 1.0, 1.0, -1.0) }.to raise_error(ArgumentError)
-    expect { @img.tint(1.0, 1.0) }.to raise_error(TypeError)
-    expect { @img.tint('red', 'green') }.to raise_error(TypeError)
-    expect { @img.tint('red', 1.0, 'green') }.to raise_error(TypeError)
-    expect { @img.tint('red', 1.0, 1.0, 'green') }.to raise_error(TypeError)
-    expect { @img.tint('red', 1.0, 1.0, 1.0, 'green') }.to raise_error(TypeError)
-  end
-
-  def test_to_blob
-    res = nil
-    expect { res = @img.to_blob { self.format = 'miff' } }.not_to raise_error
-    expect(res).to be_instance_of(String)
-    restored = Magick::Image.from_blob(res)
-    expect(restored[0]).to eq(@img)
-  end
-
-  def test_to_color
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect do
-      res = @img.to_color(red)
-      expect(res).to eq('red')
-    end.not_to raise_error
-  end
-
-  def test_transparent
-    expect do
-      res = @img.transparent('white')
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    pixel = Magick::Pixel.new
-    expect { @img.transparent(pixel) }.not_to raise_error
-    expect { @img.transparent('white', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent('white', alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.transparent('white', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent('white', alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent('white', Magick::TransparentAlpha, 2) }.to raise_error(ArgumentError)
-    expect { @img.transparent('white', Magick::QuantumRange / 2) }.to raise_error(ArgumentError)
-    expect { @img.transparent(2) }.to raise_error(TypeError)
-  end
-
-  def test_transparent_chroma
-    expect(@img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange))).to be_instance_of(Magick::Image)
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange)) }.not_to raise_error
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), Magick::TransparentAlpha, true) }.to raise_error(ArgumentError)
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), true, alpha: Magick::TransparentAlpha) }.not_to raise_error
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-    expect { @img.transparent_chroma('white', Magick::Pixel.new(Magick::QuantumRange), false, alpha: Magick::TransparentAlpha, extra: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
-  end
-
-  def test_transpose
-    expect do
-      res = @img.transpose
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect do
-      res = @img.transpose!
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_transverse
-    expect do
-      res = @img.transverse
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).not_to be(@img)
-    end.not_to raise_error
-    expect do
-      res = @img.transverse!
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res).to be(@img)
-    end.not_to raise_error
-  end
-
-  def test_trim
-    # Can't use the default image because it's a solid color
-    hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      expect(hat.trim).to be_instance_of(Magick::Image)
-      expect(hat.trim(10)).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
-
-    expect do
-      res = hat.trim!
-      expect(res).to be(hat)
-
-      res = hat.trim!(10)
-      expect(res).to be(hat)
-    end.not_to raise_error
-    expect { hat.trim!(10, 10) }.to raise_error(ArgumentError)
-  end
-
-  def test_unique_colors
-    expect do
-      res = @img.unique_colors
-      expect(res).to be_instance_of(Magick::Image)
-      expect(res.columns).to eq(1)
-      expect(res.rows).to eq(1)
-    end.not_to raise_error
-  end
-
-  def test_unsharp_mask
-    expect do
-      res = @img.unsharp_mask
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    expect { @img.unsharp_mask(2.0) }.not_to raise_error
-    expect { @img.unsharp_mask(2.0, 1.0) }.not_to raise_error
-    expect { @img.unsharp_mask(2.0, 1.0, 0.50) }.not_to raise_error
-    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
-    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(ArgumentError)
-    expect { @img.unsharp_mask(-2.0, 1.0, 0.50, 0.10) }.to raise_error(ArgumentError)
-    expect { @img.unsharp_mask(2.0, 0.0, 0.50, 0.10) }.to raise_error(ArgumentError)
-    expect { @img.unsharp_mask(2.0, 1.0, 0.0, 0.10) }.to raise_error(ArgumentError)
-    expect { @img.unsharp_mask(2.0, 1.0, 0.01, -0.10) }.to raise_error(ArgumentError)
-    expect { @img.unsharp_mask('x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask(2.0, 'x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask(2.0, 1.0, 'x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_unsharp_mask_channel
-    expect do
-      res = @img.unsharp_mask_channel
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-
-    expect { @img.unsharp_mask_channel(2.0) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, Magick::RedChannel, 2) }.to raise_error(TypeError)
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 0.10, 2) }.to raise_error(TypeError)
-    expect { @img.unsharp_mask_channel('x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask_channel(2.0, 'x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 'x') }.to raise_error(TypeError)
-    expect { @img.unsharp_mask_channel(2.0, 1.0, 0.50, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_view
-    expect do
-      res = @img.view(0, 0, 5, 5)
-      expect(res).to be_instance_of(Magick::Image::View)
-    end.not_to raise_error
-    expect do
-      @img.view(0, 0, 5, 5) { |v| expect(v).to be_instance_of(Magick::Image::View) }
-    end.not_to raise_error
-    expect { @img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
-    expect { @img.view(0, -1, 5, 5) }.to raise_error(RangeError)
-    expect { @img.view(1, 0, @img.columns, 5) }.to raise_error(RangeError)
-    expect { @img.view(0, 1, 5, @img.rows) }.to raise_error(RangeError)
-    expect { @img.view(0, 0, 0, 1) }.to raise_error(ArgumentError)
-    expect { @img.view(0, 0, 1, 0) }.to raise_error(ArgumentError)
-  end
-
-  def test_vignette
-    expect do
-      res = @img.vignette
-      expect(res).to be_instance_of(Magick::Image)
-      expect(@img).not_to be(res)
-    end.not_to raise_error
-    expect { @img.vignette(0) }.not_to raise_error
-    expect { @img.vignette(0, 0) }.not_to raise_error
-    expect { @img.vignette(0, 0, 0) }.not_to raise_error
-    expect { @img.vignette(0, 0, 0, 1) }.not_to raise_error
-    # too many arguments
-    expect { @img.vignette(0, 0, 0, 1, 1) }.to raise_error(ArgumentError)
-  end
-
-  def test_watermark
-    mark = Magick::Image.new(5, 5)
-    mark_list = Magick::ImageList.new
-    mark_list << mark.copy
-    expect { @img.watermark(mark) }.not_to raise_error
-    expect { @img.watermark(mark_list) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50) }.not_to raise_error
-    expect { @img.watermark(mark, '50%') }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, '50%') }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50, 10) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50, 10, 10) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10) }.not_to raise_error
-    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 10) }.not_to raise_error
-
-    expect { @img.watermark }.to raise_error(ArgumentError)
-    expect { @img.watermark(mark, 'x') }.to raise_error(ArgumentError)
-    expect { @img.watermark(mark, 0.50, 'x') }.to raise_error(ArgumentError)
-    expect { @img.watermark(mark, 0.50, '1500%') }.to raise_error(ArgumentError)
-    expect { @img.watermark(mark, 0.50, 0.50, 'x') }.to raise_error(TypeError)
-    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 'x') }.to raise_error(TypeError)
-    expect { @img.watermark(mark, 0.50, 0.50, Magick::NorthEastGravity, 10, 'x') }.to raise_error(TypeError)
-
-    mark.destroy!
-    expect { @img.watermark(mark) }.to raise_error(Magick::DestroyedImageError)
-  end
-
-  def test_wave
-    expect do
-      res = @img.wave
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @img.wave(25) }.not_to raise_error
-    expect { @img.wave(25, 200) }.not_to raise_error
-    expect { @img.wave(25, 200, 2) }.to raise_error(ArgumentError)
-    expect { @img.wave('x') }.to raise_error(TypeError)
-    expect { @img.wave(25, 'x') }.to raise_error(TypeError)
-  end
-
-  def test_wet_floor
-    expect(@img.wet_floor).to be_instance_of(Magick::Image)
-    expect { @img.wet_floor(0.0) }.not_to raise_error
-    expect { @img.wet_floor(0.5) }.not_to raise_error
-    expect { @img.wet_floor(0.5, 10) }.not_to raise_error
-    expect { @img.wet_floor(0.5, 0.0) }.not_to raise_error
-
-    expect { @img.wet_floor(2.0) }.to raise_error(ArgumentError)
-    expect { @img.wet_floor(-2.0) }.to raise_error(ArgumentError)
-    expect { @img.wet_floor(0.5, -1.0) }.to raise_error(ArgumentError)
-    expect { @img.wet_floor(0.5, 10, 0.5) }.to raise_error(ArgumentError)
-  end
-
-  def test_white_threshold
-    expect { @img.white_threshold }.to raise_error(ArgumentError)
-    expect { @img.white_threshold(50) }.not_to raise_error
-    expect { @img.white_threshold(50, 50) }.not_to raise_error
-    expect { @img.white_threshold(50, 50, 50) }.not_to raise_error
-    expect { @img.white_threshold(50, 50, 50, 50) }.to raise_error(ArgumentError)
-    expect { @img.white_threshold(50, 50, 50, alpha: 50) }.not_to raise_error
-    expect { @img.white_threshold(50, 50, 50, wrong: 50) }.to raise_error(ArgumentError)
-    expect { @img.white_threshold(50, 50, 50, alpha: 50, extra: 50) }.to raise_error(ArgumentError)
-    expect { @img.white_threshold(50, 50, 50, 50, 50) }.to raise_error(ArgumentError)
-    res = @img.white_threshold(50)
-    expect(res).to be_instance_of(Magick::Image)
+    end
   end
 
   # test write with #format= attribute
-  def test_write
-    @img.write('temp.gif')
-    img = Magick::Image.read('temp.gif')
-    expect(img.first.format).to eq('GIF')
-    FileUtils.rm('temp.gif')
+  describe '#write' do
+    it 'works' do
+      @img.write('temp.gif')
+      img = Magick::Image.read('temp.gif')
+      expect(img.first.format).to eq('GIF')
+      FileUtils.rm('temp.gif')
 
-    @img.write('jpg:temp.foo')
-    img = Magick::Image.read('temp.foo')
-    expect(img.first.format).to eq('JPEG')
-    FileUtils.rm('temp.foo')
+      @img.write('jpg:temp.foo')
+      img = Magick::Image.read('temp.foo')
+      expect(img.first.format).to eq('JPEG')
+      FileUtils.rm('temp.foo')
 
-    @img.write('temp.0') { self.format = 'JPEG' }
-    img = Magick::Image.read('temp.0')
-    expect(img.first.format).to eq('JPEG')
+      @img.write('temp.0') { self.format = 'JPEG' }
+      img = Magick::Image.read('temp.0')
+      expect(img.first.format).to eq('JPEG')
 
-    # JPEG has two names.
-    @img.write('jpeg:temp.0') { self.format = 'JPEG' }
-    img = Magick::Image.read('temp.0')
-    expect(img.first.format).to eq('JPEG')
+      # JPEG has two names.
+      @img.write('jpeg:temp.0') { self.format = 'JPEG' }
+      img = Magick::Image.read('temp.0')
+      expect(img.first.format).to eq('JPEG')
 
-    @img.write('jpg:temp.0') { self.format = 'JPG' }
-    img = Magick::Image.read('temp.0')
-    expect(img.first.format).to eq('JPEG')
+      @img.write('jpg:temp.0') { self.format = 'JPG' }
+      img = Magick::Image.read('temp.0')
+      expect(img.first.format).to eq('JPEG')
 
-    @img.write('jpg:temp.0') { self.format = 'JPEG' }
-    img = Magick::Image.read('temp.0')
-    expect(img.first.format).to eq('JPEG')
+      @img.write('jpg:temp.0') { self.format = 'JPEG' }
+      img = Magick::Image.read('temp.0')
+      expect(img.first.format).to eq('JPEG')
 
-    @img.write('jpeg:temp.0') { self.format = 'JPG' }
-    img = Magick::Image.read('temp.0')
-    expect(img.first.format).to eq('JPEG')
+      @img.write('jpeg:temp.0') { self.format = 'JPG' }
+      img = Magick::Image.read('temp.0')
+      expect(img.first.format).to eq('JPEG')
 
-    expect do
-      @img.write('gif:temp.0') { self.format = 'JPEG' }
-    end.to raise_error(RuntimeError)
+      expect do
+        @img.write('gif:temp.0') { self.format = 'JPEG' }
+      end.to raise_error(RuntimeError)
 
-    f = File.new('test.0', 'w')
-    @img.write(f) { self.format = 'JPEG' }
-    f.close
-    img = Magick::Image.read('test.0')
-    expect(img.first.format).to eq('JPEG')
-    FileUtils.rm('test.0')
+      f = File.new('test.0', 'w')
+      @img.write(f) { self.format = 'JPEG' }
+      f.close
+      img = Magick::Image.read('test.0')
+      expect(img.first.format).to eq('JPEG')
+      FileUtils.rm('test.0')
 
-    @img.write('test.webp')
-    img = Magick::Image.read('test.webp')
-    expect(img.first.format).to eq('WEBP')
-    FileUtils.rm('test.webp') rescue nil # Avoid failure on AppVeyor
+      @img.write('test.webp')
+      img = Magick::Image.read('test.webp')
+      expect(img.first.format).to eq('WEBP')
+      FileUtils.rm('test.webp') rescue nil # Avoid failure on AppVeyor
 
-    f = File.new('test.0', 'w')
-    Magick::Image.new(100, 100).write(f) do
-      self.format = 'JPEG'
-      self.colorspace = Magick::CMYKColorspace
+      f = File.new('test.0', 'w')
+      Magick::Image.new(100, 100).write(f) do
+        self.format = 'JPEG'
+        self.colorspace = Magick::CMYKColorspace
+      end
+      f.close
+      img = Magick::Image.read('test.0')
+      expect(img.first.format).to eq('JPEG')
+      FileUtils.rm('test.0')
     end
-    f.close
-    img = Magick::Image.read('test.0')
-    expect(img.first.format).to eq('JPEG')
-    FileUtils.rm('test.0')
   end
 end
 

--- a/test/ImageList1.rb
+++ b/test/ImageList1.rb
@@ -1,8 +1,8 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class ImageList1UT < Minitest::Test
-  def setup
+describe Magick::ImageList do
+  before do
     @list = Magick::ImageList.new(*FILES[0..9])
     @list2 = Magick::ImageList.new # intersection is 5..9
     @list2 << @list[5]
@@ -12,839 +12,957 @@ class ImageList1UT < Minitest::Test
     @list2 << @list[9]
   end
 
-  def test_combine
-    red   = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    green = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    blue  = Magick::Image.new(20, 20) { self.background_color = 'blue' }
-    black = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    alpha = Magick::Image.new(20, 20) { self.background_color = 'transparent' }
+  describe '#combine' do
+    it 'works' do
+      red   = Magick::Image.new(20, 20) { self.background_color = 'red' }
+      green = Magick::Image.new(20, 20) { self.background_color = 'green' }
+      blue  = Magick::Image.new(20, 20) { self.background_color = 'blue' }
+      black = Magick::Image.new(20, 20) { self.background_color = 'black' }
+      alpha = Magick::Image.new(20, 20) { self.background_color = 'transparent' }
 
-    list = Magick::ImageList.new
-    expect { list.combine }.to raise_error(ArgumentError)
+      list = Magick::ImageList.new
+      expect { list.combine }.to raise_error(ArgumentError)
 
-    list << red
-    expect { list.combine }.not_to raise_error
+      list << red
+      expect { list.combine }.not_to raise_error
 
-    res = list.combine
-    expect(res).to be_instance_of(Magick::Image)
+      res = list.combine
+      expect(res).to be_instance_of(Magick::Image)
 
-    list << alpha
-    expect { list.combine }.not_to raise_error
+      list << alpha
+      expect { list.combine }.not_to raise_error
 
-    list.pop
-    list << green
-    list << blue
-    expect { list.combine }.not_to raise_error
+      list.pop
+      list << green
+      list << blue
+      expect { list.combine }.not_to raise_error
 
-    list << alpha
-    expect { list.combine }.not_to raise_error
+      list << alpha
+      expect { list.combine }.not_to raise_error
 
-    list.pop
-    list << black
-    expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
-    expect { list.combine(Magick::SRGBColorspace) }.not_to raise_error
+      list.pop
+      list << black
+      expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
+      expect { list.combine(Magick::SRGBColorspace) }.not_to raise_error
 
-    list << alpha
-    expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
-    expect { list.combine(Magick::SRGBColorspace) }.to raise_error(ArgumentError)
+      list << alpha
+      expect { list.combine(Magick::CMYKColorspace) }.not_to raise_error
+      expect { list.combine(Magick::SRGBColorspace) }.to raise_error(ArgumentError)
 
-    list << alpha
-    expect { list.combine }.to raise_error(ArgumentError)
+      list << alpha
+      expect { list.combine }.to raise_error(ArgumentError)
 
-    expect { list.combine(nil) }.to raise_error(TypeError)
-    expect { list.combine(Magick::SRGBColorspace, 1) }.to raise_error(ArgumentError)
-  end
-
-  def test_composite_layers
-    expect { @list.composite_layers(@list2) }.not_to raise_error
-    Magick::CompositeOperator.values do |op|
-      expect { @list.composite_layers(@list2, op) }.not_to raise_error
+      expect { list.combine(nil) }.to raise_error(TypeError)
+      expect { list.combine(Magick::SRGBColorspace, 1) }.to raise_error(ArgumentError)
     end
-
-    expect { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }.to raise_error(ArgumentError)
   end
 
-  def test_delay
-    expect { @list.delay }.not_to raise_error
-    expect(@list.delay).to eq(0)
-    expect { @list.delay = 20 }.not_to raise_error
-    expect(@list.delay).to eq(20)
-    expect { @list.delay = 'x' }.to raise_error(ArgumentError)
+  describe '#composite_layers' do
+    it 'works' do
+      expect { @list.composite_layers(@list2) }.not_to raise_error
+      Magick::CompositeOperator.values do |op|
+        expect { @list.composite_layers(@list2, op) }.not_to raise_error
+      end
+
+      expect { @list.composite_layers(@list2, Magick::ModulusAddCompositeOp, 42) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_flatten_images
-    expect { @list.flatten_images }.not_to raise_error
+  describe '#delay' do
+    it 'works' do
+      expect { @list.delay }.not_to raise_error
+      expect(@list.delay).to eq(0)
+      expect { @list.delay = 20 }.not_to raise_error
+      expect(@list.delay).to eq(20)
+      expect { @list.delay = 'x' }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_ticks_per_second
-    expect { @list.ticks_per_second }.not_to raise_error
-    expect(@list.ticks_per_second).to eq(100)
-    expect { @list.ticks_per_second = 1000 }.not_to raise_error
-    expect(@list.ticks_per_second).to eq(1000)
-    expect { @list.ticks_per_second = 'x' }.to raise_error(ArgumentError)
+  describe '#flatten_images' do
+    it 'works' do
+      expect { @list.flatten_images }.not_to raise_error
+    end
   end
 
-  def test_iterations
-    expect { @list.iterations }.not_to raise_error
-    expect(@list.iterations).to be_kind_of(Integer)
-    expect { @list.iterations = 20 }.not_to raise_error
-    expect(@list.iterations).to eq(20)
-    expect { @list.iterations = 'x' }.to raise_error(ArgumentError)
+  describe '#ticks_per_second' do
+    it 'works' do
+      expect { @list.ticks_per_second }.not_to raise_error
+      expect(@list.ticks_per_second).to eq(100)
+      expect { @list.ticks_per_second = 1000 }.not_to raise_error
+      expect(@list.ticks_per_second).to eq(1000)
+      expect { @list.ticks_per_second = 'x' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#iterations' do
+    it 'works' do
+      expect { @list.iterations }.not_to raise_error
+      expect(@list.iterations).to be_kind_of(Integer)
+      expect { @list.iterations = 20 }.not_to raise_error
+      expect(@list.iterations).to eq(20)
+      expect { @list.iterations = 'x' }.to raise_error(ArgumentError)
+    end
   end
 
   # also tests #size
-  def test_length
-    expect { @list.length }.not_to raise_error
-    expect(@list.length).to eq(10)
-    expect { @list.length = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_scene
-    expect { @list.scene }.not_to raise_error
-    expect(@list.scene).to eq(9)
-    expect { @list.scene = 0 }.not_to raise_error
-    expect(@list.scene).to eq(0)
-    expect { @list.scene = 1 }.not_to raise_error
-    expect(@list.scene).to eq(1)
-    expect { @list.scene = -1 }.to raise_error(IndexError)
-    expect { @list.scene = 1000 }.to raise_error(IndexError)
-    expect { @list.scene = nil }.to raise_error(IndexError)
-
-    # allow nil on empty list
-    empty_list = Magick::ImageList.new
-    expect { empty_list.scene = nil }.not_to raise_error
-  end
-
-  def test_undef_array_methods
-    expect { @list.assoc }.to raise_error(NoMethodError)
-    expect { @list.flatten }.to raise_error(NoMethodError)
-    expect { @list.flatten! }.to raise_error(NoMethodError)
-    expect { @list.join }.to raise_error(NoMethodError)
-    expect { @list.pack }.to raise_error(NoMethodError)
-    expect { @list.rassoc }.to raise_error(NoMethodError)
-  end
-
-  def test_all
-    q = nil
-    expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
-    expect(q).to be(true)
-  end
-
-  def test_any
-    q = nil
-    expect { q = @list.all? { |_i| false } }.not_to raise_error
-    expect(q).to be(false)
-    expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
-    expect(q).to be(true)
-  end
-
-  def test_aref
-    expect { @list[0] }.not_to raise_error
-    expect(@list[0]).to be_instance_of(Magick::Image)
-    expect(@list[-1]).to be_instance_of(Magick::Image)
-    expect(@list[0, 1]).to be_instance_of(Magick::ImageList)
-    expect(@list[0..2]).to be_instance_of(Magick::ImageList)
-    expect(@list[20]).to be(nil)
-  end
-
-  def test_aset
-    img = Magick::Image.new(5, 5)
-    expect do
-      rv = @list[0] = img
-      expect(rv).to be(img)
-      expect(@list[0]).to be(img)
-      expect(@list.scene).to eq(0)
-    end.not_to raise_error
-
-    # replace 2 images with 1
-    expect do
-      img = Magick::Image.new(5, 5)
-      rv = @list[1, 2] = img
-      expect(rv).to be(img)
-      expect(@list.length).to eq(9)
-      expect(@list[1]).to be(img)
-      expect(@list.scene).to eq(1)
-    end.not_to raise_error
-
-    # replace 1 image with 2
-    expect do
-      img = Magick::Image.new(5, 5)
-      img2 = Magick::Image.new(5, 5)
-      ary = [img, img2]
-      rv = @list[3, 1] = ary
-      expect(rv).to be(ary)
+  describe '#length' do
+    it 'works' do
+      expect { @list.length }.not_to raise_error
       expect(@list.length).to eq(10)
-      expect(@list[3]).to be(img)
-      expect(@list[4]).to be(img2)
-      expect(@list.scene).to eq(4)
-    end.not_to raise_error
+      expect { @list.length = 2 }.to raise_error(NoMethodError)
+    end
+  end
 
-    expect do
+  describe '#scene' do
+    it 'works' do
+      expect { @list.scene }.not_to raise_error
+      expect(@list.scene).to eq(9)
+      expect { @list.scene = 0 }.not_to raise_error
+      expect(@list.scene).to eq(0)
+      expect { @list.scene = 1 }.not_to raise_error
+      expect(@list.scene).to eq(1)
+      expect { @list.scene = -1 }.to raise_error(IndexError)
+      expect { @list.scene = 1000 }.to raise_error(IndexError)
+      expect { @list.scene = nil }.to raise_error(IndexError)
+
+      # allow nil on empty list
+      empty_list = Magick::ImageList.new
+      expect { empty_list.scene = nil }.not_to raise_error
+    end
+  end
+
+  describe '#undef_array_methods' do
+    it 'works' do
+      expect { @list.assoc }.to raise_error(NoMethodError)
+      expect { @list.flatten }.to raise_error(NoMethodError)
+      expect { @list.flatten! }.to raise_error(NoMethodError)
+      expect { @list.join }.to raise_error(NoMethodError)
+      expect { @list.pack }.to raise_error(NoMethodError)
+      expect { @list.rassoc }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#all' do
+    it 'works' do
+      q = nil
+      expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
+      expect(q).to be(true)
+    end
+  end
+
+  describe '#any' do
+    it 'works' do
+      q = nil
+      expect { q = @list.all? { |_i| false } }.not_to raise_error
+      expect(q).to be(false)
+      expect { q = @list.all? { |i| i.class == Magick::Image } }.not_to raise_error
+      expect(q).to be(true)
+    end
+  end
+
+  describe '#aref' do
+    it 'works' do
+      expect { @list[0] }.not_to raise_error
+      expect(@list[0]).to be_instance_of(Magick::Image)
+      expect(@list[-1]).to be_instance_of(Magick::Image)
+      expect(@list[0, 1]).to be_instance_of(Magick::ImageList)
+      expect(@list[0..2]).to be_instance_of(Magick::ImageList)
+      expect(@list[20]).to be(nil)
+    end
+  end
+
+  describe '#aset' do
+    it 'works' do
       img = Magick::Image.new(5, 5)
-      rv = @list[5..6] = img
-      expect(rv).to be(img)
-      expect(@list.length).to eq(9)
-      expect(@list[5]).to be(img)
-      expect(@list.scene).to eq(5)
-    end.not_to raise_error
-
-    expect do
-      ary = [img, img]
-      rv = @list[7..8] = ary
-      expect(rv).to be(ary)
-      expect(@list.length).to eq(9)
-      expect(@list[7]).to be(img)
-      expect(@list[8]).to be(img)
-      expect(@list.scene).to eq(8)
-    end.not_to raise_error
-
-    expect do
-      rv = @list[-1] = img
-      expect(rv).to be(img)
-      expect(@list.length).to eq(9)
-      expect(@list[8]).to be(img)
-      expect(@list.scene).to eq(8)
-    end.not_to raise_error
-
-    expect { @list[0] = 1 }.to raise_error(ArgumentError)
-    expect { @list[0, 1] = [1, 2] }.to raise_error(ArgumentError)
-    expect { @list[2..3] = 'x' }.to raise_error(ArgumentError)
-  end
-
-  def test_and
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      res = @list & @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(@list).not_to be(res)
-      expect(@list2).not_to be(res)
-      expect(res.length).to eq(5)
-      expect(res.scene).to eq(2)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
-
-    # current scene not in the result, set result scene to last image in result
-    @list.scene = 2
-    expect do
-      res = @list & @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.scene).to eq(4)
-    end.not_to raise_error
-
-    expect { @list & 2 }.to raise_error(ArgumentError)
-  end
-
-  def test_at
-    expect do
-      cur = @list.cur_image
-      img = @list.at(7)
-      expect(@list[7]).to be(img)
-      expect(@list.cur_image).to be(cur)
-      img = @list.at(10)
-      expect(img).to be(nil)
-      expect(@list.cur_image).to be(cur)
-      img = @list.at(-1)
-      expect(@list[9]).to be(img)
-      expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
-  end
-
-  def test_star
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      res = @list * 2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(20)
-      expect(@list).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
-
-    expect { @list * 'x' }.to raise_error(ArgumentError)
-  end
-
-  def test_plus
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      res = @list + @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(15)
-      expect(@list).not_to be(res)
-      expect(@list2).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
-
-    expect { @list + [2] }.to raise_error(ArgumentError)
-  end
-
-  def test_minus
-    @list.scene = 0
-    cur = @list.cur_image
-    expect do
-      res = @list - @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(5)
-      expect(@list).not_to be(res)
-      expect(@list2).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
-
-    # current scene not in result - set result scene to last image in result
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      res = @list - @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(5)
-      expect(res.scene).to eq(4)
-    end.not_to raise_error
-  end
-
-  def test_catenate
-    expect do
-      @list2.each { |img| @list << img }
-      expect(@list.length).to eq(15)
-      expect(@list.scene).to eq(14)
-    end.not_to raise_error
-
-    expect { @list << 2 }.to raise_error(ArgumentError)
-    expect { @list << [2] }.to raise_error(ArgumentError)
-  end
-
-  def test_or
-    expect do
-      @list.scene = 7
-      # The or of these two lists should be the same as @list
-      # but not be the *same* list
-      res = @list | @list2
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(@list).not_to be(res)
-      expect(@list2).not_to be(res)
-      expect(@list).to eq(res)
-    end.not_to raise_error
-
-    # Try or'ing disjoint lists
-    temp_list = Magick::ImageList.new(*FILES[10..14])
-    res = @list | temp_list
-    expect(res).to be_instance_of(Magick::ImageList)
-    expect(res.length).to eq(15)
-    expect(res.scene).to eq(7)
-
-    expect { @list | 2 }.to raise_error(ArgumentError)
-    expect { @list | [2] }.to raise_error(ArgumentError)
-  end
-
-  def test_clear
-    expect { @list.clear }.not_to raise_error
-    expect(@list).to be_instance_of(Magick::ImageList)
-    expect(@list.length).to eq(0)
-    expect(@list.scene).to be(nil)
-  end
-
-  def test_collect
-    expect do
-      scene = @list.scene
-      res = @list.collect(&:negate)
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(@list).not_to be(res)
-      expect(res.scene).to eq(scene)
-    end.not_to raise_error
-    expect do
-      scene = @list.scene
-      @list.collect!(&:negate)
-      expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list.scene).to eq(scene)
-    end.not_to raise_error
-  end
-
-  def test_compact
-    expect do
-      res = @list.compact
-      expect(@list).not_to be(res)
-      expect(@list).to eq(res)
-    end.not_to raise_error
-    expect do
-      res = @list
-      @list.compact!
-      expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list).to eq(res)
-      expect(@list).to be(res)
-    end.not_to raise_error
-  end
-
-  def test_concat
-    expect do
-      res = @list.concat(@list2)
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(15)
-      expect(res.cur_image).to be(res[14])
-    end.not_to raise_error
-    expect { @list.concat(2) }.to raise_error(ArgumentError)
-    expect { @list.concat([2]) }.to raise_error(ArgumentError)
-  end
-
-  def test_delete
-    expect do
-      cur = @list.cur_image
-      img = @list[7]
-      expect(@list.delete(img)).to be(img)
-      expect(@list.length).to eq(9)
-      expect(@list.cur_image).to be(cur)
-
-      # Try deleting the current image.
-      expect(@list.delete(cur)).to be(cur)
-      expect(@list.cur_image).to be(@list[-1])
-
-      expect { @list.delete(2) }.to raise_error(ArgumentError)
-      expect { @list.delete([2]) }.to raise_error(ArgumentError)
-
-      # Try deleting something that isn't in the list.
-      # Should return the value of the block.
       expect do
-        img = Magick::Image.read(FILES[10]).first
-        res = @list.delete(img) { 1 }
-        expect(res).to eq(1)
+        rv = @list[0] = img
+        expect(rv).to be(img)
+        expect(@list[0]).to be(img)
+        expect(@list.scene).to eq(0)
       end.not_to raise_error
-    end.not_to raise_error
+
+      # replace 2 images with 1
+      expect do
+        img = Magick::Image.new(5, 5)
+        rv = @list[1, 2] = img
+        expect(rv).to be(img)
+        expect(@list.length).to eq(9)
+        expect(@list[1]).to be(img)
+        expect(@list.scene).to eq(1)
+      end.not_to raise_error
+
+      # replace 1 image with 2
+      expect do
+        img = Magick::Image.new(5, 5)
+        img2 = Magick::Image.new(5, 5)
+        ary = [img, img2]
+        rv = @list[3, 1] = ary
+        expect(rv).to be(ary)
+        expect(@list.length).to eq(10)
+        expect(@list[3]).to be(img)
+        expect(@list[4]).to be(img2)
+        expect(@list.scene).to eq(4)
+      end.not_to raise_error
+
+      expect do
+        img = Magick::Image.new(5, 5)
+        rv = @list[5..6] = img
+        expect(rv).to be(img)
+        expect(@list.length).to eq(9)
+        expect(@list[5]).to be(img)
+        expect(@list.scene).to eq(5)
+      end.not_to raise_error
+
+      expect do
+        ary = [img, img]
+        rv = @list[7..8] = ary
+        expect(rv).to be(ary)
+        expect(@list.length).to eq(9)
+        expect(@list[7]).to be(img)
+        expect(@list[8]).to be(img)
+        expect(@list.scene).to eq(8)
+      end.not_to raise_error
+
+      expect do
+        rv = @list[-1] = img
+        expect(rv).to be(img)
+        expect(@list.length).to eq(9)
+        expect(@list[8]).to be(img)
+        expect(@list.scene).to eq(8)
+      end.not_to raise_error
+
+      expect { @list[0] = 1 }.to raise_error(ArgumentError)
+      expect { @list[0, 1] = [1, 2] }.to raise_error(ArgumentError)
+      expect { @list[2..3] = 'x' }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_delete_at
-    @list.scene = 7
-    cur = @list.cur_image
-    expect { @list.delete_at(9) }.not_to raise_error
-    expect(@list.cur_image).to be(cur)
-    expect { @list.delete_at(7) }.not_to raise_error
-    expect(@list.cur_image).to be(@list[-1])
+  describe '#and' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        res = @list & @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(@list).not_to be(res)
+        expect(@list2).not_to be(res)
+        expect(res.length).to eq(5)
+        expect(res.scene).to eq(2)
+        expect(res.cur_image).to be(cur)
+      end.not_to raise_error
+
+      # current scene not in the result, set result scene to last image in result
+      @list.scene = 2
+      expect do
+        res = @list & @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.scene).to eq(4)
+      end.not_to raise_error
+
+      expect { @list & 2 }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_delete_if
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      @list.delete_if { |img| File.basename(img.filename) =~ /5/ }
+  describe '#at' do
+    it 'works' do
+      expect do
+        cur = @list.cur_image
+        img = @list.at(7)
+        expect(@list[7]).to be(img)
+        expect(@list.cur_image).to be(cur)
+        img = @list.at(10)
+        expect(img).to be(nil)
+        expect(@list.cur_image).to be(cur)
+        img = @list.at(-1)
+        expect(@list[9]).to be(img)
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#star' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        res = @list * 2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(20)
+        expect(@list).not_to be(res)
+        expect(res.cur_image).to be(cur)
+      end.not_to raise_error
+
+      expect { @list * 'x' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#plus' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        res = @list + @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(15)
+        expect(@list).not_to be(res)
+        expect(@list2).not_to be(res)
+        expect(res.cur_image).to be(cur)
+      end.not_to raise_error
+
+      expect { @list + [2] }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#minus' do
+    it 'works' do
+      @list.scene = 0
+      cur = @list.cur_image
+      expect do
+        res = @list - @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(5)
+        expect(@list).not_to be(res)
+        expect(@list2).not_to be(res)
+        expect(res.cur_image).to be(cur)
+      end.not_to raise_error
+
+      # current scene not in result - set result scene to last image in result
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        res = @list - @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(5)
+        expect(res.scene).to eq(4)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#catenate' do
+    it 'works' do
+      expect do
+        @list2.each { |img| @list << img }
+        expect(@list.length).to eq(15)
+        expect(@list.scene).to eq(14)
+      end.not_to raise_error
+
+      expect { @list << 2 }.to raise_error(ArgumentError)
+      expect { @list << [2] }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#or' do
+    it 'works' do
+      expect do
+        @list.scene = 7
+        # The or of these two lists should be the same as @list
+        # but not be the *same* list
+        res = @list | @list2
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(@list).not_to be(res)
+        expect(@list2).not_to be(res)
+        expect(@list).to eq(res)
+      end.not_to raise_error
+
+      # Try or'ing disjoint lists
+      temp_list = Magick::ImageList.new(*FILES[10..14])
+      res = @list | temp_list
+      expect(res).to be_instance_of(Magick::ImageList)
+      expect(res.length).to eq(15)
+      expect(res.scene).to eq(7)
+
+      expect { @list | 2 }.to raise_error(ArgumentError)
+      expect { @list | [2] }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#clear' do
+    it 'works' do
+      expect { @list.clear }.not_to raise_error
       expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list.length).to eq(9)
+      expect(@list.length).to eq(0)
+      expect(@list.scene).to be(nil)
+    end
+  end
+
+  describe '#collect' do
+    it 'works' do
+      expect do
+        scene = @list.scene
+        res = @list.collect(&:negate)
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(@list).not_to be(res)
+        expect(res.scene).to eq(scene)
+      end.not_to raise_error
+      expect do
+        scene = @list.scene
+        @list.collect!(&:negate)
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list.scene).to eq(scene)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#compact' do
+    it 'works' do
+      expect do
+        res = @list.compact
+        expect(@list).not_to be(res)
+        expect(@list).to eq(res)
+      end.not_to raise_error
+      expect do
+        res = @list
+        @list.compact!
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list).to eq(res)
+        expect(@list).to be(res)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#concat' do
+    it 'works' do
+      expect do
+        res = @list.concat(@list2)
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(15)
+        expect(res.cur_image).to be(res[14])
+      end.not_to raise_error
+      expect { @list.concat(2) }.to raise_error(ArgumentError)
+      expect { @list.concat([2]) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#delete' do
+    it 'works' do
+      expect do
+        cur = @list.cur_image
+        img = @list[7]
+        expect(@list.delete(img)).to be(img)
+        expect(@list.length).to eq(9)
+        expect(@list.cur_image).to be(cur)
+
+        # Try deleting the current image.
+        expect(@list.delete(cur)).to be(cur)
+        expect(@list.cur_image).to be(@list[-1])
+
+        expect { @list.delete(2) }.to raise_error(ArgumentError)
+        expect { @list.delete([2]) }.to raise_error(ArgumentError)
+
+        # Try deleting something that isn't in the list.
+        # Should return the value of the block.
+        expect do
+          img = Magick::Image.read(FILES[10]).first
+          res = @list.delete(img) { 1 }
+          expect(res).to eq(1)
+        end.not_to raise_error
+      end.not_to raise_error
+    end
+  end
+
+  describe '#delete_at' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect { @list.delete_at(9) }.not_to raise_error
       expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
-
-    # Delete the current image
-    expect do
-      @list.delete_if { |img| File.basename(img.filename) =~ /7/ }
-      expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list.length).to eq(8)
+      expect { @list.delete_at(7) }.not_to raise_error
       expect(@list.cur_image).to be(@list[-1])
-    end.not_to raise_error
+    end
+  end
+
+  describe '#delete_if' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        @list.delete_if { |img| File.basename(img.filename) =~ /5/ }
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list.length).to eq(9)
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
+
+      # Delete the current image
+      expect do
+        @list.delete_if { |img| File.basename(img.filename) =~ /7/ }
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list.length).to eq(8)
+        expect(@list.cur_image).to be(@list[-1])
+      end.not_to raise_error
+    end
   end
 
   # defined by Enumerable
-  def test_enumerables
-    expect { @list.detect { true } }.not_to raise_error
-    expect do
-      @list.each_with_index { |img, _n| expect(img).to be_instance_of(Magick::Image) }
-    end.not_to raise_error
-    expect { @list.entries }.not_to raise_error
-    expect { @list.include?(@list[0]) }.not_to raise_error
-    expect { @list.inject(0) { 0 } }.not_to raise_error
-    expect { @list.max }.not_to raise_error
-    expect { @list.min }.not_to raise_error
-    expect { @list.sort }.not_to raise_error
-    expect { @list.sort_by(&:signature) }.not_to raise_error
-    expect { @list.zip }.not_to raise_error
+  describe '#enumerables' do
+    it 'works' do
+      expect { @list.detect { true } }.not_to raise_error
+      expect do
+        @list.each_with_index { |img, _n| expect(img).to be_instance_of(Magick::Image) }
+      end.not_to raise_error
+      expect { @list.entries }.not_to raise_error
+      expect { @list.include?(@list[0]) }.not_to raise_error
+      expect { @list.inject(0) { 0 } }.not_to raise_error
+      expect { @list.max }.not_to raise_error
+      expect { @list.min }.not_to raise_error
+      expect { @list.sort }.not_to raise_error
+      expect { @list.sort_by(&:signature) }.not_to raise_error
+      expect { @list.zip }.not_to raise_error
+    end
   end
 
-  def test_eql?
-    list2 = @list
-    expect(@list.eql?(list2)).to be(true)
-    list2 = @list.copy
-    expect(@list.eql?(list2)).to be(false)
+  describe '#eql?' do
+    it 'works' do
+      list2 = @list
+      expect(@list.eql?(list2)).to be(true)
+      list2 = @list.copy
+      expect(@list.eql?(list2)).to be(false)
+    end
   end
 
-  def test_fill
-    list = @list.copy
-    img = list[0].copy
-    expect do
-      expect(list.fill(img)).to be_instance_of(Magick::ImageList)
-    end.not_to raise_error
-    list.each { |el| expect(img).to be(el) }
+  describe '#fill' do
+    it 'works' do
+      list = @list.copy
+      img = list[0].copy
+      expect do
+        expect(list.fill(img)).to be_instance_of(Magick::ImageList)
+      end.not_to raise_error
+      list.each { |el| expect(img).to be(el) }
 
-    list = @list.copy
-    list.fill(img, 0, 3)
-    0.upto(2) { |i| expect(list[i]).to be(img) }
+      list = @list.copy
+      list.fill(img, 0, 3)
+      0.upto(2) { |i| expect(list[i]).to be(img) }
 
-    list = @list.copy
-    list.fill(img, 4..7)
-    4.upto(7) { |i| expect(list[i]).to be(img) }
+      list = @list.copy
+      list.fill(img, 4..7)
+      4.upto(7) { |i| expect(list[i]).to be(img) }
 
-    list = @list.copy
-    list.fill { |i| list[i] = img }
-    list.each { |el| expect(img).to be(el) }
+      list = @list.copy
+      list.fill { |i| list[i] = img }
+      list.each { |el| expect(img).to be(el) }
 
-    list = @list.copy
-    list.fill(0, 3) { |i| list[i] = img }
-    0.upto(2) { |i| expect(list[i]).to be(img) }
+      list = @list.copy
+      list.fill(0, 3) { |i| list[i] = img }
+      0.upto(2) { |i| expect(list[i]).to be(img) }
 
-    expect { list.fill('x', 0) }.to raise_error(ArgumentError)
+      expect { list.fill('x', 0) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_find
-    expect { @list.find { true } }.not_to raise_error
+  describe '#find' do
+    it 'works' do
+      expect { @list.find { true } }.not_to raise_error
+    end
   end
 
-  def find_all
-    expect do
-      res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(1)
-      expect(@list[2]).to be(res[0])
-    end.not_to raise_error
+  describe '#find_all' do
+    it 'works' do
+      expect do
+        res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(1)
+        expect(@list[2]).to be(res[0])
+      end.not_to raise_error
+    end
   end
 
-  def test_insert
-    expect do
-      @list.scene = 7
+  describe '#insert' do
+    it 'works' do
+      expect do
+        @list.scene = 7
+        cur = @list.cur_image
+        expect(@list.insert(1, @list[2])).to be_instance_of(Magick::ImageList)
+        expect(@list.cur_image).to be(cur)
+        @list.insert(1, @list[2], @list[3], @list[4])
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
+
+      expect { @list.insert(0, 'x') }.to raise_error(ArgumentError)
+      expect { @list.insert(0, 'x', 'y') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#last' do
+    it 'works' do
+      img = Magick::Image.new(5, 5)
+      @list << img
+      img2 = nil
+      expect { img2 = @list.last }.not_to raise_error
+      expect(img2).to be_instance_of(Magick::Image)
+      expect(img).to eq(img2)
+      img2 = Magick::Image.new(5, 5)
+      @list << img2
+      ilist = nil
+      expect { ilist = @list.last(2) }.not_to raise_error
+      expect(ilist).to be_instance_of(Magick::ImageList)
+      expect(ilist.length).to eq(2)
+      expect(ilist.scene).to eq(1)
+      expect(ilist[0]).to eq(img)
+      expect(ilist[1]).to eq(img2)
+    end
+  end
+
+  describe '#__map__' do
+    it 'works' do
+      img = @list[0]
+      expect do
+        @list.__map__ { |_x| img }
+      end.not_to raise_error
+      expect(@list).to be_instance_of(Magick::ImageList)
+      expect { @list.__map__ { 2 } }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#map!' do
+    it 'works' do
+      img = @list[0]
+      expect do
+        @list.map! { img }
+      end.not_to raise_error
+      expect(@list).to be_instance_of(Magick::ImageList)
+      expect { @list.map! { 2 } }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#partition' do
+    it 'works' do
+      a = nil
+      n = -1
+      expect do
+        a = @list.partition do
+          n += 1
+          (n & 1).zero?
+        end
+      end.not_to raise_error
+      expect(a).to be_instance_of(Array)
+      expect(a.size).to eq(2)
+      expect(a[0]).to be_instance_of(Magick::ImageList)
+      expect(a[1]).to be_instance_of(Magick::ImageList)
+      expect(a[0].scene).to eq(4)
+      expect(a[0].length).to eq(5)
+      expect(a[1].scene).to eq(4)
+      expect(a[1].length).to eq(5)
+    end
+  end
+
+  describe '#pop' do
+    it 'works' do
+      @list.scene = 8
       cur = @list.cur_image
-      expect(@list.insert(1, @list[2])).to be_instance_of(Magick::ImageList)
-      expect(@list.cur_image).to be(cur)
-      @list.insert(1, @list[2], @list[3], @list[4])
-      expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
+      last = @list[-1]
+      expect do
+        expect(@list.pop).to be(last)
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
 
-    expect { @list.insert(0, 'x') }.to raise_error(ArgumentError)
-    expect { @list.insert(0, 'x', 'y') }.to raise_error(ArgumentError)
-  end
-
-  def test_last
-    img = Magick::Image.new(5, 5)
-    @list << img
-    img2 = nil
-    expect { img2 = @list.last }.not_to raise_error
-    expect(img2).to be_instance_of(Magick::Image)
-    expect(img).to eq(img2)
-    img2 = Magick::Image.new(5, 5)
-    @list << img2
-    ilist = nil
-    expect { ilist = @list.last(2) }.not_to raise_error
-    expect(ilist).to be_instance_of(Magick::ImageList)
-    expect(ilist.length).to eq(2)
-    expect(ilist.scene).to eq(1)
-    expect(ilist[0]).to eq(img)
-    expect(ilist[1]).to eq(img2)
-  end
-
-  def test___map__
-    img = @list[0]
-    expect do
-      @list.__map__ { |_x| img }
-    end.not_to raise_error
-    expect(@list).to be_instance_of(Magick::ImageList)
-    expect { @list.__map__ { 2 } }.to raise_error(ArgumentError)
-  end
-
-  def test_map!
-    img = @list[0]
-    expect do
-      @list.map! { img }
-    end.not_to raise_error
-    expect(@list).to be_instance_of(Magick::ImageList)
-    expect { @list.map! { 2 } }.to raise_error(ArgumentError)
-  end
-
-  def test_partition
-    a = nil
-    n = -1
-    expect do
-      a = @list.partition do
-        n += 1
-        (n & 1).zero?
-      end
-    end.not_to raise_error
-    expect(a).to be_instance_of(Array)
-    expect(a.size).to eq(2)
-    expect(a[0]).to be_instance_of(Magick::ImageList)
-    expect(a[1]).to be_instance_of(Magick::ImageList)
-    expect(a[0].scene).to eq(4)
-    expect(a[0].length).to eq(5)
-    expect(a[1].scene).to eq(4)
-    expect(a[1].length).to eq(5)
-  end
-
-  def test_pop
-    @list.scene = 8
-    cur = @list.cur_image
-    last = @list[-1]
-    expect do
-      expect(@list.pop).to be(last)
-      expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
-
-    expect(@list.pop).to be(cur)
-    expect(@list.cur_image).to be(@list[-1])
-  end
-
-  def test_push
-    list = @list
-    img1 = @list[0]
-    img2 = @list[1]
-    expect { @list.push(img1, img2) }.not_to raise_error
-    expect(@list).to be(list) # push returns self
-    expect(@list.cur_image).to be(img2)
-  end
-
-  def test_reject
-    @list.scene = 7
-    cur = @list.cur_image
-    list = @list
-    expect do
-      res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
-      expect(res.length).to eq(9)
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
-    expect(@list).to be(list)
-    expect(@list.cur_image).to be(cur)
-
-    # Omit current image from result list - result cur_image s/b last image
-    res = @list.reject { |img| File.basename(img.filename) =~ /Button_7/ }
-    expect(res.length).to eq(9)
-    expect(res.cur_image).to be(res[-1])
-    expect(@list.cur_image).to be(cur)
-  end
-
-  def test_reject!
-    @list.scene = 7
-    cur = @list.cur_image
-    expect do
-      @list.reject! { |img| File.basename(img.filename) =~ /5/ }
-      expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list.length).to eq(9)
-      expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
-
-    # Delete the current image
-    expect do
-      @list.reject! { |img| File.basename(img.filename) =~ /7/ }
-      expect(@list).to be_instance_of(Magick::ImageList)
-      expect(@list.length).to eq(8)
+      expect(@list.pop).to be(cur)
       expect(@list.cur_image).to be(@list[-1])
-    end.not_to raise_error
-
-    # returns nil if no changes are made
-    expect(@list.reject! { false }).to be(nil)
+    end
   end
 
-  def test_replace1
-    # Replace with empty list
-    expect do
-      res = @list.replace([])
-      expect(@list).to be(res)
-      expect(@list.length).to eq(0)
-      expect(@list.scene).to be(nil)
-    end.not_to raise_error
-
-    # Replace empty list with non-empty list
-    temp = Magick::ImageList.new
-    expect do
-      temp.replace(@list2)
-      expect(temp.length).to eq(5)
-      expect(temp.scene).to eq(4)
-    end.not_to raise_error
-
-    # Try to replace with illegal values
-    expect { @list.replace([1, 2, 3]) }.to raise_error(ArgumentError)
+  describe '#push' do
+    it 'works' do
+      list = @list
+      img1 = @list[0]
+      img2 = @list[1]
+      expect { @list.push(img1, img2) }.not_to raise_error
+      expect(@list).to be(list) # push returns self
+      expect(@list.cur_image).to be(img2)
+    end
   end
 
-  def test_replace2
-    # Replace with shorter list
-    expect do
+  describe '#reject' do
+    it 'works' do
       @list.scene = 7
       cur = @list.cur_image
-      res = @list.replace(@list2)
-      expect(@list).to be(res)
-      expect(@list.length).to eq(5)
-      expect(@list.scene).to eq(2)
+      list = @list
+      expect do
+        res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
+        expect(res.length).to eq(9)
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.cur_image).to be(cur)
+      end.not_to raise_error
+      expect(@list).to be(list)
       expect(@list.cur_image).to be(cur)
-    end.not_to raise_error
+
+      # Omit current image from result list - result cur_image s/b last image
+      res = @list.reject { |img| File.basename(img.filename) =~ /Button_7/ }
+      expect(res.length).to eq(9)
+      expect(res.cur_image).to be(res[-1])
+      expect(@list.cur_image).to be(cur)
+    end
   end
 
-  def test_replace3
-    # Replace with longer list
-    expect do
-      @list2.scene = 2
-      cur = @list2.cur_image
-      res = @list2.replace(@list)
-      expect(@list2).to be(res)
-      expect(@list2.length).to eq(10)
-      expect(@list2.scene).to eq(7)
-      expect(@list2.cur_image).to be(cur)
-    end.not_to raise_error
+  describe '#reject!' do
+    it 'works' do
+      @list.scene = 7
+      cur = @list.cur_image
+      expect do
+        @list.reject! { |img| File.basename(img.filename) =~ /5/ }
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list.length).to eq(9)
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
+
+      # Delete the current image
+      expect do
+        @list.reject! { |img| File.basename(img.filename) =~ /7/ }
+        expect(@list).to be_instance_of(Magick::ImageList)
+        expect(@list.length).to eq(8)
+        expect(@list.cur_image).to be(@list[-1])
+      end.not_to raise_error
+
+      # returns nil if no changes are made
+      expect(@list.reject! { false }).to be(nil)
+    end
   end
 
-  def test_reverse
-    list = nil
-    cur = @list.cur_image
-    expect { list = @list.reverse }.not_to raise_error
-    expect(@list.length).to eq(list.length)
-    expect(@list.cur_image).to be(cur)
+  describe '#replace1' do
+    it 'works' do
+      # Replace with empty list
+      expect do
+        res = @list.replace([])
+        expect(@list).to be(res)
+        expect(@list.length).to eq(0)
+        expect(@list.scene).to be(nil)
+      end.not_to raise_error
+
+      # Replace empty list with non-empty list
+      temp = Magick::ImageList.new
+      expect do
+        temp.replace(@list2)
+        expect(temp.length).to eq(5)
+        expect(temp.scene).to eq(4)
+      end.not_to raise_error
+
+      # Try to replace with illegal values
+      expect { @list.replace([1, 2, 3]) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_reverse!
-    list = @list
-    cur = @list.cur_image
-    expect { @list.reverse! }.not_to raise_error
-    expect(@list).to be(list)
-    expect(@list.cur_image).to be(cur)
+  describe '#replace2' do
+    it 'works' do
+      # Replace with shorter list
+      expect do
+        @list.scene = 7
+        cur = @list.cur_image
+        res = @list.replace(@list2)
+        expect(@list).to be(res)
+        expect(@list.length).to eq(5)
+        expect(@list.scene).to eq(2)
+        expect(@list.cur_image).to be(cur)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#replace3' do
+    it 'works' do
+      # Replace with longer list
+      expect do
+        @list2.scene = 2
+        cur = @list2.cur_image
+        res = @list2.replace(@list)
+        expect(@list2).to be(res)
+        expect(@list2.length).to eq(10)
+        expect(@list2.scene).to eq(7)
+        expect(@list2.cur_image).to be(cur)
+      end.not_to raise_error
+    end
+  end
+
+  describe '#reverse' do
+    it 'works' do
+      list = nil
+      cur = @list.cur_image
+      expect { list = @list.reverse }.not_to raise_error
+      expect(@list.length).to eq(list.length)
+      expect(@list.cur_image).to be(cur)
+    end
+  end
+
+  describe '#reverse!' do
+    it 'works' do
+      list = @list
+      cur = @list.cur_image
+      expect { @list.reverse! }.not_to raise_error
+      expect(@list).to be(list)
+      expect(@list.cur_image).to be(cur)
+    end
   end
 
   # Just validate its existence
-  def test_reverse_each
-    expect do
-      @list.reverse_each { |img| expect(img).to be_instance_of(Magick::Image) }
-    end.not_to raise_error
+  describe '#reverse_each' do
+    it 'works' do
+      expect do
+        @list.reverse_each { |img| expect(img).to be_instance_of(Magick::Image) }
+      end.not_to raise_error
+    end
   end
 
-  def test_rindex
-    img = @list.last
-    n = nil
-    expect { n = @list.rindex(img) }.not_to raise_error
-    expect(n).to eq(9)
+  describe '#rindex' do
+    it 'works' do
+      img = @list.last
+      n = nil
+      expect { n = @list.rindex(img) }.not_to raise_error
+      expect(n).to eq(9)
+    end
   end
 
-  def test_select
-    expect do
-      res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(1)
-      expect(@list[2]).to be(res[0])
-    end.not_to raise_error
+  describe '#select' do
+    it 'works' do
+      expect do
+        res = @list.select { |img| File.basename(img.filename) =~ /Button_2/ }
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(1)
+        expect(@list[2]).to be(res[0])
+      end.not_to raise_error
+    end
   end
 
-  def test_shift
-    expect do
-      @list.scene = 0
+  describe '#shift' do
+    it 'works' do
+      expect do
+        @list.scene = 0
+        res = @list[0]
+        img = @list.shift
+        expect(img).to be(res)
+        expect(@list.scene).to eq(8)
+      end.not_to raise_error
       res = @list[0]
       img = @list.shift
       expect(img).to be(res)
-      expect(@list.scene).to eq(8)
-    end.not_to raise_error
-    res = @list[0]
-    img = @list.shift
-    expect(img).to be(res)
-    expect(@list.scene).to eq(7)
+      expect(@list.scene).to eq(7)
+    end
   end
 
-  def test_slice
-    expect { @list.slice(0) }.not_to raise_error
-    expect { @list.slice(-1) }.not_to raise_error
-    expect { @list.slice(0, 1) }.not_to raise_error
-    expect { @list.slice(0..2) }.not_to raise_error
-    expect { @list.slice(20) }.not_to raise_error
+  describe '#slice' do
+    it 'works' do
+      expect { @list.slice(0) }.not_to raise_error
+      expect { @list.slice(-1) }.not_to raise_error
+      expect { @list.slice(0, 1) }.not_to raise_error
+      expect { @list.slice(0..2) }.not_to raise_error
+      expect { @list.slice(20) }.not_to raise_error
+    end
   end
 
-  def test_slice!
-    @list.scene = 7
-    expect do
-      img0 = @list[0]
-      img = @list.slice!(0)
-      expect(img).to be(img0)
-      expect(@list.length).to eq(9)
-      expect(@list.scene).to eq(6)
-    end.not_to raise_error
-    cur = @list.cur_image
-    img = @list.slice!(6)
-    expect(img).to be(cur)
-    expect(@list.length).to eq(8)
-    expect(@list.scene).to eq(7)
-    expect { @list.slice!(-1) }.not_to raise_error
-    expect { @list.slice!(0, 1) }.not_to raise_error
-    expect { @list.slice!(0..2) }.not_to raise_error
-    expect { @list.slice!(20) }.not_to raise_error
+  describe '#slice!' do
+    it 'works' do
+      @list.scene = 7
+      expect do
+        img0 = @list[0]
+        img = @list.slice!(0)
+        expect(img).to be(img0)
+        expect(@list.length).to eq(9)
+        expect(@list.scene).to eq(6)
+      end.not_to raise_error
+      cur = @list.cur_image
+      img = @list.slice!(6)
+      expect(img).to be(cur)
+      expect(@list.length).to eq(8)
+      expect(@list.scene).to eq(7)
+      expect { @list.slice!(-1) }.not_to raise_error
+      expect { @list.slice!(0, 1) }.not_to raise_error
+      expect { @list.slice!(0..2) }.not_to raise_error
+      expect { @list.slice!(20) }.not_to raise_error
+    end
   end
 
   # simply ensure existence
-  def test_sort
-    expect { @list.sort }.not_to raise_error
-    expect { @list.sort! }.not_to raise_error
+  describe '#sort' do
+    it 'works' do
+      expect { @list.sort }.not_to raise_error
+      expect { @list.sort! }.not_to raise_error
+    end
   end
 
-  def test_to_a
-    a = nil
-    expect { a = @list.to_a }.not_to raise_error
-    expect(a).to be_instance_of(Array)
-    expect(a.length).to eq(10)
+  describe '#to_a' do
+    it 'works' do
+      a = nil
+      expect { a = @list.to_a }.not_to raise_error
+      expect(a).to be_instance_of(Array)
+      expect(a.length).to eq(10)
+    end
   end
 
-  def test_uniq
-    expect { @list.uniq }.not_to raise_error
-    expect(@list.uniq).to be_instance_of(Magick::ImageList)
-    @list[1] = @list[0]
-    @list.scene = 7
-    list = @list.uniq
-    expect(list.length).to eq(9)
-    expect(list.scene).to eq(6)
-    expect(@list.scene).to eq(7)
-    @list[6] = @list[7]
-    list = @list.uniq
-    expect(list.length).to eq(8)
-    expect(list.scene).to eq(5)
-    expect(@list.scene).to eq(7)
+  describe '#uniq' do
+    it 'works' do
+      expect { @list.uniq }.not_to raise_error
+      expect(@list.uniq).to be_instance_of(Magick::ImageList)
+      @list[1] = @list[0]
+      @list.scene = 7
+      list = @list.uniq
+      expect(list.length).to eq(9)
+      expect(list.scene).to eq(6)
+      expect(@list.scene).to eq(7)
+      @list[6] = @list[7]
+      list = @list.uniq
+      expect(list.length).to eq(8)
+      expect(list.scene).to eq(5)
+      expect(@list.scene).to eq(7)
+    end
   end
 
-  def test_uniq!
-    expect do
-      expect(@list.uniq!).to be(nil)
-    end.not_to raise_error
-    @list[1] = @list[0]
-    @list.scene = 7
-    cur = @list.cur_image
-    list = @list
-    @list.uniq!
-    expect(@list).to be(list)
-    expect(@list.cur_image).to be(cur)
-    expect(@list.scene).to eq(6)
-    @list[5] = @list[6]
-    @list.uniq!
-    expect(@list.cur_image).to be(cur)
-    expect(@list.scene).to eq(5)
+  describe '#uniq!' do
+    it 'works' do
+      expect do
+        expect(@list.uniq!).to be(nil)
+      end.not_to raise_error
+      @list[1] = @list[0]
+      @list.scene = 7
+      cur = @list.cur_image
+      list = @list
+      @list.uniq!
+      expect(@list).to be(list)
+      expect(@list.cur_image).to be(cur)
+      expect(@list.scene).to eq(6)
+      @list[5] = @list[6]
+      @list.uniq!
+      expect(@list.cur_image).to be(cur)
+      expect(@list.scene).to eq(5)
+    end
   end
 
-  def test_unshift
-    img = @list[9]
-    @list.scene = 7
-    @list.unshift(img)
-    expect(@list.scene).to eq(0)
-    expect { @list.unshift(2) }.to raise_error(ArgumentError)
-    expect { @list.unshift([1, 2]) }.to raise_error(ArgumentError)
+  describe '#unshift' do
+    it 'works' do
+      img = @list[9]
+      @list.scene = 7
+      @list.unshift(img)
+      expect(@list.scene).to eq(0)
+      expect { @list.unshift(2) }.to raise_error(ArgumentError)
+      expect { @list.unshift([1, 2]) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_values_at
-    ilist = nil
-    expect { ilist = @list.values_at(1, 3, 5) }.not_to raise_error
-    expect(ilist).to be_instance_of(Magick::ImageList)
-    expect(ilist.length).to eq(3)
-    expect(ilist.scene).to eq(2)
+  describe '#values_at' do
+    it 'works' do
+      ilist = nil
+      expect { ilist = @list.values_at(1, 3, 5) }.not_to raise_error
+      expect(ilist).to be_instance_of(Magick::ImageList)
+      expect(ilist.length).to eq(3)
+      expect(ilist.scene).to eq(2)
+    end
   end
 
-  def test_spaceship
-    list2 = @list.copy
-    expect(list2.scene).to eq(@list.scene)
-    expect(list2).to eq(@list)
-    list2.scene = 0
-    expect(list2).not_to eq(@list)
-    list2 = @list.copy
-    list2[9] = list2[0]
-    expect(list2).not_to eq(@list)
-    list2 = @list.copy
-    list2 << @list[9]
-    expect(list2).not_to eq(@list)
+  describe '#spaceship' do
+    it 'works' do
+      list2 = @list.copy
+      expect(list2.scene).to eq(@list.scene)
+      expect(list2).to eq(@list)
+      list2.scene = 0
+      expect(list2).not_to eq(@list)
+      list2 = @list.copy
+      list2[9] = list2[0]
+      expect(list2).not_to eq(@list)
+      list2 = @list.copy
+      list2 << @list[9]
+      expect(list2).not_to eq(@list)
 
-    expect { @list <=> 2 }.to raise_error(TypeError)
-    list = Magick::ImageList.new
-    list2 = Magick::ImageList.new
-    expect { list2 <=> @list }.to raise_error(TypeError)
-    expect { @list <=> list2 }.to raise_error(TypeError)
-    expect { list <=> list2 }.not_to raise_error
+      expect { @list <=> 2 }.to raise_error(TypeError)
+      list = Magick::ImageList.new
+      list2 = Magick::ImageList.new
+      expect { list2 <=> @list }.to raise_error(TypeError)
+      expect { @list <=> list2 }.to raise_error(TypeError)
+      expect { list <=> list2 }.not_to raise_error
+    end
   end
 end
 

--- a/test/ImageList2.rb
+++ b/test/ImageList2.rb
@@ -2,366 +2,410 @@ require 'fileutils'
 require 'rmagick'
 require 'minitest/autorun'
 
-class ImageList2UT < Minitest::Test
-  def setup
+describe Magick::ImageList do
+  before do
     @ilist = Magick::ImageList.new
   end
 
-  def test_append
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    expect do
-      img = @ilist.append(true)
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect do
-      img = @ilist.append(false)
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @ilist.append }.to raise_error(ArgumentError)
-    expect { @ilist.append(true, 1) }.to raise_error(ArgumentError)
-  end
-
-  def test_average
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    expect do
-      img = @ilist.average
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect { @ilist.average(1) }.to raise_error(ArgumentError)
-  end
-
-  def test_clone
-    @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    ilist2 = @ilist.clone
-    expect(@ilist).to eq(ilist2)
-    expect(ilist2.frozen?).to eq(@ilist.frozen?)
-    expect(ilist2.tainted?).to eq(@ilist.tainted?)
-    @ilist.taint
-    @ilist.freeze
-    ilist2 = @ilist.clone
-    expect(ilist2.frozen?).to eq(@ilist.frozen?)
-    expect(ilist2.tainted?).to eq(@ilist.tainted?)
-  end
-
-  def test_coalesce
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    ilist = nil
-    expect { ilist = @ilist.coalesce }.not_to raise_error
-    expect(ilist).to be_instance_of(Magick::ImageList)
-    expect(ilist.length).to eq(2)
-    expect(ilist.scene).to eq(0)
-  end
-
-  def test_copy
-    @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    @ilist.scene = 7
-    ilist2 = @ilist.copy
-    expect(ilist2).not_to be(@ilist)
-    expect(ilist2.scene).to eq(@ilist.scene)
-    @ilist.each_with_index do |img, x|
-      expect(ilist2[x]).to eq(img)
+  describe "#append" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
+      expect do
+        img = @ilist.append(true)
+        expect(img).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect do
+        img = @ilist.append(false)
+        expect(img).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @ilist.append }.to raise_error(ArgumentError)
+      expect { @ilist.append(true, 1) }.to raise_error(ArgumentError)
     end
   end
 
-  def test_deconstruct
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    ilist = nil
-    expect { ilist = @ilist.deconstruct }.not_to raise_error
-    expect(ilist).to be_instance_of(Magick::ImageList)
-    expect(ilist.length).to eq(2)
-    expect(ilist.scene).to eq(0)
-  end
-
-  def test_dup
-    @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    ilist2 = @ilist.dup
-    expect(@ilist).to eq(ilist2)
-    expect(ilist2.frozen?).to eq(@ilist.frozen?)
-    expect(ilist2.tainted?).to eq(@ilist.tainted?)
-    @ilist.taint
-    @ilist.freeze
-    ilist2 = @ilist.dup
-    expect(ilist2.frozen?).not_to eq(@ilist.frozen?)
-    expect(ilist2.tainted?).to eq(@ilist.tainted?)
-  end
-
-  def flatten_images
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    expect do
-      img = @ilist.flatten_images
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_from_blob
-    hat = File.open(FLOWER_HAT, 'rb')
-    blob = hat.read
-    expect { @ilist.from_blob(blob) }.not_to raise_error
-    expect(@ilist[0]).to be_instance_of(Magick::Image)
-    expect(@ilist.scene).to eq(0)
-
-    ilist2 = Magick::ImageList.new(FLOWER_HAT)
-    expect(ilist2).to eq(@ilist)
-  end
-
-  def test_marshal
-    ilist1 = Magick::ImageList.new(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    d = nil
-    ilist2 = nil
-    expect { d = Marshal.dump(ilist1) }.not_to raise_error
-    expect { ilist2 = Marshal.load(d) }.not_to raise_error
-    expect(ilist2).to eq(ilist1)
-  end
-
-  def test_montage
-    @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    ilist = @ilist.copy
-    montage = nil
-    expect do
-      montage = ilist.montage do
-        self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-        self.background_color = 'blue'
-        self.border_color = Magick::Pixel.new(0, 0, 0)
-        self.border_color = 'red'
-        self.border_width = 2
-        self.compose = Magick::OverCompositeOp
-        self.filename = 'test.png'
-        self.fill = 'green'
-        self.font = Magick.fonts.first.name
-        self.frame = '20x20+4+4'
-        self.frame = Magick::Geometry.new(20, 20, 4, 4)
-        self.geometry = '63x60+5+5'
-        self.geometry = Magick::Geometry.new(63, 60, 5, 5)
-        self.gravity = Magick::SouthGravity
-        self.matte_color = '#bdbdbd'
-        self.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-        self.pointsize = 12
-        self.shadow = true
-        self.stroke = 'transparent'
-        self.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-        self.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-        self.tile = '4x9'
-        self.tile = Magick::Geometry.new(4, 9)
-        self.title = 'sample'
-      end
-      expect(montage).to be_instance_of(Magick::ImageList)
-      expect(ilist).to eq(@ilist)
-
-      montage_image = montage.first
-      expect(montage_image.background_color).to eq('blue')
-      expect(montage_image.border_color).to eq('red')
-    end.not_to raise_error
-
-    # test illegal option arguments
-    # looks like IM doesn't diagnose invalid geometry args
-    # to tile= and geometry=
-    expect do
-      montage = ilist.montage { self.background_color = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.border_color = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.border_width = [2] }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.compose = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.filename = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.fill = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.font = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.gravity = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.matte_color = 2 }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.pointsize = 'x' }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(TypeError)
-    expect do
-      montage = ilist.montage { self.stroke = 'x' }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(ArgumentError)
-    expect do
-      montage = ilist.montage { self.texture = 'x' }
-      expect(ilist).to eq(@ilist)
-    end.to raise_error(NoMethodError)
-  end
-
-  def test_morph
-    # can't morph an empty list
-    expect { @ilist.morph(1) }.to raise_error(ArgumentError)
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    # can't specify a negative argument
-    expect { @ilist.morph(-1) }.to raise_error(ArgumentError)
-    expect do
-      res = @ilist.morph(2)
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.length).to eq(4)
-      expect(res.scene).to eq(0)
-    end.not_to raise_error
-  end
-
-  def test_mosaic
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    expect do
-      res = @ilist.mosaic
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-  end
-
-  def test_mosaic_with_invalid_imagelist
-    list = @ilist.copy
-    list.instance_variable_set("@images", nil)
-    expect { list.mosaic }.to raise_error(Magick::ImageMagickError)
-  end
-
-  def test_new_image
-    expect do
-      @ilist.new_image(20, 20)
-    end.not_to raise_error
-    expect(@ilist.length).to eq(1)
-    expect(@ilist.scene).to eq(0)
-    @ilist.new_image(20, 20, Magick::HatchFill.new('black'))
-    expect(@ilist.length).to eq(2)
-    expect(@ilist.scene).to eq(1)
-    @ilist.new_image(20, 20) { self.background_color = 'red' }
-    expect(@ilist.length).to eq(3)
-    expect(@ilist.scene).to eq(2)
-  end
-
-  def test_optimize_layers
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    Magick::LayerMethod.values do |method|
-      next if [Magick::UndefinedLayer, Magick::CompositeLayer, Magick::TrimBoundsLayer].include?(method)
-
+  describe "#average" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
       expect do
-        res = @ilist.optimize_layers(method)
-        expect(res).to be_instance_of(Magick::ImageList)
-        expect(res.length).to be_kind_of(Integer)
+        img = @ilist.average
+        expect(img).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      expect { @ilist.average(1) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#clone" do
+    it "works" do
+      @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      ilist2 = @ilist.clone
+      expect(@ilist).to eq(ilist2)
+      expect(ilist2.frozen?).to eq(@ilist.frozen?)
+      expect(ilist2.tainted?).to eq(@ilist.tainted?)
+      @ilist.taint
+      @ilist.freeze
+      ilist2 = @ilist.clone
+      expect(ilist2.frozen?).to eq(@ilist.frozen?)
+      expect(ilist2.tainted?).to eq(@ilist.tainted?)
+    end
+  end
+
+  describe "#coalesce" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
+      ilist = nil
+      expect { ilist = @ilist.coalesce }.not_to raise_error
+      expect(ilist).to be_instance_of(Magick::ImageList)
+      expect(ilist.length).to eq(2)
+      expect(ilist.scene).to eq(0)
+    end
+  end
+
+  describe "#copy" do
+    it "works" do
+      @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      @ilist.scene = 7
+      ilist2 = @ilist.copy
+      expect(ilist2).not_to be(@ilist)
+      expect(ilist2.scene).to eq(@ilist.scene)
+      @ilist.each_with_index do |img, x|
+        expect(ilist2[x]).to eq(img)
+      end
+    end
+  end
+
+  describe "#deconstruct" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      ilist = nil
+      expect { ilist = @ilist.deconstruct }.not_to raise_error
+      expect(ilist).to be_instance_of(Magick::ImageList)
+      expect(ilist.length).to eq(2)
+      expect(ilist.scene).to eq(0)
+    end
+  end
+
+  describe "#dup" do
+    it "works" do
+      @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      ilist2 = @ilist.dup
+      expect(@ilist).to eq(ilist2)
+      expect(ilist2.frozen?).to eq(@ilist.frozen?)
+      expect(ilist2.tainted?).to eq(@ilist.tainted?)
+      @ilist.taint
+      @ilist.freeze
+      ilist2 = @ilist.dup
+      expect(ilist2.frozen?).not_to eq(@ilist.frozen?)
+      expect(ilist2.tainted?).to eq(@ilist.tainted?)
+    end
+  end
+
+  describe "#flatten_images" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      expect do
+        img = @ilist.flatten_images
+        expect(img).to be_instance_of(Magick::Image)
       end.not_to raise_error
     end
-
-    expect { @ilist.optimize_layers(Magick::CompareClearLayer) }.not_to raise_error
-    expect { @ilist.optimize_layers(Magick::UndefinedLayer) }.to raise_error(ArgumentError)
-    expect { @ilist.optimize_layers(2) }.to raise_error(TypeError)
-    expect { @ilist.optimize_layers(Magick::CompositeLayer) }.to raise_error(NotImplementedError)
   end
 
-  def test_ping
-    expect { @ilist.ping(FLOWER_HAT) }.not_to raise_error
-    expect(@ilist.length).to eq(1)
-    expect(@ilist.scene).to eq(0)
-    expect { @ilist.ping(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
-    expect(@ilist.length).to eq(3)
-    expect(@ilist.scene).to eq(2)
-    expect { @ilist.ping(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
-    expect(@ilist.length).to eq(4)
-    expect(@ilist.scene).to eq(3)
+  describe "#from_blob" do
+    it "works" do
+      hat = File.open(FLOWER_HAT, 'rb')
+      blob = hat.read
+      expect { @ilist.from_blob(blob) }.not_to raise_error
+      expect(@ilist[0]).to be_instance_of(Magick::Image)
+      expect(@ilist.scene).to eq(0)
+
+      ilist2 = Magick::ImageList.new(FLOWER_HAT)
+      expect(ilist2).to eq(@ilist)
+    end
   end
 
-  def test_quantize
-    @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    expect do
-      res = @ilist.quantize
-      expect(res).to be_instance_of(Magick::ImageList)
-      expect(res.scene).to eq(1)
-    end.not_to raise_error
-    expect { @ilist.quantize(128) }.not_to raise_error
-    expect { @ilist.quantize('x') }.to raise_error(TypeError)
-    expect { @ilist.quantize(128, Magick::RGBColorspace) }.not_to raise_error
-    expect { @ilist.quantize(128, 'x') }.to raise_error(TypeError)
-    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, true) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, false) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }.not_to raise_error
-    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }.to raise_error(TypeError)
-    expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }.to raise_error(ArgumentError)
+  describe "#marshal" do
+    it "works" do
+      ilist1 = Magick::ImageList.new(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      d = nil
+      ilist2 = nil
+      expect { d = Marshal.dump(ilist1) }.not_to raise_error
+      expect { ilist2 = Marshal.load(d) }.not_to raise_error
+      expect(ilist2).to eq(ilist1)
+    end
   end
 
-  def test_read
-    expect { @ilist.read(FLOWER_HAT) }.not_to raise_error
-    expect(@ilist.length).to eq(1)
-    expect(@ilist.scene).to eq(0)
-    expect { @ilist.read(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
-    expect(@ilist.length).to eq(3)
-    expect(@ilist.scene).to eq(2)
-    expect { @ilist.read(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
-    expect(@ilist.length).to eq(4)
-    expect(@ilist.scene).to eq(3)
+  describe "#montage" do
+    it "works" do
+      @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      ilist = @ilist.copy
+      montage = nil
+      expect do
+        montage = ilist.montage do
+          self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+          self.background_color = 'blue'
+          self.border_color = Magick::Pixel.new(0, 0, 0)
+          self.border_color = 'red'
+          self.border_width = 2
+          self.compose = Magick::OverCompositeOp
+          self.filename = 'test.png'
+          self.fill = 'green'
+          self.font = Magick.fonts.first.name
+          self.frame = '20x20+4+4'
+          self.frame = Magick::Geometry.new(20, 20, 4, 4)
+          self.geometry = '63x60+5+5'
+          self.geometry = Magick::Geometry.new(63, 60, 5, 5)
+          self.gravity = Magick::SouthGravity
+          self.matte_color = '#bdbdbd'
+          self.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+          self.pointsize = 12
+          self.shadow = true
+          self.stroke = 'transparent'
+          self.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+          self.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+          self.tile = '4x9'
+          self.tile = Magick::Geometry.new(4, 9)
+          self.title = 'sample'
+        end
+        expect(montage).to be_instance_of(Magick::ImageList)
+        expect(ilist).to eq(@ilist)
+
+        montage_image = montage.first
+        expect(montage_image.background_color).to eq('blue')
+        expect(montage_image.border_color).to eq('red')
+      end.not_to raise_error
+
+      # test illegal option arguments
+      # looks like IM doesn't diagnose invalid geometry args
+      # to tile= and geometry=
+      expect do
+        montage = ilist.montage { self.background_color = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.border_color = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.border_width = [2] }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.compose = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.filename = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.fill = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.font = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.gravity = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.matte_color = 2 }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.pointsize = 'x' }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(TypeError)
+      expect do
+        montage = ilist.montage { self.stroke = 'x' }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(ArgumentError)
+      expect do
+        montage = ilist.montage { self.texture = 'x' }
+        expect(ilist).to eq(@ilist)
+      end.to raise_error(NoMethodError)
+    end
   end
 
-  def test_remap
-    @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    expect { @ilist.remap }.not_to raise_error
-    remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    expect { @ilist.remap(remap_image) }.not_to raise_error
-    expect { @ilist.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
-    expect { @ilist.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
-    expect { @ilist.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
-    expect { @ilist.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
-
-    remap_image.destroy!
-    expect { @ilist.remap(remap_image) }.to raise_error(Magick::DestroyedImageError)
-    # expect { @ilist.affinity(affinity_image, 1) }.to raise_error(TypeError)
+  describe "#morph" do
+    it "works" do
+      # can't morph an empty list
+      expect { @ilist.morph(1) }.to raise_error(ArgumentError)
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      # can't specify a negative argument
+      expect { @ilist.morph(-1) }.to raise_error(ArgumentError)
+      expect do
+        res = @ilist.morph(2)
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.length).to eq(4)
+        expect(res.scene).to eq(0)
+      end.not_to raise_error
+    end
   end
 
-  def test_to_blob
-    @ilist.read(IMAGES_DIR + '/Button_0.gif')
-    blob = nil
-    expect { blob = @ilist.to_blob }.not_to raise_error
-    img = @ilist.from_blob(blob)
-    expect(img[0]).to eq(@ilist[0])
-    expect(img.scene).to eq(1)
+  describe "#mosaic" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      expect do
+        res = @ilist.mosaic
+        expect(res).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+    end
   end
 
-  def test_write
-    @ilist.read(IMAGES_DIR + '/Button_0.gif')
-    expect do
-      @ilist.write('temp.gif')
-    end.not_to raise_error
-    list = Magick::ImageList.new('temp.gif')
-    expect(list.format).to eq('GIF')
-    FileUtils.rm('temp.gif')
+  describe "#mosaic_with_invalid_imagelist" do
+    it "works" do
+      list = @ilist.copy
+      list.instance_variable_set("@images", nil)
+      expect { list.mosaic }.to raise_error(Magick::ImageMagickError)
+    end
+  end
 
-    @ilist.write('jpg:temp.foo')
-    list = Magick::ImageList.new('temp.foo')
-    expect(list.format).to eq('JPEG')
-    FileUtils.rm('temp.foo')
+  describe "#new_image" do
+    it "works" do
+      expect do
+        @ilist.new_image(20, 20)
+      end.not_to raise_error
+      expect(@ilist.length).to eq(1)
+      expect(@ilist.scene).to eq(0)
+      @ilist.new_image(20, 20, Magick::HatchFill.new('black'))
+      expect(@ilist.length).to eq(2)
+      expect(@ilist.scene).to eq(1)
+      @ilist.new_image(20, 20) { self.background_color = 'red' }
+      expect(@ilist.length).to eq(3)
+      expect(@ilist.scene).to eq(2)
+    end
+  end
 
-    @ilist.write('temp.0') { self.format = 'JPEG' }
-    list = Magick::ImageList.new('temp.0')
-    expect(list.format).to eq('JPEG')
-    FileUtils.rm('temp.0')
+  describe "#optimize_layers" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      Magick::LayerMethod.values do |method|
+        next if [Magick::UndefinedLayer, Magick::CompositeLayer, Magick::TrimBoundsLayer].include?(method)
 
-    f = File.new('test.0', 'w')
-    @ilist.write(f) { self.format = 'JPEG' }
-    f.close
-    list = Magick::ImageList.new('test.0')
-    expect(list.format).to eq('JPEG')
-    FileUtils.rm('test.0')
+        expect do
+          res = @ilist.optimize_layers(method)
+          expect(res).to be_instance_of(Magick::ImageList)
+          expect(res.length).to be_kind_of(Integer)
+        end.not_to raise_error
+      end
+
+      expect { @ilist.optimize_layers(Magick::CompareClearLayer) }.not_to raise_error
+      expect { @ilist.optimize_layers(Magick::UndefinedLayer) }.to raise_error(ArgumentError)
+      expect { @ilist.optimize_layers(2) }.to raise_error(TypeError)
+      expect { @ilist.optimize_layers(Magick::CompositeLayer) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#ping" do
+    it "works" do
+      expect { @ilist.ping(FLOWER_HAT) }.not_to raise_error
+      expect(@ilist.length).to eq(1)
+      expect(@ilist.scene).to eq(0)
+      expect { @ilist.ping(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
+      expect(@ilist.length).to eq(3)
+      expect(@ilist.scene).to eq(2)
+      expect { @ilist.ping(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
+      expect(@ilist.length).to eq(4)
+      expect(@ilist.scene).to eq(3)
+    end
+  end
+
+  describe "#quantize" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
+      expect do
+        res = @ilist.quantize
+        expect(res).to be_instance_of(Magick::ImageList)
+        expect(res.scene).to eq(1)
+      end.not_to raise_error
+      expect { @ilist.quantize(128) }.not_to raise_error
+      expect { @ilist.quantize('x') }.to raise_error(TypeError)
+      expect { @ilist.quantize(128, Magick::RGBColorspace) }.not_to raise_error
+      expect { @ilist.quantize(128, 'x') }.to raise_error(TypeError)
+      expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, true) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, false) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, true) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod, 32, false) }.not_to raise_error
+      expect { @ilist.quantize(128, Magick::RGBColorspace, true, 'x') }.to raise_error(TypeError)
+      expect { @ilist.quantize(128, Magick::RGBColorspace, true, 0, false, 'extra') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#read" do
+    it "works" do
+      expect { @ilist.read(FLOWER_HAT) }.not_to raise_error
+      expect(@ilist.length).to eq(1)
+      expect(@ilist.scene).to eq(0)
+      expect { @ilist.read(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
+      expect(@ilist.length).to eq(3)
+      expect(@ilist.scene).to eq(2)
+      expect { @ilist.read(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
+      expect(@ilist.length).to eq(4)
+      expect(@ilist.scene).to eq(3)
+    end
+  end
+
+  describe "#remap" do
+    it "works" do
+      @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
+      expect { @ilist.remap }.not_to raise_error
+      remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
+      expect { @ilist.remap(remap_image) }.not_to raise_error
+      expect { @ilist.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
+      expect { @ilist.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
+      expect { @ilist.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+      expect { @ilist.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
+
+      remap_image.destroy!
+      expect { @ilist.remap(remap_image) }.to raise_error(Magick::DestroyedImageError)
+      # expect { @ilist.affinity(affinity_image, 1) }.to raise_error(TypeError)
+    end
+  end
+
+  describe "#to_blob" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif')
+      blob = nil
+      expect { blob = @ilist.to_blob }.not_to raise_error
+      img = @ilist.from_blob(blob)
+      expect(img[0]).to eq(@ilist[0])
+      expect(img.scene).to eq(1)
+    end
+  end
+
+  describe "#write" do
+    it "works" do
+      @ilist.read(IMAGES_DIR + '/Button_0.gif')
+      expect do
+        @ilist.write('temp.gif')
+      end.not_to raise_error
+      list = Magick::ImageList.new('temp.gif')
+      expect(list.format).to eq('GIF')
+      FileUtils.rm('temp.gif')
+
+      @ilist.write('jpg:temp.foo')
+      list = Magick::ImageList.new('temp.foo')
+      expect(list.format).to eq('JPEG')
+      FileUtils.rm('temp.foo')
+
+      @ilist.write('temp.0') { self.format = 'JPEG' }
+      list = Magick::ImageList.new('temp.0')
+      expect(list.format).to eq('JPEG')
+      FileUtils.rm('temp.0')
+
+      f = File.new('test.0', 'w')
+      @ilist.write(f) { self.format = 'JPEG' }
+      f.close
+      list = Magick::ImageList.new('test.0')
+      expect(list.format).to eq('JPEG')
+      FileUtils.rm('test.0')
+    end
   end
 end
 

--- a/test/Image_attributes.rb
+++ b/test/Image_attributes.rb
@@ -7,8 +7,8 @@ require 'minitest/autorun'
 #   improve test_directory
 #   improve test_montage
 
-class Image_Attributes_UT < Minitest::Test
-  def setup
+describe Magick::Image do
+  before do
     @img = Magick::Image.new(100, 100)
     gc = Magick::Draw.new
 
@@ -20,609 +20,719 @@ class Image_Attributes_UT < Minitest::Test
     @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
-  def test_background_color
-    expect { @img.background_color }.not_to raise_error
-    expect(@img.background_color).to eq('white')
-    expect { @img.background_color = '#dfdfdf' }.not_to raise_error
-    # expect(@img.background_color).to eq("rgb(223,223,223)")
-    background_color = @img.background_color
-    if background_color.length == 13
-      expect(background_color).to eq('#DFDFDFDFDFDF')
-    else
-      expect(background_color).to eq('#DFDFDFDFDFDFFFFF')
+  describe '#background_color' do
+    it 'works' do
+      expect { @img.background_color }.not_to raise_error
+      expect(@img.background_color).to eq('white')
+      expect { @img.background_color = '#dfdfdf' }.not_to raise_error
+      # expect(@img.background_color).to eq("rgb(223,223,223)")
+      background_color = @img.background_color
+      if background_color.length == 13
+        expect(background_color).to eq('#DFDFDFDFDFDF')
+      else
+        expect(background_color).to eq('#DFDFDFDFDFDFFFFF')
+      end
+      expect { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }.not_to raise_error
+      # expect(@img.background_color).to eq("rgb(100%,49.9992%,49.9992%)")
+      background_color = @img.background_color
+      if background_color.length == 13
+        expect(background_color).to eq('#FFFF7FFF7FFF')
+      else
+        expect(background_color).to eq('#FFFF7FFF7FFFFFFF')
+      end
+      expect { @img.background_color = 2 }.to raise_error(TypeError)
     end
-    expect { @img.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }.not_to raise_error
-    # expect(@img.background_color).to eq("rgb(100%,49.9992%,49.9992%)")
-    background_color = @img.background_color
-    if background_color.length == 13
-      expect(background_color).to eq('#FFFF7FFF7FFF')
-    else
-      expect(background_color).to eq('#FFFF7FFF7FFFFFFF')
+  end
+
+  describe '#base_columns' do
+    it 'works' do
+      expect { @img.base_columns }.not_to raise_error
+      expect(@img.base_columns).to eq(0)
+      expect { @img.base_columns = 1 }.to raise_error(NoMethodError)
     end
-    expect { @img.background_color = 2 }.to raise_error(TypeError)
   end
 
-  def test_base_columns
-    expect { @img.base_columns }.not_to raise_error
-    expect(@img.base_columns).to eq(0)
-    expect { @img.base_columns = 1 }.to raise_error(NoMethodError)
-  end
-
-  def test_base_filename
-    expect { @img.base_filename }.not_to raise_error
-    expect(@img.base_filename).to eq('')
-    expect { @img.base_filename = 'xxx' }.to raise_error(NoMethodError)
-  end
-
-  def test_base_rows
-    expect { @img.base_rows }.not_to raise_error
-    expect(@img.base_rows).to eq(0)
-    expect { @img.base_rows = 1 }.to raise_error(NoMethodError)
-  end
-
-  def test_bias
-    expect { @img.bias }.not_to raise_error
-    expect(@img.bias).to eq(0.0)
-    expect(@img.bias).to be_instance_of(Float)
-
-    expect { @img.bias = 0.1 }.not_to raise_error
-    expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.1)
-
-    expect { @img.bias = '10%' }.not_to raise_error
-    expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.10)
-
-    expect { @img.bias = [] }.to raise_error(TypeError)
-    expect { @img.bias = 'x' }.to raise_error(ArgumentError)
-  end
-
-  def test_black_point_compensation
-    expect { @img.black_point_compensation = true }.not_to raise_error
-    expect(@img.black_point_compensation).to be(true)
-    expect { @img.black_point_compensation = false }.not_to raise_error
-    expect(@img.black_point_compensation).to be(false)
-  end
-
-  def test_border_color
-    expect { @img.border_color }.not_to raise_error
-    # expect(@img.border_color).to eq("rgb(223,223,223)")
-    border_color = @img.border_color
-    if border_color.length == 13
-      expect(border_color).to eq('#DFDFDFDFDFDF')
-    else
-      expect(border_color).to eq('#DFDFDFDFDFDFFFFF')
+  describe '#base_filename' do
+    it 'works' do
+      expect { @img.base_filename }.not_to raise_error
+      expect(@img.base_filename).to eq('')
+      expect { @img.base_filename = 'xxx' }.to raise_error(NoMethodError)
     end
-    expect { @img.border_color = 'red' }.not_to raise_error
-    expect(@img.border_color).to eq('red')
-    expect { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }.not_to raise_error
-    # expect(@img.border_color).to eq("rgb(100%,49.9992%,49.9992%)")
-    border_color = @img.border_color
-    if border_color.length == 13
-      expect(border_color).to eq('#FFFF7FFF7FFF')
-    else
-      expect(border_color).to eq('#FFFF7FFF7FFFFFFF')
+  end
+
+  describe '#base_rows' do
+    it 'works' do
+      expect { @img.base_rows }.not_to raise_error
+      expect(@img.base_rows).to eq(0)
+      expect { @img.base_rows = 1 }.to raise_error(NoMethodError)
     end
-    expect { @img.border_color = 2 }.to raise_error(TypeError)
   end
 
-  def test_bounding_box
-    expect { @img.bounding_box }.not_to raise_error
-    box = @img.bounding_box
-    expect(box.width).to eq(87)
-    expect(box.height).to eq(87)
-    expect(box.x).to eq(7)
-    expect(box.y).to eq(7)
-    expect { @img.bounding_box = 2 }.to raise_error(NoMethodError)
+  describe '#bias' do
+    it 'works' do
+      expect { @img.bias }.not_to raise_error
+      expect(@img.bias).to eq(0.0)
+      expect(@img.bias).to be_instance_of(Float)
+
+      expect { @img.bias = 0.1 }.not_to raise_error
+      expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.1)
+
+      expect { @img.bias = '10%' }.not_to raise_error
+      expect(@img.bias).to be_within(0.1).of(Magick::QuantumRange * 0.10)
+
+      expect { @img.bias = [] }.to raise_error(TypeError)
+      expect { @img.bias = 'x' }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_chromaticity
-    chrom = @img.chromaticity
-    expect { @img.chromaticity }.not_to raise_error
-    expect(chrom).to be_instance_of(Magick::Chromaticity)
-    expect(chrom.red_primary.x).to eq(0)
-    expect(chrom.red_primary.y).to eq(0)
-    expect(chrom.red_primary.z).to eq(0)
-    expect(chrom.green_primary.x).to eq(0)
-    expect(chrom.green_primary.y).to eq(0)
-    expect(chrom.green_primary.z).to eq(0)
-    expect(chrom.blue_primary.x).to eq(0)
-    expect(chrom.blue_primary.y).to eq(0)
-    expect(chrom.blue_primary.z).to eq(0)
-    expect(chrom.white_point.x).to eq(0)
-    expect(chrom.white_point.y).to eq(0)
-    expect(chrom.white_point.z).to eq(0)
-    expect { @img.chromaticity = chrom }.not_to raise_error
-    expect { @img.chromaticity = 2 }.to raise_error(TypeError)
+  describe '#black_point_compensation' do
+    it 'works' do
+      expect { @img.black_point_compensation = true }.not_to raise_error
+      expect(@img.black_point_compensation).to be(true)
+      expect { @img.black_point_compensation = false }.not_to raise_error
+      expect(@img.black_point_compensation).to be(false)
+    end
   end
 
-  def test_class_type
-    expect { @img.class_type }.not_to raise_error
-    expect(@img.class_type).to be_instance_of(Magick::ClassType)
-    expect(@img.class_type).to eq(Magick::DirectClass)
-    expect { @img.class_type = Magick::PseudoClass }.not_to raise_error
-    expect(@img.class_type).to eq(Magick::PseudoClass)
-    expect { @img.class_type = 2 }.to raise_error(TypeError)
+  describe '#border_color' do
+    it 'works' do
+      expect { @img.border_color }.not_to raise_error
+      # expect(@img.border_color).to eq("rgb(223,223,223)")
+      border_color = @img.border_color
+      if border_color.length == 13
+        expect(border_color).to eq('#DFDFDFDFDFDF')
+      else
+        expect(border_color).to eq('#DFDFDFDFDFDFFFFF')
+      end
+      expect { @img.border_color = 'red' }.not_to raise_error
+      expect(@img.border_color).to eq('red')
+      expect { @img.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }.not_to raise_error
+      # expect(@img.border_color).to eq("rgb(100%,49.9992%,49.9992%)")
+      border_color = @img.border_color
+      if border_color.length == 13
+        expect(border_color).to eq('#FFFF7FFF7FFF')
+      else
+        expect(border_color).to eq('#FFFF7FFF7FFFFFFF')
+      end
+      expect { @img.border_color = 2 }.to raise_error(TypeError)
+    end
+  end
 
-    expect do
-      @img.class_type = Magick::PseudoClass
-      @img.class_type = Magick::DirectClass
+  describe '#bounding_box' do
+    it 'works' do
+      expect { @img.bounding_box }.not_to raise_error
+      box = @img.bounding_box
+      expect(box.width).to eq(87)
+      expect(box.height).to eq(87)
+      expect(box.x).to eq(7)
+      expect(box.y).to eq(7)
+      expect { @img.bounding_box = 2 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#chromaticity' do
+    it 'works' do
+      chrom = @img.chromaticity
+      expect { @img.chromaticity }.not_to raise_error
+      expect(chrom).to be_instance_of(Magick::Chromaticity)
+      expect(chrom.red_primary.x).to eq(0)
+      expect(chrom.red_primary.y).to eq(0)
+      expect(chrom.red_primary.z).to eq(0)
+      expect(chrom.green_primary.x).to eq(0)
+      expect(chrom.green_primary.y).to eq(0)
+      expect(chrom.green_primary.z).to eq(0)
+      expect(chrom.blue_primary.x).to eq(0)
+      expect(chrom.blue_primary.y).to eq(0)
+      expect(chrom.blue_primary.z).to eq(0)
+      expect(chrom.white_point.x).to eq(0)
+      expect(chrom.white_point.y).to eq(0)
+      expect(chrom.white_point.z).to eq(0)
+      expect { @img.chromaticity = chrom }.not_to raise_error
+      expect { @img.chromaticity = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#class_type' do
+    it 'works' do
+      expect { @img.class_type }.not_to raise_error
+      expect(@img.class_type).to be_instance_of(Magick::ClassType)
       expect(@img.class_type).to eq(Magick::DirectClass)
-    end.not_to raise_error
-  end
+      expect { @img.class_type = Magick::PseudoClass }.not_to raise_error
+      expect(@img.class_type).to eq(Magick::PseudoClass)
+      expect { @img.class_type = 2 }.to raise_error(TypeError)
 
-  def test_color_profile
-    expect { @img.color_profile }.not_to raise_error
-    expect(@img.color_profile).to be(nil)
-    expect { @img.color_profile = @p }.not_to raise_error
-    expect(@img.color_profile).to eq(@p)
-    expect { @img.color_profile = 2 }.to raise_error(TypeError)
-  end
-
-  def test_colors
-    expect { @img.colors }.not_to raise_error
-    expect(@img.colors).to eq(0)
-    img = @img.copy
-    img.class_type = Magick::PseudoClass
-    expect(img.colors).to be_kind_of(Integer)
-    expect { img.colors = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_colorspace
-    expect { @img.colorspace }.not_to raise_error
-    expect(@img.colorspace).to be_instance_of(Magick::ColorspaceType)
-    expect(@img.colorspace).to eq(Magick::SRGBColorspace)
-    img = @img.copy
-
-    Magick::ColorspaceType.values do |colorspace|
-      expect { img.colorspace = colorspace }.not_to raise_error
-    end
-    expect { @img.colorspace = 2 }.to raise_error(TypeError)
-    Magick::ColorspaceType.values.each do |cs|
-      expect { img.colorspace = cs }.not_to raise_error
+      expect do
+        @img.class_type = Magick::PseudoClass
+        @img.class_type = Magick::DirectClass
+        expect(@img.class_type).to eq(Magick::DirectClass)
+      end.not_to raise_error
     end
   end
 
-  def test_columns
-    expect { @img.columns }.not_to raise_error
-    expect(@img.columns).to eq(100)
-    expect { @img.columns = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_compose
-    expect { @img.compose }.not_to raise_error
-    expect(@img.compose).to be_instance_of(Magick::CompositeOperator)
-    expect(@img.compose).to eq(Magick::OverCompositeOp)
-    expect { @img.compose = 2 }.to raise_error(TypeError)
-    expect { @img.compose = Magick::UndefinedCompositeOp }.not_to raise_error
-    expect(@img.compose).to eq(Magick::UndefinedCompositeOp)
-
-    Magick::CompositeOperator.values do |composite|
-      expect { @img.compose = composite }.not_to raise_error
+  describe '#color_profile' do
+    it 'works' do
+      expect { @img.color_profile }.not_to raise_error
+      expect(@img.color_profile).to be(nil)
+      expect { @img.color_profile = @p }.not_to raise_error
+      expect(@img.color_profile).to eq(@p)
+      expect { @img.color_profile = 2 }.to raise_error(TypeError)
     end
-    expect { @img.compose = 2 }.to raise_error(TypeError)
   end
 
-  def test_compression
-    expect { @img.compression }.not_to raise_error
-    expect(@img.compression).to be_instance_of(Magick::CompressionType)
-    expect(@img.compression).to eq(Magick::UndefinedCompression)
-    expect { @img.compression = Magick::BZipCompression }.not_to raise_error
-    expect(@img.compression).to eq(Magick::BZipCompression)
-
-    Magick::CompressionType.values do |compression|
-      expect { @img.compression = compression }.not_to raise_error
+  describe '#colors' do
+    it 'works' do
+      expect { @img.colors }.not_to raise_error
+      expect(@img.colors).to eq(0)
+      img = @img.copy
+      img.class_type = Magick::PseudoClass
+      expect(img.colors).to be_kind_of(Integer)
+      expect { img.colors = 2 }.to raise_error(NoMethodError)
     end
-    expect { @img.compression = 2 }.to raise_error(TypeError)
   end
 
-  def test_delay
-    expect { @img.delay }.not_to raise_error
-    expect(@img.delay).to eq(0)
-    expect { @img.delay = 10 }.not_to raise_error
-    expect(@img.delay).to eq(10)
-    expect { @img.delay = 'x' }.to raise_error(TypeError)
-  end
+  describe '#colorspace' do
+    it 'works' do
+      expect { @img.colorspace }.not_to raise_error
+      expect(@img.colorspace).to be_instance_of(Magick::ColorspaceType)
+      expect(@img.colorspace).to eq(Magick::SRGBColorspace)
+      img = @img.copy
 
-  def test_density
-    expect { @img.density }.not_to raise_error
-    expect { @img.density = '90x90' }.not_to raise_error
-    expect { @img.density = 'x90' }.not_to raise_error
-    expect { @img.density = '90' }.not_to raise_error
-    expect { @img.density = Magick::Geometry.new(@img.columns / 2, @img.rows / 2, 5, 5) }.not_to raise_error
-    expect { @img.density = 2 }.to raise_error(TypeError)
-  end
-
-  def test_depth
-    expect(@img.depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
-    expect { @img.depth = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_directory
-    expect { @img.directory }.not_to raise_error
-    expect(@img.directory).to be(nil)
-    expect { @img.directory = nil }.to raise_error(NoMethodError)
-  end
-
-  def test_dispose
-    expect { @img.dispose }.not_to raise_error
-    expect(@img.dispose).to be_instance_of(Magick::DisposeType)
-    expect(@img.dispose).to eq(Magick::UndefinedDispose)
-    expect { @img.dispose = Magick::NoneDispose }.not_to raise_error
-    expect(@img.dispose).to eq(Magick::NoneDispose)
-
-    Magick::DisposeType.values do |dispose|
-      expect { @img.dispose = dispose }.not_to raise_error
+      Magick::ColorspaceType.values do |colorspace|
+        expect { img.colorspace = colorspace }.not_to raise_error
+      end
+      expect { @img.colorspace = 2 }.to raise_error(TypeError)
+      Magick::ColorspaceType.values.each do |cs|
+        expect { img.colorspace = cs }.not_to raise_error
+      end
     end
-    expect { @img.dispose = 2 }.to raise_error(TypeError)
   end
 
-  def test_endian
-    expect { @img.endian }.not_to raise_error
-    expect(@img.endian).to be_instance_of(Magick::EndianType)
-    expect(@img.endian).to eq(Magick::UndefinedEndian)
-    expect { @img.endian = Magick::LSBEndian }.not_to raise_error
-    expect(@img.endian).to eq(Magick::LSBEndian)
-    expect { @img.endian = Magick::MSBEndian }.not_to raise_error
-    expect { @img.endian = 2 }.to raise_error(TypeError)
-  end
-
-  def test_extract_info
-    expect { @img.extract_info }.not_to raise_error
-    expect(@img.extract_info).to be_instance_of(Magick::Rectangle)
-    ext = @img.extract_info
-    expect(ext.x).to eq(0)
-    expect(ext.y).to eq(0)
-    expect(ext.width).to eq(0)
-    expect(ext.height).to eq(0)
-    ext = Magick::Rectangle.new(1, 2, 3, 4)
-    expect { @img.extract_info = ext }.not_to raise_error
-    expect(ext.width).to eq(1)
-    expect(ext.height).to eq(2)
-    expect(ext.x).to eq(3)
-    expect(ext.y).to eq(4)
-    expect { @img.extract_info = 2 }.to raise_error(TypeError)
-  end
-
-  def test_filename
-    expect { @img.filename }.not_to raise_error
-    expect(@img.filename).to eq('')
-    expect { @img.filename = 'xxx' }.to raise_error(NoMethodError)
-  end
-
-  def test_filter
-    expect { @img.filter }.not_to raise_error
-    expect(@img.filter).to be_instance_of(Magick::FilterType)
-    expect(@img.filter).to eq(Magick::UndefinedFilter)
-    expect { @img.filter = Magick::PointFilter }.not_to raise_error
-    expect(@img.filter).to eq(Magick::PointFilter)
-
-    Magick::FilterType.values do |filter|
-      expect { @img.filter = filter }.not_to raise_error
+  describe '#columns' do
+    it 'works' do
+      expect { @img.columns }.not_to raise_error
+      expect(@img.columns).to eq(100)
+      expect { @img.columns = 2 }.to raise_error(NoMethodError)
     end
-    expect { @img.filter = 2 }.to raise_error(TypeError)
   end
 
-  def test_format
-    expect { @img.format }.not_to raise_error
-    expect(@img.format).to be(nil)
-    expect { @img.format = 'GIF' }.not_to raise_error
-    expect { @img.format = 'JPG' }.not_to raise_error
-    expect { @img.format = 'TIFF' }.not_to raise_error
-    expect { @img.format = 'MIFF' }.not_to raise_error
-    expect { @img.format = 'MPEG' }.not_to raise_error
-    v = $VERBOSE
-    $VERBOSE = nil
-    expect { @img.format = 'shit' }.to raise_error(ArgumentError)
-    $VERBOSE = v
-    expect { @img.format = 2 }.to raise_error(TypeError)
-  end
+  describe '#compose' do
+    it 'works' do
+      expect { @img.compose }.not_to raise_error
+      expect(@img.compose).to be_instance_of(Magick::CompositeOperator)
+      expect(@img.compose).to eq(Magick::OverCompositeOp)
+      expect { @img.compose = 2 }.to raise_error(TypeError)
+      expect { @img.compose = Magick::UndefinedCompositeOp }.not_to raise_error
+      expect(@img.compose).to eq(Magick::UndefinedCompositeOp)
 
-  def test_fuzz
-    expect { @img.fuzz }.not_to raise_error
-    expect(@img.fuzz).to be_instance_of(Float)
-    expect(@img.fuzz).to eq(0.0)
-    expect { @img.fuzz = 50 }.not_to raise_error
-    expect(@img.fuzz).to eq(50.0)
-    expect { @img.fuzz = '50%' }.not_to raise_error
-    expect(@img.fuzz).to be_within(0.1).of(Magick::QuantumRange * 0.50)
-    expect { @img.fuzz = [] }.to raise_error(TypeError)
-    expect { @img.fuzz = 'xxx' }.to raise_error(ArgumentError)
-  end
-
-  def test_gamma
-    expect { @img.gamma }.not_to raise_error
-    expect(@img.gamma).to be_instance_of(Float)
-    expect(@img.gamma).to eq(0.45454543828964233)
-    expect { @img.gamma = 2.0 }.not_to raise_error
-    expect(@img.gamma).to eq(2.0)
-    expect { @img.gamma = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_geometry
-    expect { @img.geometry }.not_to raise_error
-    expect(@img.geometry).to be(nil)
-    expect { @img.geometry = nil }.not_to raise_error
-    expect { @img.geometry = '90x90' }.not_to raise_error
-    expect(@img.geometry).to eq('90x90')
-    expect { @img.geometry = Magick::Geometry.new(100, 80) }.not_to raise_error
-    expect(@img.geometry).to eq('100x80')
-    expect { @img.geometry = [] }.to raise_error(TypeError)
-  end
-
-  def test_gravity
-    expect(@img.gravity).to be_instance_of(Magick::GravityType)
-
-    Magick::GravityType.values do |gravity|
-      expect { @img.gravity = gravity }.not_to raise_error
+      Magick::CompositeOperator.values do |composite|
+        expect { @img.compose = composite }.not_to raise_error
+      end
+      expect { @img.compose = 2 }.to raise_error(TypeError)
     end
-    expect { @img.gravity = nil }.to raise_error(TypeError)
-    expect { @img.gravity = Magick::PointFilter }.to raise_error(TypeError)
   end
 
-  def test_image_type
-    expect(@img.image_type).to be_instance_of(Magick::ImageType)
+  describe '#compression' do
+    it 'works' do
+      expect { @img.compression }.not_to raise_error
+      expect(@img.compression).to be_instance_of(Magick::CompressionType)
+      expect(@img.compression).to eq(Magick::UndefinedCompression)
+      expect { @img.compression = Magick::BZipCompression }.not_to raise_error
+      expect(@img.compression).to eq(Magick::BZipCompression)
 
-    Magick::ImageType.values do |image_type|
-      expect { @img.image_type = image_type }.not_to raise_error
+      Magick::CompressionType.values do |compression|
+        expect { @img.compression = compression }.not_to raise_error
+      end
+      expect { @img.compression = 2 }.to raise_error(TypeError)
     end
-    expect { @img.image_type = nil }.to raise_error(TypeError)
-    expect { @img.image_type = Magick::PointFilter }.to raise_error(TypeError)
   end
 
-  def test_interlace_type
-    expect { @img.interlace }.not_to raise_error
-    expect(@img.interlace).to be_instance_of(Magick::InterlaceType)
-    expect(@img.interlace).to eq(Magick::NoInterlace)
-    expect { @img.interlace = Magick::LineInterlace }.not_to raise_error
-    expect(@img.interlace).to eq(Magick::LineInterlace)
-
-    Magick::InterlaceType.values do |interlace|
-      expect { @img.interlace = interlace }.not_to raise_error
+  describe '#delay' do
+    it 'works' do
+      expect { @img.delay }.not_to raise_error
+      expect(@img.delay).to eq(0)
+      expect { @img.delay = 10 }.not_to raise_error
+      expect(@img.delay).to eq(10)
+      expect { @img.delay = 'x' }.to raise_error(TypeError)
     end
-    expect { @img.interlace = 2 }.to raise_error(TypeError)
   end
 
-  def test_iptc_profile
-    expect { @img.iptc_profile }.not_to raise_error
-    expect(@img.iptc_profile).to be(nil)
-    expect { @img.iptc_profile = 'xxx' }.not_to raise_error
-    expect(@img.iptc_profile).to eq('xxx')
-    expect { @img.iptc_profile = 2 }.to raise_error(TypeError)
-  end
-
-  def test_mean_error
-    expect { @hat.mean_error_per_pixel }.not_to raise_error
-    expect { @hat.normalized_mean_error }.not_to raise_error
-    expect { @hat.normalized_maximum_error }.not_to raise_error
-    expect(@hat.mean_error_per_pixel).to eq(0.0)
-    expect(@hat.normalized_mean_error).to eq(0.0)
-    expect(@hat.normalized_maximum_error).to eq(0.0)
-
-    hat = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
-
-    expect(hat.mean_error_per_pixel).not_to eq(0.0)
-    expect(hat.normalized_mean_error).not_to eq(0.0)
-    expect(hat.normalized_maximum_error).not_to eq(0.0)
-    expect { hat.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
-    expect { hat.normalized_mean_error = 1 }.to raise_error(NoMethodError)
-    expect { hat.normalized_maximum_error = 1 }.to raise_error(NoMethodError)
-  end
-
-  def test_mime_type
-    img = @img.copy
-    img.format = 'GIF'
-    expect { img.mime_type }.not_to raise_error
-    expect(img.mime_type).to eq('image/gif')
-    img.format = 'JPG'
-    expect(img.mime_type).to eq('image/jpeg')
-    expect { img.mime_type = 'image/jpeg' }.to raise_error(NoMethodError)
-  end
-
-  def test_monitor
-    expect { @img.monitor }.to raise_error(NoMethodError)
-    monitor = proc { |name, _q, _s| puts name }
-    expect { @img.monitor = monitor }.not_to raise_error
-    expect { @img.monitor = nil }.not_to raise_error
-  end
-
-  def test_montage
-    expect { @img.montage }.not_to raise_error
-    expect(@img.montage).to be(nil)
-  end
-
-  def test_number_colors
-    expect { @hat.number_colors }.not_to raise_error
-    expect(@hat.number_colors).to be_kind_of(Integer)
-    expect { @hat.number_colors = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_offset
-    expect { @img.offset }.not_to raise_error
-    expect(@img.offset).to eq(0)
-    expect { @img.offset = 10 }.not_to raise_error
-    expect(@img.offset).to eq(10)
-    expect { @img.offset = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_orientation
-    expect { @img.orientation }.not_to raise_error
-    expect(@img.orientation).to be_instance_of(Magick::OrientationType)
-    expect(@img.orientation).to eq(Magick::UndefinedOrientation)
-    expect { @img.orientation = Magick::TopLeftOrientation }.not_to raise_error
-    expect(@img.orientation).to eq(Magick::TopLeftOrientation)
-
-    Magick::OrientationType.values do |orientation|
-      expect { @img.orientation = orientation }.not_to raise_error
+  describe '#density' do
+    it 'works' do
+      expect { @img.density }.not_to raise_error
+      expect { @img.density = '90x90' }.not_to raise_error
+      expect { @img.density = 'x90' }.not_to raise_error
+      expect { @img.density = '90' }.not_to raise_error
+      expect { @img.density = Magick::Geometry.new(@img.columns / 2, @img.rows / 2, 5, 5) }.not_to raise_error
+      expect { @img.density = 2 }.to raise_error(TypeError)
     end
-    expect { @img.orientation = 2 }.to raise_error(TypeError)
   end
 
-  def test_page
-    expect { @img.page }.not_to raise_error
-    page = @img.page
-    expect(page.width).to eq(0)
-    expect(page.height).to eq(0)
-    expect(page.x).to eq(0)
-    expect(page.y).to eq(0)
-    page = Magick::Rectangle.new(1, 2, 3, 4)
-    expect { @img.page = page }.not_to raise_error
-    expect(page.width).to eq(1)
-    expect(page.height).to eq(2)
-    expect(page.x).to eq(3)
-    expect(page.y).to eq(4)
-    expect { @img.page = 2 }.to raise_error(TypeError)
-  end
-
-  def test_pixel_interpolation_method
-    expect { @img.pixel_interpolation_method }.not_to raise_error
-    expect(@img.pixel_interpolation_method).to be_instance_of(Magick::PixelInterpolateMethod)
-    expect(@img.pixel_interpolation_method).to eq(Magick::UndefinedInterpolatePixel)
-    expect { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }.not_to raise_error
-    expect(@img.pixel_interpolation_method).to eq(Magick::AverageInterpolatePixel)
-
-    Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
-      expect { @img.pixel_interpolation_method = interpolate_pixel_method }.not_to raise_error
+  describe '#depth' do
+    it 'works' do
+      expect(@img.depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
+      expect { @img.depth = 2 }.to raise_error(NoMethodError)
     end
-    expect { @img.pixel_interpolation_method = 2 }.to raise_error(TypeError)
   end
 
-  def test_quality
-    expect { @hat.quality }.not_to raise_error
-    expect(@hat.quality).to eq(75)
-    expect { @img.quality = 80 }.to raise_error(NoMethodError)
-  end
-
-  def test_quantum_depth
-    expect { @img.quantum_depth }.not_to raise_error
-    expect(@img.quantum_depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
-    expect { @img.quantum_depth = 8 }.to raise_error(NoMethodError)
-  end
-
-  def test_rendering_intent
-    expect { @img.rendering_intent }.not_to raise_error
-    expect(@img.rendering_intent).to be_instance_of(Magick::RenderingIntent)
-    expect(@img.rendering_intent).to eq(Magick::PerceptualIntent)
-
-    Magick::RenderingIntent.values do |rendering_intent|
-      expect { @img.rendering_intent = rendering_intent }.not_to raise_error
+  describe '#directory' do
+    it 'works' do
+      expect { @img.directory }.not_to raise_error
+      expect(@img.directory).to be(nil)
+      expect { @img.directory = nil }.to raise_error(NoMethodError)
     end
-    expect { @img.rendering_intent = 2 }.to raise_error(TypeError)
   end
 
-  def test_rows
-    expect { @img.rows }.not_to raise_error
-    expect(@img.rows).to eq(100)
-    expect { @img.rows = 2 }.to raise_error(NoMethodError)
-  end
+  describe '#dispose' do
+    it 'works' do
+      expect { @img.dispose }.not_to raise_error
+      expect(@img.dispose).to be_instance_of(Magick::DisposeType)
+      expect(@img.dispose).to eq(Magick::UndefinedDispose)
+      expect { @img.dispose = Magick::NoneDispose }.not_to raise_error
+      expect(@img.dispose).to eq(Magick::NoneDispose)
 
-  def test_scene
-    ilist = Magick::ImageList.new
-    ilist << @img
-    img = @img.copy
-    ilist << img
-    ilist.write('temp.gif')
-    FileUtils.rm('temp.gif')
-
-    expect { img.scene }.not_to raise_error
-    expect(@img.scene).to eq(0)
-    expect(img.scene).to eq(1)
-    expect { img.scene = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_start_loop
-    expect { @img.start_loop }.not_to raise_error
-    expect(@img.start_loop).to be(false)
-    expect { @img.start_loop = true }.not_to raise_error
-    expect(@img.start_loop).to be(true)
-  end
-
-  def test_ticks_per_second
-    expect { @img.ticks_per_second }.not_to raise_error
-    expect(@img.ticks_per_second).to eq(100)
-    expect { @img.ticks_per_second = 1000 }.not_to raise_error
-    expect(@img.ticks_per_second).to eq(1000)
-    expect { @img.ticks_per_second = 'x' }.to raise_error(TypeError)
-  end
-
-  def test_total_colors
-    expect { @hat.total_colors }.not_to raise_error
-    expect(@hat.total_colors).to be_kind_of(Integer)
-    expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
-  end
-
-  def test_units
-    expect { @img.units }.not_to raise_error
-    expect(@img.units).to be_instance_of(Magick::ResolutionType)
-    expect(@img.units).to eq(Magick::UndefinedResolution)
-    expect { @img.units = Magick::PixelsPerInchResolution }.not_to raise_error
-    expect(@img.units).to eq(Magick::PixelsPerInchResolution)
-
-    Magick::ResolutionType.values do |resolution|
-      expect { @img.units = resolution }.not_to raise_error
+      Magick::DisposeType.values do |dispose|
+        expect { @img.dispose = dispose }.not_to raise_error
+      end
+      expect { @img.dispose = 2 }.to raise_error(TypeError)
     end
-    expect { @img.units = 2 }.to raise_error(TypeError)
   end
 
-  def test_virtual_pixel_method
-    expect { @img.virtual_pixel_method }.not_to raise_error
-    expect(@img.virtual_pixel_method).to eq(Magick::UndefinedVirtualPixelMethod)
-    expect { @img.virtual_pixel_method = Magick::EdgeVirtualPixelMethod }.not_to raise_error
-    expect(@img.virtual_pixel_method).to eq(Magick::EdgeVirtualPixelMethod)
-
-    Magick::VirtualPixelMethod.values do |virtual_pixel_method|
-      expect { @img.virtual_pixel_method = virtual_pixel_method }.not_to raise_error
+  describe '#endian' do
+    it 'works' do
+      expect { @img.endian }.not_to raise_error
+      expect(@img.endian).to be_instance_of(Magick::EndianType)
+      expect(@img.endian).to eq(Magick::UndefinedEndian)
+      expect { @img.endian = Magick::LSBEndian }.not_to raise_error
+      expect(@img.endian).to eq(Magick::LSBEndian)
+      expect { @img.endian = Magick::MSBEndian }.not_to raise_error
+      expect { @img.endian = 2 }.to raise_error(TypeError)
     end
-    expect { @img.virtual_pixel_method = 2 }.to raise_error(TypeError)
   end
 
-  def test_x_resolution
-    expect { @img.x_resolution }.not_to raise_error
-    expect { @img.x_resolution = 90 }.not_to raise_error
-    expect(@img.x_resolution).to eq(90.0)
-    expect { @img.x_resolution = 'x' }.to raise_error(TypeError)
+  describe '#extract_info' do
+    it 'works' do
+      expect { @img.extract_info }.not_to raise_error
+      expect(@img.extract_info).to be_instance_of(Magick::Rectangle)
+      ext = @img.extract_info
+      expect(ext.x).to eq(0)
+      expect(ext.y).to eq(0)
+      expect(ext.width).to eq(0)
+      expect(ext.height).to eq(0)
+      ext = Magick::Rectangle.new(1, 2, 3, 4)
+      expect { @img.extract_info = ext }.not_to raise_error
+      expect(ext.width).to eq(1)
+      expect(ext.height).to eq(2)
+      expect(ext.x).to eq(3)
+      expect(ext.y).to eq(4)
+      expect { @img.extract_info = 2 }.to raise_error(TypeError)
+    end
   end
 
-  def test_y_resolution
-    expect { @img.y_resolution }.not_to raise_error
-    expect { @img.y_resolution = 90 }.not_to raise_error
-    expect(@img.y_resolution).to eq(90.0)
-    expect { @img.y_resolution = 'x' }.to raise_error(TypeError)
+  describe '#filename' do
+    it 'works' do
+      expect { @img.filename }.not_to raise_error
+      expect(@img.filename).to eq('')
+      expect { @img.filename = 'xxx' }.to raise_error(NoMethodError)
+    end
   end
 
-  def test_frozen
-    @img.freeze
-    expect { @img.background_color = 'xxx' }.to raise_error(FreezeError)
-    expect { @img.border_color = 'xxx' }.to raise_error(FreezeError)
-    rp = Magick::Point.new(1, 1)
-    gp = Magick::Point.new(1, 1)
-    bp = Magick::Point.new(1, 1)
-    wp = Magick::Point.new(1, 1)
-    expect { @img.chromaticity = Magick::Chromaticity.new(rp, gp, bp, wp) }.to raise_error(FreezeError)
-    expect { @img.class_type = Magick::DirectClass }.to raise_error(FreezeError)
-    expect { @img.color_profile = 'xxx' }.to raise_error(FreezeError)
-    expect { @img.colorspace = Magick::RGBColorspace }.to raise_error(FreezeError)
-    expect { @img.compose = Magick::OverCompositeOp }.to raise_error(FreezeError)
-    expect { @img.compression = Magick::RLECompression }.to raise_error(FreezeError)
-    expect { @img.delay = 2 }.to raise_error(FreezeError)
-    expect { @img.density = '72.0x72.0' }.to raise_error(FreezeError)
-    expect { @img.dispose = Magick::NoneDispose }.to raise_error(FreezeError)
-    expect { @img.endian = Magick::MSBEndian }.to raise_error(FreezeError)
-    expect { @img.extract_info = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
-    expect { @img.filter = Magick::PointFilter }.to raise_error(FreezeError)
-    expect { @img.format = 'GIF' }.to raise_error(FreezeError)
-    expect { @img.fuzz = 50.0 }.to raise_error(FreezeError)
-    expect { @img.gamma = 2.0 }.to raise_error(FreezeError)
-    expect { @img.geometry = '100x100' }.to raise_error(FreezeError)
-    expect { @img.interlace = Magick::NoInterlace }.to raise_error(FreezeError)
-    expect { @img.iptc_profile = 'xxx' }.to raise_error(FreezeError)
-    expect { @img.monitor = proc { |name, _q, _s| puts name } }.to raise_error(FreezeError)
-    expect { @img.offset = 100 }.to raise_error(FreezeError)
-    expect { @img.page = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
-    expect { @img.rendering_intent = Magick::SaturationIntent }.to raise_error(FreezeError)
-    expect { @img.start_loop = true }.to raise_error(FreezeError)
-    expect { @img.ticks_per_second = 1000 }.to raise_error(FreezeError)
-    expect { @img.units = Magick::PixelsPerInchResolution }.to raise_error(FreezeError)
-    expect { @img.x_resolution = 72.0 }.to raise_error(FreezeError)
-    expect { @img.y_resolution = 72.0 }.to raise_error(FreezeError)
+  describe '#filter' do
+    it 'works' do
+      expect { @img.filter }.not_to raise_error
+      expect(@img.filter).to be_instance_of(Magick::FilterType)
+      expect(@img.filter).to eq(Magick::UndefinedFilter)
+      expect { @img.filter = Magick::PointFilter }.not_to raise_error
+      expect(@img.filter).to eq(Magick::PointFilter)
+
+      Magick::FilterType.values do |filter|
+        expect { @img.filter = filter }.not_to raise_error
+      end
+      expect { @img.filter = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#format' do
+    it 'works' do
+      expect { @img.format }.not_to raise_error
+      expect(@img.format).to be(nil)
+      expect { @img.format = 'GIF' }.not_to raise_error
+      expect { @img.format = 'JPG' }.not_to raise_error
+      expect { @img.format = 'TIFF' }.not_to raise_error
+      expect { @img.format = 'MIFF' }.not_to raise_error
+      expect { @img.format = 'MPEG' }.not_to raise_error
+      v = $VERBOSE
+      $VERBOSE = nil
+      expect { @img.format = 'shit' }.to raise_error(ArgumentError)
+      $VERBOSE = v
+      expect { @img.format = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#fuzz' do
+    it 'works' do
+      expect { @img.fuzz }.not_to raise_error
+      expect(@img.fuzz).to be_instance_of(Float)
+      expect(@img.fuzz).to eq(0.0)
+      expect { @img.fuzz = 50 }.not_to raise_error
+      expect(@img.fuzz).to eq(50.0)
+      expect { @img.fuzz = '50%' }.not_to raise_error
+      expect(@img.fuzz).to be_within(0.1).of(Magick::QuantumRange * 0.50)
+      expect { @img.fuzz = [] }.to raise_error(TypeError)
+      expect { @img.fuzz = 'xxx' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#gamma' do
+    it 'works' do
+      expect { @img.gamma }.not_to raise_error
+      expect(@img.gamma).to be_instance_of(Float)
+      expect(@img.gamma).to eq(0.45454543828964233)
+      expect { @img.gamma = 2.0 }.not_to raise_error
+      expect(@img.gamma).to eq(2.0)
+      expect { @img.gamma = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#geometry' do
+    it 'works' do
+      expect { @img.geometry }.not_to raise_error
+      expect(@img.geometry).to be(nil)
+      expect { @img.geometry = nil }.not_to raise_error
+      expect { @img.geometry = '90x90' }.not_to raise_error
+      expect(@img.geometry).to eq('90x90')
+      expect { @img.geometry = Magick::Geometry.new(100, 80) }.not_to raise_error
+      expect(@img.geometry).to eq('100x80')
+      expect { @img.geometry = [] }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#gravity' do
+    it 'works' do
+      expect(@img.gravity).to be_instance_of(Magick::GravityType)
+
+      Magick::GravityType.values do |gravity|
+        expect { @img.gravity = gravity }.not_to raise_error
+      end
+      expect { @img.gravity = nil }.to raise_error(TypeError)
+      expect { @img.gravity = Magick::PointFilter }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#image_type' do
+    it 'works' do
+      expect(@img.image_type).to be_instance_of(Magick::ImageType)
+
+      Magick::ImageType.values do |image_type|
+        expect { @img.image_type = image_type }.not_to raise_error
+      end
+      expect { @img.image_type = nil }.to raise_error(TypeError)
+      expect { @img.image_type = Magick::PointFilter }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#interlace_type' do
+    it 'works' do
+      expect { @img.interlace }.not_to raise_error
+      expect(@img.interlace).to be_instance_of(Magick::InterlaceType)
+      expect(@img.interlace).to eq(Magick::NoInterlace)
+      expect { @img.interlace = Magick::LineInterlace }.not_to raise_error
+      expect(@img.interlace).to eq(Magick::LineInterlace)
+
+      Magick::InterlaceType.values do |interlace|
+        expect { @img.interlace = interlace }.not_to raise_error
+      end
+      expect { @img.interlace = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#iptc_profile' do
+    it 'works' do
+      expect { @img.iptc_profile }.not_to raise_error
+      expect(@img.iptc_profile).to be(nil)
+      expect { @img.iptc_profile = 'xxx' }.not_to raise_error
+      expect(@img.iptc_profile).to eq('xxx')
+      expect { @img.iptc_profile = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#mean_error' do
+    it 'works' do
+      expect { @hat.mean_error_per_pixel }.not_to raise_error
+      expect { @hat.normalized_mean_error }.not_to raise_error
+      expect { @hat.normalized_maximum_error }.not_to raise_error
+      expect(@hat.mean_error_per_pixel).to eq(0.0)
+      expect(@hat.normalized_mean_error).to eq(0.0)
+      expect(@hat.normalized_maximum_error).to eq(0.0)
+
+      hat = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
+
+      expect(hat.mean_error_per_pixel).not_to eq(0.0)
+      expect(hat.normalized_mean_error).not_to eq(0.0)
+      expect(hat.normalized_maximum_error).not_to eq(0.0)
+      expect { hat.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
+      expect { hat.normalized_mean_error = 1 }.to raise_error(NoMethodError)
+      expect { hat.normalized_maximum_error = 1 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#mime_type' do
+    it 'works' do
+      img = @img.copy
+      img.format = 'GIF'
+      expect { img.mime_type }.not_to raise_error
+      expect(img.mime_type).to eq('image/gif')
+      img.format = 'JPG'
+      expect(img.mime_type).to eq('image/jpeg')
+      expect { img.mime_type = 'image/jpeg' }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#monitor' do
+    it 'works' do
+      expect { @img.monitor }.to raise_error(NoMethodError)
+      monitor = proc { |name, _q, _s| puts name }
+      expect { @img.monitor = monitor }.not_to raise_error
+      expect { @img.monitor = nil }.not_to raise_error
+    end
+  end
+
+  describe '#montage' do
+    it 'works' do
+      expect { @img.montage }.not_to raise_error
+      expect(@img.montage).to be(nil)
+    end
+  end
+
+  describe '#number_colors' do
+    it 'works' do
+      expect { @hat.number_colors }.not_to raise_error
+      expect(@hat.number_colors).to be_kind_of(Integer)
+      expect { @hat.number_colors = 2 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#offset' do
+    it 'works' do
+      expect { @img.offset }.not_to raise_error
+      expect(@img.offset).to eq(0)
+      expect { @img.offset = 10 }.not_to raise_error
+      expect(@img.offset).to eq(10)
+      expect { @img.offset = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#orientation' do
+    it 'works' do
+      expect { @img.orientation }.not_to raise_error
+      expect(@img.orientation).to be_instance_of(Magick::OrientationType)
+      expect(@img.orientation).to eq(Magick::UndefinedOrientation)
+      expect { @img.orientation = Magick::TopLeftOrientation }.not_to raise_error
+      expect(@img.orientation).to eq(Magick::TopLeftOrientation)
+
+      Magick::OrientationType.values do |orientation|
+        expect { @img.orientation = orientation }.not_to raise_error
+      end
+      expect { @img.orientation = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#page' do
+    it 'works' do
+      expect { @img.page }.not_to raise_error
+      page = @img.page
+      expect(page.width).to eq(0)
+      expect(page.height).to eq(0)
+      expect(page.x).to eq(0)
+      expect(page.y).to eq(0)
+      page = Magick::Rectangle.new(1, 2, 3, 4)
+      expect { @img.page = page }.not_to raise_error
+      expect(page.width).to eq(1)
+      expect(page.height).to eq(2)
+      expect(page.x).to eq(3)
+      expect(page.y).to eq(4)
+      expect { @img.page = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#pixel_interpolation_method' do
+    it 'works' do
+      expect { @img.pixel_interpolation_method }.not_to raise_error
+      expect(@img.pixel_interpolation_method).to be_instance_of(Magick::PixelInterpolateMethod)
+      expect(@img.pixel_interpolation_method).to eq(Magick::UndefinedInterpolatePixel)
+      expect { @img.pixel_interpolation_method = Magick::AverageInterpolatePixel }.not_to raise_error
+      expect(@img.pixel_interpolation_method).to eq(Magick::AverageInterpolatePixel)
+
+      Magick::PixelInterpolateMethod.values do |interpolate_pixel_method|
+        expect { @img.pixel_interpolation_method = interpolate_pixel_method }.not_to raise_error
+      end
+      expect { @img.pixel_interpolation_method = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#quality' do
+    it 'works' do
+      expect { @hat.quality }.not_to raise_error
+      expect(@hat.quality).to eq(75)
+      expect { @img.quality = 80 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#quantum_depth' do
+    it 'works' do
+      expect { @img.quantum_depth }.not_to raise_error
+      expect(@img.quantum_depth).to eq(Magick::MAGICKCORE_QUANTUM_DEPTH)
+      expect { @img.quantum_depth = 8 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#rendering_intent' do
+    it 'works' do
+      expect { @img.rendering_intent }.not_to raise_error
+      expect(@img.rendering_intent).to be_instance_of(Magick::RenderingIntent)
+      expect(@img.rendering_intent).to eq(Magick::PerceptualIntent)
+
+      Magick::RenderingIntent.values do |rendering_intent|
+        expect { @img.rendering_intent = rendering_intent }.not_to raise_error
+      end
+      expect { @img.rendering_intent = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#rows' do
+    it 'works' do
+      expect { @img.rows }.not_to raise_error
+      expect(@img.rows).to eq(100)
+      expect { @img.rows = 2 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#scene' do
+    it 'works' do
+      ilist = Magick::ImageList.new
+      ilist << @img
+      img = @img.copy
+      ilist << img
+      ilist.write('temp.gif')
+      FileUtils.rm('temp.gif')
+
+      expect { img.scene }.not_to raise_error
+      expect(@img.scene).to eq(0)
+      expect(img.scene).to eq(1)
+      expect { img.scene = 2 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#start_loop' do
+    it 'works' do
+      expect { @img.start_loop }.not_to raise_error
+      expect(@img.start_loop).to be(false)
+      expect { @img.start_loop = true }.not_to raise_error
+      expect(@img.start_loop).to be(true)
+    end
+  end
+
+  describe '#ticks_per_second' do
+    it 'works' do
+      expect { @img.ticks_per_second }.not_to raise_error
+      expect(@img.ticks_per_second).to eq(100)
+      expect { @img.ticks_per_second = 1000 }.not_to raise_error
+      expect(@img.ticks_per_second).to eq(1000)
+      expect { @img.ticks_per_second = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#total_colors' do
+    it 'works' do
+      expect { @hat.total_colors }.not_to raise_error
+      expect(@hat.total_colors).to be_kind_of(Integer)
+      expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#units' do
+    it 'works' do
+      expect { @img.units }.not_to raise_error
+      expect(@img.units).to be_instance_of(Magick::ResolutionType)
+      expect(@img.units).to eq(Magick::UndefinedResolution)
+      expect { @img.units = Magick::PixelsPerInchResolution }.not_to raise_error
+      expect(@img.units).to eq(Magick::PixelsPerInchResolution)
+
+      Magick::ResolutionType.values do |resolution|
+        expect { @img.units = resolution }.not_to raise_error
+      end
+      expect { @img.units = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#virtual_pixel_method' do
+    it 'works' do
+      expect { @img.virtual_pixel_method }.not_to raise_error
+      expect(@img.virtual_pixel_method).to eq(Magick::UndefinedVirtualPixelMethod)
+      expect { @img.virtual_pixel_method = Magick::EdgeVirtualPixelMethod }.not_to raise_error
+      expect(@img.virtual_pixel_method).to eq(Magick::EdgeVirtualPixelMethod)
+
+      Magick::VirtualPixelMethod.values do |virtual_pixel_method|
+        expect { @img.virtual_pixel_method = virtual_pixel_method }.not_to raise_error
+      end
+      expect { @img.virtual_pixel_method = 2 }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#x_resolution' do
+    it 'works' do
+      expect { @img.x_resolution }.not_to raise_error
+      expect { @img.x_resolution = 90 }.not_to raise_error
+      expect(@img.x_resolution).to eq(90.0)
+      expect { @img.x_resolution = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#y_resolution' do
+    it 'works' do
+      expect { @img.y_resolution }.not_to raise_error
+      expect { @img.y_resolution = 90 }.not_to raise_error
+      expect(@img.y_resolution).to eq(90.0)
+      expect { @img.y_resolution = 'x' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#frozen' do
+    it 'works' do
+      @img.freeze
+      expect { @img.background_color = 'xxx' }.to raise_error(FreezeError)
+      expect { @img.border_color = 'xxx' }.to raise_error(FreezeError)
+      rp = Magick::Point.new(1, 1)
+      gp = Magick::Point.new(1, 1)
+      bp = Magick::Point.new(1, 1)
+      wp = Magick::Point.new(1, 1)
+      expect { @img.chromaticity = Magick::Chromaticity.new(rp, gp, bp, wp) }.to raise_error(FreezeError)
+      expect { @img.class_type = Magick::DirectClass }.to raise_error(FreezeError)
+      expect { @img.color_profile = 'xxx' }.to raise_error(FreezeError)
+      expect { @img.colorspace = Magick::RGBColorspace }.to raise_error(FreezeError)
+      expect { @img.compose = Magick::OverCompositeOp }.to raise_error(FreezeError)
+      expect { @img.compression = Magick::RLECompression }.to raise_error(FreezeError)
+      expect { @img.delay = 2 }.to raise_error(FreezeError)
+      expect { @img.density = '72.0x72.0' }.to raise_error(FreezeError)
+      expect { @img.dispose = Magick::NoneDispose }.to raise_error(FreezeError)
+      expect { @img.endian = Magick::MSBEndian }.to raise_error(FreezeError)
+      expect { @img.extract_info = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
+      expect { @img.filter = Magick::PointFilter }.to raise_error(FreezeError)
+      expect { @img.format = 'GIF' }.to raise_error(FreezeError)
+      expect { @img.fuzz = 50.0 }.to raise_error(FreezeError)
+      expect { @img.gamma = 2.0 }.to raise_error(FreezeError)
+      expect { @img.geometry = '100x100' }.to raise_error(FreezeError)
+      expect { @img.interlace = Magick::NoInterlace }.to raise_error(FreezeError)
+      expect { @img.iptc_profile = 'xxx' }.to raise_error(FreezeError)
+      expect { @img.monitor = proc { |name, _q, _s| puts name } }.to raise_error(FreezeError)
+      expect { @img.offset = 100 }.to raise_error(FreezeError)
+      expect { @img.page = Magick::Rectangle.new(1, 2, 3, 4) }.to raise_error(FreezeError)
+      expect { @img.rendering_intent = Magick::SaturationIntent }.to raise_error(FreezeError)
+      expect { @img.start_loop = true }.to raise_error(FreezeError)
+      expect { @img.ticks_per_second = 1000 }.to raise_error(FreezeError)
+      expect { @img.units = Magick::PixelsPerInchResolution }.to raise_error(FreezeError)
+      expect { @img.x_resolution = 72.0 }.to raise_error(FreezeError)
+      expect { @img.y_resolution = 72.0 }.to raise_error(FreezeError)
+    end
   end
 end # class Image_Attributes_UT
 

--- a/test/Import_Export.rb
+++ b/test/Import_Export.rb
@@ -1,8 +1,8 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class ImportExportUT < Minitest::Test
-  def setup
+describe Magick::Image do
+  before do
     @test = Magick::Image.read(File.join(IMAGES_DIR, 'Flower_Hat.jpg')).first
   end
 
@@ -24,80 +24,83 @@ class ImportExportUT < Minitest::Test
     expect(diff).to be_within(50.0).of(0.0)
   end
 
-  def test_import_export_float
-    pixels = @test.export_pixels(0, 0, @test.columns, @test.rows, 'RGB')
-    fpixels = pixels.collect { |p| p.to_f / Magick::QuantumRange }
-    p = fpixels.pack('F*')
-    fimport(p, Magick::FloatPixel)
+  describe '#import_export_float' do
+    it 'works' do
+      pixels = @test.export_pixels(0, 0, @test.columns, @test.rows, 'RGB')
+      fpixels = pixels.collect { |p| p.to_f / Magick::QuantumRange }
+      p = fpixels.pack('F*')
+      fimport(p, Magick::FloatPixel)
 
-    p = fpixels.pack('D*')
-    fimport(p, Magick::DoublePixel)
+      p = fpixels.pack('D*')
+      fimport(p, Magick::DoublePixel)
+    end
   end
 
-  def test_import_export
-    is_hdri_support = Magick::Magick_features =~ /HDRI/
-    pixels = @test.export_pixels(0, 0, @test.columns, @test.rows, 'RGB')
+  describe '#import_export' do
+    it 'works' do
+      is_hdri_support = Magick::Magick_features =~ /HDRI/
+      pixels = @test.export_pixels(0, 0, @test.columns, @test.rows, 'RGB')
 
-    case Magick::MAGICKCORE_QUANTUM_DEPTH
-    when 8
-      p = pixels.pack('C*')
-      import(p, Magick::CharPixel)
-      p = pixels.pack('F*') if is_hdri_support
-      import(p, Magick::QuantumPixel)
+      case Magick::MAGICKCORE_QUANTUM_DEPTH
+      when 8
+        p = pixels.pack('C*')
+        import(p, Magick::CharPixel)
+        p = pixels.pack('F*') if is_hdri_support
+        import(p, Magick::QuantumPixel)
 
-      spixels = pixels.collect { |px| px * 257 }
-      p = spixels.pack('S*')
-      import(p, Magick::ShortPixel)
+        spixels = pixels.collect { |px| px * 257 }
+        p = spixels.pack('S*')
+        import(p, Magick::ShortPixel)
 
-      ipixels = pixels.collect { |px| px * 16_843_009 }
-      p = ipixels.pack('I*')
-      import(p, Magick::LongPixel)
+        ipixels = pixels.collect { |px| px * 16_843_009 }
+        p = ipixels.pack('I*')
+        import(p, Magick::LongPixel)
 
-    when 16
-      cpixels = pixels.collect { |px| px / 257 }
-      p = cpixels.pack('C*')
-      import(p, Magick::CharPixel)
+      when 16
+        cpixels = pixels.collect { |px| px / 257 }
+        p = cpixels.pack('C*')
+        import(p, Magick::CharPixel)
 
-      p = pixels.pack('S*')
-      import(p, Magick::ShortPixel)
-      p = pixels.pack('F*') if is_hdri_support
-      import(p, Magick::QuantumPixel)
+        p = pixels.pack('S*')
+        import(p, Magick::ShortPixel)
+        p = pixels.pack('F*') if is_hdri_support
+        import(p, Magick::QuantumPixel)
 
-      ipixels = pixels.collect { |px| px * 65_537 }
-      ipixels.pack('I*')
-    # Diff s/b 0.0 but never is.
-    # import(p, Magick::LongPixel, 430.7834)
+        ipixels = pixels.collect { |px| px * 65_537 }
+        ipixels.pack('I*')
+        # Diff s/b 0.0 but never is.
+        # import(p, Magick::LongPixel, 430.7834)
 
-    when 32
-      cpixels = pixels.collect { |px| px / 16_843_009 }
-      p = cpixels.pack('C*')
-      import(p, Magick::CharPixel)
+      when 32
+        cpixels = pixels.collect { |px| px / 16_843_009 }
+        p = cpixels.pack('C*')
+        import(p, Magick::CharPixel)
 
-      spixels = pixels.collect { |px| px / 65_537 }
-      p = spixels.pack('S*')
-      import(p, Magick::ShortPixel)
+        spixels = pixels.collect { |px| px / 65_537 }
+        p = spixels.pack('S*')
+        import(p, Magick::ShortPixel)
 
-      p = pixels.pack('I*')
-      import(p, Magick::LongPixel)
-      p = pixels.pack('D*') if is_hdri_support
-      import(p, Magick::QuantumPixel)
+        p = pixels.pack('I*')
+        import(p, Magick::LongPixel)
+        p = pixels.pack('D*') if is_hdri_support
+        import(p, Magick::QuantumPixel)
 
-    when 64
-      cpixels = pixels.collect { |px| px / 72_340_172_838_076_673 }
-      p = cpixels.pack('C*')
-      import(p, Magick::CharPixel)
+      when 64
+        cpixels = pixels.collect { |px| px / 72_340_172_838_076_673 }
+        p = cpixels.pack('C*')
+        import(p, Magick::CharPixel)
 
-      spixels = pixels.collect { |px| px / 281_479_271_743_489 }
-      p = spixels.pack('S*')
-      import(p, Magick::ShortPixel)
+        spixels = pixels.collect { |px| px / 281_479_271_743_489 }
+        p = spixels.pack('S*')
+        import(p, Magick::ShortPixel)
 
-      ipixels = pixels.collect { |px| px / 4_294_967_297 }
-      p = ipixels.pack('I*')
-      import(p, Magick::LongPixel)
+        ipixels = pixels.collect { |px| px / 4_294_967_297 }
+        p = ipixels.pack('I*')
+        import(p, Magick::LongPixel)
 
-      p = pixels.pack('Q*')
-      import(p, Magick::QuantumPixel)
-
+        p = pixels.pack('Q*')
+        import(p, Magick::QuantumPixel)
+      end
     end
   end
 end

--- a/test/Info.rb
+++ b/test/Info.rb
@@ -1,433 +1,533 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class InfoUT < Minitest::Test
-  def setup
+describe Magick::Image::Info do
+  before do
     @info = Magick::Image::Info.new
   end
 
-  def test_options
-    # 1-argument form
-    expect { @info['fill'] }.not_to raise_error
-    expect(@info['fill']).to be(nil)
+  describe '#options' do
+    it 'works' do
+      # 1-argument form
+      expect { @info['fill'] }.not_to raise_error
+      expect(@info['fill']).to be(nil)
 
-    expect { @info['fill'] = 'red' }.not_to raise_error
-    expect(@info['fill']).to eq('red')
+      expect { @info['fill'] = 'red' }.not_to raise_error
+      expect(@info['fill']).to eq('red')
 
-    expect { @info['fill'] = nil }.not_to raise_error
-    expect(@info['fill']).to be(nil)
+      expect { @info['fill'] = nil }.not_to raise_error
+      expect(@info['fill']).to be(nil)
 
-    # 2-argument form
-    expect { @info['tiff', 'bits-per-sample'] = 2 }.not_to raise_error
-    expect(@info['tiff', 'bits-per-sample']).to eq('2')
+      # 2-argument form
+      expect { @info['tiff', 'bits-per-sample'] = 2 }.not_to raise_error
+      expect(@info['tiff', 'bits-per-sample']).to eq('2')
 
-    # define and undefine
-    expect { @info.define('tiff', 'bits-per-sample', 4) }.not_to raise_error
-    expect(@info['tiff', 'bits-per-sample']).to eq('4')
+      # define and undefine
+      expect { @info.define('tiff', 'bits-per-sample', 4) }.not_to raise_error
+      expect(@info['tiff', 'bits-per-sample']).to eq('4')
 
-    expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
-    expect(@info['tiff', 'bits-per-sample']).to be(nil)
-    expect { @info.undefine('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
-  end
-
-  def test_antialias
-    expect(@info.antialias).to be(true)
-    expect { @info.antialias = false }.not_to raise_error
-    expect(@info.antialias).to be(false)
-  end
-
-  def test_aref_aset
-    expect { @info['tiff'] = 'xxx' }.not_to raise_error
-    expect(@info['tiff']).to eq('xxx')
-    expect { @info['tiff', 'bits-per-sample'] = 'abc' }.not_to raise_error
-    expect(@info['tiff', 'bits-per-sample']).to eq('abc')
-    expect { @info['tiff', 'a', 'b'] }.to raise_error(ArgumentError)
-    expect { @info['tiff', 'a' * 10_000] }.to raise_error(ArgumentError)
-    expect { @info['tiff', 'a' * 10_000] = 'abc' }.to raise_error(ArgumentError)
-    expect { @info['tiff', 'a', 'b'] = 'abc' }.to raise_error(ArgumentError)
-  end
-
-  def test_attenuate
-    expect { @info.attenuate = 10 }.not_to raise_error
-    expect(@info.attenuate).to eq(10)
-    expect { @info.attenuate = 5.25 }.not_to raise_error
-    expect(@info.attenuate).to eq(5.25)
-    expect { @info.attenuate = nil }.not_to raise_error
-    expect(@info.attenuate).to be(nil)
-  end
-
-  def test_authenticate
-    expect { @info.authenticate = 'string' }.not_to raise_error
-    expect(@info.authenticate).to eq('string')
-    expect { @info.authenticate = nil }.not_to raise_error
-    expect(@info.authenticate).to be(nil)
-    expect { @info.authenticate = '' }.not_to raise_error
-    expect(@info.authenticate).to eq('')
-  end
-
-  def test_background_color
-    expect { @info.background_color = 'red' }.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @info.background_color = red }.not_to raise_error
-    expect(@info.background_color).to eq('red')
-    img = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    expect(img.background_color).to eq('red')
-  end
-
-  def test_border_color
-    expect { @info.border_color = 'red' }.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @info.border_color = red }.not_to raise_error
-    expect(@info.border_color).to eq('red')
-    img = Magick::Image.new(20, 20) { self.border_color = 'red' }
-    expect(img.border_color).to eq('red')
-  end
-
-  def test_caption
-    expect { @info.caption = 'string' }.not_to raise_error
-    expect(@info.caption).to eq('string')
-    expect { @info.caption = nil }.not_to raise_error
-    expect(@info.caption).to be(nil)
-    expect { Magick::Image.new(20, 20) { self.caption = 'string' } }.not_to raise_error
-  end
-
-  def test_channel
-    expect { @info.channel(Magick::RedChannel) }.not_to raise_error
-    expect { @info.channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
-    expect { @info.channel(1) }.to raise_error(TypeError)
-    expect { @info.channel(Magick::RedChannel, 1) }.to raise_error(TypeError)
-  end
-
-  def test_colorspace
-    Magick::ColorspaceType.values.each do |cs|
-      expect { @info.colorspace = cs }.not_to raise_error
-      expect(@info.colorspace).to eq(cs)
+      expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
+      expect(@info['tiff', 'bits-per-sample']).to be(nil)
+      expect { @info.undefine('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
     end
   end
 
-  def test_comment
-    expect { @info.comment = 'comment' }.not_to raise_error
-    expect(@info.comment).to eq('comment')
-  end
-
-  def test_compression
-    Magick::CompressionType.values.each do |v|
-      expect { @info.compression = v }.not_to raise_error
-      expect(@info.compression).to eq(v)
+  describe '#antialias' do
+    it 'works' do
+      expect(@info.antialias).to be(true)
+      expect { @info.antialias = false }.not_to raise_error
+      expect(@info.antialias).to be(false)
     end
   end
 
-  def test_define
-    expect { @info.define('tiff', 'bits-per-sample', 2) }.not_to raise_error
-    expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
-    expect { @info.define('tiff', 'bits-per-sample', 2, 2) }.to raise_error(ArgumentError)
-    expect { @info.define('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
-  end
-
-  def test_density
-    expect { @info.density = '72x72' }.not_to raise_error
-    expect(@info.density).to eq('72x72')
-    expect { @info.density = Magick::Geometry.new(72, 72) }.not_to raise_error
-    expect(@info.density).to eq('72x72')
-    expect { @info.density = nil }.not_to raise_error
-    expect(@info.density).to be(nil)
-    expect { @info.density = 'aaa' }.to raise_error(ArgumentError)
-  end
-
-  def test_delay
-    expect { @info.delay = 60 }.not_to raise_error
-    expect(@info.delay).to eq(60)
-    expect { @info.delay = nil }.not_to raise_error
-    expect(@info.delay).to be(nil)
-    expect { @info.delay = '60' }.to raise_error(TypeError)
-  end
-
-  def test_depth
-    expect { @info.depth = 8 }.not_to raise_error
-    expect(@info.depth).to eq(8)
-    expect { @info.depth = 16 }.not_to raise_error
-    expect(@info.depth).to eq(16)
-    expect { @info.depth = 32 }.to raise_error(ArgumentError)
-  end
-
-  def test_dispose
-    Magick::DisposeType.values.each do |v|
-      expect { @info.dispose = v }.not_to raise_error
-      expect(@info.dispose).to eq(v)
-    end
-    expect { @info.dispose = nil }.not_to raise_error
-  end
-
-  def test_dither
-    expect { @info.dither = true }.not_to raise_error
-    expect(@info.dither).to eq(true)
-    expect { @info.dither = false }.not_to raise_error
-    expect(@info.dither).to eq(false)
-  end
-
-  def test_endian
-    expect { @info.endian = Magick::LSBEndian }.not_to raise_error
-    expect(@info.endian).to eq(Magick::LSBEndian)
-    expect { @info.endian = nil }.not_to raise_error
-  end
-
-  def test_extract
-    expect { @info.extract = '100x100' }.not_to raise_error
-    expect(@info.extract).to eq('100x100')
-    expect { @info.extract = Magick::Geometry.new(100, 100) }.not_to raise_error
-    expect(@info.extract).to eq('100x100')
-    expect { @info.extract = nil }.not_to raise_error
-    expect(@info.extract).to be(nil)
-    expect { @info.extract = 'aaa' }.to raise_error(ArgumentError)
-  end
-
-  def test_filename
-    expect { @info.filename = 'string' }.not_to raise_error
-    expect(@info.filename).to eq('string')
-    expect { @info.filename = nil }.not_to raise_error
-    expect(@info.filename).to eq('')
-  end
-
-  def test_fill
-    expect { @info.fill }.not_to raise_error
-    expect(@info.fill).to be(nil)
-
-    expect { @info.fill = 'white' }.not_to raise_error
-    expect(@info.fill).to eq('white')
-
-    expect { @info.fill = nil }.not_to raise_error
-    expect(@info.fill).to be(nil)
-
-    expect { @info.fill = 'xxx' }.to raise_error(ArgumentError)
-  end
-
-  def test_font
-    expect { @info.font = 'Arial' }.not_to raise_error
-    expect(@info.font).to eq('Arial')
-    expect { @info.font = nil }.not_to raise_error
-    expect(@info.font).to be(nil)
-  end
-
-  def test_format
-    expect { @info.format = 'GIF' }.not_to raise_error
-    expect(@info.format).to eq('GIF')
-    expect { @info.format = nil }.to raise_error(TypeError)
-  end
-
-  def test_fuzz
-    expect { @info.fuzz = 50 }.not_to raise_error
-    expect(@info.fuzz).to eq(50)
-    expect { @info.fuzz = '50%' }.not_to raise_error
-    expect(@info.fuzz).to eq(Magick::QuantumRange * 0.5)
-    expect { @info.fuzz = nil }.to raise_error(TypeError)
-    expect { @info.fuzz = 'xxx' }.to raise_error(ArgumentError)
-  end
-
-  def test_gravity
-    Magick::GravityType.values.each do |v|
-      expect { @info.gravity = v }.not_to raise_error
-      expect(@info.gravity).to eq(v)
-    end
-    expect { @info.gravity = nil }.not_to raise_error
-  end
-
-  def test_image_type
-    Magick::ImageType.values.each do |v|
-      expect { @info.image_type = v }.not_to raise_error
-      expect(@info.image_type).to eq(v)
-    end
-    expect { @info.image_type = nil }.to raise_error(TypeError)
-  end
-
-  def test_interlace
-    Magick::InterlaceType.values.each do |v|
-      expect { @info.interlace = v }.not_to raise_error
-      expect(@info.interlace).to eq(v)
-    end
-    expect { @info.interlace = nil }.to raise_error(TypeError)
-  end
-
-  def test_label
-    expect { @info.label = 'string' }.not_to raise_error
-    expect(@info.label).to eq('string')
-    expect { @info.label = nil }.not_to raise_error
-    expect(@info.label).to be(nil)
-  end
-
-  def test_matte_color
-    expect { @info.matte_color = 'red' }.not_to raise_error
-    red = Magick::Pixel.new(Magick::QuantumRange)
-    expect { @info.matte_color = red }.not_to raise_error
-    expect(@info.matte_color).to eq('red')
-    img = Magick::Image.new(20, 20) { self.matte_color = 'red' }
-    expect(img.matte_color).to eq('red')
-    expect { @info.matte_color = nil }.to raise_error(TypeError)
-  end
-
-  def test_monitor
-    expect { @info.monitor = -> {} }.not_to raise_error
-    monitor = proc do |mth, q, s|
-      expect(mth).to eq('resize!')
-      expect(q).to be_kind_of(Integer)
-      expect(s).to be_kind_of(Integer)
-      GC.start
-      true
-    end
-    img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
-    img.resize!(20, 20)
-    img.monitor = nil
-
-    expect { @info.monitor = nil }.not_to raise_error
-  end
-
-  def test_monochrome
-    expect { @info.monochrome = true }.not_to raise_error
-    expect(@info.monochrome).to be(true)
-    expect { @info.monochrome = nil }.not_to raise_error
-  end
-
-  def test_number_scenes
-    expect(@info.number_scenes).to be_kind_of(Integer)
-    expect { @info.number_scenes = 50 }.not_to raise_error
-    expect(@info.number_scenes).to eq(50)
-    expect { @info.number_scenes = nil }.to raise_error(TypeError)
-    expect { @info.number_scenes = 'xxx' }.to raise_error(TypeError)
-  end
-
-  def test_orientation
-    Magick::OrientationType.values.each do |v|
-      expect { @info.orientation = v }.not_to raise_error
-      expect(@info.orientation).to eq(v)
-    end
-    expect { @info.orientation = nil }.to raise_error(TypeError)
-  end
-
-  def test_origin
-    expect { @info.origin = '+10+10' }.not_to raise_error
-    expect(@info.origin).to eq('+10+10')
-    expect { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }.not_to raise_error
-    expect(@info.origin).to eq('+10+10')
-    expect { @info.origin = nil }.not_to raise_error
-    expect(@info.origin).to be(nil)
-    expect { @info.origin = 'aaa' }.to raise_error(ArgumentError)
-  end
-
-  def test_page
-    expect { @info.page = '612x792>' }.not_to raise_error
-    expect(@info.page).to eq('612x792>')
-    expect { @info.page = nil }.not_to raise_error
-    expect(@info.page).to be(nil)
-  end
-
-  def test_pointsize
-    expect { @info.pointsize = 12 }.not_to raise_error
-    expect(@info.pointsize).to eq(12)
-  end
-
-  def test_quality
-    expect { @info.quality = 75 }.not_to raise_error
-    expect(@info.quality).to eq(75)
-  end
-
-  def test_sampling_factor
-    expect { @info.sampling_factor = '2x1' }.not_to raise_error
-    expect(@info.sampling_factor).to eq('2x1')
-    expect { @info.sampling_factor = nil }.not_to raise_error
-    expect(@info.sampling_factor).to be(nil)
-  end
-
-  def test_scene
-    expect { @info.scene = 123 }.not_to raise_error
-    expect(@info.scene).to eq(123)
-    expect { @info.scene = 'xxx' }.to raise_error(TypeError)
-  end
-
-  def test_server_name
-    expect { @info.server_name = 'foo' }.not_to raise_error
-    expect(@info.server_name).to eq('foo')
-    expect { @info.server_name = nil }.not_to raise_error
-    expect(@info.server_name).to be(nil)
-  end
-
-  def test_size
-    expect { @info.size = '200x100' }.not_to raise_error
-    expect(@info.size).to eq('200x100')
-    expect { @info.size = Magick::Geometry.new(100, 200) }.not_to raise_error
-    expect(@info.size).to eq('100x200')
-    expect { @info.size = nil }.not_to raise_error
-    expect(@info.size).to be(nil)
-    expect { @info.size = 'aaa' }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke
-    expect { @info.stroke }.not_to raise_error
-    expect(@info.stroke).to be(nil)
-
-    expect { @info.stroke = 'white' }.not_to raise_error
-    expect(@info.stroke).to eq('white')
-
-    expect { @info.stroke = nil }.not_to raise_error
-    expect(@info.stroke).to be(nil)
-
-    expect { @info.stroke = 'xxx' }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_width
-    expect { @info.stroke_width = 10 }.not_to raise_error
-    expect(@info.stroke_width).to eq(10)
-    expect { @info.stroke_width = 5.25 }.not_to raise_error
-    expect(@info.stroke_width).to eq(5.25)
-    expect { @info.stroke_width = nil }.not_to raise_error
-    expect(@info.stroke_width).to be(nil)
-    expect { @info.stroke_width = 'xxx' }.to raise_error(TypeError)
-  end
-
-  def test_texture
-    img = Magick::Image.read('granite:') { self.size = '20x20' }
-    expect { @info.texture = img.first }.not_to raise_error
-    expect { @info.texture = nil }.not_to raise_error
-  end
-
-  def test_tile_offset
-    expect { @info.tile_offset = '200x100' }.not_to raise_error
-    expect(@info.tile_offset).to eq('200x100')
-    expect { @info.tile_offset = Magick::Geometry.new(100, 200) }.not_to raise_error
-    expect(@info.tile_offset).to eq('100x200')
-    expect { @info.tile_offset = nil }.to raise_error(ArgumentError)
-  end
-
-  def test_transparent_color
-    expect { @info.transparent_color = 'white' }.not_to raise_error
-    expect(@info.transparent_color).to eq('white')
-    expect { @info.transparent_color = nil }.to raise_error(TypeError)
-  end
-
-  def test_undercolor
-    expect { @info.undercolor }.not_to raise_error
-    expect(@info.undercolor).to be(nil)
-
-    expect { @info.undercolor = 'white' }.not_to raise_error
-    expect(@info.undercolor).to eq('white')
-
-    expect { @info.undercolor = nil }.not_to raise_error
-    expect(@info.undercolor).to be(nil)
-
-    expect { @info.undercolor = 'xxx' }.to raise_error(ArgumentError)
-  end
-
-  def test_units
-    Magick::ResolutionType.values.each do |v|
-      expect { @info.units = v }.not_to raise_error
-      expect(@info.units).to eq(v)
+  describe '#aref_aset' do
+    it 'works' do
+      expect { @info['tiff'] = 'xxx' }.not_to raise_error
+      expect(@info['tiff']).to eq('xxx')
+      expect { @info['tiff', 'bits-per-sample'] = 'abc' }.not_to raise_error
+      expect(@info['tiff', 'bits-per-sample']).to eq('abc')
+      expect { @info['tiff', 'a', 'b'] }.to raise_error(ArgumentError)
+      expect { @info['tiff', 'a' * 10_000] }.to raise_error(ArgumentError)
+      expect { @info['tiff', 'a' * 10_000] = 'abc' }.to raise_error(ArgumentError)
+      expect { @info['tiff', 'a', 'b'] = 'abc' }.to raise_error(ArgumentError)
     end
   end
 
-  def test_view
-    expect { @info.view = 'string' }.not_to raise_error
-    expect(@info.view).to eq('string')
-    expect { @info.view = nil }.not_to raise_error
-    expect(@info.view).to be(nil)
-    expect { @info.view = '' }.not_to raise_error
-    expect(@info.view).to eq('')
+  describe '#attenuate' do
+    it 'works' do
+      expect { @info.attenuate = 10 }.not_to raise_error
+      expect(@info.attenuate).to eq(10)
+      expect { @info.attenuate = 5.25 }.not_to raise_error
+      expect(@info.attenuate).to eq(5.25)
+      expect { @info.attenuate = nil }.not_to raise_error
+      expect(@info.attenuate).to be(nil)
+    end
+  end
+
+  describe '#authenticate' do
+    it 'works' do
+      expect { @info.authenticate = 'string' }.not_to raise_error
+      expect(@info.authenticate).to eq('string')
+      expect { @info.authenticate = nil }.not_to raise_error
+      expect(@info.authenticate).to be(nil)
+      expect { @info.authenticate = '' }.not_to raise_error
+      expect(@info.authenticate).to eq('')
+    end
+  end
+
+  describe '#background_color' do
+    it 'works' do
+      expect { @info.background_color = 'red' }.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @info.background_color = red }.not_to raise_error
+      expect(@info.background_color).to eq('red')
+      img = Magick::Image.new(20, 20) { self.background_color = 'red' }
+      expect(img.background_color).to eq('red')
+    end
+  end
+
+  describe '#border_color' do
+    it 'works' do
+      expect { @info.border_color = 'red' }.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @info.border_color = red }.not_to raise_error
+      expect(@info.border_color).to eq('red')
+      img = Magick::Image.new(20, 20) { self.border_color = 'red' }
+      expect(img.border_color).to eq('red')
+    end
+  end
+
+  describe '#caption' do
+    it 'works' do
+      expect { @info.caption = 'string' }.not_to raise_error
+      expect(@info.caption).to eq('string')
+      expect { @info.caption = nil }.not_to raise_error
+      expect(@info.caption).to be(nil)
+      expect { Magick::Image.new(20, 20) { self.caption = 'string' } }.not_to raise_error
+    end
+  end
+
+  describe '#channel' do
+    it 'works' do
+      expect { @info.channel(Magick::RedChannel) }.not_to raise_error
+      expect { @info.channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+      expect { @info.channel(1) }.to raise_error(TypeError)
+      expect { @info.channel(Magick::RedChannel, 1) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#colorspace' do
+    it 'works' do
+      Magick::ColorspaceType.values.each do |cs|
+        expect { @info.colorspace = cs }.not_to raise_error
+        expect(@info.colorspace).to eq(cs)
+      end
+    end
+  end
+
+  describe '#comment' do
+    it 'works' do
+      expect { @info.comment = 'comment' }.not_to raise_error
+      expect(@info.comment).to eq('comment')
+    end
+  end
+
+  describe '#compression' do
+    it 'works' do
+      Magick::CompressionType.values.each do |v|
+        expect { @info.compression = v }.not_to raise_error
+        expect(@info.compression).to eq(v)
+      end
+    end
+  end
+
+  describe '#define' do
+    it 'works' do
+      expect { @info.define('tiff', 'bits-per-sample', 2) }.not_to raise_error
+      expect { @info.undefine('tiff', 'bits-per-sample') }.not_to raise_error
+      expect { @info.define('tiff', 'bits-per-sample', 2, 2) }.to raise_error(ArgumentError)
+      expect { @info.define('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#density' do
+    it 'works' do
+      expect { @info.density = '72x72' }.not_to raise_error
+      expect(@info.density).to eq('72x72')
+      expect { @info.density = Magick::Geometry.new(72, 72) }.not_to raise_error
+      expect(@info.density).to eq('72x72')
+      expect { @info.density = nil }.not_to raise_error
+      expect(@info.density).to be(nil)
+      expect { @info.density = 'aaa' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#delay' do
+    it 'works' do
+      expect { @info.delay = 60 }.not_to raise_error
+      expect(@info.delay).to eq(60)
+      expect { @info.delay = nil }.not_to raise_error
+      expect(@info.delay).to be(nil)
+      expect { @info.delay = '60' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#depth' do
+    it 'works' do
+      expect { @info.depth = 8 }.not_to raise_error
+      expect(@info.depth).to eq(8)
+      expect { @info.depth = 16 }.not_to raise_error
+      expect(@info.depth).to eq(16)
+      expect { @info.depth = 32 }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#dispose' do
+    it 'works' do
+      Magick::DisposeType.values.each do |v|
+        expect { @info.dispose = v }.not_to raise_error
+        expect(@info.dispose).to eq(v)
+      end
+      expect { @info.dispose = nil }.not_to raise_error
+    end
+  end
+
+  describe '#dither' do
+    it 'works' do
+      expect { @info.dither = true }.not_to raise_error
+      expect(@info.dither).to eq(true)
+      expect { @info.dither = false }.not_to raise_error
+      expect(@info.dither).to eq(false)
+    end
+  end
+
+  describe '#endian' do
+    it 'works' do
+      expect { @info.endian = Magick::LSBEndian }.not_to raise_error
+      expect(@info.endian).to eq(Magick::LSBEndian)
+      expect { @info.endian = nil }.not_to raise_error
+    end
+  end
+
+  describe '#extract' do
+    it 'works' do
+      expect { @info.extract = '100x100' }.not_to raise_error
+      expect(@info.extract).to eq('100x100')
+      expect { @info.extract = Magick::Geometry.new(100, 100) }.not_to raise_error
+      expect(@info.extract).to eq('100x100')
+      expect { @info.extract = nil }.not_to raise_error
+      expect(@info.extract).to be(nil)
+      expect { @info.extract = 'aaa' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#filename' do
+    it 'works' do
+      expect { @info.filename = 'string' }.not_to raise_error
+      expect(@info.filename).to eq('string')
+      expect { @info.filename = nil }.not_to raise_error
+      expect(@info.filename).to eq('')
+    end
+  end
+
+  describe '#fill' do
+    it 'works' do
+      expect { @info.fill }.not_to raise_error
+      expect(@info.fill).to be(nil)
+
+      expect { @info.fill = 'white' }.not_to raise_error
+      expect(@info.fill).to eq('white')
+
+      expect { @info.fill = nil }.not_to raise_error
+      expect(@info.fill).to be(nil)
+
+      expect { @info.fill = 'xxx' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#font' do
+    it 'works' do
+      expect { @info.font = 'Arial' }.not_to raise_error
+      expect(@info.font).to eq('Arial')
+      expect { @info.font = nil }.not_to raise_error
+      expect(@info.font).to be(nil)
+    end
+  end
+
+  describe '#format' do
+    it 'works' do
+      expect { @info.format = 'GIF' }.not_to raise_error
+      expect(@info.format).to eq('GIF')
+      expect { @info.format = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#fuzz' do
+    it 'works' do
+      expect { @info.fuzz = 50 }.not_to raise_error
+      expect(@info.fuzz).to eq(50)
+      expect { @info.fuzz = '50%' }.not_to raise_error
+      expect(@info.fuzz).to eq(Magick::QuantumRange * 0.5)
+      expect { @info.fuzz = nil }.to raise_error(TypeError)
+      expect { @info.fuzz = 'xxx' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#gravity' do
+    it 'works' do
+      Magick::GravityType.values.each do |v|
+        expect { @info.gravity = v }.not_to raise_error
+        expect(@info.gravity).to eq(v)
+      end
+      expect { @info.gravity = nil }.not_to raise_error
+    end
+  end
+
+  describe '#image_type' do
+    it 'works' do
+      Magick::ImageType.values.each do |v|
+        expect { @info.image_type = v }.not_to raise_error
+        expect(@info.image_type).to eq(v)
+      end
+      expect { @info.image_type = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#interlace' do
+    it 'works' do
+      Magick::InterlaceType.values.each do |v|
+        expect { @info.interlace = v }.not_to raise_error
+        expect(@info.interlace).to eq(v)
+      end
+      expect { @info.interlace = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#label' do
+    it 'works' do
+      expect { @info.label = 'string' }.not_to raise_error
+      expect(@info.label).to eq('string')
+      expect { @info.label = nil }.not_to raise_error
+      expect(@info.label).to be(nil)
+    end
+  end
+
+  describe '#matte_color' do
+    it 'works' do
+      expect { @info.matte_color = 'red' }.not_to raise_error
+      red = Magick::Pixel.new(Magick::QuantumRange)
+      expect { @info.matte_color = red }.not_to raise_error
+      expect(@info.matte_color).to eq('red')
+      img = Magick::Image.new(20, 20) { self.matte_color = 'red' }
+      expect(img.matte_color).to eq('red')
+      expect { @info.matte_color = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#monitor' do
+    it 'works' do
+      expect { @info.monitor = -> {} }.not_to raise_error
+      monitor = proc do |mth, q, s|
+        expect(mth).to eq('resize!')
+        expect(q).to be_kind_of(Integer)
+        expect(s).to be_kind_of(Integer)
+        GC.start
+        true
+      end
+      img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
+      img.resize!(20, 20)
+      img.monitor = nil
+
+      expect { @info.monitor = nil }.not_to raise_error
+    end
+  end
+
+  describe '#monochrome' do
+    it 'works' do
+      expect { @info.monochrome = true }.not_to raise_error
+      expect(@info.monochrome).to be(true)
+      expect { @info.monochrome = nil }.not_to raise_error
+    end
+  end
+
+  describe '#number_scenes' do
+    it 'works' do
+      expect(@info.number_scenes).to be_kind_of(Integer)
+      expect { @info.number_scenes = 50 }.not_to raise_error
+      expect(@info.number_scenes).to eq(50)
+      expect { @info.number_scenes = nil }.to raise_error(TypeError)
+      expect { @info.number_scenes = 'xxx' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#orientation' do
+    it 'works' do
+      Magick::OrientationType.values.each do |v|
+        expect { @info.orientation = v }.not_to raise_error
+        expect(@info.orientation).to eq(v)
+      end
+      expect { @info.orientation = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#origin' do
+    it 'works' do
+      expect { @info.origin = '+10+10' }.not_to raise_error
+      expect(@info.origin).to eq('+10+10')
+      expect { @info.origin = Magick::Geometry.new(nil, nil, 10, 10) }.not_to raise_error
+      expect(@info.origin).to eq('+10+10')
+      expect { @info.origin = nil }.not_to raise_error
+      expect(@info.origin).to be(nil)
+      expect { @info.origin = 'aaa' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#page' do
+    it 'works' do
+      expect { @info.page = '612x792>' }.not_to raise_error
+      expect(@info.page).to eq('612x792>')
+      expect { @info.page = nil }.not_to raise_error
+      expect(@info.page).to be(nil)
+    end
+  end
+
+  describe '#pointsize' do
+    it 'works' do
+      expect { @info.pointsize = 12 }.not_to raise_error
+      expect(@info.pointsize).to eq(12)
+    end
+  end
+
+  describe '#quality' do
+    it 'works' do
+      expect { @info.quality = 75 }.not_to raise_error
+      expect(@info.quality).to eq(75)
+    end
+  end
+
+  describe '#sampling_factor' do
+    it 'works' do
+      expect { @info.sampling_factor = '2x1' }.not_to raise_error
+      expect(@info.sampling_factor).to eq('2x1')
+      expect { @info.sampling_factor = nil }.not_to raise_error
+      expect(@info.sampling_factor).to be(nil)
+    end
+  end
+
+  describe '#scene' do
+    it 'works' do
+      expect { @info.scene = 123 }.not_to raise_error
+      expect(@info.scene).to eq(123)
+      expect { @info.scene = 'xxx' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#server_name' do
+    it 'works' do
+      expect { @info.server_name = 'foo' }.not_to raise_error
+      expect(@info.server_name).to eq('foo')
+      expect { @info.server_name = nil }.not_to raise_error
+      expect(@info.server_name).to be(nil)
+    end
+  end
+
+  describe '#size' do
+    it 'works' do
+      expect { @info.size = '200x100' }.not_to raise_error
+      expect(@info.size).to eq('200x100')
+      expect { @info.size = Magick::Geometry.new(100, 200) }.not_to raise_error
+      expect(@info.size).to eq('100x200')
+      expect { @info.size = nil }.not_to raise_error
+      expect(@info.size).to be(nil)
+      expect { @info.size = 'aaa' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke' do
+    it 'works' do
+      expect { @info.stroke }.not_to raise_error
+      expect(@info.stroke).to be(nil)
+
+      expect { @info.stroke = 'white' }.not_to raise_error
+      expect(@info.stroke).to eq('white')
+
+      expect { @info.stroke = nil }.not_to raise_error
+      expect(@info.stroke).to be(nil)
+
+      expect { @info.stroke = 'xxx' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_width' do
+    it 'works' do
+      expect { @info.stroke_width = 10 }.not_to raise_error
+      expect(@info.stroke_width).to eq(10)
+      expect { @info.stroke_width = 5.25 }.not_to raise_error
+      expect(@info.stroke_width).to eq(5.25)
+      expect { @info.stroke_width = nil }.not_to raise_error
+      expect(@info.stroke_width).to be(nil)
+      expect { @info.stroke_width = 'xxx' }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#texture' do
+    it 'works' do
+      img = Magick::Image.read('granite:') { self.size = '20x20' }
+      expect { @info.texture = img.first }.not_to raise_error
+      expect { @info.texture = nil }.not_to raise_error
+    end
+  end
+
+  describe '#tile_offset' do
+    it 'works' do
+      expect { @info.tile_offset = '200x100' }.not_to raise_error
+      expect(@info.tile_offset).to eq('200x100')
+      expect { @info.tile_offset = Magick::Geometry.new(100, 200) }.not_to raise_error
+      expect(@info.tile_offset).to eq('100x200')
+      expect { @info.tile_offset = nil }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#transparent_color' do
+    it 'works' do
+      expect { @info.transparent_color = 'white' }.not_to raise_error
+      expect(@info.transparent_color).to eq('white')
+      expect { @info.transparent_color = nil }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#undercolor' do
+    it 'works' do
+      expect { @info.undercolor }.not_to raise_error
+      expect(@info.undercolor).to be(nil)
+
+      expect { @info.undercolor = 'white' }.not_to raise_error
+      expect(@info.undercolor).to eq('white')
+
+      expect { @info.undercolor = nil }.not_to raise_error
+      expect(@info.undercolor).to be(nil)
+
+      expect { @info.undercolor = 'xxx' }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#units' do
+    it 'works' do
+      Magick::ResolutionType.values.each do |v|
+        expect { @info.units = v }.not_to raise_error
+        expect(@info.units).to eq(v)
+      end
+    end
+  end
+
+  describe '#view' do
+    it 'works' do
+      expect { @info.view = 'string' }.not_to raise_error
+      expect(@info.view).to eq('string')
+      expect { @info.view = nil }.not_to raise_error
+      expect(@info.view).to be(nil)
+      expect { @info.view = '' }.not_to raise_error
+      expect(@info.view).to eq('')
+    end
   end
 end

--- a/test/KernelInfo.rb
+++ b/test/KernelInfo.rb
@@ -1,56 +1,68 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class KernelInfoUT < Minitest::Test
-  def setup
+describe Magick::KernelInfo do
+  before do
     @kernel = Magick::KernelInfo.new('Octagon')
   end
 
-  def test_new
-    Magick::KernelInfoType.values do |kernel|
-      k = kernel.to_s.sub('Kernel', '')
+  describe '#new' do
+    it 'works' do
+      Magick::KernelInfoType.values do |kernel|
+        k = kernel.to_s.sub('Kernel', '')
 
-      if kernel == Magick::UserDefinedKernel
-        expect { Magick::KernelInfo.new(k) }.to raise_error(RuntimeError)
-      else
-        expect(Magick::KernelInfo.new(k)).to be_instance_of(Magick::KernelInfo)
+        if kernel == Magick::UserDefinedKernel
+          expect { Magick::KernelInfo.new(k) }.to raise_error(RuntimeError)
+        else
+          expect(Magick::KernelInfo.new(k)).to be_instance_of(Magick::KernelInfo)
+        end
       end
+      expect { Magick::KernelInfo.new('') }.to raise_error(RuntimeError)
+      expect { Magick::KernelInfo.new(42) }.to raise_error(TypeError)
     end
-    expect { Magick::KernelInfo.new('') }.to raise_error(RuntimeError)
-    expect { Magick::KernelInfo.new(42) }.to raise_error(TypeError)
   end
 
-  def test_unity_add
-    expect(@kernel.unity_add(1.0)).to be(nil)
-    expect(@kernel.unity_add(12)).to be(nil)
-    expect { @kernel.unity_add('x') }.to raise_error(TypeError)
-  end
-
-  def test_scale
-    Magick::GeometryFlags.values do |flag|
-      expect(@kernel.scale(1.0, flag)).to be(nil)
-      expect(@kernel.scale(42, flag)).to be(nil)
+  describe '#unity_add' do
+    it 'works' do
+      expect(@kernel.unity_add(1.0)).to be(nil)
+      expect(@kernel.unity_add(12)).to be(nil)
+      expect { @kernel.unity_add('x') }.to raise_error(TypeError)
     end
-    expect { @kernel.scale(42, 'x') }.to raise_error(ArgumentError)
-    expect { @kernel.scale(42, Magick::BoldWeight) }.to raise_error(ArgumentError)
   end
 
-  def test_scale_geometry
-    expect(@kernel.scale_geometry('-set option:convolve:scale 1.0')).to be(nil)
-    expect { @kernel.scale_geometry(42) }.to raise_error(TypeError)
+  describe '#scale' do
+    it 'works' do
+      Magick::GeometryFlags.values do |flag|
+        expect(@kernel.scale(1.0, flag)).to be(nil)
+        expect(@kernel.scale(42, flag)).to be(nil)
+      end
+      expect { @kernel.scale(42, 'x') }.to raise_error(ArgumentError)
+      expect { @kernel.scale(42, Magick::BoldWeight) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_clone
-    expect(@kernel.clone).to be_instance_of(Magick::KernelInfo)
-    expect(@kernel.clone).not_to be(@kernel)
+  describe '#scale_geometry' do
+    it 'works' do
+      expect(@kernel.scale_geometry('-set option:convolve:scale 1.0')).to be(nil)
+      expect { @kernel.scale_geometry(42) }.to raise_error(TypeError)
+    end
   end
 
-  def test_builtin
-    expect(Magick::KernelInfo.builtin(Magick::UnityKernel, '')).to be_instance_of(Magick::KernelInfo)
-    expect(Magick::KernelInfo.builtin(Magick::GaussianKernel, 'Gaussian:10,5')).to be_instance_of(Magick::KernelInfo)
-    expect(Magick::KernelInfo.builtin(Magick::LoGKernel, 'LoG:10,5')).to be_instance_of(Magick::KernelInfo)
-    expect(Magick::KernelInfo.builtin(Magick::DoGKernel, 'DoG:10,5')).to be_instance_of(Magick::KernelInfo)
-    expect(Magick::KernelInfo.builtin(Magick::BlurKernel, 'Blur:10,5,1')).to be_instance_of(Magick::KernelInfo)
-    expect(Magick::KernelInfo.builtin(Magick::CometKernel, 'Comet:10,5,1')).to be_instance_of(Magick::KernelInfo)
+  describe '#clone' do
+    it 'works' do
+      expect(@kernel.clone).to be_instance_of(Magick::KernelInfo)
+      expect(@kernel.clone).not_to be(@kernel)
+    end
+  end
+
+  describe '#builtin' do
+    it 'works' do
+      expect(Magick::KernelInfo.builtin(Magick::UnityKernel, '')).to be_instance_of(Magick::KernelInfo)
+      expect(Magick::KernelInfo.builtin(Magick::GaussianKernel, 'Gaussian:10,5')).to be_instance_of(Magick::KernelInfo)
+      expect(Magick::KernelInfo.builtin(Magick::LoGKernel, 'LoG:10,5')).to be_instance_of(Magick::KernelInfo)
+      expect(Magick::KernelInfo.builtin(Magick::DoGKernel, 'DoG:10,5')).to be_instance_of(Magick::KernelInfo)
+      expect(Magick::KernelInfo.builtin(Magick::BlurKernel, 'Blur:10,5,1')).to be_instance_of(Magick::KernelInfo)
+      expect(Magick::KernelInfo.builtin(Magick::CometKernel, 'Comet:10,5,1')).to be_instance_of(Magick::KernelInfo)
+    end
   end
 end

--- a/test/Magick.rb
+++ b/test/Magick.rb
@@ -25,284 +25,306 @@ class Magick::AnchorType
   end
 end
 
-class MagickUT < Minitest::Test
-  def test_colors
-    res = nil
-    expect { res = Magick.colors }.not_to raise_error
-    expect(res).to be_instance_of(Array)
-    res.each do |c|
-      expect(c).to be_instance_of(Magick::Color)
-      expect(c.name).to be_instance_of(String)
-      expect(c.compliance).to be_instance_of(Magick::ComplianceType) unless c.compliance.nil?
-      expect(c.color).to be_instance_of(Magick::Pixel)
+describe Magick do
+  describe '#colors' do
+    it 'works' do
+      res = nil
+      expect { res = Magick.colors }.not_to raise_error
+      expect(res).to be_instance_of(Array)
+      res.each do |c|
+        expect(c).to be_instance_of(Magick::Color)
+        expect(c.name).to be_instance_of(String)
+        expect(c.compliance).to be_instance_of(Magick::ComplianceType) unless c.compliance.nil?
+        expect(c.color).to be_instance_of(Magick::Pixel)
+      end
+      Magick.colors { |c| expect(c).to be_instance_of(Magick::Color) }
     end
-    Magick.colors { |c| expect(c).to be_instance_of(Magick::Color) }
   end
 
   # Test a few of the @@enumerator arrays in the Enum subclasses.
   # No need to test all of them.
-  def test_enumerators
-    ary = nil
-    expect do
-      ary = Magick::AlphaChannelOption.enumerators
-    end.not_to raise_error
-    expect(ary).to be_instance_of(Array)
+  describe '#enumerators' do
+    it 'works' do
+      ary = nil
+      expect do
+        ary = Magick::AlphaChannelOption.enumerators
+      end.not_to raise_error
+      expect(ary).to be_instance_of(Array)
 
-    expect do
-      ary = Magick::AlignType.enumerators
-    end.not_to raise_error
-    expect(ary).to be_instance_of(Array)
-    expect(ary.length).to eq(4)
+      expect do
+        ary = Magick::AlignType.enumerators
+      end.not_to raise_error
+      expect(ary).to be_instance_of(Array)
+      expect(ary.length).to eq(4)
 
-    expect do
-      ary = Magick::AnchorType.enumerators
-    end.not_to raise_error
-    expect(ary).to be_instance_of(Array)
-    expect(ary.length).to eq(3)
-  end
-
-  def test_features
-    res = nil
-    expect { res = Magick::Magick_features }.not_to raise_error
-    expect(res).to be_instance_of(String)
-  end
-
-  def test_fonts
-    res = nil
-    expect { res = Magick.fonts }.not_to raise_error
-    expect(res).to be_instance_of(Array)
-    res.each do |f|
-      expect(f).to be_instance_of(Magick::Font)
-      expect(f.name).to be_instance_of(String)
-      expect(f.description).to be_instance_of(String) unless f.description.nil?
-      expect(f.family).to be_instance_of(String)
-      expect(f.style).to be_instance_of(Magick::StyleType) unless f.style.nil?
-      expect(f.stretch).to be_instance_of(Magick::StretchType) unless f.stretch.nil?
-      expect(f.weight).to be_kind_of(Integer)
-      expect(f.encoding).to be_instance_of(String) unless f.encoding.nil?
-      expect(f.foundry).to be_instance_of(String) unless f.foundry.nil?
-      expect(f.format).to be_instance_of(String) unless f.format.nil?
+      expect do
+        ary = Magick::AnchorType.enumerators
+      end.not_to raise_error
+      expect(ary).to be_instance_of(Array)
+      expect(ary.length).to eq(3)
     end
-    Magick.fonts { |f| expect(f).to be_instance_of(Magick::Font) }
   end
 
-  def test_geometry
-    g = nil
-    gs = nil
-    g2 = nil
-    expect { g = Magick::Geometry.new }.not_to raise_error
-    expect { gs = g.to_s }.not_to raise_error
-    expect(gs).to eq('')
-
-    g = Magick::Geometry.new(40)
-    gs = g.to_s
-    expect(gs).to eq('40x')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50)
-    gs = g.to_s
-    expect(gs).to eq('40x50')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 10)
-    gs = g.to_s
-    expect(gs).to eq('40x50+10+0')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 10, -15)
-    gs = g.to_s
-    expect(gs).to eq('40x50+10-15')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 0, 0, Magick::AreaGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40x50@')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 0, 0, Magick::AspectGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40x50!')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 0, 0, Magick::LessGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40x50<')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 0, 0, Magick::GreaterGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40x50>')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 50, 0, 0, Magick::MinimumGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40x50^')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 0, 0, 0, Magick::PercentGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40%')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 60, 0, 0, Magick::PercentGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40%x60%')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 60, 10, 0, Magick::PercentGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40%x60%+10+0')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40, 60, 10, 20, Magick::PercentGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40%x60%+10+20')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40.5, 60.75)
-    gs = g.to_s
-    expect(gs).to eq('40.50x60.75')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(40.5, 60.75, 0, 0, Magick::PercentGeometry)
-    gs = g.to_s
-    expect(gs).to eq('40.50%x60.75%')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(0, 0, 10, 20)
-    gs = g.to_s
-    expect(gs).to eq('+10+20')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    g = Magick::Geometry.new(0, 0, 10)
-    gs = g.to_s
-    expect(gs).to eq('+10+0')
-
-    expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
-    gs2 = g2.to_s
-    expect(gs2).to eq(gs)
-
-    # check behavior with empty string argument
-    expect { g = Magick::Geometry.from_s('') }.not_to raise_error
-    expect(g.to_s).to eq('')
-
-    expect { Magick::Geometry.new(Magick::AreaGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(40, Magick::AreaGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(40, 20, Magick::AreaGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(40, 20, 10, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+  describe '#features' do
+    it 'works' do
+      res = nil
+      expect { res = Magick::Magick_features }.not_to raise_error
+      expect(res).to be_instance_of(String)
+    end
   end
 
-  def test_init_formats
-    expect(Magick.init_formats).to be_instance_of(Hash)
+  describe '#fonts' do
+    it 'works' do
+      res = nil
+      expect { res = Magick.fonts }.not_to raise_error
+      expect(res).to be_instance_of(Array)
+      res.each do |f|
+        expect(f).to be_instance_of(Magick::Font)
+        expect(f.name).to be_instance_of(String)
+        expect(f.description).to be_instance_of(String) unless f.description.nil?
+        expect(f.family).to be_instance_of(String)
+        expect(f.style).to be_instance_of(Magick::StyleType) unless f.style.nil?
+        expect(f.stretch).to be_instance_of(Magick::StretchType) unless f.stretch.nil?
+        expect(f.weight).to be_kind_of(Integer)
+        expect(f.encoding).to be_instance_of(String) unless f.encoding.nil?
+        expect(f.foundry).to be_instance_of(String) unless f.foundry.nil?
+        expect(f.format).to be_instance_of(String) unless f.format.nil?
+      end
+      Magick.fonts { |f| expect(f).to be_instance_of(Magick::Font) }
+    end
   end
 
-  def test_opaque_alpha
-    expect(Magick::OpaqueAlpha).to eq(Magick::QuantumRange)
+  describe '#geometry' do
+    it 'works' do
+      g = nil
+      gs = nil
+      g2 = nil
+      expect { g = Magick::Geometry.new }.not_to raise_error
+      expect { gs = g.to_s }.not_to raise_error
+      expect(gs).to eq('')
+
+      g = Magick::Geometry.new(40)
+      gs = g.to_s
+      expect(gs).to eq('40x')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50)
+      gs = g.to_s
+      expect(gs).to eq('40x50')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 10)
+      gs = g.to_s
+      expect(gs).to eq('40x50+10+0')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 10, -15)
+      gs = g.to_s
+      expect(gs).to eq('40x50+10-15')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 0, 0, Magick::AreaGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40x50@')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 0, 0, Magick::AspectGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40x50!')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 0, 0, Magick::LessGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40x50<')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 0, 0, Magick::GreaterGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40x50>')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 50, 0, 0, Magick::MinimumGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40x50^')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 0, 0, 0, Magick::PercentGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40%')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 60, 0, 0, Magick::PercentGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40%x60%')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 60, 10, 0, Magick::PercentGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40%x60%+10+0')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40, 60, 10, 20, Magick::PercentGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40%x60%+10+20')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40.5, 60.75)
+      gs = g.to_s
+      expect(gs).to eq('40.50x60.75')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(40.5, 60.75, 0, 0, Magick::PercentGeometry)
+      gs = g.to_s
+      expect(gs).to eq('40.50%x60.75%')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(0, 0, 10, 20)
+      gs = g.to_s
+      expect(gs).to eq('+10+20')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      g = Magick::Geometry.new(0, 0, 10)
+      gs = g.to_s
+      expect(gs).to eq('+10+0')
+
+      expect { g2 = Magick::Geometry.from_s(gs) }.not_to raise_error
+      gs2 = g2.to_s
+      expect(gs2).to eq(gs)
+
+      # check behavior with empty string argument
+      expect { g = Magick::Geometry.from_s('') }.not_to raise_error
+      expect(g.to_s).to eq('')
+
+      expect { Magick::Geometry.new(Magick::AreaGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(40, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(40, 20, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(40, 20, 10, Magick::AreaGeometry) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_set_log_event_mask
-    expect { Magick.set_log_event_mask('Module,Coder') }.not_to raise_error
-    expect { Magick.set_log_event_mask('None') }.not_to raise_error
+  describe '#init_formats' do
+    it 'works' do
+      expect(Magick.init_formats).to be_instance_of(Hash)
+    end
   end
 
-  def test_set_log_format
-    expect { Magick.set_log_format('format %d%e%f') }.not_to raise_error
+  describe '#opaque_alpha' do
+    it 'works' do
+      expect(Magick::OpaqueAlpha).to eq(Magick::QuantumRange)
+    end
   end
 
-  def test_limit_resources
-    cur = new = nil
-
-    expect { cur = Magick.limit_resource(:memory, 500) }.not_to raise_error
-    expect(cur).to be_kind_of(Integer)
-    expect(cur > 1024**2).to be(true)
-    expect { new = Magick.limit_resource('memory') }.not_to raise_error
-    expect(new).to eq(500)
-    Magick.limit_resource(:memory, cur)
-
-    expect { cur = Magick.limit_resource(:map, 3500) }.not_to raise_error
-    expect(cur).to be_kind_of(Integer)
-    expect(cur > 1024**2).to be(true)
-    expect { new = Magick.limit_resource('map') }.not_to raise_error
-    expect(new).to eq(3500)
-    Magick.limit_resource(:map, cur)
-
-    expect { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }.not_to raise_error
-    expect(cur).to be_kind_of(Integer)
-    expect(cur > 1024**2).to be(true)
-    expect { new = Magick.limit_resource('disk') }.not_to raise_error
-    expect(new).to eq(3_221_225_472)
-    Magick.limit_resource(:disk, cur)
-
-    expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
-    expect(cur).to be_kind_of(Integer)
-    expect(cur > 512).to be(true)
-    expect { new = Magick.limit_resource('file') }.not_to raise_error
-    expect(new).to eq(500)
-    Magick.limit_resource(:file, cur)
-
-    expect { cur = Magick.limit_resource(:time, 300) }.not_to raise_error
-    expect(cur).to be_kind_of(Integer)
-    expect(cur > 300).to be(true)
-    expect { new = Magick.limit_resource('time') }.not_to raise_error
-    expect(new).to eq(300)
-    Magick.limit_resource(:time, cur)
-
-    expect { Magick.limit_resource(:xxx) }.to raise_error(ArgumentError)
-    expect { Magick.limit_resource('xxx') }.to raise_error(ArgumentError)
-    expect { Magick.limit_resource('map', 3500, 2) }.to raise_error(ArgumentError)
-    expect { Magick.limit_resource }.to raise_error(ArgumentError)
+  describe '#set_log_event_mask' do
+    it 'works' do
+      expect { Magick.set_log_event_mask('Module,Coder') }.not_to raise_error
+      expect { Magick.set_log_event_mask('None') }.not_to raise_error
+    end
   end
 
-  def test_transparent_alpha
-    expect(Magick::TransparentAlpha).to eq(0)
+  describe '#set_log_format' do
+    it 'works' do
+      expect { Magick.set_log_format('format %d%e%f') }.not_to raise_error
+    end
+  end
+
+  describe '#limit_resources' do
+    it 'works' do
+      cur = new = nil
+
+      expect { cur = Magick.limit_resource(:memory, 500) }.not_to raise_error
+      expect(cur).to be_kind_of(Integer)
+      expect(cur > 1024**2).to be(true)
+      expect { new = Magick.limit_resource('memory') }.not_to raise_error
+      expect(new).to eq(500)
+      Magick.limit_resource(:memory, cur)
+
+      expect { cur = Magick.limit_resource(:map, 3500) }.not_to raise_error
+      expect(cur).to be_kind_of(Integer)
+      expect(cur > 1024**2).to be(true)
+      expect { new = Magick.limit_resource('map') }.not_to raise_error
+      expect(new).to eq(3500)
+      Magick.limit_resource(:map, cur)
+
+      expect { cur = Magick.limit_resource(:disk, 3 * 1024 * 1024 * 1024) }.not_to raise_error
+      expect(cur).to be_kind_of(Integer)
+      expect(cur > 1024**2).to be(true)
+      expect { new = Magick.limit_resource('disk') }.not_to raise_error
+      expect(new).to eq(3_221_225_472)
+      Magick.limit_resource(:disk, cur)
+
+      expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
+      expect(cur).to be_kind_of(Integer)
+      expect(cur > 512).to be(true)
+      expect { new = Magick.limit_resource('file') }.not_to raise_error
+      expect(new).to eq(500)
+      Magick.limit_resource(:file, cur)
+
+      expect { cur = Magick.limit_resource(:time, 300) }.not_to raise_error
+      expect(cur).to be_kind_of(Integer)
+      expect(cur > 300).to be(true)
+      expect { new = Magick.limit_resource('time') }.not_to raise_error
+      expect(new).to eq(300)
+      Magick.limit_resource(:time, cur)
+
+      expect { Magick.limit_resource(:xxx) }.to raise_error(ArgumentError)
+      expect { Magick.limit_resource('xxx') }.to raise_error(ArgumentError)
+      expect { Magick.limit_resource('map', 3500, 2) }.to raise_error(ArgumentError)
+      expect { Magick.limit_resource }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#transparent_alpha' do
+    it 'works' do
+      expect(Magick::TransparentAlpha).to eq(0)
+    end
   end
 end
 

--- a/test/Pixel.rb
+++ b/test/Pixel.rb
@@ -1,256 +1,296 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class PixelUT < Minitest::Test
-  def setup
+describe Magick::Pixel do
+  before do
     @pixel = Magick::Pixel.from_color('brown')
   end
 
-  def test_red
-    expect { @pixel.red = 123 }.not_to raise_error
-    expect(@pixel.red).to eq(123)
-    expect { @pixel.red = 255.25 }.not_to raise_error
-    expect(@pixel.red).to eq(255)
-    expect { @pixel.red = 'x' }.to raise_error(TypeError)
+  describe '#red' do
+    it 'works' do
+      expect { @pixel.red = 123 }.not_to raise_error
+      expect(@pixel.red).to eq(123)
+      expect { @pixel.red = 255.25 }.not_to raise_error
+      expect(@pixel.red).to eq(255)
+      expect { @pixel.red = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_green
-    expect { @pixel.green = 123 }.not_to raise_error
-    expect(@pixel.green).to eq(123)
-    expect { @pixel.green = 255.25 }.not_to raise_error
-    expect(@pixel.green).to eq(255)
-    expect { @pixel.green = 'x' }.to raise_error(TypeError)
+  describe '#green' do
+    it 'works' do
+      expect { @pixel.green = 123 }.not_to raise_error
+      expect(@pixel.green).to eq(123)
+      expect { @pixel.green = 255.25 }.not_to raise_error
+      expect(@pixel.green).to eq(255)
+      expect { @pixel.green = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_blue
-    expect { @pixel.blue = 123 }.not_to raise_error
-    expect(@pixel.blue).to eq(123)
-    expect { @pixel.blue = 255.25 }.not_to raise_error
-    expect(@pixel.blue).to eq(255)
-    expect { @pixel.blue = 'x' }.to raise_error(TypeError)
+  describe '#blue' do
+    it 'works' do
+      expect { @pixel.blue = 123 }.not_to raise_error
+      expect(@pixel.blue).to eq(123)
+      expect { @pixel.blue = 255.25 }.not_to raise_error
+      expect(@pixel.blue).to eq(255)
+      expect { @pixel.blue = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_alpha
-    expect { @pixel.alpha = 123 }.not_to raise_error
-    expect(@pixel.alpha).to eq(123)
-    expect { @pixel.alpha = 255.25 }.not_to raise_error
-    expect(@pixel.alpha).to eq(255)
-    expect { @pixel.alpha = 'x' }.to raise_error(TypeError)
+  describe '#alpha' do
+    it 'works' do
+      expect { @pixel.alpha = 123 }.not_to raise_error
+      expect(@pixel.alpha).to eq(123)
+      expect { @pixel.alpha = 255.25 }.not_to raise_error
+      expect(@pixel.alpha).to eq(255)
+      expect { @pixel.alpha = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_cyan
-    expect { @pixel.cyan = 123 }.not_to raise_error
-    expect(@pixel.cyan).to eq(123)
-    expect { @pixel.cyan = 255.25 }.not_to raise_error
-    expect(@pixel.cyan).to eq(255)
-    expect { @pixel.cyan = 'x' }.to raise_error(TypeError)
+  describe '#cyan' do
+    it 'works' do
+      expect { @pixel.cyan = 123 }.not_to raise_error
+      expect(@pixel.cyan).to eq(123)
+      expect { @pixel.cyan = 255.25 }.not_to raise_error
+      expect(@pixel.cyan).to eq(255)
+      expect { @pixel.cyan = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_magenta
-    expect { @pixel.magenta = 123 }.not_to raise_error
-    expect(@pixel.magenta).to eq(123)
-    expect { @pixel.magenta = 255.25 }.not_to raise_error
-    expect(@pixel.magenta).to eq(255)
-    expect { @pixel.magenta = 'x' }.to raise_error(TypeError)
+  describe '#magenta' do
+    it 'works' do
+      expect { @pixel.magenta = 123 }.not_to raise_error
+      expect(@pixel.magenta).to eq(123)
+      expect { @pixel.magenta = 255.25 }.not_to raise_error
+      expect(@pixel.magenta).to eq(255)
+      expect { @pixel.magenta = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_yellow
-    expect { @pixel.yellow = 123 }.not_to raise_error
-    expect(@pixel.yellow).to eq(123)
-    expect { @pixel.yellow = 255.25 }.not_to raise_error
-    expect(@pixel.yellow).to eq(255)
-    expect { @pixel.yellow = 'x' }.to raise_error(TypeError)
+  describe '#yellow' do
+    it 'works' do
+      expect { @pixel.yellow = 123 }.not_to raise_error
+      expect(@pixel.yellow).to eq(123)
+      expect { @pixel.yellow = 255.25 }.not_to raise_error
+      expect(@pixel.yellow).to eq(255)
+      expect { @pixel.yellow = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_black
-    expect { @pixel.black = 123 }.not_to raise_error
-    expect(@pixel.black).to eq(123)
-    expect { @pixel.black = 255.25 }.not_to raise_error
-    expect(@pixel.black).to eq(255)
-    expect { @pixel.black = 'x' }.to raise_error(TypeError)
+  describe '#black' do
+    it 'works' do
+      expect { @pixel.black = 123 }.not_to raise_error
+      expect(@pixel.black).to eq(123)
+      expect { @pixel.black = 255.25 }.not_to raise_error
+      expect(@pixel.black).to eq(255)
+      expect { @pixel.black = 'x' }.to raise_error(TypeError)
+    end
   end
 
-  def test_case_eq
-    pixel = Magick::Pixel.from_color('brown')
-    expect(@pixel === pixel).to be(true)
-    expect(@pixel === 'red').to be(false)
+  describe '#case_eq' do
+    it 'works' do
+      pixel = Magick::Pixel.from_color('brown')
+      expect(@pixel === pixel).to be(true)
+      expect(@pixel === 'red').to be(false)
 
-    pixel = Magick::Pixel.from_color('red')
-    expect(@pixel === pixel).to be(false)
+      pixel = Magick::Pixel.from_color('red')
+      expect(@pixel === pixel).to be(false)
+    end
   end
 
-  def test_clone
-    pixel = @pixel.clone
-    expect(pixel).to eq(@pixel)
-    expect(pixel.object_id).not_to eq(@pixel.object_id)
+  describe '#clone' do
+    it 'works' do
+      pixel = @pixel.clone
+      expect(pixel).to eq(@pixel)
+      expect(pixel.object_id).not_to eq(@pixel.object_id)
 
-    pixel = @pixel.taint.clone
-    expect(pixel.tainted?).to be(true)
+      pixel = @pixel.taint.clone
+      expect(pixel.tainted?).to be(true)
 
-    pixel = @pixel.freeze.clone
-    expect(pixel.frozen?).to be(true)
+      pixel = @pixel.freeze.clone
+      expect(pixel.frozen?).to be(true)
+    end
   end
 
-  def test_dup
-    pixel = @pixel.dup
-    expect(@pixel === pixel).to be(true)
-    expect(pixel.object_id).not_to eq(@pixel.object_id)
+  describe '#dup' do
+    it 'works' do
+      pixel = @pixel.dup
+      expect(@pixel === pixel).to be(true)
+      expect(pixel.object_id).not_to eq(@pixel.object_id)
 
-    pixel = @pixel.taint.dup
-    expect(pixel.tainted?).to be(true)
+      pixel = @pixel.taint.dup
+      expect(pixel.tainted?).to be(true)
 
-    pixel = @pixel.freeze.dup
-    expect(pixel.frozen?).to be(false)
+      pixel = @pixel.freeze.dup
+      expect(pixel.frozen?).to be(false)
+    end
   end
 
-  def test_hash
-    hash = nil
-    expect { hash = @pixel.hash }.not_to raise_error
-    expect(hash).not_to be(nil)
-    expect(hash).to eq(1_385_502_079)
+  describe '#hash' do
+    it 'works' do
+      hash = nil
+      expect { hash = @pixel.hash }.not_to raise_error
+      expect(hash).not_to be(nil)
+      expect(hash).to eq(1_385_502_079)
 
-    p = Magick::Pixel.new
-    expect(p.hash).to eq(127)
+      p = Magick::Pixel.new
+      expect(p.hash).to eq(127)
 
-    p = Magick::Pixel.from_color('red')
-    expect(p.hash).to eq(2_139_095_167)
+      p = Magick::Pixel.from_color('red')
+      expect(p.hash).to eq(2_139_095_167)
 
-    # Pixel.hash sacrifices the last bit of the opacity channel
-    p = Magick::Pixel.new(0, 0, 0, 72)
-    p2 = Magick::Pixel.new(0, 0, 0, 73)
-    expect(p2).not_to eq(p)
-    expect(p2.hash).to eq(p.hash)
+      # Pixel.hash sacrifices the last bit of the opacity channel
+      p = Magick::Pixel.new(0, 0, 0, 72)
+      p2 = Magick::Pixel.new(0, 0, 0, 73)
+      expect(p2).not_to eq(p)
+      expect(p2.hash).to eq(p.hash)
+    end
   end
 
-  def test_eql?
-    p = @pixel
-    expect(@pixel.eql?(p)).to be(true)
-    p = Magick::Pixel.new
-    expect(@pixel.eql?(p)).to be(false)
+  describe '#eql?' do
+    it 'works' do
+      p = @pixel
+      expect(@pixel.eql?(p)).to be(true)
+      p = Magick::Pixel.new
+      expect(@pixel.eql?(p)).to be(false)
+    end
   end
 
-  def test_fcmp
-    red = Magick::Pixel.from_color('red')
-    blue = Magick::Pixel.from_color('blue')
-    expect { red.fcmp(red) }.not_to raise_error
-    expect(red.fcmp(red)).to be(true)
-    expect(red.fcmp(blue)).to be(false)
+  describe '#fcmp' do
+    it 'works' do
+      red = Magick::Pixel.from_color('red')
+      blue = Magick::Pixel.from_color('blue')
+      expect { red.fcmp(red) }.not_to raise_error
+      expect(red.fcmp(red)).to be(true)
+      expect(red.fcmp(blue)).to be(false)
 
-    expect { red.fcmp(blue, 10) }.not_to raise_error
-    expect { red.fcmp(blue, 10, Magick::RGBColorspace) }.not_to raise_error
-    expect { red.fcmp(blue, 'x') }.to raise_error(TypeError)
-    expect { red.fcmp(blue, 10, 'x') }.to raise_error(TypeError)
-    expect { red.fcmp }.to raise_error(ArgumentError)
-    expect { red.fcmp(blue, 10, 'x', 'y') }.to raise_error(ArgumentError)
+      expect { red.fcmp(blue, 10) }.not_to raise_error
+      expect { red.fcmp(blue, 10, Magick::RGBColorspace) }.not_to raise_error
+      expect { red.fcmp(blue, 'x') }.to raise_error(TypeError)
+      expect { red.fcmp(blue, 10, 'x') }.to raise_error(TypeError)
+      expect { red.fcmp }.to raise_error(ArgumentError)
+      expect { red.fcmp(blue, 10, 'x', 'y') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_from_hsla
-    expect { Magick::Pixel.from_hsla(127, 50, 50) }.not_to raise_error
-    expect { Magick::Pixel.from_hsla(127, 50, 50, 0) }.not_to raise_error
-    expect { Magick::Pixel.from_hsla('99%', '100%', '100%', '100%') }.not_to raise_error
-    expect { Magick::Pixel.from_hsla(0, 0, 0, 0) }.not_to raise_error
-    expect { Magick::Pixel.from_hsla(359, 255, 255, 1.0) }.not_to raise_error
-    expect { Magick::Pixel.from_hsla([], 50, 50, 0) }.to raise_error(TypeError)
-    expect { Magick::Pixel.from_hsla(127, [], 50, 0) }.to raise_error(TypeError)
-    expect { Magick::Pixel.from_hsla(127, 50, [], 0) }.to raise_error(TypeError)
-    expect { Magick::Pixel.from_hsla }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(127, 50, 50, 50, 50) }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(-0.01, 0, 0) }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(0, -0.01, 0) }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(0, 0, -0.01) }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(0, 0, 0, -0.01) }.to raise_error(ArgumentError)
-    expect { Magick::Pixel.from_hsla(0, 0, 0, 1.01) }.to raise_error(RangeError)
-    expect { Magick::Pixel.from_hsla(360, 0, 0) }.to raise_error(RangeError)
-    expect { Magick::Pixel.from_hsla(0, 256, 0) }.to raise_error(RangeError)
-    expect { Magick::Pixel.from_hsla(0, 0, 256) }.to raise_error(RangeError)
-    expect { @pixel.to_hsla }.not_to raise_error
+  describe '#from_hsla' do
+    it 'works' do
+      expect { Magick::Pixel.from_hsla(127, 50, 50) }.not_to raise_error
+      expect { Magick::Pixel.from_hsla(127, 50, 50, 0) }.not_to raise_error
+      expect { Magick::Pixel.from_hsla('99%', '100%', '100%', '100%') }.not_to raise_error
+      expect { Magick::Pixel.from_hsla(0, 0, 0, 0) }.not_to raise_error
+      expect { Magick::Pixel.from_hsla(359, 255, 255, 1.0) }.not_to raise_error
+      expect { Magick::Pixel.from_hsla([], 50, 50, 0) }.to raise_error(TypeError)
+      expect { Magick::Pixel.from_hsla(127, [], 50, 0) }.to raise_error(TypeError)
+      expect { Magick::Pixel.from_hsla(127, 50, [], 0) }.to raise_error(TypeError)
+      expect { Magick::Pixel.from_hsla }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(127, 50, 50, 50, 50) }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(-0.01, 0, 0) }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(0, -0.01, 0) }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(0, 0, -0.01) }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(0, 0, 0, -0.01) }.to raise_error(ArgumentError)
+      expect { Magick::Pixel.from_hsla(0, 0, 0, 1.01) }.to raise_error(RangeError)
+      expect { Magick::Pixel.from_hsla(360, 0, 0) }.to raise_error(RangeError)
+      expect { Magick::Pixel.from_hsla(0, 256, 0) }.to raise_error(RangeError)
+      expect { Magick::Pixel.from_hsla(0, 0, 256) }.to raise_error(RangeError)
+      expect { @pixel.to_hsla }.not_to raise_error
 
-    args = [200, 125.125, 250.5, 0.6]
-    px = Magick::Pixel.from_hsla(*args)
-    hsla = px.to_hsla
-    expect(hsla[0]).to be_within(0.25).of(args[0])
-    expect(hsla[1]).to be_within(0.25).of(args[1])
-    expect(hsla[2]).to be_within(0.25).of(args[2])
-    expect(hsla[3]).to be_within(0.005).of(args[3])
+      args = [200, 125.125, 250.5, 0.6]
+      px = Magick::Pixel.from_hsla(*args)
+      hsla = px.to_hsla
+      expect(hsla[0]).to be_within(0.25).of(args[0])
+      expect(hsla[1]).to be_within(0.25).of(args[1])
+      expect(hsla[2]).to be_within(0.25).of(args[2])
+      expect(hsla[3]).to be_within(0.005).of(args[3])
 
-    # test percentages
-    args = ['20%', '20%', '20%', '20%']
-    args2 = [360.0 / 5, 255.0 / 5, 255.0 / 5, 1.0 / 5]
-    px = Magick::Pixel.from_hsla(*args)
-    hsla = px.to_hsla
-    px2 = Magick::Pixel.from_hsla(*args2)
-    hsla2 = px2.to_hsla
+      # test percentages
+      args = ['20%', '20%', '20%', '20%']
+      args2 = [360.0 / 5, 255.0 / 5, 255.0 / 5, 1.0 / 5]
+      px = Magick::Pixel.from_hsla(*args)
+      hsla = px.to_hsla
+      px2 = Magick::Pixel.from_hsla(*args2)
+      hsla2 = px2.to_hsla
 
-    expect(hsla2[0]).to be_within(0.25).of(hsla[0])
-    expect(hsla2[1]).to be_within(0.25).of(hsla[1])
-    expect(hsla2[2]).to be_within(0.25).of(hsla[2])
-    expect(hsla2[3]).to be_within(0.005).of(hsla[3])
+      expect(hsla2[0]).to be_within(0.25).of(hsla[0])
+      expect(hsla2[1]).to be_within(0.25).of(hsla[1])
+      expect(hsla2[2]).to be_within(0.25).of(hsla[2])
+      expect(hsla2[3]).to be_within(0.005).of(hsla[3])
+    end
   end
 
-  def test_intensity
-    expect(@pixel.intensity).to be_kind_of(Integer)
+  describe '#intensity' do
+    it 'works' do
+      expect(@pixel.intensity).to be_kind_of(Integer)
+    end
   end
 
-  def test_marshal
-    marshal = @pixel.marshal_dump
+  describe '#marshal' do
+    it 'works' do
+      marshal = @pixel.marshal_dump
 
-    pixel = Magick::Pixel.new
-    expect(pixel.marshal_load(marshal)).to eq(@pixel)
+      pixel = Magick::Pixel.new
+      expect(pixel.marshal_load(marshal)).to eq(@pixel)
+    end
   end
 
-  def test_spaceship
-    @pixel.red = 100
-    pixel = @pixel.dup
-    expect(@pixel <=> pixel).to eq(0)
+  describe '#spaceship' do
+    it 'works' do
+      @pixel.red = 100
+      pixel = @pixel.dup
+      expect(@pixel <=> pixel).to eq(0)
 
-    pixel.red -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.red += 20
-    expect(@pixel <=> pixel).to eq(-1)
+      pixel.red -= 10
+      expect(@pixel <=> pixel).to eq(1)
+      pixel.red += 20
+      expect(@pixel <=> pixel).to eq(-1)
 
-    @pixel.green = 100
-    pixel = @pixel.dup
-    pixel.green -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.green += 20
-    expect(@pixel <=> pixel).to eq(-1)
+      @pixel.green = 100
+      pixel = @pixel.dup
+      pixel.green -= 10
+      expect(@pixel <=> pixel).to eq(1)
+      pixel.green += 20
+      expect(@pixel <=> pixel).to eq(-1)
 
-    @pixel.blue = 100
-    pixel = @pixel.dup
-    pixel.blue -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.blue += 20
-    expect(@pixel <=> pixel).to eq(-1)
+      @pixel.blue = 100
+      pixel = @pixel.dup
+      pixel.blue -= 10
+      expect(@pixel <=> pixel).to eq(1)
+      pixel.blue += 20
+      expect(@pixel <=> pixel).to eq(-1)
 
-    @pixel.alpha = 100
-    pixel = @pixel.dup
-    pixel.alpha -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.alpha += 20
-    expect(@pixel <=> pixel).to eq(-1)
+      @pixel.alpha = 100
+      pixel = @pixel.dup
+      pixel.alpha -= 10
+      expect(@pixel <=> pixel).to eq(1)
+      pixel.alpha += 20
+      expect(@pixel <=> pixel).to eq(-1)
+    end
   end
 
-  def test_to_color
-    expect { @pixel.to_color(Magick::AllCompliance) }.not_to raise_error
-    expect { @pixel.to_color(Magick::SVGCompliance) }.not_to raise_error
-    expect { @pixel.to_color(Magick::X11Compliance) }.not_to raise_error
-    expect { @pixel.to_color(Magick::XPMCompliance) }.not_to raise_error
-    expect { @pixel.to_color(Magick::AllCompliance, true) }.not_to raise_error
-    expect { @pixel.to_color(Magick::AllCompliance, false) }.not_to raise_error
-    expect { @pixel.to_color(Magick::AllCompliance, false, 8) }.not_to raise_error
-    expect { @pixel.to_color(Magick::AllCompliance, false, 16) }.not_to raise_error
-    # test "hex" format
-    expect { @pixel.to_color(Magick::AllCompliance, false, 8, true) }.not_to raise_error
-    expect { @pixel.to_color(Magick::AllCompliance, false, 16, true) }.not_to raise_error
+  describe '#to_color' do
+    it 'works' do
+      expect { @pixel.to_color(Magick::AllCompliance) }.not_to raise_error
+      expect { @pixel.to_color(Magick::SVGCompliance) }.not_to raise_error
+      expect { @pixel.to_color(Magick::X11Compliance) }.not_to raise_error
+      expect { @pixel.to_color(Magick::XPMCompliance) }.not_to raise_error
+      expect { @pixel.to_color(Magick::AllCompliance, true) }.not_to raise_error
+      expect { @pixel.to_color(Magick::AllCompliance, false) }.not_to raise_error
+      expect { @pixel.to_color(Magick::AllCompliance, false, 8) }.not_to raise_error
+      expect { @pixel.to_color(Magick::AllCompliance, false, 16) }.not_to raise_error
+      # test "hex" format
+      expect { @pixel.to_color(Magick::AllCompliance, false, 8, true) }.not_to raise_error
+      expect { @pixel.to_color(Magick::AllCompliance, false, 16, true) }.not_to raise_error
 
-    expect(@pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
-    expect(@pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')
+      expect(@pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
+      expect(@pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')
 
-    expect { @pixel.to_color(Magick::AllCompliance, false, 32) }.to raise_error(ArgumentError)
-    expect { @pixel.to_color(1) }.to raise_error(TypeError)
+      expect { @pixel.to_color(Magick::AllCompliance, false, 32) }.to raise_error(ArgumentError)
+      expect { @pixel.to_color(1) }.to raise_error(TypeError)
+    end
   end
 
-  def test_to_s
-    expect(@pixel.to_s).to match(/red=\d+, green=\d+, blue=\d+, alpha=\d+/)
+  describe '#to_s' do
+    it 'works' do
+      expect(@pixel.to_s).to match(/red=\d+, green=\d+, blue=\d+, alpha=\d+/)
+    end
   end
 end

--- a/test/PolaroidOptions.rb
+++ b/test/PolaroidOptions.rb
@@ -1,22 +1,26 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class PolaroidOptionsUT < Minitest::Test
-  def setup
+describe Magick::Image::PolaroidOptions do
+  before do
     @options = Magick::Image::PolaroidOptions.new
   end
 
-  def test_shadow_color
-    expect { @options.shadow_color = "gray50" }.not_to raise_error
+  describe "#shadow_color" do
+    it "works" do
+      expect { @options.shadow_color = "gray50" }.not_to raise_error
 
-    @options.freeze
-    expect { @options.shadow_color = "gray50" }.to raise_error(FreezeError)
+      @options.freeze
+      expect { @options.shadow_color = "gray50" }.to raise_error(FreezeError)
+    end
   end
 
-  def test_border_color
-    expect { @options.border_color = "gray50" }.not_to raise_error
+  describe "#border_color" do
+    it "works" do
+      expect { @options.border_color = "gray50" }.not_to raise_error
 
-    @options.freeze
-    expect { @options.border_color = "gray50" }.to raise_error(FreezeError)
+      @options.freeze
+      expect { @options.border_color = "gray50" }.to raise_error(FreezeError)
+    end
   end
 end

--- a/test/Preview.rb
+++ b/test/Preview.rb
@@ -1,17 +1,19 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class PreviewUT < Minitest::Test
-  def test_preview
-    hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      prev = hat.preview(Magick::RotatePreview)
-      expect(prev).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    Magick::PreviewType.values do |type|
-      expect { hat.preview(type) }.not_to raise_error
+describe Magick::PreviewType do
+  describe '#preview' do
+    it 'works' do
+      hat = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+      expect do
+        prev = hat.preview(Magick::RotatePreview)
+        expect(prev).to be_instance_of(Magick::Image)
+      end.not_to raise_error
+      Magick::PreviewType.values do |type|
+        expect { hat.preview(type) }.not_to raise_error
+      end
+      expect { hat.preview(2) }.to raise_error(TypeError)
     end
-    expect { hat.preview(2) }.to raise_error(TypeError)
   end
 end
 

--- a/test/Struct.rb
+++ b/test/Struct.rb
@@ -1,42 +1,56 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class StructUT < Minitest::Test
-  def test_chromaticity_to_s
-    image = Magick::Image.new(10, 10)
-    expect(image.chromaticity.to_s).to match(/red_primary=\(x=.+,y=.+\) green_primary=\(x=.+,y=.+\) blue_primary=\(x=.+,y=.+\) white_point=\(x=.+,y=.+\)/)
+describe Magick do
+  describe '#chromaticity_to_s' do
+    it 'works' do
+      image = Magick::Image.new(10, 10)
+      expect(image.chromaticity.to_s).to match(/red_primary=\(x=.+,y=.+\) green_primary=\(x=.+,y=.+\) blue_primary=\(x=.+,y=.+\) white_point=\(x=.+,y=.+\)/)
+    end
   end
 
-  def test_export_color_info
-    color = Magick.colors[0]
-    expect(color).to be_instance_of(Magick::Color)
-    expect(color.to_s).to match(/name=.+, compliance=.+, color.red=.+, color.green=.+, color.blue=.+, color.alpha=.+/)
+  describe '#export_color_info' do
+    it 'works' do
+      color = Magick.colors[0]
+      expect(color).to be_instance_of(Magick::Color)
+      expect(color.to_s).to match(/name=.+, compliance=.+, color.red=.+, color.green=.+, color.blue=.+, color.alpha=.+/)
+    end
   end
 
-  def test_export_type_info
-    font = Magick.fonts[0]
-    expect(font.to_s).to match(/^name=.+, description=.+, family=.+, style=.+, stretch=.+, weight=.+, encoding=.*, foundry=.*, format=.*$/)
+  describe '#export_type_info' do
+    it 'works' do
+      font = Magick.fonts[0]
+      expect(font.to_s).to match(/^name=.+, description=.+, family=.+, style=.+, stretch=.+, weight=.+, encoding=.*, foundry=.*, format=.*$/)
+    end
   end
 
-  def test_export_point_info
-    draw = Magick::Draw.new
-    metric = draw.get_type_metrics('ABCDEF')
-    expect(metric.to_s).to match(/^pixels_per_em=\(x=.+,y=.+\) ascent=.+ descent=.+ width=.+ height=.+ max_advance=.+ bounds.x1=.+ bounds.y1=.+ bounds.x2=.+ bounds.y2=.+ underline_position=.+ underline_thickness=.+$/)
+  describe '#export_point_info' do
+    it 'works' do
+      draw = Magick::Draw.new
+      metric = draw.get_type_metrics('ABCDEF')
+      expect(metric.to_s).to match(/^pixels_per_em=\(x=.+,y=.+\) ascent=.+ descent=.+ width=.+ height=.+ max_advance=.+ bounds.x1=.+ bounds.y1=.+ bounds.x2=.+ bounds.y2=.+ underline_position=.+ underline_thickness=.+$/)
+    end
   end
 
-  def test_primary_info_to_s
-    chrom = Magick::Image.new(10, 10).chromaticity
-    red_primary = chrom.red_primary
-    expect(red_primary.to_s).to match(/^x=.+, y=.+, z=.+$/)
+  describe '#primary_info_to_s' do
+    it 'works' do
+      chrom = Magick::Image.new(10, 10).chromaticity
+      red_primary = chrom.red_primary
+      expect(red_primary.to_s).to match(/^x=.+, y=.+, z=.+$/)
+    end
   end
 
-  def test_rectangle_info_to_s
-    rect = Magick::Rectangle.new(10, 20, 30, 40)
-    expect(rect.to_s).to eq('width=10, height=20, x=30, y=40')
+  describe '#rectangle_info_to_s' do
+    it 'works' do
+      rect = Magick::Rectangle.new(10, 20, 30, 40)
+      expect(rect.to_s).to eq('width=10, height=20, x=30, y=40')
+    end
   end
 
-  def test_segment_info_to_s
-    segment = Magick::Segment.new(10, 20, 30, 40)
-    expect(segment.to_s).to eq('x1=10, y1=20, x2=30, y2=40')
+  describe '#segment_info_to_s' do
+    it 'works' do
+      segment = Magick::Segment.new(10, 20, 30, 40)
+      expect(segment.to_s).to eq('x1=10, y1=20, x2=30, y2=40')
+    end
   end
 end

--- a/test/appearance/Montage.rb
+++ b/test/appearance/Montage.rb
@@ -2,22 +2,24 @@ require 'rmagick'
 require 'minitest/autorun'
 require_relative 'appearance_assertion'
 
-class AppearanceMontageUT < Minitest::Test
+describe Magick::ImageList do
   include AppearanceAssertion
 
-  def test_color
-    imagelist = Magick::ImageList.new(IMAGES_DIR + '/Flower_Hat.jpg')
+  describe '#color' do
+    it 'works' do
+      imagelist = Magick::ImageList.new(IMAGES_DIR + '/Flower_Hat.jpg')
 
-    new_imagelist = imagelist.montage do
-      self.border_width = 100
-      self.border_color = 'red'
-      self.background_color = 'blue'
-      self.matte_color = 'yellow'
-      self.frame = '10x10'
-      self.gravity = Magick::CenterGravity
+      new_imagelist = imagelist.montage do
+        self.border_width = 100
+        self.border_color = 'red'
+        self.background_color = 'blue'
+        self.matte_color = 'yellow'
+        self.frame = '10x10'
+        self.gravity = Magick::CenterGravity
+      end
+
+      # montage ../../doc/ex/images/Flower_Hat.jpg -border 100x -bordercolor red -mattecolor yellow -background blue -frame 10x10 -gravity Center expected/montage_border_color.jpg
+      assert_same_image('expected/montage_border_color.jpg', new_imagelist.first)
     end
-
-    # montage ../../doc/ex/images/Flower_Hat.jpg -border 100x -bordercolor red -mattecolor yellow -background blue -frame 10x10 -gravity Center expected/montage_border_color.jpg
-    assert_same_image('expected/montage_border_color.jpg', new_imagelist.first)
   end
 end

--- a/test/lib/internal/Draw.rb
+++ b/test/lib/internal/Draw.rb
@@ -1,811 +1,927 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class LibDrawUT < Minitest::Test
-  def setup
+describe Magick::Draw do
+  before do
     @draw = Magick::Draw.new
     @img = Magick::Image.new(200, 200)
   end
 
-  def test_affine
-    @draw.affine(10.5, 12, 15, 20, 22, 25)
-    expect(@draw.inspect).to eq('affine 10.5,12,15,20,22,25')
-    expect { @draw.draw(@img) }.not_to raise_error
+  describe '#affine' do
+    it 'works' do
+      @draw.affine(10.5, 12, 15, 20, 22, 25)
+      expect(@draw.inspect).to eq('affine 10.5,12,15,20,22,25')
+      expect { @draw.draw(@img) }.not_to raise_error
 
-    expect { @draw.affine('x', 12, 15, 20, 22, 25) }.to raise_error(ArgumentError)
-    expect { @draw.affine(10, 'x', 15, 20, 22, 25) }.to raise_error(ArgumentError)
-    expect { @draw.affine(10, 12, 'x', 20, 22, 25) }.to raise_error(ArgumentError)
-    expect { @draw.affine(10, 12, 15, 'x', 22, 25) }.to raise_error(ArgumentError)
-    expect { @draw.affine(10, 12, 15, 20, 'x', 25) }.to raise_error(ArgumentError)
-    expect { @draw.affine(10, 12, 15, 20, 22, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_alpha
-    Magick::PaintMethod.values do |method|
-      draw = Magick::Draw.new
-      draw.alpha(10, '20.5', method)
-      expect { draw.draw(@img) }.not_to raise_error
+      expect { @draw.affine('x', 12, 15, 20, 22, 25) }.to raise_error(ArgumentError)
+      expect { @draw.affine(10, 'x', 15, 20, 22, 25) }.to raise_error(ArgumentError)
+      expect { @draw.affine(10, 12, 'x', 20, 22, 25) }.to raise_error(ArgumentError)
+      expect { @draw.affine(10, 12, 15, 'x', 22, 25) }.to raise_error(ArgumentError)
+      expect { @draw.affine(10, 12, 15, 20, 'x', 25) }.to raise_error(ArgumentError)
+      expect { @draw.affine(10, 12, 15, 20, 22, 'x') }.to raise_error(ArgumentError)
     end
-
-    expect { @draw.alpha(10, '20.5', 'xxx') }.to raise_error(ArgumentError)
-    expect { @draw.alpha('x', 10, Magick::PointMethod) }.to raise_error(ArgumentError)
-    expect { @draw.alpha(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
   end
 
-  def test_arc
-    @draw.arc(100.5, 120.5, 200, 250, 20, 370)
-    expect(@draw.inspect).to eq('arc 100.5,120.5 200,250 20,370')
-    expect { @draw.draw(@img) }.not_to raise_error
+  describe '#alpha' do
+    it 'works' do
+      Magick::PaintMethod.values do |method|
+        draw = Magick::Draw.new
+        draw.alpha(10, '20.5', method)
+        expect { draw.draw(@img) }.not_to raise_error
+      end
 
-    expect { @draw.arc('x', 120.5, 200, 250, 20, 370) }.to raise_error(ArgumentError)
-    expect { @draw.arc(100.5, 'x', 200, 250, 20, 370) }.to raise_error(ArgumentError)
-    expect { @draw.arc(100.5, 120.5, 'x', 250, 20, 370) }.to raise_error(ArgumentError)
-    expect { @draw.arc(100.5, 120.5, 200, 'x', 20, 370) }.to raise_error(ArgumentError)
-    expect { @draw.arc(100.5, 120.5, 200, 250, 'x', 370) }.to raise_error(ArgumentError)
-    expect { @draw.arc(100.5, 120.5, 200, 250, 20, 'x') }.to raise_error(ArgumentError)
+      expect { @draw.alpha(10, '20.5', 'xxx') }.to raise_error(ArgumentError)
+      expect { @draw.alpha('x', 10, Magick::PointMethod) }.to raise_error(ArgumentError)
+      expect { @draw.alpha(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_bezier
-    @draw.bezier(10, '20', '20.5', 30, 40.5, 50)
-    expect(@draw.inspect).to eq('bezier 10,20,20.5,30,40.5,50')
-    expect { @draw.draw(@img) }.not_to raise_error
+  describe '#arc' do
+    it 'works' do
+      @draw.arc(100.5, 120.5, 200, 250, 20, 370)
+      expect(@draw.inspect).to eq('arc 100.5,120.5 200,250 20,370')
+      expect { @draw.draw(@img) }.not_to raise_error
 
-    expect { @draw.bezier }.to raise_error(ArgumentError)
-    expect { @draw.bezier(1) }.to raise_error(ArgumentError)
-    expect { @draw.bezier('x', 20, 30, 40.5) }.to raise_error(ArgumentError)
+      expect { @draw.arc('x', 120.5, 200, 250, 20, 370) }.to raise_error(ArgumentError)
+      expect { @draw.arc(100.5, 'x', 200, 250, 20, 370) }.to raise_error(ArgumentError)
+      expect { @draw.arc(100.5, 120.5, 'x', 250, 20, 370) }.to raise_error(ArgumentError)
+      expect { @draw.arc(100.5, 120.5, 200, 'x', 20, 370) }.to raise_error(ArgumentError)
+      expect { @draw.arc(100.5, 120.5, 200, 250, 'x', 370) }.to raise_error(ArgumentError)
+      expect { @draw.arc(100.5, 120.5, 200, 250, 20, 'x') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_circle
-    @draw.circle(10, '20.5', 30, 40.5)
-    expect(@draw.inspect).to eq('circle 10,20.5 30,40.5')
-    expect { @draw.draw(@img) }.not_to raise_error
+  describe '#bezier' do
+    it 'works' do
+      @draw.bezier(10, '20', '20.5', 30, 40.5, 50)
+      expect(@draw.inspect).to eq('bezier 10,20,20.5,30,40.5,50')
+      expect { @draw.draw(@img) }.not_to raise_error
 
-    expect { @draw.circle('x', 20, 30, 40) }.to raise_error(ArgumentError)
-    expect { @draw.circle(10, 'x', 30, 40) }.to raise_error(ArgumentError)
-    expect { @draw.circle(10, 20, 'x', 40) }.to raise_error(ArgumentError)
-    expect { @draw.circle(10, 20, 30, 'x') }.to raise_error(ArgumentError)
+      expect { @draw.bezier }.to raise_error(ArgumentError)
+      expect { @draw.bezier(1) }.to raise_error(ArgumentError)
+      expect { @draw.bezier('x', 20, 30, 40.5) }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_clip_path
-    @draw.clip_path('test')
-    expect(@draw.inspect).to eq('clip-path test')
-    expect { @draw.draw(@img) }.not_to raise_error
+  describe '#circle' do
+    it 'works' do
+      @draw.circle(10, '20.5', 30, 40.5)
+      expect(@draw.inspect).to eq('circle 10,20.5 30,40.5')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.circle('x', 20, 30, 40) }.to raise_error(ArgumentError)
+      expect { @draw.circle(10, 'x', 30, 40) }.to raise_error(ArgumentError)
+      expect { @draw.circle(10, 20, 'x', 40) }.to raise_error(ArgumentError)
+      expect { @draw.circle(10, 20, 30, 'x') }.to raise_error(ArgumentError)
+    end
   end
 
-  def test_clip_rule
-    draw = Magick::Draw.new
-    draw.clip_rule('evenodd')
-    expect(draw.inspect).to eq('clip-rule evenodd')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.clip_rule('nonzero')
-    expect(draw.inspect).to eq('clip-rule nonzero')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.clip_rule('foo') }.to raise_error(ArgumentError)
+  describe '#clip_path' do
+    it 'works' do
+      @draw.clip_path('test')
+      expect(@draw.inspect).to eq('clip-path test')
+      expect { @draw.draw(@img) }.not_to raise_error
+    end
   end
 
-  def test_clip_units
-    draw = Magick::Draw.new
-    draw.clip_units('userspace')
-    expect(draw.inspect).to eq('clip-units userspace')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.clip_units('userspaceonuse')
-    expect(draw.inspect).to eq('clip-units userspaceonuse')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.clip_units('objectboundingbox')
-    expect(draw.inspect).to eq('clip-units objectboundingbox')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.clip_units('foo') }.to raise_error(ArgumentError)
-  end
-
-  def test_color
-    draw = Magick::Draw.new
-    draw.color(50.5, 50, Magick::PointMethod)
-    expect(draw.inspect).to eq('color 50.5,50,point')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.color(50.5, 50, Magick::ReplaceMethod)
-    expect(draw.inspect).to eq('color 50.5,50,replace')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.color(50.5, 50, Magick::FloodfillMethod)
-    expect(draw.inspect).to eq('color 50.5,50,floodfill')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.color(50.5, 50, Magick::FillToBorderMethod)
-    expect(draw.inspect).to eq('color 50.5,50,filltoborder')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.color(50.5, 50, Magick::ResetMethod)
-    expect(draw.inspect).to eq('color 50.5,50,reset')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.color(10, 20, 'unknown') }.to raise_error(ArgumentError)
-    expect { @draw.color('x', 20, Magick::PointMethod) }.to raise_error(ArgumentError)
-    expect { @draw.color(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
-  end
-
-  def test_decorate
-    draw = Magick::Draw.new
-    draw.decorate(Magick::NoDecoration)
-    expect(draw.inspect).to eq('decorate none')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.decorate(Magick::UnderlineDecoration)
-    expect(draw.inspect).to eq('decorate underline')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.decorate(Magick::OverlineDecoration)
-    expect(draw.inspect).to eq('decorate overline')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.decorate(Magick::OverlineDecoration)
-    expect(draw.inspect).to eq('decorate overline')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    # draw = Magick::Draw.new
-    # draw.decorate('tomato')
-    # expect(draw.inspect).to eq('decorate "tomato"')
-    # draw.text(50, 50, 'Hello world')
-    # expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_define_clip_path
-    expect { @draw.define_clip_path('test') { @draw } }.not_to raise_error
-    expect(@draw.inspect).to eq("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs")
-  end
-
-  def test_ellipse
-    @draw.ellipse(50.5, 30, 25, 25, 60, 120)
-    expect(@draw.inspect).to eq('ellipse 50.5,30 25,25 60,120')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.ellipse('x', 20, 30, 40, 50, 60) }.to raise_error(ArgumentError)
-    expect { @draw.ellipse(10, 'x', 30, 40, 50, 60) }.to raise_error(ArgumentError)
-    expect { @draw.ellipse(10, 20, 'x', 40, 50, 60) }.to raise_error(ArgumentError)
-    expect { @draw.ellipse(10, 20, 30, 'x', 50, 60) }.to raise_error(ArgumentError)
-    expect { @draw.ellipse(10, 20, 30, 40, 'x', 60) }.to raise_error(ArgumentError)
-    expect { @draw.ellipse(10, 20, 30, 40, 50, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_encoding
-    @draw.encoding('UTF-8')
-    expect(@draw.inspect).to eq('encoding UTF-8')
-    expect { @draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_fill
-    draw = Magick::Draw.new
-    draw.fill('tomato')
-    expect(draw.inspect).to eq('fill "tomato"')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.fill_color('tomato')
-    expect(draw.inspect).to eq('fill "tomato"')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.fill_pattern('tomato')
-    expect(draw.inspect).to eq('fill "tomato"')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    # draw = Magick::Draw.new
-    # draw.fill_pattern('foo')
-    # expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_fill_opacity
-    draw = Magick::Draw.new
-    draw.fill_opacity(0.5)
-    expect(draw.inspect).to eq('fill-opacity 0.5')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.fill_opacity('50%')
-    expect(draw.inspect).to eq('fill-opacity 50%')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.fill_opacity(0.0) }.not_to raise_error
-    expect { @draw.fill_opacity(1.0) }.not_to raise_error
-    expect { @draw.fill_opacity('0.0') }.not_to raise_error
-    expect { @draw.fill_opacity('1.0') }.not_to raise_error
-    expect { @draw.fill_opacity('20%') }.not_to raise_error
-
-    expect { @draw.fill_opacity(-0.01) }.to raise_error(ArgumentError)
-    expect { @draw.fill_opacity(1.01) }.to raise_error(ArgumentError)
-    expect { @draw.fill_opacity('-0.01') }.to raise_error(ArgumentError)
-    expect { @draw.fill_opacity('1.01') }.to raise_error(ArgumentError)
-    expect { @draw.fill_opacity('xxx') }.to raise_error(ArgumentError)
-  end
-
-  def test_fill_rule
-    draw = Magick::Draw.new
-    draw.fill_rule('evenodd')
-    expect(draw.inspect).to eq('fill-rule evenodd')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.fill_rule('nonzero')
-    expect(draw.inspect).to eq('fill-rule nonzero')
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.fill_rule('zero') }.to raise_error(ArgumentError)
-  end
-
-  def test_font
-    draw = Magick::Draw.new
-    font_name = Magick.fonts.first.name
-    draw.font(font_name)
-    expect(draw.inspect).to eq("font '#{font_name}'")
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_font_family
-    draw = Magick::Draw.new
-    draw.font_family('sans-serif')
-    expect(draw.inspect).to eq("font-family 'sans-serif'")
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_font_stretch
-    Magick::StretchType.values do |stretch|
-      next if stretch == Magick::AnyStretch
+  describe '#clip_rule' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.clip_rule('evenodd')
+      expect(draw.inspect).to eq('clip-rule evenodd')
+      expect { draw.draw(@img) }.not_to raise_error
 
       draw = Magick::Draw.new
-      draw.font_stretch(stretch)
+      draw.clip_rule('nonzero')
+      expect(draw.inspect).to eq('clip-rule nonzero')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.clip_rule('foo') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#clip_units' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.clip_units('userspace')
+      expect(draw.inspect).to eq('clip-units userspace')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.clip_units('userspaceonuse')
+      expect(draw.inspect).to eq('clip-units userspaceonuse')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.clip_units('objectboundingbox')
+      expect(draw.inspect).to eq('clip-units objectboundingbox')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.clip_units('foo') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#color' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.color(50.5, 50, Magick::PointMethod)
+      expect(draw.inspect).to eq('color 50.5,50,point')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.color(50.5, 50, Magick::ReplaceMethod)
+      expect(draw.inspect).to eq('color 50.5,50,replace')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.color(50.5, 50, Magick::FloodfillMethod)
+      expect(draw.inspect).to eq('color 50.5,50,floodfill')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.color(50.5, 50, Magick::FillToBorderMethod)
+      expect(draw.inspect).to eq('color 50.5,50,filltoborder')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.color(50.5, 50, Magick::ResetMethod)
+      expect(draw.inspect).to eq('color 50.5,50,reset')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.color(10, 20, 'unknown') }.to raise_error(ArgumentError)
+      expect { @draw.color('x', 20, Magick::PointMethod) }.to raise_error(ArgumentError)
+      expect { @draw.color(10, 'x', Magick::PointMethod) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#decorate' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.decorate(Magick::NoDecoration)
+      expect(draw.inspect).to eq('decorate none')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.decorate(Magick::UnderlineDecoration)
+      expect(draw.inspect).to eq('decorate underline')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.decorate(Magick::OverlineDecoration)
+      expect(draw.inspect).to eq('decorate overline')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.decorate(Magick::OverlineDecoration)
+      expect(draw.inspect).to eq('decorate overline')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      # draw = Magick::Draw.new
+      # draw.decorate('tomato')
+      # expect(draw.inspect).to eq('decorate "tomato"')
+      # draw.text(50, 50, 'Hello world')
+      # expect { draw.draw(@img) }.not_to raise_error
+    end
+  end
+
+  describe '#define_clip_path' do
+    it 'works' do
+      expect { @draw.define_clip_path('test') { @draw } }.not_to raise_error
+      expect(@draw.inspect).to eq("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs")
+    end
+  end
+
+  describe '#ellipse' do
+    it 'works' do
+      @draw.ellipse(50.5, 30, 25, 25, 60, 120)
+      expect(@draw.inspect).to eq('ellipse 50.5,30 25,25 60,120')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.ellipse('x', 20, 30, 40, 50, 60) }.to raise_error(ArgumentError)
+      expect { @draw.ellipse(10, 'x', 30, 40, 50, 60) }.to raise_error(ArgumentError)
+      expect { @draw.ellipse(10, 20, 'x', 40, 50, 60) }.to raise_error(ArgumentError)
+      expect { @draw.ellipse(10, 20, 30, 'x', 50, 60) }.to raise_error(ArgumentError)
+      expect { @draw.ellipse(10, 20, 30, 40, 'x', 60) }.to raise_error(ArgumentError)
+      expect { @draw.ellipse(10, 20, 30, 40, 50, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#encoding' do
+    it 'works' do
+      @draw.encoding('UTF-8')
+      expect(@draw.inspect).to eq('encoding UTF-8')
+      expect { @draw.draw(@img) }.not_to raise_error
+    end
+  end
+
+  describe '#fill' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.fill('tomato')
+      expect(draw.inspect).to eq('fill "tomato"')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.fill_color('tomato')
+      expect(draw.inspect).to eq('fill "tomato"')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.fill_pattern('tomato')
+      expect(draw.inspect).to eq('fill "tomato"')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      # draw = Magick::Draw.new
+      # draw.fill_pattern('foo')
+      # expect { draw.draw(@img) }.not_to raise_error
+    end
+  end
+
+  describe '#fill_opacity' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.fill_opacity(0.5)
+      expect(draw.inspect).to eq('fill-opacity 0.5')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.fill_opacity('50%')
+      expect(draw.inspect).to eq('fill-opacity 50%')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.fill_opacity(0.0) }.not_to raise_error
+      expect { @draw.fill_opacity(1.0) }.not_to raise_error
+      expect { @draw.fill_opacity('0.0') }.not_to raise_error
+      expect { @draw.fill_opacity('1.0') }.not_to raise_error
+      expect { @draw.fill_opacity('20%') }.not_to raise_error
+
+      expect { @draw.fill_opacity(-0.01) }.to raise_error(ArgumentError)
+      expect { @draw.fill_opacity(1.01) }.to raise_error(ArgumentError)
+      expect { @draw.fill_opacity('-0.01') }.to raise_error(ArgumentError)
+      expect { @draw.fill_opacity('1.01') }.to raise_error(ArgumentError)
+      expect { @draw.fill_opacity('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#fill_rule' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.fill_rule('evenodd')
+      expect(draw.inspect).to eq('fill-rule evenodd')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.fill_rule('nonzero')
+      expect(draw.inspect).to eq('fill-rule nonzero')
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.fill_rule('zero') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#font' do
+    it 'works' do
+      draw = Magick::Draw.new
+      font_name = Magick.fonts.first.name
+      draw.font(font_name)
+      expect(draw.inspect).to eq("font '#{font_name}'")
       draw.text(50, 50, 'Hello world')
       expect { draw.draw(@img) }.not_to raise_error
     end
-
-    expect { @draw.font_stretch('xxx') }.to raise_error(ArgumentError)
   end
 
-  def test_font_style
-    draw = Magick::Draw.new
-    draw.font_style(Magick::NormalStyle)
-    expect(draw.inspect).to eq('font-style normal')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.font_style(Magick::ItalicStyle)
-    expect(draw.inspect).to eq('font-style italic')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.font_style(Magick::ObliqueStyle)
-    expect(draw.inspect).to eq('font-style oblique')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.font_style('xxx') }.to raise_error(ArgumentError)
-  end
-
-  def test_font_weight
-    Magick::WeightType.values do |weight|
+  describe '#font_family' do
+    it 'works' do
       draw = Magick::Draw.new
-      draw.font_weight(weight)
+      draw.font_family('sans-serif')
+      expect(draw.inspect).to eq("font-family 'sans-serif'")
       draw.text(50, 50, 'Hello world')
       expect { draw.draw(@img) }.not_to raise_error
     end
-
-    draw = Magick::Draw.new
-    draw.font_weight(400)
-    expect(draw.inspect).to eq('font-weight 400')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.font_weight('xxx') }.to raise_error(ArgumentError)
   end
 
-  def test_gravity
-    Magick::GravityType.values do |gravity|
-      next if [Magick::UndefinedGravity].include?(gravity)
+  describe '#font_stretch' do
+    it 'works' do
+      Magick::StretchType.values do |stretch|
+        next if stretch == Magick::AnyStretch
+
+        draw = Magick::Draw.new
+        draw.font_stretch(stretch)
+        draw.text(50, 50, 'Hello world')
+        expect { draw.draw(@img) }.not_to raise_error
+      end
+
+      expect { @draw.font_stretch('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#font_style' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.font_style(Magick::NormalStyle)
+      expect(draw.inspect).to eq('font-style normal')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
 
       draw = Magick::Draw.new
-      draw.gravity(gravity)
+      draw.font_style(Magick::ItalicStyle)
+      expect(draw.inspect).to eq('font-style italic')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.font_style(Magick::ObliqueStyle)
+      expect(draw.inspect).to eq('font-style oblique')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.font_style('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#font_weight' do
+    it 'works' do
+      Magick::WeightType.values do |weight|
+        draw = Magick::Draw.new
+        draw.font_weight(weight)
+        draw.text(50, 50, 'Hello world')
+        expect { draw.draw(@img) }.not_to raise_error
+      end
+
+      draw = Magick::Draw.new
+      draw.font_weight(400)
+      expect(draw.inspect).to eq('font-weight 400')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.font_weight('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#gravity' do
+    it 'works' do
+      Magick::GravityType.values do |gravity|
+        next if [Magick::UndefinedGravity].include?(gravity)
+
+        draw = Magick::Draw.new
+        draw.gravity(gravity)
+        draw.circle(10, '20.5', 30, 40.5)
+        expect { draw.draw(@img) }.not_to raise_error
+      end
+
+      expect { @draw.gravity('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#image' do
+    it 'works' do
+      Magick::CompositeOperator.values do |composite|
+        next if [Magick::CopyAlphaCompositeOp, Magick::NoCompositeOp].include?(composite)
+
+        draw = Magick::Draw.new
+        draw.image(composite, 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg")
+        expect { draw.draw(@img) }.not_to raise_error
+      end
+
+      expect { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+      expect { @draw.image(Magick::AtopCompositeOp, 'x', 100, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+      expect { @draw.image(Magick::AtopCompositeOp, 100, 'x', 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+      expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 'x', 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+      expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 200, 'x', "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#interline_spacing' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.interline_spacing(40.5)
+      expect(draw.inspect).to eq('interline-spacing 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.interline_spacing('40.5')
+      expect(draw.inspect).to eq('interline-spacing 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.interline_spacing(Float::NAN) }.to raise_error(ArgumentError)
+      expect { @draw.interline_spacing('nan') }.to raise_error(ArgumentError)
+      expect { @draw.interline_spacing('xxx') }.to raise_error(ArgumentError)
+      expect { @draw.interline_spacing(nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#interword_spacing' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.interword_spacing(40.5)
+      expect(draw.inspect).to eq('interword-spacing 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.interword_spacing('40.5')
+      expect(draw.inspect).to eq('interword-spacing 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.interword_spacing(Float::NAN) }.to raise_error(ArgumentError)
+      expect { @draw.interword_spacing('nan') }.to raise_error(ArgumentError)
+      expect { @draw.interword_spacing('xxx') }.to raise_error(ArgumentError)
+      expect { @draw.interword_spacing(nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#kerning' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.kerning(40.5)
+      expect(draw.inspect).to eq('kerning 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.kerning('40.5')
+      expect(draw.inspect).to eq('kerning 40.5')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.kerning(Float::NAN) }.to raise_error(ArgumentError)
+      expect { @draw.kerning('nan') }.to raise_error(ArgumentError)
+      expect { @draw.kerning('xxx') }.to raise_error(ArgumentError)
+      expect { @draw.kerning(nil) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#line' do
+    it 'works' do
+      @draw.line(10, '20.5', 30, 40.5)
+      expect(@draw.inspect).to eq('line 10,20.5 30,40.5')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.line('x', '20.5', 30, 40.5) }.to raise_error(ArgumentError)
+      expect { @draw.line(10, 'x', 30, 40.5) }.to raise_error(ArgumentError)
+      expect { @draw.line(10, '20.5', 'x', 40.5) }.to raise_error(ArgumentError)
+      expect { @draw.line(10, '20.5', 30, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#opacity' do
+    it 'works' do
+      @draw.opacity(0.8)
+      expect(@draw.inspect).to eq('opacity 0.8')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.opacity(0.0) }.not_to raise_error
+      expect { @draw.opacity(1.0) }.not_to raise_error
+      expect { @draw.opacity('0.0') }.not_to raise_error
+      expect { @draw.opacity('1.0') }.not_to raise_error
+      expect { @draw.opacity('20%') }.not_to raise_error
+
+      expect { @draw.opacity(-0.01) }.to raise_error(ArgumentError)
+      expect { @draw.opacity(1.01) }.to raise_error(ArgumentError)
+      expect { @draw.opacity('-0.01') }.to raise_error(ArgumentError)
+      expect { @draw.opacity('1.01') }.to raise_error(ArgumentError)
+      expect { @draw.opacity('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#path' do
+    it 'works' do
+      @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
+      expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'")
+      expect { @draw.draw(@img) }.not_to raise_error
+    end
+  end
+
+  describe '#pattern' do
+    it 'works' do
+      @draw.pattern('hat', 0, 10.5, 20, '20') {}
+      expect(@draw.inspect).to eq("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs")
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.pattern('hat', 'x', 0, 20, 20) {} }.to raise_error(ArgumentError)
+      expect { @draw.pattern('hat', 0, 'x', 20, 20) {} }.to raise_error(ArgumentError)
+      expect { @draw.pattern('hat', 0, 0, 'x', 20) {} }.to raise_error(ArgumentError)
+      expect { @draw.pattern('hat', 0, 0, 20, 'x') {} }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#point' do
+    it 'works' do
+      @draw.point(10.5, '20')
+      expect(@draw.inspect).to eq('point 10.5,20')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.point('x', 20) }.to raise_error(ArgumentError)
+      expect { @draw.point(10, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#pointsize' do
+    it 'works' do
+      @draw.pointsize(20.5)
+      expect(@draw.inspect).to eq('font-size 20.5')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.pointsize('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#font_size' do
+    it 'works' do
+      @draw.font_size(20)
+      expect(@draw.inspect).to eq('font-size 20')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.font_size('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#polygon' do
+    it 'works' do
+      @draw.polygon(0, '0.5', 8.5, 16, 16, 0, 0, 0)
+      expect(@draw.inspect).to eq('polygon 0,0.5,8.5,16,16,0,0,0')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.polygon }.to raise_error(ArgumentError)
+      expect { @draw.polygon(0) }.to raise_error(ArgumentError)
+      expect { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#polyline' do
+    it 'works' do
+      @draw.polyline(0, '0.5', 16.5, 16)
+      expect(@draw.inspect).to eq('polyline 0,0.5,16.5,16')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.polyline }.to raise_error(ArgumentError)
+      expect { @draw.polyline(0) }.to raise_error(ArgumentError)
+      expect { @draw.polyline('x', 0, 16, 16) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#rectangle' do
+    it 'works' do
+      @draw.rectangle(10, '10', 100, 100)
+      expect(@draw.inspect).to eq('rectangle 10,10 100,100')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.rectangle('x', 10, 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.rectangle(10, 'x', 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.rectangle(10, 10, 'x', 20) }.to raise_error(ArgumentError)
+      expect { @draw.rectangle(10, 10, 20, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#rotate' do
+    it 'works' do
+      @draw.rotate(45)
+      expect(@draw.inspect).to eq('rotate 45')
+      @draw.text(50, 50, 'Hello world')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.rotate('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#roundrectangle' do
+    it 'works' do
+      @draw.roundrectangle(10, '10', 100, 100, 20, 20)
+      expect(@draw.inspect).to eq('roundrectangle 10,10,100,100,20,20')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.roundrectangle(10, 'x', 100, 100, 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.roundrectangle(10, '10', 'x', 100, 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.roundrectangle(10, '10', 100, 'x', 20, 20) }.to raise_error(ArgumentError)
+      expect { @draw.roundrectangle(10, '10', 100, 100, 'x', 20) }.to raise_error(ArgumentError)
+      expect { @draw.roundrectangle(10, '10', 100, 100, 20, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#scale' do
+    it 'works' do
+      @draw.scale('0.5', 1.5)
+      expect(@draw.inspect).to eq('scale 0.5,1.5')
+      @draw.rectangle(10, '10', 100, 100)
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.scale('x', 1.5) }.to raise_error(ArgumentError)
+      expect { @draw.scale(0.5, 'x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#skewx' do
+    it 'works' do
+      @draw.skewx(45)
+      expect(@draw.inspect).to eq('skewX 45')
+      @draw.text(50, 50, 'Hello world')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.skewx('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#skewy' do
+    it 'works' do
+      @draw.skewy(45)
+      expect(@draw.inspect).to eq('skewY 45')
+      @draw.text(50, 50, 'Hello world')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.skewy('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke' do
+    it 'works' do
+      @draw.stroke('red')
+      expect(@draw.inspect).to eq('stroke "red"')
+      @draw.rectangle(10, '10', 100, 100)
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.stroke(100) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_color' do
+    it 'works' do
+      @draw.stroke_color('red')
+      expect(@draw.inspect).to eq('stroke "red"')
+      @draw.rectangle(10, '10', 100, 100)
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.stroke_color(100) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_pattern' do
+    it 'works' do
+      @draw.stroke_pattern('red')
+      expect(@draw.inspect).to eq('stroke "red"')
+      @draw.rectangle(10, '10', 100, 100)
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      # expect { @draw.stroke_pattern(100) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_antialias' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.stroke_antialias(true)
+      expect(draw.inspect).to eq('stroke-antialias 1')
+      draw.stroke_pattern('red')
+      draw.stroke_width(5)
+      draw.circle(10, '20.5', 30, 40.5)
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.stroke_antialias(false)
+      expect(draw.inspect).to eq('stroke-antialias 0')
+      draw.stroke_pattern('red')
+      draw.stroke_width(5)
       draw.circle(10, '20.5', 30, 40.5)
       expect { draw.draw(@img) }.not_to raise_error
     end
-
-    expect { @draw.gravity('xxx') }.to raise_error(ArgumentError)
   end
 
-  def test_image
-    Magick::CompositeOperator.values do |composite|
-      next if [Magick::CopyAlphaCompositeOp, Magick::NoCompositeOp].include?(composite)
+  describe '#stroke_dasharray' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.stroke_dasharray(2, 2)
+      expect(draw.inspect).to eq('stroke-dasharray 2,2')
+      draw.stroke_pattern('red')
+      draw.stroke_width(2)
+      draw.rectangle(10, '10', 100, 100)
+      expect { draw.draw(@img) }.not_to raise_error
 
       draw = Magick::Draw.new
-      draw.image(composite, 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg")
+      draw.stroke_dasharray
+      expect(draw.inspect).to eq('stroke-dasharray none')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_dasharray(-0.1) }.to raise_error(ArgumentError)
+      expect { @draw.stroke_dasharray('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_dashoffset' do
+    it 'works' do
+      @draw.stroke_dashoffset(10)
+      expect(@draw.inspect).to eq('stroke-dashoffset 10')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_dashoffset('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_linecap' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.stroke_linecap('butt')
+      expect(draw.inspect).to eq('stroke-linecap butt')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.stroke_linecap('round')
+      expect(draw.inspect).to eq('stroke-linecap round')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.stroke_linecap('square')
+      expect(draw.inspect).to eq('stroke-linecap square')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_linecap('foo') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_linejoin' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.stroke_linejoin('round')
+      expect(draw.inspect).to eq('stroke-linejoin round')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.stroke_linejoin('miter')
+      expect(draw.inspect).to eq('stroke-linejoin miter')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.stroke_linejoin('bevel')
+      expect(draw.inspect).to eq('stroke-linejoin bevel')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_linejoin('foo') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_miterlimit' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.stroke_miterlimit(1.0)
+      expect(draw.inspect).to eq('stroke-miterlimit 1.0')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_miterlimit(0.9) }.to raise_error(ArgumentError)
+      expect { @draw.stroke_miterlimit('foo') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_opacity' do
+    it 'works' do
+      @draw.stroke_opacity(0.8)
+      expect(@draw.inspect).to eq('stroke-opacity 0.8')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_opacity(0.0) }.not_to raise_error
+      expect { @draw.stroke_opacity(1.0) }.not_to raise_error
+      expect { @draw.stroke_opacity('0.0') }.not_to raise_error
+      expect { @draw.stroke_opacity('1.0') }.not_to raise_error
+      expect { @draw.stroke_opacity('20%') }.not_to raise_error
+
+      expect { @draw.stroke_opacity(-0.01) }.to raise_error(ArgumentError)
+      expect { @draw.stroke_opacity(1.01) }.to raise_error(ArgumentError)
+      expect { @draw.stroke_opacity('-0.01') }.to raise_error(ArgumentError)
+      expect { @draw.stroke_opacity('1.01') }.to raise_error(ArgumentError)
+      expect { @draw.stroke_opacity('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#stroke_width' do
+    it 'works' do
+      @draw.stroke_width(2.5)
+      expect(@draw.inspect).to eq('stroke-width 2.5')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.stroke_width('xxx') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#text' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.text(50, 50, 'Hello world')
+      expect(draw.inspect).to eq("text 50,50 'Hello world'")
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text(50, 50, "Hello 'world'")
+      expect(draw.inspect).to eq("text 50,50 \"Hello 'world'\"")
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text(50, 50, 'Hello "world"')
+      expect(draw.inspect).to eq("text 50,50 'Hello \"world\"'")
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text(50, 50, "Hello 'world\"")
+      expect(draw.inspect).to eq("text 50,50 {Hello 'world\"}")
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text(50, 50, "Hello {'world\"")
+      expect(draw.inspect).to eq("text 50,50 {Hello {'world\"}")
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.text(50, 50, '') }.to raise_error(ArgumentError)
+      expect { @draw.text('x', 50, 'Hello world') }.to raise_error(ArgumentError)
+      expect { @draw.text(50, 'x', 'Hello world') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#text_align' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.text_align(Magick::LeftAlign)
+      expect(draw.inspect).to eq('text-align left')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text_align(Magick::RightAlign)
+      expect(draw.inspect).to eq('text-align right')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text_align(Magick::CenterAlign)
+      expect(draw.inspect).to eq('text-align center')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.text_align('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#text_anchor' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.text_anchor(Magick::StartAnchor)
+      expect(draw.inspect).to eq('text-anchor start')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text_anchor(Magick::MiddleAnchor)
+      expect(draw.inspect).to eq('text-anchor middle')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text_anchor(Magick::EndAnchor)
+      expect(draw.inspect).to eq('text-anchor end')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.text_anchor('x') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#text_antialias' do
+    it 'works' do
+      draw = Magick::Draw.new
+      draw.text_antialias(true)
+      expect(draw.inspect).to eq('text-antialias 1')
+      draw.text(50, 50, 'Hello world')
+      expect { draw.draw(@img) }.not_to raise_error
+
+      draw = Magick::Draw.new
+      draw.text_antialias(false)
+      expect(draw.inspect).to eq('text-antialias 0')
+      draw.text(50, 50, 'Hello world')
       expect { draw.draw(@img) }.not_to raise_error
     end
-
-    expect { @draw.image('xxx', 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
-    expect { @draw.image(Magick::AtopCompositeOp, 'x', 100, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
-    expect { @draw.image(Magick::AtopCompositeOp, 100, 'x', 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
-    expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 'x', 100, "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
-    expect { @draw.image(Magick::AtopCompositeOp, 100, 100, 200, 'x', "#{IMAGES_DIR}/Flower_Hat.jpg") }.to raise_error(ArgumentError)
   end
 
-  def test_interline_spacing
-    draw = Magick::Draw.new
-    draw.interline_spacing(40.5)
-    expect(draw.inspect).to eq('interline-spacing 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.interline_spacing('40.5')
-    expect(draw.inspect).to eq('interline-spacing 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.interline_spacing(Float::NAN) }.to raise_error(ArgumentError)
-    expect { @draw.interline_spacing('nan') }.to raise_error(ArgumentError)
-    expect { @draw.interline_spacing('xxx') }.to raise_error(ArgumentError)
-    expect { @draw.interline_spacing(nil) }.to raise_error(TypeError)
+  describe '#text_undercolor' do
+    it 'works' do
+      @draw.text_undercolor('red')
+      expect(@draw.inspect).to eq('text-undercolor "red"')
+      @draw.text(50, 50, 'Hello world')
+      expect { @draw.draw(@img) }.not_to raise_error
+    end
   end
 
-  def test_interword_spacing
-    draw = Magick::Draw.new
-    draw.interword_spacing(40.5)
-    expect(draw.inspect).to eq('interword-spacing 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.interword_spacing('40.5')
-    expect(draw.inspect).to eq('interword-spacing 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.interword_spacing(Float::NAN) }.to raise_error(ArgumentError)
-    expect { @draw.interword_spacing('nan') }.to raise_error(ArgumentError)
-    expect { @draw.interword_spacing('xxx') }.to raise_error(ArgumentError)
-    expect { @draw.interword_spacing(nil) }.to raise_error(TypeError)
-  end
-
-  def test_kerning
-    draw = Magick::Draw.new
-    draw.kerning(40.5)
-    expect(draw.inspect).to eq('kerning 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.kerning('40.5')
-    expect(draw.inspect).to eq('kerning 40.5')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.kerning(Float::NAN) }.to raise_error(ArgumentError)
-    expect { @draw.kerning('nan') }.to raise_error(ArgumentError)
-    expect { @draw.kerning('xxx') }.to raise_error(ArgumentError)
-    expect { @draw.kerning(nil) }.to raise_error(TypeError)
-  end
-
-  def test_line
-    @draw.line(10, '20.5', 30, 40.5)
-    expect(@draw.inspect).to eq('line 10,20.5 30,40.5')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.line('x', '20.5', 30, 40.5) }.to raise_error(ArgumentError)
-    expect { @draw.line(10, 'x', 30, 40.5) }.to raise_error(ArgumentError)
-    expect { @draw.line(10, '20.5', 'x', 40.5) }.to raise_error(ArgumentError)
-    expect { @draw.line(10, '20.5', 30, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_opacity
-    @draw.opacity(0.8)
-    expect(@draw.inspect).to eq('opacity 0.8')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.opacity(0.0) }.not_to raise_error
-    expect { @draw.opacity(1.0) }.not_to raise_error
-    expect { @draw.opacity('0.0') }.not_to raise_error
-    expect { @draw.opacity('1.0') }.not_to raise_error
-    expect { @draw.opacity('20%') }.not_to raise_error
-
-    expect { @draw.opacity(-0.01) }.to raise_error(ArgumentError)
-    expect { @draw.opacity(1.01) }.to raise_error(ArgumentError)
-    expect { @draw.opacity('-0.01') }.to raise_error(ArgumentError)
-    expect { @draw.opacity('1.01') }.to raise_error(ArgumentError)
-    expect { @draw.opacity('xxx') }.to raise_error(ArgumentError)
-  end
-
-  def test_path
-    @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-    expect(@draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'")
-    expect { @draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_pattern
-    @draw.pattern('hat', 0, 10.5, 20, '20') {}
-    expect(@draw.inspect).to eq("push defs\npush pattern hat 0 10.5 20 20\npush graphic-context\npop graphic-context\npop pattern\npop defs")
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.pattern('hat', 'x', 0, 20, 20) {} }.to raise_error(ArgumentError)
-    expect { @draw.pattern('hat', 0, 'x', 20, 20) {} }.to raise_error(ArgumentError)
-    expect { @draw.pattern('hat', 0, 0, 'x', 20) {} }.to raise_error(ArgumentError)
-    expect { @draw.pattern('hat', 0, 0, 20, 'x') {} }.to raise_error(ArgumentError)
-  end
-
-  def test_point
-    @draw.point(10.5, '20')
-    expect(@draw.inspect).to eq('point 10.5,20')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.point('x', 20) }.to raise_error(ArgumentError)
-    expect { @draw.point(10, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_pointsize
-    @draw.pointsize(20.5)
-    expect(@draw.inspect).to eq('font-size 20.5')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.pointsize('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_font_size
-    @draw.font_size(20)
-    expect(@draw.inspect).to eq('font-size 20')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.font_size('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_polygon
-    @draw.polygon(0, '0.5', 8.5, 16, 16, 0, 0, 0)
-    expect(@draw.inspect).to eq('polygon 0,0.5,8.5,16,16,0,0,0')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.polygon }.to raise_error(ArgumentError)
-    expect { @draw.polygon(0) }.to raise_error(ArgumentError)
-    expect { @draw.polygon('x', 0, 8, 16, 16, 0, 0, 0) }.to raise_error(ArgumentError)
-  end
-
-  def test_polyline
-    @draw.polyline(0, '0.5', 16.5, 16)
-    expect(@draw.inspect).to eq('polyline 0,0.5,16.5,16')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.polyline }.to raise_error(ArgumentError)
-    expect { @draw.polyline(0) }.to raise_error(ArgumentError)
-    expect { @draw.polyline('x', 0, 16, 16) }.to raise_error(ArgumentError)
-  end
-
-  def test_rectangle
-    @draw.rectangle(10, '10', 100, 100)
-    expect(@draw.inspect).to eq('rectangle 10,10 100,100')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.rectangle('x', 10, 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.rectangle(10, 'x', 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.rectangle(10, 10, 'x', 20) }.to raise_error(ArgumentError)
-    expect { @draw.rectangle(10, 10, 20, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_rotate
-    @draw.rotate(45)
-    expect(@draw.inspect).to eq('rotate 45')
-    @draw.text(50, 50, 'Hello world')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.rotate('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_roundrectangle
-    @draw.roundrectangle(10, '10', 100, 100, 20, 20)
-    expect(@draw.inspect).to eq('roundrectangle 10,10,100,100,20,20')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.roundrectangle('x', '10', 100, 100, 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.roundrectangle(10, 'x', 100, 100, 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.roundrectangle(10, '10', 'x', 100, 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.roundrectangle(10, '10', 100, 'x', 20, 20) }.to raise_error(ArgumentError)
-    expect { @draw.roundrectangle(10, '10', 100, 100, 'x', 20) }.to raise_error(ArgumentError)
-    expect { @draw.roundrectangle(10, '10', 100, 100, 20, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_scale
-    @draw.scale('0.5', 1.5)
-    expect(@draw.inspect).to eq('scale 0.5,1.5')
-    @draw.rectangle(10, '10', 100, 100)
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.scale('x', 1.5) }.to raise_error(ArgumentError)
-    expect { @draw.scale(0.5, 'x') }.to raise_error(ArgumentError)
-  end
-
-  def test_skewx
-    @draw.skewx(45)
-    expect(@draw.inspect).to eq('skewX 45')
-    @draw.text(50, 50, 'Hello world')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.skewx('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_skewy
-    @draw.skewy(45)
-    expect(@draw.inspect).to eq('skewY 45')
-    @draw.text(50, 50, 'Hello world')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.skewy('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke
-    @draw.stroke('red')
-    expect(@draw.inspect).to eq('stroke "red"')
-    @draw.rectangle(10, '10', 100, 100)
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.stroke(100) }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_color
-    @draw.stroke_color('red')
-    expect(@draw.inspect).to eq('stroke "red"')
-    @draw.rectangle(10, '10', 100, 100)
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.stroke_color(100) }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_pattern
-    @draw.stroke_pattern('red')
-    expect(@draw.inspect).to eq('stroke "red"')
-    @draw.rectangle(10, '10', 100, 100)
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    # expect { @draw.stroke_pattern(100) }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_antialias
-    draw = Magick::Draw.new
-    draw.stroke_antialias(true)
-    expect(draw.inspect).to eq('stroke-antialias 1')
-    draw.stroke_pattern('red')
-    draw.stroke_width(5)
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_antialias(false)
-    expect(draw.inspect).to eq('stroke-antialias 0')
-    draw.stroke_pattern('red')
-    draw.stroke_width(5)
-    draw.circle(10, '20.5', 30, 40.5)
-    expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_stroke_dasharray
-    draw = Magick::Draw.new
-    draw.stroke_dasharray(2, 2)
-    expect(draw.inspect).to eq('stroke-dasharray 2,2')
-    draw.stroke_pattern('red')
-    draw.stroke_width(2)
-    draw.rectangle(10, '10', 100, 100)
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_dasharray
-    expect(draw.inspect).to eq('stroke-dasharray none')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_dasharray(-0.1) }.to raise_error(ArgumentError)
-    expect { @draw.stroke_dasharray('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_dashoffset
-    @draw.stroke_dashoffset(10)
-    expect(@draw.inspect).to eq('stroke-dashoffset 10')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_dashoffset('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_linecap
-    draw = Magick::Draw.new
-    draw.stroke_linecap('butt')
-    expect(draw.inspect).to eq('stroke-linecap butt')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_linecap('round')
-    expect(draw.inspect).to eq('stroke-linecap round')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_linecap('square')
-    expect(draw.inspect).to eq('stroke-linecap square')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_linecap('foo') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_linejoin
-    draw = Magick::Draw.new
-    draw.stroke_linejoin('round')
-    expect(draw.inspect).to eq('stroke-linejoin round')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_linejoin('miter')
-    expect(draw.inspect).to eq('stroke-linejoin miter')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.stroke_linejoin('bevel')
-    expect(draw.inspect).to eq('stroke-linejoin bevel')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_linejoin('foo') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_miterlimit
-    draw = Magick::Draw.new
-    draw.stroke_miterlimit(1.0)
-    expect(draw.inspect).to eq('stroke-miterlimit 1.0')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_miterlimit(0.9) }.to raise_error(ArgumentError)
-    expect { @draw.stroke_miterlimit('foo') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_opacity
-    @draw.stroke_opacity(0.8)
-    expect(@draw.inspect).to eq('stroke-opacity 0.8')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_opacity(0.0) }.not_to raise_error
-    expect { @draw.stroke_opacity(1.0) }.not_to raise_error
-    expect { @draw.stroke_opacity('0.0') }.not_to raise_error
-    expect { @draw.stroke_opacity('1.0') }.not_to raise_error
-    expect { @draw.stroke_opacity('20%') }.not_to raise_error
-
-    expect { @draw.stroke_opacity(-0.01) }.to raise_error(ArgumentError)
-    expect { @draw.stroke_opacity(1.01) }.to raise_error(ArgumentError)
-    expect { @draw.stroke_opacity('-0.01') }.to raise_error(ArgumentError)
-    expect { @draw.stroke_opacity('1.01') }.to raise_error(ArgumentError)
-    expect { @draw.stroke_opacity('xxx') }.to raise_error(ArgumentError)
-  end
-
-  def test_stroke_width
-    @draw.stroke_width(2.5)
-    expect(@draw.inspect).to eq('stroke-width 2.5')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.stroke_width('xxx') }.to raise_error(ArgumentError)
-  end
-
-  def test_text
-    draw = Magick::Draw.new
-    draw.text(50, 50, 'Hello world')
-    expect(draw.inspect).to eq("text 50,50 'Hello world'")
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text(50, 50, "Hello 'world'")
-    expect(draw.inspect).to eq("text 50,50 \"Hello 'world'\"")
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text(50, 50, 'Hello "world"')
-    expect(draw.inspect).to eq("text 50,50 'Hello \"world\"'")
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text(50, 50, "Hello 'world\"")
-    expect(draw.inspect).to eq("text 50,50 {Hello 'world\"}")
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text(50, 50, "Hello {'world\"")
-    expect(draw.inspect).to eq("text 50,50 {Hello {'world\"}")
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.text(50, 50, '') }.to raise_error(ArgumentError)
-    expect { @draw.text('x', 50, 'Hello world') }.to raise_error(ArgumentError)
-    expect { @draw.text(50, 'x', 'Hello world') }.to raise_error(ArgumentError)
-  end
-
-  def test_text_align
-    draw = Magick::Draw.new
-    draw.text_align(Magick::LeftAlign)
-    expect(draw.inspect).to eq('text-align left')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text_align(Magick::RightAlign)
-    expect(draw.inspect).to eq('text-align right')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text_align(Magick::CenterAlign)
-    expect(draw.inspect).to eq('text-align center')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.text_align('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_text_anchor
-    draw = Magick::Draw.new
-    draw.text_anchor(Magick::StartAnchor)
-    expect(draw.inspect).to eq('text-anchor start')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text_anchor(Magick::MiddleAnchor)
-    expect(draw.inspect).to eq('text-anchor middle')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text_anchor(Magick::EndAnchor)
-    expect(draw.inspect).to eq('text-anchor end')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.text_anchor('x') }.to raise_error(ArgumentError)
-  end
-
-  def test_text_antialias
-    draw = Magick::Draw.new
-    draw.text_antialias(true)
-    expect(draw.inspect).to eq('text-antialias 1')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-
-    draw = Magick::Draw.new
-    draw.text_antialias(false)
-    expect(draw.inspect).to eq('text-antialias 0')
-    draw.text(50, 50, 'Hello world')
-    expect { draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_text_undercolor
-    @draw.text_undercolor('red')
-    expect(@draw.inspect).to eq('text-undercolor "red"')
-    @draw.text(50, 50, 'Hello world')
-    expect { @draw.draw(@img) }.not_to raise_error
-  end
-
-  def test_translate
-    @draw.translate('200', 300)
-    expect(@draw.inspect).to eq('translate 200,300')
-    expect { @draw.draw(@img) }.not_to raise_error
-
-    expect { @draw.translate('x', 300) }.to raise_error(ArgumentError)
-    expect { @draw.translate(200, 'x') }.to raise_error(ArgumentError)
+  describe '#translate' do
+    it 'works' do
+      @draw.translate('200', 300)
+      expect(@draw.inspect).to eq('translate 200,300')
+      expect { @draw.draw(@img) }.not_to raise_error
+
+      expect { @draw.translate('x', 300) }.to raise_error(ArgumentError)
+      expect { @draw.translate(200, 'x') }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/test/lib/internal/Geometry.rb
+++ b/test/lib/internal/Geometry.rb
@@ -1,95 +1,103 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class LibGeometryUT < Minitest::Test
-  def test_constants
-    expect(Magick::PercentGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::PercentGeometry.to_s).to eq('PercentGeometry')
-    expect(Magick::PercentGeometry.to_i).to eq(1)
+describe Magick::Geometry do
+  describe '#constants' do
+    it 'works' do
+      expect(Magick::PercentGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::PercentGeometry.to_s).to eq('PercentGeometry')
+      expect(Magick::PercentGeometry.to_i).to eq(1)
 
-    expect(Magick::AspectGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::AspectGeometry.to_s).to eq('AspectGeometry')
-    expect(Magick::AspectGeometry.to_i).to eq(2)
+      expect(Magick::AspectGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::AspectGeometry.to_s).to eq('AspectGeometry')
+      expect(Magick::AspectGeometry.to_i).to eq(2)
 
-    expect(Magick::LessGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::LessGeometry.to_s).to eq('LessGeometry')
-    expect(Magick::LessGeometry.to_i).to eq(3)
+      expect(Magick::LessGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::LessGeometry.to_s).to eq('LessGeometry')
+      expect(Magick::LessGeometry.to_i).to eq(3)
 
-    expect(Magick::GreaterGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::GreaterGeometry.to_s).to eq('GreaterGeometry')
-    expect(Magick::GreaterGeometry.to_i).to eq(4)
+      expect(Magick::GreaterGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::GreaterGeometry.to_s).to eq('GreaterGeometry')
+      expect(Magick::GreaterGeometry.to_i).to eq(4)
 
-    expect(Magick::AreaGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::AreaGeometry.to_s).to eq('AreaGeometry')
-    expect(Magick::AreaGeometry.to_i).to eq(5)
+      expect(Magick::AreaGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::AreaGeometry.to_s).to eq('AreaGeometry')
+      expect(Magick::AreaGeometry.to_i).to eq(5)
 
-    expect(Magick::MinimumGeometry).to be_kind_of(Magick::GeometryValue)
-    expect(Magick::MinimumGeometry.to_s).to eq('MinimumGeometry')
-    expect(Magick::MinimumGeometry.to_i).to eq(6)
+      expect(Magick::MinimumGeometry).to be_kind_of(Magick::GeometryValue)
+      expect(Magick::MinimumGeometry.to_s).to eq('MinimumGeometry')
+      expect(Magick::MinimumGeometry.to_i).to eq(6)
+    end
   end
 
-  def test_initialize
-    expect { Magick::Geometry.new(Magick::PercentGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(0, 0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
+  describe '#initialize' do
+    it 'works' do
+      expect { Magick::Geometry.new(Magick::PercentGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(0, 0, 0, Magick::PercentGeometry) }.to raise_error(ArgumentError)
 
-    expect { Magick::Geometry.new(-1) }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.new(0, -1) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(-1) }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.new(0, -1) }.to raise_error(ArgumentError)
 
-    geometry = Magick::Geometry.new
-    expect(geometry.width).to eq(0)
-    expect(geometry.height).to eq(0)
-    expect(geometry.x).to eq(0)
-    expect(geometry.y).to eq(0)
-    expect(geometry.flag).to be(nil)
+      geometry = Magick::Geometry.new
+      expect(geometry.width).to eq(0)
+      expect(geometry.height).to eq(0)
+      expect(geometry.x).to eq(0)
+      expect(geometry.y).to eq(0)
+      expect(geometry.flag).to be(nil)
 
-    geometry = Magick::Geometry.new(10, 20, 30, 40)
-    expect(geometry.width).to eq(10)
-    expect(geometry.height).to eq(20)
-    expect(geometry.x).to eq(30)
-    expect(geometry.y).to eq(40)
+      geometry = Magick::Geometry.new(10, 20, 30, 40)
+      expect(geometry.width).to eq(10)
+      expect(geometry.height).to eq(20)
+      expect(geometry.x).to eq(30)
+      expect(geometry.y).to eq(40)
+    end
   end
 
-  def test_to_s
-    expect(Magick::Geometry.new.to_s).to eq('')
-    expect(Magick::Geometry.new(10).to_s).to eq('10x')
-    expect(Magick::Geometry.new(10, 20).to_s).to eq('10x20')
-    expect(Magick::Geometry.new(10, 20, 30).to_s).to eq('10x20+30+0')
-    expect(Magick::Geometry.new(10, 20, 30, 40).to_s).to eq('10x20+30+40')
-    expect(Magick::Geometry.new(0, 20, 30, 40).to_s).to eq('x20+30+40')
-    expect(Magick::Geometry.new(0, 0, 30, 40).to_s).to eq('+30+40')
-    expect(Magick::Geometry.new(0, 0, 0, 40).to_s).to eq('+0+40')
+  describe '#to_s' do
+    it 'works' do
+      expect(Magick::Geometry.new.to_s).to eq('')
+      expect(Magick::Geometry.new(10).to_s).to eq('10x')
+      expect(Magick::Geometry.new(10, 20).to_s).to eq('10x20')
+      expect(Magick::Geometry.new(10, 20, 30).to_s).to eq('10x20+30+0')
+      expect(Magick::Geometry.new(10, 20, 30, 40).to_s).to eq('10x20+30+40')
+      expect(Magick::Geometry.new(0, 20, 30, 40).to_s).to eq('x20+30+40')
+      expect(Magick::Geometry.new(0, 0, 30, 40).to_s).to eq('+30+40')
+      expect(Magick::Geometry.new(0, 0, 0, 40).to_s).to eq('+0+40')
 
-    expect(Magick::Geometry.new(10, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('10%x20%+30+40')
-    expect(Magick::Geometry.new(0, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('x20%+30+40')
+      expect(Magick::Geometry.new(10, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('10%x20%+30+40')
+      expect(Magick::Geometry.new(0, 20, 30, 40, Magick::PercentGeometry).to_s).to eq('x20%+30+40')
 
-    expect(Magick::Geometry.new(10.2, 20.5, 30, 40).to_s).to eq('10.20x20.50+30+40')
-    expect(Magick::Geometry.new(10.2, 20.5, 30, 40, Magick::PercentGeometry).to_s).to eq('10.20%x20.50%+30+40')
+      expect(Magick::Geometry.new(10.2, 20.5, 30, 40).to_s).to eq('10.20x20.50+30+40')
+      expect(Magick::Geometry.new(10.2, 20.5, 30, 40, Magick::PercentGeometry).to_s).to eq('10.20%x20.50%+30+40')
+    end
   end
 
-  def test_from_s
-    expect(Magick::Geometry.from_s('').to_s).to eq('')
-    expect(Magick::Geometry.from_s('x').to_s).to eq('')
-    expect(Magick::Geometry.from_s('10').to_s).to eq('10x')
-    expect(Magick::Geometry.from_s('10x').to_s).to eq('10x')
-    expect(Magick::Geometry.from_s('10x20').to_s).to eq('10x20')
-    expect(Magick::Geometry.from_s('10x20+30+40').to_s).to eq('10x20+30+40')
-    expect(Magick::Geometry.from_s('x20+30+40').to_s).to eq('x20+30+40')
-    expect(Magick::Geometry.from_s('+30+40').to_s).to eq('+30+40')
-    expect(Magick::Geometry.from_s('+0+40').to_s).to eq('+0+40')
-    expect(Magick::Geometry.from_s('+30').to_s).to eq('+30+0')
+  describe '#from_s' do
+    it 'works' do
+      expect(Magick::Geometry.from_s('').to_s).to eq('')
+      expect(Magick::Geometry.from_s('x').to_s).to eq('')
+      expect(Magick::Geometry.from_s('10').to_s).to eq('10x')
+      expect(Magick::Geometry.from_s('10x').to_s).to eq('10x')
+      expect(Magick::Geometry.from_s('10x20').to_s).to eq('10x20')
+      expect(Magick::Geometry.from_s('10x20+30+40').to_s).to eq('10x20+30+40')
+      expect(Magick::Geometry.from_s('x20+30+40').to_s).to eq('x20+30+40')
+      expect(Magick::Geometry.from_s('+30+40').to_s).to eq('+30+40')
+      expect(Magick::Geometry.from_s('+0+40').to_s).to eq('+0+40')
+      expect(Magick::Geometry.from_s('+30').to_s).to eq('+30+0')
 
-    expect(Magick::Geometry.from_s('10%x20%+30+40').to_s).to eq('10%x20%+30+40')
-    expect(Magick::Geometry.from_s('x20%+30+40').to_s).to eq('x20%+30+40')
+      expect(Magick::Geometry.from_s('10%x20%+30+40').to_s).to eq('10%x20%+30+40')
+      expect(Magick::Geometry.from_s('x20%+30+40').to_s).to eq('x20%+30+40')
 
-    expect(Magick::Geometry.from_s('10.2x20.5+30+40').to_s).to eq('10.20x20.50+30+40')
-    expect(Magick::Geometry.from_s('10.2%x20.500%+30+40').to_s).to eq('10.20%x20.50%+30+40')
+      expect(Magick::Geometry.from_s('10.2x20.5+30+40').to_s).to eq('10.20x20.50+30+40')
+      expect(Magick::Geometry.from_s('10.2%x20.500%+30+40').to_s).to eq('10.20%x20.50%+30+40')
 
-    expect { Magick::Geometry.from_s('10x20+') }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.from_s('+30.000+40') }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.from_s('+30.000+40.000') }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.from_s('10x20+30.000+40') }.to raise_error(ArgumentError)
-    expect { Magick::Geometry.from_s('10x20+30.000+40.000') }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.from_s('10x20+') }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.from_s('+30.000+40') }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.from_s('+30.000+40.000') }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.from_s('10x20+30.000+40') }.to raise_error(ArgumentError)
+      expect { Magick::Geometry.from_s('10x20+30.000+40.000') }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/test/lib/internal/Magick.rb
+++ b/test/lib/internal/Magick.rb
@@ -1,37 +1,43 @@
 require 'rmagick'
 require 'minitest/autorun'
 
-class LibMagickUT < Minitest::Test
-  def test_formats
-    expect(Magick.formats).to be_instance_of(Hash)
-    Magick.formats.each do |f, v|
-      expect(f).to be_instance_of(String)
-      expect(v).to match(/[\*\+\srw]+/)
-    end
+describe Magick do
+  describe '#formats' do
+    it 'works' do
+      expect(Magick.formats).to be_instance_of(Hash)
+      Magick.formats.each do |f, v|
+        expect(f).to be_instance_of(String)
+        expect(v).to match(/[\*\+\srw]+/)
+      end
 
-    Magick.formats do |f, v|
-      expect(f).to be_instance_of(String)
-      expect(v).to match(/[\*\+\srw]+/)
+      Magick.formats do |f, v|
+        expect(f).to be_instance_of(String)
+        expect(v).to match(/[\*\+\srw]+/)
+      end
     end
   end
 
-  def test_trace_proc
-    Magick.trace_proc = proc do |which, description, id, method|
-      expect(which).to eq(:c)
-      expect(description).to be_instance_of(String)
-      expect(id).to be_instance_of(String)
-      expect(method).to eq(:initialize)
-    end
-    img = Magick::Image.new(20, 20)
+  describe '#trace_proc' do
+    it 'works' do
+      Magick.trace_proc = proc do |which, description, id, method|
+        expect(which).to eq(:c)
+        expect(description).to be_instance_of(String)
+        expect(id).to be_instance_of(String)
+        expect(method).to eq(:initialize)
+      end
+      img = Magick::Image.new(20, 20)
 
-    Magick.trace_proc = proc do |which, description, id, method|
-      expect(which).to eq(:d)
-      expect(description).to be_instance_of(String)
-      expect(id).to be_instance_of(String)
-      expect(method).to eq(:"destroy!")
+      Magick.trace_proc = proc do |which, description, id, method|
+        expect(which).to eq(:d)
+        expect(description).to be_instance_of(String)
+        expect(id).to be_instance_of(String)
+        expect(method).to eq(:"destroy!")
+      end
+      img.destroy!
     end
-    img.destroy!
-  ensure
-    Magick.trace_proc = nil
+
+    after do
+      Magick.trace_proc = nil
+    end
   end
 end

--- a/test/test_all_basic.rb
+++ b/test/test_all_basic.rb
@@ -43,35 +43,29 @@ module Minitest
     end
   end
 
-  module Assertions
-    def expect(actual = :__not_set__, &actual_block)
-      @actual = actual
-      @actual_block = actual_block
-      self
-    end
-
+  module Expectations
     def to(matcher)
       case matcher.type
       when :be
-        assert_same(matcher.expected, @actual)
+        ctx.assert_same(matcher.expected, target)
       when :be_instance_of
-        assert_instance_of(matcher.expected, @actual)
+        ctx.assert_instance_of(matcher.expected, target)
       when :be_kind_of
-        assert_kind_of(matcher.expected, @actual)
+        ctx.assert_kind_of(matcher.expected, target)
       when :be_within
-        assert_in_delta(matcher.expected, @actual, matcher.delta)
+        ctx.assert_in_delta(matcher.expected, target, matcher.delta)
       when :eq
-        assert_equal(matcher.expected, @actual)
+        ctx.assert_equal(matcher.expected, target)
       when :have_key
-        assert(@actual.key?(matcher.expected))
+        ctx.assert(target.key?(matcher.expected))
       when :include
-        assert(@actual.include?(matcher.expected))
+        ctx.assert(target.include?(matcher.expected))
       when :match
-        assert_match(matcher.expected, @actual)
+        ctx.assert_match(matcher.expected, target)
       when :raise_error
-        assert_raises(matcher.expected, &@actual_block)
+        ctx.assert_raises(matcher.expected, &target)
       when :respond_to
-        assert(@actual.respond_to?(matcher.expected))
+        ctx.assert(target.respond_to?(matcher.expected))
       else
         raise ArgumentError, "no matcher: #{matcher.inspect}"
       end
@@ -80,13 +74,13 @@ module Minitest
     def not_to(matcher)
       case matcher.type
       when :be
-        refute_same(matcher.expected, @actual)
+        ctx.refute_same(matcher.expected, target)
       when :eq
-        refute_equal(matcher.expected, @actual)
+        ctx.refute_equal(matcher.expected, target)
       when :have_key
-        refute(@actual.key?(matcher.expected))
+        ctx.refute(target.key?(matcher.expected))
       when :raise_error
-        @actual_block.call
+        target.call
       else
         raise ArgumentError, "no negated matcher: #{matcher.inspect}"
       end

--- a/test/tmpnam_test.rb
+++ b/test/tmpnam_test.rb
@@ -1,50 +1,52 @@
 require 'minitest/autorun'
 require 'rmagick'
 
-class TmpnamTest < Minitest::Test
+describe Magick do
   # test the @@_tmpnam_ class variable
   # the count is incremented by Image::Info#texture=,
   # ImageList::Montage#texture=, and Draw.composite
-  def test_tmpnam
-    tmpfiles = Dir[ENV['HOME'] + '/tmp/magick*'].length
+  describe '#tmpnam' do
+    it 'works' do
+      tmpfiles = Dir[ENV['HOME'] + '/tmp/magick*'].length
 
-    texture = Magick::Image.read('granite:') { self.size = '20x20' }.first
-    info = Magick::Image::Info.new
+      texture = Magick::Image.read('granite:') { self.size = '20x20' }.first
+      info = Magick::Image::Info.new
 
-    # does not exist at first
-    expect { Magick._tmpnam_ }.to raise_error(NameError)
+      # does not exist at first
+      expect { Magick._tmpnam_ }.to raise_error(NameError)
 
-    info.texture = texture
+      info.texture = texture
 
-    # now it exists
-    expect { Magick._tmpnam_ }.not_to raise_error
-    expect(Magick._tmpnam_).to eq(1)
+      # now it exists
+      expect { Magick._tmpnam_ }.not_to raise_error
+      expect(Magick._tmpnam_).to eq(1)
 
-    info.texture = texture
-    expect(Magick._tmpnam_).to eq(2)
+      info.texture = texture
+      expect(Magick._tmpnam_).to eq(2)
 
-    mon = Magick::ImageList::Montage.new
-    mon.texture = texture
-    expect(Magick._tmpnam_).to eq(3)
+      mon = Magick::ImageList::Montage.new
+      mon.texture = texture
+      expect(Magick._tmpnam_).to eq(3)
 
-    mon.texture = texture
-    expect(Magick._tmpnam_).to eq(4)
+      mon.texture = texture
+      expect(Magick._tmpnam_).to eq(4)
 
-    gc = Magick::Draw.new
-    gc.composite(0, 0, 20, 20, texture)
-    expect(Magick._tmpnam_).to eq(5)
+      gc = Magick::Draw.new
+      gc.composite(0, 0, 20, 20, texture)
+      expect(Magick._tmpnam_).to eq(5)
 
-    gc.composite(0, 0, 20, 20, texture)
-    expect(Magick._tmpnam_).to eq(6)
+      gc.composite(0, 0, 20, 20, texture)
+      expect(Magick._tmpnam_).to eq(6)
 
-    tmpfiles2 = Dir[ENV['HOME'] + '/tmp/magick*'].length
+      tmpfiles2 = Dir[ENV['HOME'] + '/tmp/magick*'].length
 
-    # The 2nd montage texture deletes the first.
-    # The 2nd info texture deletes the first.
-    # Both composite images are still alive.
-    # Therefore only 4 tmp files are left.
-    # expect(tmpfiles2).to eq(tmpfiles+4)
-    # 6.4.1-5 - only 1 tmpfile?
-    expect(tmpfiles2).to eq(tmpfiles)
+      # The 2nd montage texture deletes the first.
+      # The 2nd info texture deletes the first.
+      # Both composite images are still alive.
+      # Therefore only 4 tmp files are left.
+      # expect(tmpfiles2).to eq(tmpfiles+4)
+      # 6.4.1-5 - only 1 tmpfile?
+      expect(tmpfiles2).to eq(tmpfiles)
+    end
   end
 end


### PR DESCRIPTION
This switches all of our test files to use the `minitest/spec` syntax,
which is more or less the same as RSpec. It's pretty brute force at this
point. I used `it 'works'` blocks everywhere rather than a better
description. I'll flesh them out more after they have been split up by
method. Most of the `test_` methods referenced method names, but a few
were more descriptive. I changed them all to the same format, however,
with the intention of cleaning all of that up again after they're all on
RSpec. There were also a handful of test methods that were not prefixed
with `test_` (see `find_all` and `flatten_images`), so this actually
enables a little more testing for those cases.

This commit is best viewed with the `-w` option to hide whitespace
changes.