### PR TITLE
Reduce gem package size by removing test/document/example files

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   tracked_files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
-  file_exclusion_regex = %r{(\Alib/rvg/to_c.rb)}
+  file_exclusion_regex = %r{(\Alib/rvg/to_c.rb)|^(doc|benchmarks|examples|spec)}
   files         = tracked_files.reject { |file| file[file_exclusion_regex] }
   test_files    = files.grep(%r{^(test|spec|features)/})
   executables   = files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   tracked_files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
-  file_exclusion_regex = %r{(\Alib/rvg/to_c.rb)|^(doc|benchmarks|examples|spec)}
+  file_exclusion_regex = %r{\A(doc|benchmarks|examples|spec|lib/rvg/to_c.rb)}
   files         = tracked_files.reject { |file| file[file_exclusion_regex] }
   test_files    = files.grep(%r{^(test|spec|features)/})
   executables   = files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
I think almost users do not refer test/document/example files in gem package and the users refer this repository directly if needed.

### Before
```
$ rake build
$ ls -lh pkg/rmagick*
-rw-r--r--  1 watson  staff   1.9M 11 28 01:36 pkg/rmagick-4.1.0.rc2.gem
```

### After
```
$ rake build
$ ls -lh pkg/rmagick*
-rw-r--r--  1 watson  staff   230K 11 28 01:37 pkg/rmagick-4.1.0.rc2.gem
```