### PR TITLE
Relax expected value in spec of Magick.limit_resource for macOS

### DIFF
--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Magick do
 
       expect { cur = Magick.limit_resource(:file, 500) }.not_to raise_error
       expect(cur).to be_kind_of(Integer)
-      expect(cur > 512).to be(true)
+      expect(cur > 100).to be(true)
       expect { new = Magick.limit_resource('file') }.not_to raise_error
       expect(new).to eq(500)
       Magick.limit_resource(:file, cur)


### PR DESCRIPTION
macOS assigns `256` as maximum number of open files per process.

```c
#include <stdio.h>
#include <unistd.h>

int main()
{
    printf("files = %ld\n", sysconf(_SC_OPEN_MAX));
    return 0;
}
```

```
$ /usr/bin/sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.2
BuildVersion:	19C57
$ ./a.out
files = 256
```

ImageMagick calculates and assigns the limit from the upper limit specified by OS platform with following codes.

```c
  (void) SetMagickResourceLimit(FileResource,MagickMax((size_t)
    (3*files/4),64));
```
https://github.com/ImageMagick/ImageMagick6/blob/8b3bf460054d8769104139b28d863202e70eb26c/magick/resource.c#L1426-L1427

So, in macOS platform, `192` will be assinged as default limit value for `file` resource.

This patch relaxes expected value to fix following failure on macOS.

```
Failures:

  1) Magick#limit_resources works
     Failure/Error: expect(cur > 512).to be(true)

       expected true
            got false
     # ./spec/magick_spec.rb:302:in `block (3 levels) in <top (required)>'

Finished in 43.44 seconds (files took 0.37919 seconds to load)
639 examples, 1 failure, 3 pending
```