### PR TITLE
RSpec: convert "s*" Image specs to files

### DIFF
--- a/spec/rmagick/image/sample_bang_spec.rb
+++ b/spec/rmagick/image/sample_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#sample!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sample!(2)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.sample!(0.50) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/sample_spec.rb
+++ b/spec/rmagick/image/sample_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#sample' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sample(10, 10)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.sample(2) }.not_to raise_error
+    expect { @img.sample }.to raise_error(ArgumentError)
+    expect { @img.sample(0) }.to raise_error(ArgumentError)
+    expect { @img.sample(0, 25) }.to raise_error(ArgumentError)
+    expect { @img.sample(25, 0) }.to raise_error(ArgumentError)
+    expect { @img.sample(25, 25, 25) }.to raise_error(ArgumentError)
+    expect { @img.sample('x') }.to raise_error(TypeError)
+    expect { @img.sample(10, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/scale_bang_spec.rb
+++ b/spec/rmagick/image/scale_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#scale!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.scale!(2)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.scale!(0.50) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/scale_spec.rb
+++ b/spec/rmagick/image/scale_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#scale' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.scale(10, 10)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.scale(2) }.not_to raise_error
+    expect { @img.scale }.to raise_error(ArgumentError)
+    expect { @img.scale(25, 25, 25) }.to raise_error(ArgumentError)
+    expect { @img.scale('x') }.to raise_error(TypeError)
+    expect { @img.scale(10, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/segment_spec.rb
+++ b/spec/rmagick/image/segment_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Magick::Image, '#segment' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.segment
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+
+    # Don't test colorspaces that require PsuedoColor images
+    (Magick::ColorspaceType.values - [
+      Magick::OHTAColorspace,
+      Magick::LabColorspace,
+      Magick::XYZColorspace,
+      Magick::YCbCrColorspace,
+      Magick::YCCColorspace,
+      Magick::YIQColorspace,
+      Magick::YPbPrColorspace,
+      Magick::YUVColorspace,
+      Magick::Rec601YCbCrColorspace,
+      Magick::Rec709YCbCrColorspace,
+      Magick::LogColorspace
+    ]).each do |cs|
+      expect { @img.segment(cs) }.not_to raise_error
+    end
+
+    expect { @img.segment(Magick::RGBColorspace, 2.0) }.not_to raise_error
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0) }.not_to raise_error
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false) }.not_to raise_error
+
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 2.0, false, 2) }.to raise_error(ArgumentError)
+    expect { @img.segment(2) }.to raise_error(TypeError)
+    expect { @img.segment(Magick::RGBColorspace, 'x') }.to raise_error(TypeError)
+    expect { @img.segment(Magick::RGBColorspace, 2.0, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/selective_blur_channel_spec.rb
+++ b/spec/rmagick/image/selective_blur_channel_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#selective_blur_channel' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    res = nil
+    expect { res = @img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
+    expect(res).to be_instance_of(Magick::Image)
+    expect(res).not_to be(@img)
+    expect([res.columns, res.rows]).to eq([@img.columns, @img.rows])
+
+    expect { @img.selective_blur_channel(0, 1, 0.1) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.selective_blur_channel(0, 1, '10%', Magick::RedChannel, Magick::BlueChannel, Magick::GreenChannel) }.not_to raise_error
+
+    expect { @img.selective_blur_channel(0, 1) }.to raise_error(ArgumentError)
+    expect { @img.selective_blur_channel(0, 1, 0.1, '10%') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/separate_spec.rb
+++ b/spec/rmagick/image/separate_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#separate' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect(@img.separate).to be_instance_of(Magick::ImageList)
+    expect(@img.separate(Magick::BlueChannel)).to be_instance_of(Magick::ImageList)
+    expect { @img.separate('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/sepiatone_spec.rb
+++ b/spec/rmagick/image/sepiatone_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#sepiatone' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sepiatone
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
+    expect { @img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
+    expect { @img.sepiatone('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/set_channel_depth_spec.rb
+++ b/spec/rmagick/image/set_channel_depth_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Magick::Image, '#set_channel_depth' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    Magick::ChannelType.values do |ch|
+      expect { @img.set_channel_depth(ch, 8) }.not_to raise_error
+    end
+  end
+end

--- a/spec/rmagick/image/shade_spec.rb
+++ b/spec/rmagick/image/shade_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Magick::Image, '#shade' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.shade
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.shade(true) }.not_to raise_error
+    expect { @img.shade(true, 30) }.not_to raise_error
+    expect { @img.shade(true, 30, 30) }.not_to raise_error
+    expect { @img.shade(true, 30, 30, 2) }.to raise_error(ArgumentError)
+    expect { @img.shade(true, 'x') }.to raise_error(TypeError)
+    expect { @img.shade(true, 30, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/shadow_spec.rb
+++ b/spec/rmagick/image/shadow_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Magick::Image, '#shadow' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.shadow
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.shadow(5) }.not_to raise_error
+    expect { @img.shadow(5, 5) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0, 0.50) }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0, '50%') }.not_to raise_error
+    expect { @img.shadow(5, 5, 3.0, 0.50, 2) }.to raise_error(ArgumentError)
+    expect { @img.shadow('x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 'x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 5, 'x') }.to raise_error(TypeError)
+    expect { @img.shadow(5, 5, 3.0, 'x') }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/rmagick/image/sharpen_channel_spec.rb
+++ b/spec/rmagick/image/sharpen_channel_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Magick::Image, '#sharpen_channel' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sharpen_channel
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.sharpen_channel(2.0) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.sharpen_channel(2.0, 1.0, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { @img.sharpen_channel('x') }.to raise_error(TypeError)
+    expect { @img.sharpen_channel(2.0, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/sharpen_spec.rb
+++ b/spec/rmagick/image/sharpen_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#sharpen' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sharpen
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.sharpen(2.0) }.not_to raise_error
+    expect { @img.sharpen(2.0, 1.0) }.not_to raise_error
+    expect { @img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.sharpen('x') }.to raise_error(TypeError)
+    expect { @img.sharpen(2.0, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/shave_bang_spec.rb
+++ b/spec/rmagick/image/shave_bang_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Magick::Image, '#shave' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.shave!(5, 5)
+      expect(res).to be(@img)
+    end.not_to raise_error
+    @img.freeze
+    expect { @img.shave!(2, 2) }.to raise_error(FreezeError)
+  end
+end

--- a/spec/rmagick/image/shave_spec.rb
+++ b/spec/rmagick/image/shave_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#shave' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.shave(5, 5)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/shear_spec.rb
+++ b/spec/rmagick/image/shear_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#shear' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.shear(30, 30)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/sigmoidal_contrast_channel_spec.rb
+++ b/spec/rmagick/image/sigmoidal_contrast_channel_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Magick::Image, '#sigmoidal_contrast_channel' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.sigmoidal_contrast_channel
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+    expect { @img.sigmoidal_contrast_channel(3.0, 50.0, true, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { @img.sigmoidal_contrast_channel('x') }.to raise_error(TypeError)
+    expect { @img.sigmoidal_contrast_channel(3.0, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/signature_spec.rb
+++ b/spec/rmagick/image/signature_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#signature' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.signature
+      expect(res).to be_instance_of(String)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/sketch_spec.rb
+++ b/spec/rmagick/image/sketch_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Magick::Image, '#sketch' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect { @img.sketch }.not_to raise_error
+    expect { @img.sketch(0) }.not_to raise_error
+    expect { @img.sketch(0, 1) }.not_to raise_error
+    expect { @img.sketch(0, 1, 0) }.not_to raise_error
+    expect { @img.sketch(0, 1, 0, 1) }.to raise_error(ArgumentError)
+    expect { @img.sketch('x') }.to raise_error(TypeError)
+    expect { @img.sketch(0, 'x') }.to raise_error(TypeError)
+    expect { @img.sketch(0, 1, 'x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/solarize_spec.rb
+++ b/spec/rmagick/image/solarize_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#solarize' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.solarize
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.solarize(100) }.not_to raise_error
+    expect { @img.solarize(-100) }.to raise_error(ArgumentError)
+    expect { @img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)
+    expect { @img.solarize(100, 2) }.to raise_error(ArgumentError)
+    expect { @img.solarize('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/sparse_color_spec.rb
+++ b/spec/rmagick/image/sparse_color_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Magick::Image, '#sparse_color' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    img = Magick::Image.new(100, 100)
+    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
+    # ensure good calls work
+    Magick::SparseColorMethod.values do |v|
+      next if v == Magick::UndefinedColorInterpolate
+
+      expect { img.sparse_color(v, *args) }.not_to raise_error
+    end
+    args << Magick::RedChannel
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+    args << Magick::GreenChannel
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+    args << Magick::BlueChannel
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.not_to raise_error
+
+    # bad calls
+    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, 20, 'yellow']
+    # invalid method
+    expect { img.sparse_color(1, *args) }.to raise_error(TypeError)
+    # missing arguments
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate) }.to raise_error(ArgumentError)
+    args << 10 # too many arguments
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
+    args.shift
+    args.shift # too few
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(ArgumentError)
+
+    args = [30, 10, 'red', 10, 80, 'blue', 70, 60, 'lime', 80, '20', 'yellow']
+    expect { img.sparse_color(Magick::VoronoiColorInterpolate, *args) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/splice_spec.rb
+++ b/spec/rmagick/image/splice_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#splice' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.splice(0, 0, 2, 2)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
+    red = Magick::Pixel.new(Magick::QuantumRange)
+    expect { @img.splice(0, 0, 2, 2, red) }.not_to raise_error
+    expect { @img.splice(0, 0, 2, 2, red, 'x') }.to raise_error(ArgumentError)
+    expect { @img.splice([], 0, 2, 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 'x', 2, 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 'x', 2, red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 2, [], red) }.to raise_error(TypeError)
+    expect { @img.splice(0, 0, 2, 2, /m/) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/spread_spec.rb
+++ b/spec/rmagick/image/spread_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Magick::Image, '#spread' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.spread
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+    expect { @img.spread(3.0) }.not_to raise_error
+    expect { @img.spread(3.0, 2) }.to raise_error(ArgumentError)
+    expect { @img.spread('x') }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/stegano_spec.rb
+++ b/spec/rmagick/image/stegano_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Magick::Image, '#stegano' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    @img = Magick::Image.new(100, 100) { self.background_color = 'black' }
+    watermark = Magick::Image.new(10, 10) { self.background_color = 'white' }
+    expect do
+      res = @img.stegano(watermark, 0)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+
+    watermark.destroy!
+    expect { @img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/stereo_spec.rb
+++ b/spec/rmagick/image/stereo_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Magick::Image, '#stereo' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.stereo(@img)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+
+    img = Magick::Image.new(20, 20)
+    img.destroy!
+    expect { @img.stereo(img) }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/store_pixels_spec.rb
+++ b/spec/rmagick/image/store_pixels_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Magick::Image, '#store_pixels' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    pixels = @img.get_pixels(0, 0, @img.columns, 1)
+    expect do
+      res = @img.store_pixels(0, 0, @img.columns, 1, pixels)
+      expect(res).to be(@img)
+    end.not_to raise_error
+
+    pixels[0] = 'x'
+    expect { @img.store_pixels(0, 0, @img.columns, 1, pixels) }.to raise_error(TypeError)
+    expect { @img.store_pixels(-1, 0, @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, -1, @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, 0, 1 + @img.columns, 1, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(-1, 0, 1, 1 + @img.rows, pixels) }.to raise_error(RangeError)
+    expect { @img.store_pixels(0, 0, @img.columns, 1, ['x']) }.to raise_error(IndexError)
+  end
+end

--- a/spec/rmagick/image/strip_bang_spec.rb
+++ b/spec/rmagick/image/strip_bang_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#strip!' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.strip!
+      expect(res).to be(@img)
+    end.not_to raise_error
+  end
+end

--- a/spec/rmagick/image/swirl_spec.rb
+++ b/spec/rmagick/image/swirl_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Magick::Image, '#swirl' do
+  before do
+    @img = Magick::Image.new(20, 20)
+    @p = Magick::Image.read(IMAGE_WITH_PROFILE).first.color_profile
+  end
+
+  it 'works' do
+    expect do
+      res = @img.swirl(30)
+      expect(res).to be_instance_of(Magick::Image)
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
This pulls spec blocks for methods starting with s from
`image_3_spec.rb` into files.