### PR TITLE
Remove taint logic which will be deprecated in Ruby

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1229,11 +1229,6 @@ Draw_dup(VALUE self)
     draw = ALLOC(Draw);
     memset(draw, 0, sizeof(Draw));
     dup = Data_Wrap_Struct(CLASS_OF(self), mark_Draw, destroy_Draw, draw);
-    if (rb_obj_tainted(self))
-    {
-        (void)rb_obj_taint(dup);
-    }
-
     RB_GC_GUARD(dup);
 
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -5883,11 +5883,6 @@ Image_dup(VALUE self)
 
     (void) rm_check_destroyed(self);
     dup = Data_Wrap_Struct(CLASS_OF(self), NULL, rm_image_destroy, NULL);
-    if (rb_obj_tainted(self))
-    {
-        (void) rb_obj_taint(dup);
-    }
-
     RB_GC_GUARD(dup);
 
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -417,11 +417,6 @@ Pixel_dup(VALUE self)
     pixel = ALLOC(Pixel);
     memset(pixel, '\0', sizeof(Pixel));
     dup = Data_Wrap_Struct(CLASS_OF(self), NULL, destroy_Pixel, pixel);
-    if (rb_obj_tainted(self))
-    {
-        (void) rb_obj_taint(dup);
-    }
-
     RB_GC_GUARD(dup);
 
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1421,7 +1421,6 @@ module Magick
       ditto = self.class.new
       @images.each { |f| ditto << f.copy }
       ditto.scene = @scene
-      ditto.taint if tainted?
       ditto
     end
 
@@ -1495,7 +1494,6 @@ module Magick
       ditto = self.class.new
       @images.each { |img| ditto << img }
       ditto.scene = @scene
-      ditto.taint if tainted?
       ditto
     end
 

--- a/spec/draw_spec.rb
+++ b/spec/draw_spec.rb
@@ -252,7 +252,6 @@ RSpec.describe Magick::Draw do
   describe '#dup' do
     it 'works' do
       @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
-      @draw.taint
       @draw.freeze
       dup = @draw.dup
       expect(dup).to be_instance_of(Magick::Draw)
@@ -261,7 +260,6 @@ RSpec.describe Magick::Draw do
 
   describe '#clone' do
     it 'works' do
-      @draw.taint
       @draw.freeze
       clone = @draw.clone
       expect(clone).to be_instance_of(Magick::Draw)

--- a/spec/image_2_spec.rb
+++ b/spec/image_2_spec.rb
@@ -252,11 +252,6 @@ RSpec.describe Magick::Image do
         ditto = @img.copy
         expect(ditto).to eq(@img)
       end.not_to raise_error
-      ditto = @img.copy
-      expect(ditto.tainted?).to eq(@img.tainted?)
-      @img.taint
-      ditto = @img.copy
-      expect(ditto.tainted?).to eq(@img.tainted?)
     end
   end
 
@@ -578,11 +573,6 @@ RSpec.describe Magick::Image do
         ditto = @img.dup
         expect(ditto).to eq(@img)
       end.not_to raise_error
-      ditto = @img.dup
-      expect(ditto.tainted?).to eq(@img.tainted?)
-      @img.taint
-      ditto = @img.dup
-      expect(ditto.tainted?).to eq(@img.tainted?)
     end
   end
 

--- a/spec/image_list_2_spec.rb
+++ b/spec/image_list_2_spec.rb
@@ -36,12 +36,9 @@ RSpec.describe Magick::ImageList do
       ilist2 = @ilist.clone
       expect(@ilist).to eq(ilist2)
       expect(ilist2.frozen?).to eq(@ilist.frozen?)
-      expect(ilist2.tainted?).to eq(@ilist.tainted?)
-      @ilist.taint
       @ilist.freeze
       ilist2 = @ilist.clone
       expect(ilist2.frozen?).to eq(@ilist.frozen?)
-      expect(ilist2.tainted?).to eq(@ilist.tainted?)
     end
   end
 
@@ -86,12 +83,9 @@ RSpec.describe Magick::ImageList do
       ilist2 = @ilist.dup
       expect(@ilist).to eq(ilist2)
       expect(ilist2.frozen?).to eq(@ilist.frozen?)
-      expect(ilist2.tainted?).to eq(@ilist.tainted?)
-      @ilist.taint
       @ilist.freeze
       ilist2 = @ilist.dup
       expect(ilist2.frozen?).not_to eq(@ilist.frozen?)
-      expect(ilist2.tainted?).to eq(@ilist.tainted?)
     end
   end
 

--- a/spec/pixel_spec.rb
+++ b/spec/pixel_spec.rb
@@ -100,9 +100,6 @@ RSpec.describe Magick::Pixel do
       expect(pixel).to eq(@pixel)
       expect(pixel.object_id).not_to eq(@pixel.object_id)
 
-      pixel = @pixel.taint.clone
-      expect(pixel.tainted?).to be(true)
-
       pixel = @pixel.freeze.clone
       expect(pixel.frozen?).to be(true)
     end
@@ -113,9 +110,6 @@ RSpec.describe Magick::Pixel do
       pixel = @pixel.dup
       expect(@pixel === pixel).to be(true)
       expect(pixel.object_id).not_to eq(@pixel.object_id)
-
-      pixel = @pixel.taint.dup
-      expect(pixel.tainted?).to be(true)
 
       pixel = @pixel.freeze.dup
       expect(pixel.frozen?).to be(false)


### PR DESCRIPTION
`Object#tainted?` has been marked as deprecated as Ruby 2.7 and it will always return `false`.

https://github.com/ruby/ruby/blob/1140625cd31f7ad74c42dc625b9dab389b12653c/object.c#L1169-L1173

So we should remove taint logic from RMagick.