### PR TITLE
RSpec: convert "l*" and "m*" Image specs to files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -303,21 +303,7 @@ RSpec/HooksBeforeExamples:
 # Offense count: 2876
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/draw_2_spec.rb'
-    - 'spec/draw_spec.rb'
-    - 'spec/image_1_spec.rb'
-    - 'spec/image_2_spec.rb'
-    - 'spec/image_3_spec.rb'
-    - 'spec/image_attributes_spec.rb'
-    - 'spec/image_list_1_spec.rb'
-    - 'spec/image_list_2_spec.rb'
-    - 'spec/import_export_spec.rb'
-    - 'spec/info_spec.rb'
-    - 'spec/kernel_info_spec.rb'
-    - 'spec/pixel_spec.rb'
-    - 'spec/polaroid_options_spec.rb'
-    - 'spec/rmagick/image/read_spec.rb'
+  Enabled: false
 
 # Offense count: 1
 RSpec/IteratedExpectation:
@@ -336,9 +322,7 @@ RSpec/MultipleExpectations:
 
 # Offense count: 3
 RSpec/Pending:
-  Exclude:
-    - 'spec/rmagick/draw/marshal_dump_spec.rb'
-    - 'spec/rmagick/image/read_spec.rb'
+  Enabled: false
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -374,11 +358,7 @@ Rails/TimeZone:
 
 # Offense count: 4
 Security/MarshalLoad:
-  Exclude:
-    - 'lib/rmagick_internal.rb'
-    - 'spec/image_2_spec.rb'
-    - 'spec/image_list_2_spec.rb'
-    - 'spec/rmagick/draw/marshal_dump_spec.rb'
+  Enabled: false
 
 # Offense count: 2
 Style/AutoResourceCleanup:

