### PR TITLE
RSpec: convert "d*" and "e*" Image specs to files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -246,15 +246,12 @@ Performance/ChainArrayAllocation:
 
 # Offense count: 6
 Performance/FixedSize:
-  Exclude:
-    - 'spec/image_2_spec.rb'
+  Enabled: false
 
 # Offense count: 2
 # Cop supports --auto-correct.
 Performance/RedundantMatch:
-  Exclude:
-    - 'examples/demo.rb'
-    - 'spec/image_2_spec.rb'
+  Enabled: false
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -284,9 +281,7 @@ RSpec/ExampleLength:
 
 # Offense count: 1
 RSpec/ExpectActual:
-  Exclude:
-    - 'spec/routing/**/*'
-    - 'spec/image_2_spec.rb'
+  Enabled: false
 
 # Offense count: 18
 # Configuration parameters: CustomTransform, IgnoreMethods.
@@ -303,26 +298,11 @@ RSpec/HooksBeforeExamples:
 # Offense count: 2876
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/draw_2_spec.rb'
-    - 'spec/draw_spec.rb'
-    - 'spec/image_1_spec.rb'
-    - 'spec/image_2_spec.rb'
-    - 'spec/image_3_spec.rb'
-    - 'spec/image_attributes_spec.rb'
-    - 'spec/image_list_1_spec.rb'
-    - 'spec/image_list_2_spec.rb'
-    - 'spec/import_export_spec.rb'
-    - 'spec/info_spec.rb'
-    - 'spec/kernel_info_spec.rb'
-    - 'spec/pixel_spec.rb'
-    - 'spec/polaroid_options_spec.rb'
-    - 'spec/rmagick/image/read_spec.rb'
+  Enabled: false
 
 # Offense count: 1
 RSpec/IteratedExpectation:
-  Exclude:
-    - 'spec/image_2_spec.rb'
+  Enabled: false
 
 # Offense count: 1
 RSpec/MultipleDescribes:
@@ -565,9 +545,7 @@ Style/SafeNavigation:
 
 # Offense count: 5
 Style/Send:
-  Exclude:
-    - 'lib/rmagick_internal.rb'
-    - 'spec/image_2_spec.rb'
+  Enabled: false
 
 # Offense count: 2
 # Configuration parameters: Methods.

--- a/spec/rmagick/image/decipher_spec.rb
+++ b/spec/rmagick/image/decipher_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#decipher' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    res = res2 = nil
+    expect do
+      res = @img.encipher 'passphrase'
+      res2 = res.decipher 'passphrase'
+    end.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+    expect(res.columns).to eq(@img.columns)
+    expect(res.rows).to eq(@img.rows)
+    expect(res2).to be_instance_of(Magick::Image)
+    expect(res2).not_to be(@img)
+    expect(res2.columns).to eq(@img.columns)
+    expect(res2.rows).to eq(@img.rows)
+    expect(res2).to eq(@img)
+  end
+end

