### PR TITLE
remove reference to taint from comment

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2639,7 +2639,7 @@ Image_chromaticity_eq(VALUE self, VALUE chroma)
 
 
 /**
- * Copy an image, along with its frozen and tainted state.
+ * Copy an image, along with its frozen state.
  *
  * Ruby usage:
  *   - @verbatim Image#clone @endverbatim


### PR DESCRIPTION
Support for ruby `taint` has been removed.