### PR TITLE
RSpec: convert "p*" through "r*" Image specs to files

### DIFF
--- a/spec/rmagick/image/profile_bang_spec.rb
+++ b/spec/rmagick/image/profile_bang_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Magick::Image, '#profile!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.profile!('*', nil)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    expect { @img.profile!('icc', @p) }.not_to raise_error
+    expect { @img.profile!('iptc', 'xxx') }.not_to raise_error
+    expect { @img.profile!('icc', nil) }.not_to raise_error
+    expect { @img.profile!('iptc', nil) }.not_to raise_error
+
+    expect { @img.profile!('test', 'foobarbaz') }.to raise_error(ArgumentError)
+
+    @img.freeze
+    expect { @img.profile!('icc', 'xxx') }.to raise_error(FreezeError)
+    expect { @img.profile!('*', nil) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/quantize_spec.rb
+++ b/spec/rmagick/image/quantize_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Magick::Image, '#quantize' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.quantize
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+
+    Magick::ColorspaceType.values do |cs|
+      expect { @img.quantize(256, cs) }.not_to raise_error
+    end
+    expect { @img.quantize(256, Magick::RGBColorspace, false) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2) }.not_to raise_error
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true) }.not_to raise_error
+    expect { @img.quantize('x') }.to raise_error(TypeError)
+    expect { @img.quantize(16, 2) }.to raise_error(TypeError)
+    expect { @img.quantize(16, Magick::RGBColorspace, false, 'x') }.to raise_error(TypeError)
+    expect { @img.quantize(256, Magick::RGBColorspace, true, 2, true, true) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/quantum_operator_spec.rb
+++ b/spec/rmagick/image/quantum_operator_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#quantum_operator' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.quantum_operator(Magick::AddQuantumOperator, 2)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    Magick::QuantumExpressionOperator.values do |op|
+      expect { @img.quantum_operator(op, 2) }.not_to raise_error
+    end
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel) }.not_to raise_error
+    expect { @img.quantum_operator(2, 2) }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 'x') }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, 2) }.to raise_error(TypeError)
+    expect { @img.quantum_operator(Magick::AddQuantumOperator, 2, Magick::RedChannel, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/radial_blur_channel_spec.rb
+++ b/spec/rmagick/image/radial_blur_channel_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#radial_blur_channel' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    res = nil
+    expect { res = @img.radial_blur_channel(30) }.not_to raise_error
+    expect(res).not_to be(nil)
+    expect(res).to be_instance_of(Magick::Image)
+    expect { res = @img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
+    expect { res = @img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+
+    expect { @img.radial_blur_channel }.to raise_error(ArgumentError)
+    expect { @img.radial_blur_channel(30, 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/radial_blur_spec.rb
+++ b/spec/rmagick/image/radial_blur_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#radial_blur' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.radial_blur(30)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/raise_spec.rb
+++ b/spec/rmagick/image/raise_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#raise' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.raise
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.raise(4) }.not_to raise_error
+    expect { @img.raise(4, 4) }.not_to raise_error
+    expect { @img.raise(4, 4, false) }.not_to raise_error
+    expect { @img.raise('x') }.to raise_error(TypeError)
+    expect { @img.raise(2, 'x') }.to raise_error(TypeError)
+    expect { @img.raise(4, 4, false, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/random_threshold_channel_spec.rb
+++ b/spec/rmagick/image/random_threshold_channel_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#random_threshold_channel' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.random_threshold_channel('20%')
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    threshold = Magick::Geometry.new(20)
+    expect { @img.random_threshold_channel(threshold) }.not_to raise_error
+    expect { @img.random_threshold_channel(threshold, Magick::RedChannel) }.not_to raise_error
+    expect { @img.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.random_threshold_channel }.to raise_error(ArgumentError)
+    expect { @img.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/recolor_spec.rb
+++ b/spec/rmagick/image/recolor_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#recolor' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect { @img.recolor([1, 1, 2, 1]) }.not_to raise_error
+    expect { @img.recolor('x') }.to raise_error(TypeError)
+    expect { @img.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/reduce_noise_spec.rb
+++ b/spec/rmagick/image/reduce_noise_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Magick::Image, '#reduce_noise' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.reduce_noise(0)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.reduce_noise(4) }.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/remap_spec.rb
+++ b/spec/rmagick/image/remap_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#remap' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
+    expect { @img.remap(remap_image) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error
+    expect { @img.remap(remap_image, Magick::FloydSteinbergDitherMethod) }.not_to raise_error
+
+    expect { @img.remap }.to raise_error(ArgumentError)
+    expect { @img.remap(remap_image, Magick::NoDitherMethod, 1) }.to raise_error(ArgumentError)
+    expect { @img.remap(remap_image, 1) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/resample_bang_spec.rb
+++ b/spec/rmagick/image/resample_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#resample!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.resample!(50)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.resample!(50) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/resample_spec.rb
+++ b/spec/rmagick/image/resample_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Magick::Image, '#resample' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    @img.x_resolution = 72
+    @img.y_resolution = 72
+    expect { @img.resample }.not_to raise_error
+    expect { @img.resample(100) }.not_to raise_error
+    expect { @img.resample(100, 100) }.not_to raise_error
+
+    @img.x_resolution = 0
+    @img.y_resolution = 0
+    expect { @img.resample }.not_to raise_error
+    expect { @img.resample(100) }.not_to raise_error
+    expect { @img.resample(100, 100) }.not_to raise_error
+
+    girl = Magick::Image.read(IMAGES_DIR + '/Flower_Hat.jpg').first
+    expect(girl.x_resolution).to eq(240.0)
+    expect(girl.y_resolution).to eq(240.0)
+    res = girl.resample(120, 120)
+    expect(res.columns).to eq(100)
+    expect(res.rows).to eq(125)
+    expect(res.x_resolution).to eq(120.0)
+    expect(res.y_resolution).to eq(120.0)
+    expect(girl.columns).to eq(200)
+    expect(girl.rows).to eq(250)
+    expect(girl.x_resolution).to eq(240.0)
+    expect(girl.y_resolution).to eq(240.0)
+
+    Magick::FilterType.values do |filter|
+      expect { @img.resample(50, 50, filter) }.not_to raise_error
+    end
+    expect { @img.resample(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
+
+    expect { @img.resample('x') }.to raise_error(TypeError)
+    expect { @img.resample(100, 'x') }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, 2) }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+    expect { @img.resample(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.resample(-100) }.to raise_error(ArgumentError)
+    expect { @img.resample(100, -100) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/resize_bang_spec.rb
+++ b/spec/rmagick/image/resize_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#resize!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.resize!(2)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.resize!(0.50) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/resize_spec.rb
+++ b/spec/rmagick/image/resize_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Magick::Image, '#resize' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.resize(2)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.resize(50, 50) }.not_to raise_error
+
+    Magick::FilterType.values do |filter|
+      expect { @img.resize(50, 50, filter) }.not_to raise_error
+    end
+    expect { @img.resize(50, 50, Magick::PointFilter, 2.0) }.not_to raise_error
+    expect { @img.resize('x') }.to raise_error(TypeError)
+    expect { @img.resize(50, 'x') }.to raise_error(TypeError)
+    expect { @img.resize(50, 50, 2) }.to raise_error(TypeError)
+    expect { @img.resize(50, 50, Magick::CubicFilter, 'x') }.to raise_error(TypeError)
+    expect { @img.resize(-1.0) }.to raise_error(ArgumentError)
+    expect { @img.resize(0, 50) }.to raise_error(ArgumentError)
+    expect { @img.resize(50, 0) }.to raise_error(ArgumentError)
+    expect { @img.resize(50, 50, Magick::SincFilter, 2.0, 'x') }.to raise_error(ArgumentError)
+    expect { @img.resize }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/resize_to_fill_spec.rb
+++ b/spec/rmagick/image/resize_to_fill_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Magick::Image, '#resize_to_fill' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'does not change image when using the same dimensions' do
+    changed = @img.resize_to_fill(@img.columns, @img.rows)
+    expect(changed.columns).to eq(@img.columns)
+    expect(changed.rows).to eq(@img.rows)
+    expect(@img).not_to be(changed)
+  end
+
+  it 'resizes to the given dimensions' do
+    @img = Magick::Image.new(200, 250)
+    @img.resize_to_fill!(100, 100)
+    expect(@img.columns).to eq(100)
+    expect(@img.rows).to eq(100)
+
+    @img = Magick::Image.new(200, 250)
+    changed = @img.resize_to_fill(300, 100)
+    expect(changed.columns).to eq(300)
+    expect(changed.rows).to eq(100)
+
+    @img = Magick::Image.new(200, 250)
+    changed = @img.resize_to_fill(100, 300)
+    expect(changed.columns).to eq(100)
+    expect(changed.rows).to eq(300)
+
+    @img = Magick::Image.new(200, 250)
+    changed = @img.resize_to_fill(300, 350)
+    expect(changed.columns).to eq(300)
+    expect(changed.rows).to eq(350)
+
+    @img = Magick::Image.new(200, 250)
+    changed = @img.resize_to_fill(20, 400)
+    expect(changed.columns).to eq(20)
+    expect(changed.rows).to eq(400)
+
+    @img = Magick::Image.new(200, 250)
+    changed = @img.resize_to_fill(3000, 400)
+    expect(changed.columns).to eq(3000)
+    expect(changed.rows).to eq(400)
+  end
+
+  it 'squares the image when given only one argument' do
+    changed = @img.resize_to_fill(100)
+    expect(changed.columns).to eq(100)
+    expect(changed.rows).to eq(100)
+  end
+end

--- a/spec/rmagick/image/resize_to_fit_bang_spec.rb
+++ b/spec/rmagick/image/resize_to_fit_bang_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Magick::Image, '#resize_to_fit!' do
+  it 'works' do
+    img = Magick::Image.new(200, 300)
+    img.resize_to_fit!(100)
+    expect(img).to be_instance_of(Magick::Image)
+    expect(img.columns).to eq(67)
+    expect(img.rows).to eq(100)
+  end
+end

--- a/spec/rmagick/image/resize_to_fit_spec.rb
+++ b/spec/rmagick/image/resize_to_fit_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#resize_to_fit' do
+  it 'works with two arguments' do
+    img = Magick::Image.new(200, 250)
+    res = nil
+    expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
+    expect(res).not_to be(nil)
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(img)
+    expect(res.columns).to eq(40)
+    expect(res.rows).to eq(50)
+  end
+
+  it 'works with one argument' do
+    img = Magick::Image.new(200, 300)
+    changed = img.resize_to_fit(100)
+    expect(changed).to be_instance_of(Magick::Image)
+    expect(changed).not_to be(img)
+    expect(changed.columns).to eq(67)
+    expect(changed.rows).to eq(100)
+  end
+end

--- a/spec/rmagick/image/roll_spec.rb
+++ b/spec/rmagick/image/roll_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#roll' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.roll(5, 5)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/rotate_bang_spec.rb
+++ b/spec/rmagick/image/rotate_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#rotate!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.rotate!(45)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.rotate!(45) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/rotate_spec.rb
+++ b/spec/rmagick/image/rotate_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Magick::Image, '#rotate' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.rotate(45)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.rotate(-45) }.not_to raise_error
+
+    img = Magick::Image.new(100, 50)
+    expect do
+      res = img.rotate(90, '>')
+      expect(res).to be_instance_of(Magick::Image)
+      expect(res.columns).to eq(50)
+      expect(res.rows).to eq(100)
+    end.not_to raise_error
+    expect do
+      res = img.rotate(90, '<')
+      expect(res).to be(nil)
+    end.not_to raise_error
+    expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
+    expect { img.rotate(90, []) }.to raise_error(TypeError)
+  end
+end


### PR DESCRIPTION
This pulls spec blocks for methods starting with p-r from
`image_3_spec.rb` into files.