--- a/spec/rmagick/image/level2_spec.rb
+++ b/spec/rmagick/image/level2_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#level2' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img1 = @img.level(10, 2, 200)
+    img2 = @img.level(10, 200, 2)
+    expect(img1).to eq(img2)
+
+    # Ensure that level2 uses new arg order
+    img1 = @img.level2(10, 200, 2)
+    expect(img1).to eq(img2)
+
+    expect { @img.level2 }.not_to raise_error
+    expect { @img.level2(10) }.not_to raise_error
+    expect { @img.level2(10, 10) }.not_to raise_error
+    expect { @img.level2(10, 10, 10) }.not_to raise_error
+    expect { @img.level2(10, 10, 10, 10) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/level_channel_spec.rb
+++ b/spec/rmagick/image/level_channel_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#level_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.level_channel }.to raise_error(ArgumentError)
+    expect do
+      res = @img.level_channel(Magick::RedChannel)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    expect { @img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0) }.not_to raise_error
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
+
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.level_channel(2) }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 'x') }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 'x') }.to raise_error(TypeError)
+    expect { @img.level_channel(Magick::RedChannel, 0.0, 1.0, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/level_colors_spec.rb
+++ b/spec/rmagick/image/level_colors_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#level_colors' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    res = nil
+    expect do
+      res = @img.level_colors
+    end.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+
+    expect { @img.level_colors('black') }.not_to raise_error
+    expect { @img.level_colors('black', Magick::Pixel.new(0, 0, 0)) }.not_to raise_error
+    expect { @img.level_colors(Magick::Pixel.new(0, 0, 0), Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange, Magick::QuantumRange)) }.not_to raise_error
+    expect { @img.level_colors('black', 'white') }.not_to raise_error
+    expect { @img.level_colors('black', 'white', false) }.not_to raise_error
+
+    expect { @img.level_colors('black', 'white', false, 1) }.to raise_error(TypeError)
+    expect { @img.level_colors([]) }.to raise_error(TypeError)
+    expect { @img.level_colors('xxx') }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/level_spec.rb
+++ b/spec/rmagick/image/level_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#level' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.level
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.level(0.0) }.not_to raise_error
+    expect { @img.level(0.0, 1.0) }.not_to raise_error
+    expect { @img.level(0.0, 1.0, Magick::QuantumRange) }.not_to raise_error
+    expect { @img.level(0.0, 1.0, Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.level('x') }.to raise_error(ArgumentError)
+    expect { @img.level(0.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.level(0.0, 1.0, 'x') }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/levelize_channel_spec.rb
+++ b/spec/rmagick/image/levelize_channel_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#levelize_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    res = nil
+    expect do
+      res = @img.levelize_channel(0, Magick::QuantumRange)
+    end.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+
+    expect { @img.levelize_channel(0) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel) }.not_to raise_error
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+
+    expect { @img.levelize_channel(0, Magick::QuantumRange, 0.5, 1, Magick::RedChannel) }.to raise_error(TypeError)
+    expect { @img.levelize_channel }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/liquid_rescale_spec.rb
+++ b/spec/rmagick/image/liquid_rescale_spec.rb
@@ -1,0 +1,27 @@
+describe Magick::Image, '#liquid_rescale' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    skip "delegate library support not built-in ''"
+    begin
+      @img.liquid_rescale(15, 15)
+    rescue NotImplementedError
+      puts 'liquid_rescale not implemented.'
+      return
+    end
+
+    res = nil
+    expect do
+      res = @img.liquid_rescale(15, 15)
+    end.not_to raise_error
+    expect(res.columns).to eq(15)
+    expect(res.rows).to eq(15)
+    expect { @img.liquid_rescale(15, 15, 0, 0) }.not_to raise_error
+    expect { @img.liquid_rescale(15) }.to raise_error(ArgumentError)
+    expect { @img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)
+    expect { @img.liquid_rescale([], 15) }.to raise_error(TypeError)
+    expect { @img.liquid_rescale(15, []) }.to raise_error(TypeError)
+    expect { @img.liquid_rescale(15, 15, []) }.to raise_error(TypeError)
+    expect { @img.liquid_rescale(15, 15, 0, []) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/magnify_spec.rb
+++ b/spec/rmagick/image/magnify_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#magnify' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.magnify
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    res = @img.magnify!
+    expect(res).to be(@img)
+  end
+end

--- a/spec/rmagick/image/marshal_spec.rb
+++ b/spec/rmagick/image/marshal_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#marshal' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    img = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+    d = nil
+    img2 = nil
+    expect { d = Marshal.dump(img) }.not_to raise_error
+    expect { img2 = Marshal.load(d) }.not_to raise_error
+    expect(img2).to eq(img)
+  end
+end

--- a/spec/rmagick/image/mask_spec.rb
+++ b/spec/rmagick/image/mask_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Magick::Image, '#mask' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    cimg = Magick::Image.new(10, 10)
+    expect { @img.mask(cimg) }.not_to raise_error
+    res = nil
+    expect { res = @img.mask }.not_to raise_error
+    expect(res).not_to be(nil)
+    expect(res).not_to be(cimg)
+    expect(res.columns).to eq(20)
+    expect(res.rows).to eq(20)
+
+    expect { @img.mask(cimg, 'x') }.to raise_error(ArgumentError)
+    # mask expects an Image and calls `cur_image'
+    expect { @img.mask = 2 }.to raise_error(NoMethodError)
+
+    img = @img.copy.freeze
+    expect { img.mask cimg }.to raise_error(FreezeError)
+
+    @img.destroy!
+    expect { @img.mask cimg }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/matte_fill_to_border_spec.rb
+++ b/spec/rmagick/image/matte_fill_to_border_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#matte_fill_to_border' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.matte_fill_to_border(@img.columns / 2, @img.rows / 2)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.matte_fill_to_border(@img.columns, @img.rows) }.not_to raise_error
+    expect { @img.matte_fill_to_border(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+    expect { @img.matte_fill_to_border(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/matte_floodfill_spec.rb
+++ b/spec/rmagick/image/matte_floodfill_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#matte_floodfill' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.matte_floodfill(@img.columns / 2, @img.rows / 2)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.matte_floodfill(@img.columns, @img.rows) }.not_to raise_error
+
+    Magick::PaintMethod.values do |method|
+      next if [Magick::FillToBorderMethod, Magick::FloodfillMethod].include?(method)
+
+      expect { @img.matte_flood_fill('blue', Magick::TransparentAlpha, @img.columns, @img.rows, method) }.to raise_error(ArgumentError)
+    end
+    expect { @img.matte_floodfill(@img.columns + 1, @img.rows) }.to raise_error(ArgumentError)
+    expect { @img.matte_floodfill(@img.columns, @img.rows + 1) }.to raise_error(ArgumentError)
+    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
+    expect { @img.matte_flood_fill('blue', @img.columns, @img.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/matte_replace_spec.rb
+++ b/spec/rmagick/image/matte_replace_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Magick::Image, '#matte_replace' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.matte_replace(@img.columns / 2, @img.rows / 2)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/matte_reset_bang_spec.rb
+++ b/spec/rmagick/image/matte_reset_bang_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Magick::Image, '#matte_reset!' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.matte_reset!
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/median_filter_spec.rb
+++ b/spec/rmagick/image/median_filter_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#median_filter' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.median_filter
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.median_filter(0.5) }.not_to raise_error
+    expect { @img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
+    expect { @img.median_filter('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/minify_spec.rb
+++ b/spec/rmagick/image/minify_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#minify' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.minify
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+
+    res = @img.minify!
+    expect(res).to be(@img)
+  end
+end

--- a/spec/rmagick/image/modulate_spec.rb
+++ b/spec/rmagick/image/modulate_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#modulate' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.modulate
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.modulate(0.5) }.not_to raise_error
+    expect { @img.modulate(0.5, 0.5) }.not_to raise_error
+    expect { @img.modulate(0.5, 0.5, 0.5) }.not_to raise_error
+    expect { @img.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
+    expect { @img.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
+    expect { @img.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
+    expect { @img.modulate(0.5, 'x', 0.5) }.to raise_error(TypeError)
+    expect { @img.modulate(0.5, 0.5, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/monochrome_predicate_spec.rb
+++ b/spec/rmagick/image/monochrome_predicate_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Magick::Image, '#monochrome?' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    #       expect(@img.monochrome?).to be(true)
+    @img.pixel_color(0, 0, 'red')
+    expect(@img.monochrome?).to be(false)
+  end
+end

--- a/spec/rmagick/image/morphology_channel_spec.rb
+++ b/spec/rmagick/image/morphology_channel_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#morphology_channel' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect { @img.morphology_channel }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2) }.to raise_error(ArgumentError)
+    expect { @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
+
+    kernel = Magick::KernelInfo.new('Octagon')
+    expect do
+      res = @img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/morphology_spec.rb
+++ b/spec/rmagick/image/morphology_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#morphology' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    kernel = Magick::KernelInfo.new('Octagon')
+    Magick::MorphologyMethod.values do |method|
+      expect do
+        res = @img.morphology(method, 2, kernel)
+        expect(res).to be_instance_of(Magick::Image)
+        expect(res).not_to be(@img)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/rmagick/image/motion_blur_spec.rb
+++ b/spec/rmagick/image/motion_blur_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#motion_blur' do
+  before { @img = Magick::Image.new(20, 20) }
+
+  it 'works' do
+    expect do
+      res = @img.motion_blur(1.0, 7.0, 180)
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res).not_to be(@img)
+    end.not_to raise_error
+    expect { @img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
+    expect { @img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
This pulls the fourth batch of spec blocks from `image_2_spec.rb` into
files.

* The original specs for `liquid_rescale` were commented out. I
  uncommented them, but they errored out with a complaint about a
  delegate library. I added a `skip` for now.
* I'm leaving `image_2_spec.rb` unchanged for the moment to make it
easier to manage parallel pull requests. I'll remove it at the end.