### PR TITLE
CI: Fix certificate error

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -50,7 +50,7 @@ build_imagemagick() {
     rm ${IMAGEMAGICK_VERSION}.tar.gz
     mv ImageMagick6-${IMAGEMAGICK_VERSION} $build_dir
   else
-    wget https://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+    wget https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
     tar -xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
     rm ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
     mv ImageMagick-${IMAGEMAGICK_VERSION} $build_dir


### PR DESCRIPTION
This patch fix following error.

```
wget https://www.imagemagick.org/download/releases/ImageMagick-6.7.7-10.tar.xz
--2019-12-21 08:10:09--  https://www.imagemagick.org/download/releases/ImageMagick-6.7.7-10.tar.xz
Resolving www.imagemagick.org (www.imagemagick.org)... 198.72.81.86
Connecting to www.imagemagick.org (www.imagemagick.org)|198.72.81.86|:443... connected.
ERROR: no certificate subject alternative name matches
	requested host name ‘www.imagemagick.org’.
To connect to www.imagemagick.org insecurely, use `--no-check-certificate'.
The command "/bin/bash before_install_$TRAVIS_OS_NAME.sh" failed and exited with 5 during .
```