--- a/spec/rmagick/image/define_spec.rb
+++ b/spec/rmagick/image/define_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Magick::Image, '#define' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.define('deskew:auto-crop', 40) }.not_to raise_error
+    expect { @img.undefine('deskew:auto-crop') }.not_to raise_error
+    expect { @img.define('deskew:auto-crop', nil) }.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/deskew_spec.rb
+++ b/spec/rmagick/image/deskew_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Magick::Image, '#deskew' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.deskew
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    expect { @img.deskew(0.10) }.not_to raise_error
+    expect { @img.deskew('95%') }.not_to raise_error
+    expect { @img.deskew('x') }.to raise_error(ArgumentError)
+    expect { @img.deskew(0.40, 'x') }.to raise_error(TypeError)
+    expect { @img.deskew(0.40, 20, [1]) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/despeckle_spec.rb
+++ b/spec/rmagick/image/despeckle_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#despeckle' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.despeckle
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/destroy_spec.rb
+++ b/spec/rmagick/image/destroy_spec.rb
@@ -1,0 +1,45 @@
+# ensure methods detect destroyed images
+RSpec.describe Magick::Image, '#destroy' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    methods = Magick::Image.instance_methods(false).sort
+    methods -= %i[__display__ destroy! destroyed? inspect cur_image marshal_load]
+
+    expect(@img.destroyed?).to eq(false)
+    @img.destroy!
+    expect(@img.destroyed?).to eq(true)
+    expect { @img.check_destroyed }.to raise_error(Magick::DestroyedImageError)
+
+    methods.each do |method|
+      arity = @img.method(method).arity
+      method = method.to_s
+
+      if method == '[]='
+        expect { @img['foo'] = 1 }.to raise_error(Magick::DestroyedImageError)
+      elsif method == 'difference'
+        other = Magick::Image.new(20, 20)
+        expect { @img.difference(other) }.to raise_error(Magick::DestroyedImageError)
+      elsif method == 'channel_entropy' && IM_VERSION < Gem::Version.new('6.9')
+        expect { @img.channel_entropy }.to raise_error(NotImplementedError)
+      elsif method == 'get_iptc_dataset'
+        expect { @img.get_iptc_dataset('x') }.to raise_error(Magick::DestroyedImageError)
+      elsif method == 'profile!'
+        expect { @img.profile!('x', 'y') }.to raise_error(Magick::DestroyedImageError)
+      elsif /=\Z/.match(method)
+        expect { @img.send(method, 1) }.to raise_error(Magick::DestroyedImageError)
+      elsif arity.zero?
+        expect { @img.send(method) }.to raise_error(Magick::DestroyedImageError)
+      elsif arity < 0
+        args = (1..-arity).to_a
+        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
+      elsif arity > 0
+        args = (1..arity).to_a
+        expect { @img.send(method, *args) }.to raise_error(Magick::DestroyedImageError)
+      else
+        # Don't know how to test!
+        flunk("don't know how to test method #{method}")
+      end
+    end
+  end
+end

--- a/spec/rmagick/image/difference_spec.rb
+++ b/spec/rmagick/image/difference_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#difference' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img1 = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+    expect do
+      res = img1.difference(img2)
+      expect(res).to be_instance_of(Array)
+      expect(res.length).to eq(3)
+      expect(res[0]).to be_instance_of(Float)
+      expect(res[1]).to be_instance_of(Float)
+      expect(res[2]).to be_instance_of(Float)
+    end.not_to raise_error
+
+    expect { img1.difference(2) }.to raise_error(NoMethodError)
+    img2.destroy!
+    expect { img1.difference(img2) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/displace_spec.rb
+++ b/spec/rmagick/image/displace_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Magick::Image, '#displace' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    @img2 = Magick::Image.new(20, 20) { self.background_color = 'black' }
+    expect { @img.displace(@img2, 25) }.not_to raise_error
+    res = @img.displace(@img2, 25)
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+    expect { @img.displace(@img2, 25, 25) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, 10, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10) }.not_to raise_error
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, 10) }.not_to raise_error
+    expect { @img.displace }.to raise_error(ArgumentError)
+    expect { @img.displace(@img2, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, []) }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 'x') }.to raise_error(TypeError)
+    expect { @img.displace(@img2, 25, 25, Magick::CenterGravity, 10, []) }.to raise_error(TypeError)
+
+    @img2.destroy!
+    expect { @img.displace(@img2, 25, 25) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/distort_spec.rb
+++ b/spec/rmagick/image/distort_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Magick::Image, '#distort' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    @img = Magick::Image.new(200, 200)
+    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 35]) }.not_to raise_error
+    expect { @img.distort(Magick::AffineProjectionDistortion, [1, 0, 0, 1, 0, 0]) }.not_to raise_error
+    expect { @img.distort(Magick::BilinearDistortion, [7, 40, 4, 30, 4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+    expect { @img.distort(Magick::PerspectiveDistortion, [7, 40, 4, 30,   4, 124, 4, 123, 85, 122, 100, 123, 85, 2, 100, 30]) }.not_to raise_error
+    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60]) }.not_to raise_error
+    expect { @img.distort(Magick::ScaleRotateTranslateDistortion, [28, 24, 0.4, 0.8 - 110, 37.5, 60], true) }.not_to raise_error
+    expect { @img.distort }.to raise_error(ArgumentError)
+    expect { @img.distort(Magick::AffineDistortion) }.to raise_error(ArgumentError)
+    expect { @img.distort(1, [1]) }.to raise_error(TypeError)
+    expect { @img.distort(Magick::AffineDistortion, [2, 60, 2, 60, 32, 60, 32, 60, 2, 30, 17, 'x']) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/distortion_channel_spec.rb
+++ b/spec/rmagick/image/distortion_channel_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Magick::Image, '#distortion_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      metric = @img.distortion_channel(@img, Magick::MeanAbsoluteErrorMetric)
+      expect(metric).to be_instance_of(Float)
+      expect(metric).to eq(0.0)
+    end.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::PeakAbsoluteErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::PeakSignalToNoiseRatioErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::MeanSquaredErrorMetric, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::NormalizedCrossCorrelationErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, Magick::FuzzErrorMetric) }.not_to raise_error
+    expect { @img.distortion_channel(@img, 2) }.to raise_error(TypeError)
+    expect { @img.distortion_channel(@img, Magick::RootMeanSquaredErrorMetric, 2) }.to raise_error(TypeError)
+    expect { @img.distortion_channel }.to raise_error(ArgumentError)
+    expect { @img.distortion_channel(@img) }.to raise_error(ArgumentError)
+
+    img = Magick::Image.new(20, 20)
+    img.destroy!
+    expect { @img.distortion_channel(img, Magick::MeanSquaredErrorMetric) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/dup_spec.rb
+++ b/spec/rmagick/image/dup_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#dup' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      ditto = @img.dup
+      expect(ditto).to eq(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/each_profile_spec.rb
+++ b/spec/rmagick/image/each_profile_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#each_profile' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect(@img.each_profile {}).to be(nil)
+
+    @img.iptc_profile = 'test profile'
+    expect do
+      @img.each_profile do |name, value|
+        expect(name).to eq('iptc')
+        expect(value).to eq('test profile')
+      end
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/edge_spec.rb
+++ b/spec/rmagick/image/edge_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#edge' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.edge
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.edge(2.0) }.not_to raise_error
+    expect { @img.edge(2.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.edge('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/emboss_spec.rb
+++ b/spec/rmagick/image/emboss_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#emboss' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.emboss
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.emboss(1.0) }.not_to raise_error
+    expect { @img.emboss(1.0, 0.5) }.not_to raise_error
+    expect { @img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)
+    expect { @img.emboss(1.0, 'x') }.to raise_error(TypeError)
+    expect { @img.emboss('x', 1.0) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/enhance_spec.rb
+++ b/spec/rmagick/image/enhance_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#enhance' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.enhance
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/equalize_channel_spec.rb
+++ b/spec/rmagick/image/equalize_channel_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#equalize_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.equalize_channel
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.equalize_channel }.not_to raise_error
+    expect { @img.equalize_channel(Magick::RedChannel) }.not_to raise_error
+    expect { @img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.equalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/equalize_spec.rb
+++ b/spec/rmagick/image/equalize_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#equalize' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.equalize
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/erase_bang_spec.rb
+++ b/spec/rmagick/image/erase_bang_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#erase!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.erase!
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/excerpt_spec.rb
+++ b/spec/rmagick/image/excerpt_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#excerpt' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    res = nil
+    img = Magick::Image.new(200, 200)
+    expect { res = @img.excerpt(20, 20, 50, 100) }.not_to raise_error
+    expect(res).not_to be(img)
+    expect(res.columns).to eq(50)
+    expect(res.rows).to eq(100)
+
+    expect { img.excerpt!(20, 20, 50, 100) }.not_to raise_error
+    expect(img.columns).to eq(50)
+    expect(img.rows).to eq(100)
+  end
+end

--- a/spec/rmagick/image/export_pixels_spec.rb
+++ b/spec/rmagick/image/export_pixels_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Magick::Image, '#export_pixels' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.export_pixels
+      expect(res).to be_instance_of(Array)
+      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
+      res.each do |p|
+        expect(p).to be_kind_of(Integer)
+      end
+    end.not_to raise_error
+    expect { @img.export_pixels(0) }.not_to raise_error
+    expect { @img.export_pixels(0, 0) }.not_to raise_error
+    expect { @img.export_pixels(0, 0, 10) }.not_to raise_error
+    expect { @img.export_pixels(0, 0, 10, 10) }.not_to raise_error
+    expect do
+      res = @img.export_pixels(0, 0, 10, 10, 'RGBA')
+      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels(0, 0, 10, 10, 'I')
+      expect(res.length).to eq(10 * 10 * 'I'.length)
+    end.not_to raise_error
+
+    # too many arguments
+    expect { @img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/export_pixels_to_str_spec.rb
+++ b/spec/rmagick/image/export_pixels_to_str_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Magick::Image, '#export_pixels_to_str' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.export_pixels_to_str
+      expect(res).to be_instance_of(String)
+      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
+    end.not_to raise_error
+    expect { @img.export_pixels_to_str(0) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10) }.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10, 10) }.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
+      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I')
+      expect(res.length).to eq(10 * 10 * 'I'.length)
+    end.not_to raise_error
+
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
+      expect(res.length).to eq(10 * 10 * 1)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
+      expect(res.length).to eq(10 * 10 * 2)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
+      expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
+      expect(res.length).to eq(10 * 10 * 4)
+    end.not_to raise_error
+    expect do
+      res = @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
+      expect(res.length).to eq(10 * 10 * 8)
+    end.not_to raise_error
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }.not_to raise_error
+
+    # too many arguments
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel, 1) }.to raise_error(ArgumentError)
+    # last arg s/b StorageType
+    expect { @img.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/extent_spec.rb
+++ b/spec/rmagick/image/extent_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Magick::Image, '#extent' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.extent(40, 40) }.not_to raise_error
+    res = @img.extent(40, 40)
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+    expect(res.columns).to eq(40)
+    expect(res.rows).to eq(40)
+    expect { @img.extent(40, 40, 5) }.not_to raise_error
+    expect { @img.extent(40, 40, 5, 5) }.not_to raise_error
+    expect { @img.extent(-40) }.to raise_error(ArgumentError)
+    expect { @img.extent(-40, 40) }.to raise_error(ArgumentError)
+    expect { @img.extent(40, -40) }.to raise_error(ArgumentError)
+    expect { @img.extent(40, 40, 5, 5, 0) }.to raise_error(ArgumentError)
+    expect { @img.extent(0, 0, 5, 5) }.to raise_error(ArgumentError)
+    expect { @img.extent('x', 40) }.to raise_error(TypeError)
+    expect { @img.extent(40, 'x') }.to raise_error(TypeError)
+    expect { @img.extent(40, 40, 'x') }.to raise_error(TypeError)
+    expect { @img.extent(40, 40, 5, 'x') }.to raise_error(TypeError)
+  end
+end


### PR DESCRIPTION
This pulls the second batch of spec blocks from `image_2_spec.rb` into
files.

* `dissolve_spec.rb` already existed, so I left it as-is. It already
  looks decent.
* I'm leaving `image_2_spec.rb` unchanged for the moment to make it
  easier to manage parallel pull requests. I'll remove it at the end.