### PR TITLE
RSpec: convert "_*" and "c*" Image specs to files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -303,21 +303,7 @@ RSpec/HooksBeforeExamples:
 # Offense count: 2876
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/draw_2_spec.rb'
-    - 'spec/draw_spec.rb'
-    - 'spec/image_1_spec.rb'
-    - 'spec/image_2_spec.rb'
-    - 'spec/image_3_spec.rb'
-    - 'spec/image_attributes_spec.rb'
-    - 'spec/image_list_1_spec.rb'
-    - 'spec/image_list_2_spec.rb'
-    - 'spec/import_export_spec.rb'
-    - 'spec/info_spec.rb'
-    - 'spec/kernel_info_spec.rb'
-    - 'spec/pixel_spec.rb'
-    - 'spec/polaroid_options_spec.rb'
-    - 'spec/rmagick/image/read_spec.rb'
+  Enabled: false
 
 # Offense count: 1
 RSpec/IteratedExpectation:

--- a/spec/rmagick/image/_dump_spec.rb
+++ b/spec/rmagick/image/_dump_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Magick::Image, '#_dump' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    expect(img._dump(10)).to be_instance_of(String)
+  end
+end

--- a/spec/rmagick/image/_load_spec.rb
+++ b/spec/rmagick/image/_load_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#_load' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    res = img._dump(10)
+
+    expect(Magick::Image._load(res)).to be_instance_of(Magick::Image)
+  end
+end

