### PR TITLE
CI: Use pre-installed Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ install: bundle install --path=vendor/bundle --verbose
 
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
   - 2.7.0-preview3
 
 matrix:


### PR DESCRIPTION
Travis CI has following pre-installed Ruby on bionic platform.

```
Pre-installed Ruby versions
ruby-2.4.9
ruby-2.5.3
ruby-2.5.7
ruby-2.6.5
```

https://travis-ci.org/rmagick/rmagick/jobs/627579147#L160

If we can them, it will reduce setup time.