### PR TITLE
RSpec: tidy up some of the existing specs

### DIFF
--- a/spec/rmagick/image/class_type_writer_spec.rb
+++ b/spec/rmagick/image/class_type_writer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Magick::Image, '#class_type' do
+RSpec.describe Magick::Image, '#class_type=' do
   it 'does not allow setting to UndefinedClass' do
     img = Magick::Image.new(20, 20)
 

--- a/spec/rmagick/image/element_assignment_spec.rb
+++ b/spec/rmagick/image/element_assignment_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#[]=' do
+  let(:img) { Magick::Image.new(20, 20) }
+
+  it 'allows assignment of arbitrary properties' do
+    img['comment'] = 'str_1'
+    img['label'] = 'str_2'
+    img['jpeg:sampling-factor'] = '2x1,1x1,1x1'
+
+    expect(img['comment']).to eq 'str_1'
+    expect(img['label']).to eq 'str_2'
+    expect(img['jpeg:sampling-factor']).to eq '2x1,1x1,1x1'
+  end
+
+  it 'raises an error when trying to assign properties to a frozen image' do
+    img.freeze
+
+    expect { img['comment'] = 'str_4' }.to raise_error(RuntimeError)
+  end
+end

--- a/spec/rmagick/image/element_reference_spec.rb
+++ b/spec/rmagick/image/element_reference_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#[]' do
+  let(:img) { Magick::Image.new(20, 20) }
+
+  it 'allows accessing arbitrary properties' do
+    img['comment'] = 'str_1'
+    img['label'] = 'str_2'
+    img['jpeg:sampling-factor'] = '2x1,1x1,1x1'
+
+    expect(img['comment']).to eq 'str_1'
+    expect(img['label']).to eq 'str_2'
+    expect(img['jpeg:sampling-factor']).to eq '2x1,1x1,1x1'
+    expect(img['d']).to be nil
+  end
+end

--- a/spec/rmagick/image/properties_spec.rb
+++ b/spec/rmagick/image/properties_spec.rb
@@ -1,27 +1,12 @@
 RSpec.describe Magick::Image, '#properties' do
   let(:img) { Magick::Image.new(20, 20) }
-  let(:freeze_error) { RuntimeError }
 
-  before do
+  it 'returns a hash of assigned properties' do
     img['comment'] = 'str_1'
     img['label'] = 'str_2'
     img['jpeg:sampling-factor'] = '2x1,1x1,1x1'
-  end
-
-  it 'allows assignment of arbitrary properties' do
-    expect(img['comment']).to eq 'str_1'
-    expect(img['label']).to eq 'str_2'
-    expect(img['jpeg:sampling-factor']).to eq '2x1,1x1,1x1'
-    expect(img['d']).to be nil
-  end
-
-  it 'returns a hash of assigned properties' do
     expected_properties = { 'comment' => 'str_1', 'label' => 'str_2', 'jpeg:sampling-factor' => '2x1,1x1,1x1' }
-    expect(img.properties).to eq(expected_properties)
-  end
 
-  it 'raises an error when trying to assign properties to a frozen image' do
-    img.freeze
-    expect { img['comment'] = 'str_4' }.to raise_error(freeze_error)
+    expect(img.properties).to eq(expected_properties)
   end
 end


### PR DESCRIPTION
This corrects the spec naming and splits out some specs into more
appropriately named files.

One of the somewhat awkward things about having one spec file per method
is the file naming for methods that have symbols like `[]` and `thing=`.
Having a filename like `[]_spec.rb` is a recipe for disaster, so we have
to come up with proper names for them. For setters in ruby it is
typically `thing_writer_spec.rb`. For the square braces operators I'm
using the naming [from the ruby docs][1], `element_reference_spec.rb`
and `element_assignment_spec.rb`.

[1]: https://ruby-doc.org/core-2.6.5/Hash.html#method-i-5B-5D