--- a/spec/rmagick/image/composite_affine_spec.rb
+++ b/spec/rmagick/image/composite_affine_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#composite_affine' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    affine = Magick::AffineMatrix.new(1, 0, 1, 0, 0, 0)
+    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+    img1.define('compose:args', '1x1')
+    img2.define('compose:args', '1x1')
+    expect do
+      res = img1.composite_affine(img2, affine)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/composite_bang_spec.rb
+++ b/spec/rmagick/image/composite_bang_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#composite!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+    img1.define('compose:args', '1x1')
+    img2.define('compose:args', '1x1')
+    Magick::CompositeOperator.values do |op|
+      Magick::GravityType.values do |gravity|
+        expect do
+          res = img1.composite!(img2, gravity, op)
+          expect(res).to be(img1)
+        end.not_to raise_error
+      end
+    end
+    img1.freeze
+    expect { img1.composite!(img2, Magick::NorthWestGravity, Magick::OverCompositeOp) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/composite_channel_spec.rb
+++ b/spec/rmagick/image/composite_channel_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#composite_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+    img1.define('compose:args', '1x1')
+    img2.define('compose:args', '1x1')
+    Magick::CompositeOperator.values do |op|
+      Magick::GravityType.values do |gravity|
+        expect do
+          res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
+          expect(res).not_to be(img1)
+        end.not_to raise_error
+      end
+    end
+
+    expect { img1.composite_channel(img2, Magick::NorthWestGravity) }.to raise_error(ArgumentError)
+    expect { img1.composite_channel(img2, Magick::NorthWestGravity, 5, 5, Magick::OverCompositeOp, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/composite_mathematics_spec.rb
+++ b/spec/rmagick/image/composite_mathematics_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#composite_mathematics' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    bg = Magick::Image.new(50, 50)
+    fg = Magick::Image.new(50, 50) { self.background_color = 'black' }
+    res = nil
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(bg)
+    expect(res).not_to be(fg)
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
+    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
+
+    # too few arguments
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)
+    # too many arguments
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0, 'x') }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/composite_tiled_spec.rb
+++ b/spec/rmagick/image/composite_tiled_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Magick::Image, '#composite_tiled' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    bg = Magick::Image.new(200, 200)
+    fg = Magick::Image.new(50, 100) { self.background_color = 'black' }
+    res = nil
+    expect do
+      res = bg.composite_tiled(fg)
+    end.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(bg)
+    expect(res).not_to be(fg)
+    expect { bg.composite_tiled!(fg) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::RedChannel) }.not_to raise_error
+    expect { bg.composite_tiled(fg, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+
+    expect { bg.composite_tiled }.to raise_error(ArgumentError)
+    expect { bg.composite_tiled(fg, 'x') }.to raise_error(TypeError)
+    expect { bg.composite_tiled(fg, Magick::AtopCompositeOp, Magick::RedChannel, 'x') }.to raise_error(TypeError)
+
+    fg.destroy!
+    expect { bg.composite_tiled(fg) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/compress_colormap_bang_spec.rb
+++ b/spec/rmagick/image/compress_colormap_bang_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#compress_colormap!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    # DirectClass images are converted to PseudoClass in older versions of ImageMagick.
+    expect(@img.class_type).to eq(Magick::DirectClass)
+    expect { @img.compress_colormap! }.not_to raise_error
+    # expect(@img.class_type).to eq(Magick::PseudoClass)
+    @img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    expect(@img.class_type).to eq(Magick::PseudoClass)
+    expect { @img.compress_colormap! }.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/contrast_spec.rb
+++ b/spec/rmagick/image/contrast_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#contrast' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.contrast
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.contrast(true) }.not_to raise_error
+    expect { @img.contrast(true, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/contrast_stretch_channel_spec.rb
+++ b/spec/rmagick/image/contrast_stretch_channel_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#contrast_stretch_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.contrast_stretch_channel(25)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50) }.not_to raise_error
+    expect { @img.contrast_stretch_channel('10%') }.not_to raise_error
+    expect { @img.contrast_stretch_channel('10%', '50%') }.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel) }.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50, Magick::RedChannel, Magick::GreenChannel) }.not_to raise_error
+    expect { @img.contrast_stretch_channel(25, 50, 'x') }.to raise_error(TypeError)
+    expect { @img.contrast_stretch_channel }.to raise_error(ArgumentError)
+    expect { @img.contrast_stretch_channel('x') }.to raise_error(ArgumentError)
+    expect { @img.contrast_stretch_channel(25, 'x') }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/convolve_channel_spec.rb
+++ b/spec/rmagick/image/convolve_channel_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#convolve_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.convolve_channel }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(0) }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(-1) }.to raise_error(ArgumentError)
+    expect { @img.convolve_channel(3) }.to raise_error(ArgumentError)
+    kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    order = 3
+    expect do
+      res = @img.convolve_channel(order, kernel, Magick::RedChannel)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
+    expect { @img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/convolve_spec.rb
+++ b/spec/rmagick/image/convolve_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#convolve' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    order = 3
+    expect do
+      res = @img.convolve(order, kernel)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.convolve }.to raise_error(ArgumentError)
+    expect { @img.convolve(0) }.to raise_error(ArgumentError)
+    expect { @img.convolve(-1) }.to raise_error(ArgumentError)
+    expect { @img.convolve(order) }.to raise_error(ArgumentError)
+    expect { @img.convolve(5, kernel) }.to raise_error(IndexError)
+    expect { @img.convolve(order, 'x') }.to raise_error(IndexError)
+    expect { @img.convolve(3, [1.0, 1.0, 1.0, 1.0, 'x', 1.0, 1.0, 1.0, 1.0]) }.to raise_error(TypeError)
+    expect { @img.convolve(-1, [1.0, 1.0, 1.0, 1.0]) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/copy_spec.rb
+++ b/spec/rmagick/image/copy_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#copy' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      ditto = @img.copy
+      expect(ditto).to eq(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/crop_bang_spec.rb
+++ b/spec/rmagick/image/crop_bang_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#crop!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.crop!(0, 0, @img.columns / 2, @img.rows / 2)
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/crop_spec.rb
+++ b/spec/rmagick/image/crop_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Magick::Image, '#crop' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.crop }.to raise_error(ArgumentError)
+    expect { @img.crop(0, 0) }.to raise_error(ArgumentError)
+    expect do
+      res = @img.crop(0, 0, @img.columns / 2, @img.rows / 2)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    # 3-argument form
+    Magick::GravityType.values do |grav|
+      expect { @img.crop(grav, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+    end
+    expect { @img.crop(2, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(Magick::NorthWestGravity, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+
+    # 4-argument form
+    expect { @img.crop(0, 0, @img.columns / 2, 'x') }.to raise_error(TypeError)
+    expect { @img.crop(0, 0, 'x', @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(0, 'x', @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop('x', 0, @img.columns / 2, @img.rows / 2) }.to raise_error(TypeError)
+    expect { @img.crop(0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(TypeError)
+
+    # 5-argument form
+    Magick::GravityType.values do |grav|
+      expect { @img.crop(grav, 0, 0, @img.columns / 2, @img.rows / 2) }.not_to raise_error
+    end
+
+    expect { @img.crop(Magick::NorthWestGravity, 0, 0, @img.columns / 2, @img.rows / 2, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/cycle_colormap_spec.rb
+++ b/spec/rmagick/image/cycle_colormap_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#cycle_colormap' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.cycle_colormap(5)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+      expect(res.class_type).to eq(Magick::PseudoClass)
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
This pulls the first batch of spec blocks from `image_2_spec.rb` into
files.

* `composite_spec.rb` already existed, so I left it as-is. It already
  looks decent.
* I'm leaving `image_2_spec.rb` unchanged for the moment to make it
  easier to manage parallel pull requests. I'll remove it at the end.