### PR TITLE
RSpec: convert "f*" through "i*" Image specs to files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -303,21 +303,7 @@ RSpec/HooksBeforeExamples:
 # Offense count: 2876
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/draw_2_spec.rb'
-    - 'spec/draw_spec.rb'
-    - 'spec/image_1_spec.rb'
-    - 'spec/image_2_spec.rb'
-    - 'spec/image_3_spec.rb'
-    - 'spec/image_attributes_spec.rb'
-    - 'spec/image_list_1_spec.rb'
-    - 'spec/image_list_2_spec.rb'
-    - 'spec/import_export_spec.rb'
-    - 'spec/info_spec.rb'
-    - 'spec/kernel_info_spec.rb'
-    - 'spec/pixel_spec.rb'
-    - 'spec/polaroid_options_spec.rb'
-    - 'spec/rmagick/image/read_spec.rb'
+  Enabled: false
 
 # Offense count: 1
 RSpec/IteratedExpectation:

--- a/spec/rmagick/image/find_similar_region_spec.rb
+++ b/spec/rmagick/image/find_similar_region_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Magick::Image, '#find_similar_region' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+    region = girl.crop(10, 10, 50, 50)
+    expect do
+      x, y = girl.find_similar_region(region)
+      expect(x).not_to be(nil)
+      expect(y).not_to be(nil)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
+    end.not_to raise_error
+    expect do
+      x, y = girl.find_similar_region(region, 0)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
+    end.not_to raise_error
+    expect do
+      x, y = girl.find_similar_region(region, 0, 0)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
+    end.not_to raise_error
+
+    list = Magick::ImageList.new
+    list << region
+    expect do
+      x, y = girl.find_similar_region(list, 0, 0)
+      expect(x).to eq(10)
+      expect(y).to eq(10)
+    end.not_to raise_error
+
+    x = girl.find_similar_region(@img)
+    expect(x).to be(nil)
+
+    expect { girl.find_similar_region(region, 10, 10, 10) }.to raise_error(ArgumentError)
+    expect { girl.find_similar_region(region, 10, 'x') }.to raise_error(TypeError)
+    expect { girl.find_similar_region(region, 'x') }.to raise_error(TypeError)
+
+    region.destroy!
+    expect { girl.find_similar_region(region) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/flip_bang_spec.rb
+++ b/spec/rmagick/image/flip_bang_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#flip!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.flip!
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/flip_spec.rb
+++ b/spec/rmagick/image/flip_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#flip' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.flip
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/flop_bang_spec.rb
+++ b/spec/rmagick/image/flop_bang_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#flop!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.flop!
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/flop_spec.rb
+++ b/spec/rmagick/image/flop_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#flop' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.flop
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/frame_spec.rb
+++ b/spec/rmagick/image/frame_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#frame' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.frame
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.frame(50) }.not_to raise_error
+    expect { @img.frame(50, 50) }.not_to raise_error
+    expect { @img.frame(50, 50, 25) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6, 6) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6, 6, 'red') }.not_to raise_error
+    red = Magick::Pixel.new(Magick::QuantumRange)
+    expect { @img.frame(50, 50, 25, 25, 6, 6, red) }.not_to raise_error
+    expect { @img.frame(50, 50, 25, 25, 6, 6, 2) }.to raise_error(TypeError)
+    expect { @img.frame(50, 50, 25, 25, 6, 6, red, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/function_channel_spec.rb
+++ b/spec/rmagick/image/function_channel_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Magick::Image, '#function_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img = Magick::Image.read('gradient:') { self.size = '20x600' }
+    img = img.first
+    img.rotate!(90)
+    expect { img.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, 4, -1.5 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, 4, -4, 1 }.not_to raise_error
+    expect { img.function_channel Magick::PolynomialFunction, -25, 53, -36, 8.3, 0.2 }.not_to raise_error
+
+    expect { img.function_channel Magick::SinusoidFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 1, 90 }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75 }.not_to raise_error
+
+    expect { img.function_channel Magick::ArcsinFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.5 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.4, 0.7 }.not_to raise_error
+    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5 }.not_to raise_error
+
+    expect { img.function_channel Magick::ArctanFunction, 1 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 10, 0.7 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 5, 0.7, 1.2 }.not_to raise_error
+    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75 }.not_to raise_error
+
+    # with channel args
+    expect { img.function_channel Magick::PolynomialFunction, 0.33, Magick::RedChannel }.not_to raise_error
+    expect { img.function_channel Magick::SinusoidFunction, 1, Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+
+    # invalid args
+    expect { img.function_channel }.to raise_error(ArgumentError)
+    expect { img.function_channel 1 }.to raise_error(TypeError)
+    expect { img.function_channel Magick::PolynomialFunction }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::PolynomialFunction, [] }.to raise_error(TypeError)
+    expect { img.function_channel Magick::SinusoidFunction, 5, 90, 0.25, 0.75, 0.1 }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::ArcsinFunction, 0.5, 0.5, 0.5, 0.5, 0.1 }.to raise_error(ArgumentError)
+    expect { img.function_channel Magick::ArctanFunction, 15, 0.7, 0.5, 0.75, 0.1 }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/fx_spec.rb
+++ b/spec/rmagick/image/fx_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#fx' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.fx('1/2') }.not_to raise_error
+    expect { @img.fx('1/2', Magick::BlueChannel) }.not_to raise_error
+    expect { @img.fx('1/2', Magick::BlueChannel, Magick::RedChannel) }.not_to raise_error
+    expect { @img.fx }.to raise_error(ArgumentError)
+    expect { @img.fx(Magick::BlueChannel) }.to raise_error(ArgumentError)
+    expect { @img.fx(1) }.to raise_error(TypeError)
+    expect { @img.fx('1/2', 1) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/gamma_channel_spec.rb
+++ b/spec/rmagick/image/gamma_channel_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#gamma_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.gamma_channel(0.8)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.gamma_channel }.to raise_error(ArgumentError)
+    expect { @img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
+    expect { @img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.gamma_channel(0.8, Magick::RedChannel, 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/gamma_correct_spec.rb
+++ b/spec/rmagick/image/gamma_correct_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Magick::Image, '#gamma_correct' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.gamma_correct }.to raise_error(ArgumentError)
+    expect do
+      res = @img.gamma_correct(0.8)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9) }.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
+    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1) }.not_to raise_error
+    # too many arguments
+    expect { @img.gamma_correct(0.8, 0.9, 1.0, 1.1, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/gaussian_blur_channel_spec.rb
+++ b/spec/rmagick/image/gaussian_blur_channel_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#gaussian_blur_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.gaussian_blur_channel
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/gaussian_blur_spec.rb
+++ b/spec/rmagick/image/gaussian_blur_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#gaussian_blur' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.gaussian_blur
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.gaussian_blur(0.0) }.not_to raise_error
+    expect { @img.gaussian_blur(0.0, 3.0) }.not_to raise_error
+    # sigma must be != 0.0
+    expect { @img.gaussian_blur(1.0, 0.0) }.to raise_error(ArgumentError)
+    expect { @img.gaussian_blur(1.0, 3.0, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/get_exif_by_entry_spec.rb
+++ b/spec/rmagick/image/get_exif_by_entry_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#get_exif_by_entry' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.get_exif_by_entry
+      expect(res).to be_instance_of(Array)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/get_exif_by_number_spec.rb
+++ b/spec/rmagick/image/get_exif_by_number_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#get_exif_by_number' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.get_exif_by_number
+      expect(res).to be_instance_of(Hash)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/get_pixels_spec.rb
+++ b/spec/rmagick/image/get_pixels_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#get_pixels' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      pixels = @img.get_pixels(0, 0, @img.columns, 1)
+      expect(pixels).to be_instance_of(Array)
+      expect(pixels.length).to eq(@img.columns)
+      expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
+    end.not_to raise_error
+    expect { @img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns, -1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns + 1, 1) }.to raise_error(RangeError)
+    expect { @img.get_pixels(0,  0, @img.columns, @img.rows + 1) }.to raise_error(RangeError)
+  end
+end

--- a/spec/rmagick/image/gray_predicate_spec.rb
+++ b/spec/rmagick/image/gray_predicate_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#gray?' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    gray = Magick::Image.new(20, 20) { self.background_color = 'gray50' }
+    expect(gray.gray?).to be(true)
+    red = Magick::Image.new(20, 20) { self.background_color = 'red' }
+    expect(red.gray?).to be(false)
+  end
+end

--- a/spec/rmagick/image/histogram_predicate_spec.rb
+++ b/spec/rmagick/image/histogram_predicate_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Magick::Image, '#histogram?' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.histogram? }.not_to raise_error
+    expect(@img.histogram?).to be(true)
+  end
+end

--- a/spec/rmagick/image/implode_spec.rb
+++ b/spec/rmagick/image/implode_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#implode' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.implode(0.5)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/import_pixels_spec.rb
+++ b/spec/rmagick/image/import_pixels_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Magick::Image, '#import_pixels' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    pixels = @img.export_pixels(0, 0, @img.columns, 1, 'RGB')
+    expect do
+      res = @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    expect { @img.import_pixels }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB') }.to raise_error(ArgumentError)
+    expect { @img.import_pixels('x', 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 'x', @img.columns, 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, 'x', 1, 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, @img.columns, 'x', 'RGB', pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(0, 0, @img.columns, 1, [2], pixels) }.to raise_error(TypeError)
+    expect { @img.import_pixels(-1, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, -1, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, -1, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+    expect { @img.import_pixels(0, 0, @img.columns, -1, 'RGB', pixels) }.to raise_error(ArgumentError)
+
+    # pixel array is too small
+    expect { @img.import_pixels(0, 0, @img.columns, 2, 'RGB', pixels) }.to raise_error(ArgumentError)
+    # pixel array doesn't contain a multiple of the map length
+    pixels.shift
+    expect { @img.import_pixels(0, 0, @img.columns, 1, 'RGB', pixels) }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
This pulls the third batch of spec blocks from `image_2_spec.rb` into
files.

* I'm leaving `image_2_spec.rb` unchanged for the moment to make it
  easier to manage parallel pull requests. I'll remove it at the end.