### PR TITLE
Eliminate compiler warnings with clang for ImageMagick 6

### DIFF
--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -988,7 +988,7 @@ Pixel_spaceship(VALUE self, VALUE other)
 #else
     else if(this->opacity != that->opacity)
     {
-        return INT2NUM(((QuantumRange - this->opacity) - (QuantumRange - that->opacity))/abs((QuantumRange - this->opacity) - (QuantumRange - that->opacity)));
+        return INT2NUM(((QuantumRange - this->opacity) - (QuantumRange - that->opacity))/abs((int)((QuantumRange - this->opacity) - (QuantumRange - that->opacity))));
     }
 #endif
 


### PR DESCRIPTION
This patch will eliminate compiler warnings on ImageMagick 6 which is same with #864