### PR TITLE
Eliminate compiler warnings with Ruby 2.7

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11576,7 +11576,7 @@ Image_read(VALUE class, VALUE file_arg)
  * @return 0
  */
 static VALUE
-file_arg_rescue(VALUE arg)
+file_arg_rescue(VALUE arg, VALUE raised_exc ATTRIBUTE_UNUSED)
 {
     rb_raise(rb_eTypeError, "argument must be path name or open file (%s given)",
              rb_class2name(CLASS_OF(arg)));

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -244,7 +244,7 @@ DEF_PIXEL_CMYK_CHANNEL_ACCESSOR(black, opacity)
  * @throw ArgumentError
  */
 static VALUE
-color_arg_rescue(VALUE arg)
+color_arg_rescue(VALUE arg, VALUE raised_exc ATTRIBUTE_UNUSED)
 {
     rb_raise(rb_eTypeError, "argument must be color name or pixel (%s given)",
             rb_class2name(CLASS_OF(arg)));

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -373,7 +373,7 @@ arg_is_number(VALUE arg)
  * @throw TypeError
  */
 static VALUE
-rescue_not_str(VALUE arg)
+rescue_not_str(VALUE arg, VALUE raised_exc ATTRIBUTE_UNUSED)
 {
     rb_raise(rb_eTypeError, "argument must be a number or a string in the form 'NN%%' (%s given)",
             rb_class2name(CLASS_OF(arg)));
@@ -469,7 +469,7 @@ check_num2dbl(VALUE obj)
  * @return 0
  */
 static VALUE
-rescue_not_dbl(VALUE ignored ATTRIBUTE_UNUSED)
+rescue_not_dbl(VALUE ignored ATTRIBUTE_UNUSED, VALUE raised_exc ATTRIBUTE_UNUSED)
 {
     return INT2FIX(0);
 }


### PR DESCRIPTION
This patch will eliminate following compiler warnings with Ruby 2.7

```
../../../../ext/RMagick/rmimage.c:11630:43: warning: passing argument 3 of ‘rb_rescue’ from incompatible pointer type [-Wincompatible-pointer-types]
1955         file = rb_rescue(rb_String, file, file_arg_rescue, file);
1956                                           ^~~~~~~~~~~~~~~
1957In file included from /home/travis/.rvm/rubies/ruby-2.7.0-preview3/include/ruby-2.7.0/ruby.h:33:0,
1958                 from ../../../../ext/RMagick/rmagick.h:25,
1959                 from ../../../../ext/RMagick/rmimage.c:13:
1960/home/travis/.rvm/rubies/ruby-2.7.0-preview3/include/ruby-2.7.0/ruby/ruby.h:1987:7: note: expected ‘VALUE (*)(VALUE,  VALUE) {aka long unsigned int (*)(long unsigned int,  long unsigned int)}’ but argument is of type ‘VALUE (*)(VALUE) {aka long unsigned int (*)(long unsigned int)}’
1961 VALUE rb_rescue(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE);
1962       ^~~~~~~~~
…
```
https://travis-ci.org/rmagick/rmagick/jobs/624745572#L1954-L2032