### PR TITLE
Retrieve opacity value properly in Image#get_pixels

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -7761,6 +7761,7 @@ Image_get_pixels(VALUE self, VALUE x_arg, VALUE y_arg, VALUE cols_arg, VALUE row
         mpp.red = GetPixelRed(pixels);
         mpp.green = GetPixelGreen(pixels);
         mpp.blue = GetPixelBlue(pixels);
+        mpp.opacity = GetPixelOpacity(pixels);
         if (indexes)
         {
             mpp.index = GetPixelIndex(indexes + n);


### PR DESCRIPTION
Forgot to handle opacity value in https://github.com/rmagick/rmagick/pull/871