### PR TITLE
Eliminate compiler warnings with clang for ImageMagick 7

### DIFF
--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -973,20 +973,20 @@ Pixel_spaceship(VALUE self, VALUE other)
 
     if (this->red != that->red)
     {
-        return INT2NUM((this->red - that->red)/abs(this->red - that->red));
+        return INT2NUM((this->red - that->red)/abs((int)(this->red - that->red)));
     }
     else if(this->green != that->green)
     {
-        return INT2NUM((this->green - that->green)/abs(this->green - that->green));
+        return INT2NUM((this->green - that->green)/abs((int)(this->green - that->green)));
     }
     else if(this->blue != that->blue)
     {
-        return INT2NUM((this->blue - that->blue)/abs(this->blue - that->blue));
+        return INT2NUM((this->blue - that->blue)/abs((int)(this->blue - that->blue)));
     }
 #if defined(IMAGEMAGICK_7)
     else if(this->alpha != that->alpha)
     {
-        return INT2NUM((this->alpha - that->alpha)/abs(this->alpha - that->alpha));
+        return INT2NUM((this->alpha - that->alpha)/abs((int)(this->alpha - that->alpha)));
     }
 #else
     else if(this->opacity != that->opacity)


### PR DESCRIPTION
This patch will eliminate following compiler warnings.

```
$ clang -v
Apple clang version 11.0.0 (clang-1100.0.33.12)
Target: x86_64-apple-darwin19.2.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ ruby extconf.rb
checking for brew... yes
checking for clang... yes
checking for pkg-config... yes
checking for outdated ImageMagick version (<= 6.7.7)... no
Usage: file [bcCdEhikLlNnprsvzZ0] [-e test] [-f namefile] [-F separator] [-m magicfiles] [-M magicfiles] file...
       file -C -m magicfiles
Try `file --help' for more information.
checking for __GNUC__... yes
checking for Ruby version >= 2.3.0... yes
checking for MagickCore/MagickCore.h... yes
checking for GetImageChannelEntropy() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,MagickCore/MagickCore.h... no
checking for SetImageGray() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,MagickCore/MagickCore.h... yes
creating extconf.h
creating Makefile

======================================================================
Thu 19 Dec 19 21:20:39
This installation of RMagick 4.1.0.rc2 is configured for
Ruby 2.7.0 (x86_64-darwin19) and ImageMagick 7.0.9
======================================================================

Configured compile options: {:magick_version=>"7.0.9", :local_libs=>" -L/Users/watson/imagemagick7.0/lib -lMagickCore-7.Q16HDRI", :cflags=>" -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/Users/watson/imagemagick7.0/include/ImageMagick-7 -std=gnu99", :cppflags=>" -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/Users/watson/imagemagick7.0/include/ImageMagick-7", :ldflags=>" -L/Users/watson/imagemagick7.0/lib -lMagickCore-7.Q16HDRI", :defs=>[], :config_h=>"Makefile rmagick.h"}

$ make
compiling rmagick.c
compiling rmdraw.c
compiling rmenum.c
compiling rmfill.c
compiling rmilist.c
compiling rmimage.c
compiling rminfo.c
compiling rmkinfo.c
compiling rmmain.c
compiling rmmontage.c
compiling rmpixel.c
rmpixel.c:976:48: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        return INT2NUM((this->red - that->red)/abs(this->red - that->red));
                                               ^
rmpixel.c:976:48: note: use function 'fabsf' instead
        return INT2NUM((this->red - that->red)/abs(this->red - that->red));
                                               ^~~
                                               fabsf
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1609:31: note: expanded from macro 'INT2NUM'
#define INT2NUM(x) RB_INT2NUM(x)
                              ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1586:41: note: expanded from macro 'RB_INT2NUM'
# define RB_INT2NUM(v) RB_INT2FIX((int)(v))
                                        ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:262:33: note: expanded from macro 'RB_INT2FIX'
#define RB_INT2FIX(i) (((VALUE)(i))<<1 | RUBY_FIXNUM_FLAG)
                                ^
rmpixel.c:980:52: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        return INT2NUM((this->green - that->green)/abs(this->green - that->green));
                                                   ^
rmpixel.c:980:52: note: use function 'fabsf' instead
        return INT2NUM((this->green - that->green)/abs(this->green - that->green));
                                                   ^~~
                                                   fabsf
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1609:31: note: expanded from macro 'INT2NUM'
#define INT2NUM(x) RB_INT2NUM(x)
                              ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1586:41: note: expanded from macro 'RB_INT2NUM'
# define RB_INT2NUM(v) RB_INT2FIX((int)(v))
                                        ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:262:33: note: expanded from macro 'RB_INT2FIX'
#define RB_INT2FIX(i) (((VALUE)(i))<<1 | RUBY_FIXNUM_FLAG)
                                ^
rmpixel.c:984:50: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        return INT2NUM((this->blue - that->blue)/abs(this->blue - that->blue));
                                                 ^
rmpixel.c:984:50: note: use function 'fabsf' instead
        return INT2NUM((this->blue - that->blue)/abs(this->blue - that->blue));
                                                 ^~~
                                                 fabsf
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1609:31: note: expanded from macro 'INT2NUM'
#define INT2NUM(x) RB_INT2NUM(x)
                              ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1586:41: note: expanded from macro 'RB_INT2NUM'
# define RB_INT2NUM(v) RB_INT2FIX((int)(v))
                                        ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:262:33: note: expanded from macro 'RB_INT2FIX'
#define RB_INT2FIX(i) (((VALUE)(i))<<1 | RUBY_FIXNUM_FLAG)
                                ^
rmpixel.c:989:52: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        return INT2NUM((this->alpha - that->alpha)/abs(this->alpha - that->alpha));
                                                   ^
rmpixel.c:989:52: note: use function 'fabsf' instead
        return INT2NUM((this->alpha - that->alpha)/abs(this->alpha - that->alpha));
                                                   ^~~
                                                   fabsf
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1609:31: note: expanded from macro 'INT2NUM'
#define INT2NUM(x) RB_INT2NUM(x)
                              ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:1586:41: note: expanded from macro 'RB_INT2NUM'
# define RB_INT2NUM(v) RB_INT2FIX((int)(v))
                                        ^
/Users/watson/.rbenv/versions/2.7.0-rc1/include/ruby-2.7.0/ruby/ruby.h:262:33: note: expanded from macro 'RB_INT2FIX'
#define RB_INT2FIX(i) (((VALUE)(i))<<1 | RUBY_FIXNUM_FLAG)
                                ^
4 warnings generated.
compiling rmstruct.c
compiling rmutil.c
linking shared-object RMagick2.bundle
```