### PR TITLE
Remove unused function

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -16,7 +16,6 @@ static Image *clone_imagelist(Image *);
 static Image *images_from_imagelist(VALUE);
 static long imagelist_length(VALUE);
 static long check_imagelist_length(VALUE);
-static VALUE imagelist_scene_eq(VALUE, VALUE);
 static void imagelist_push(VALUE, VALUE);
 static VALUE ImageList_new(void);
 
@@ -811,24 +810,6 @@ images_from_imagelist(VALUE imagelist)
     RB_GC_GUARD(t);
 
     return head;
-}
-
-
-/**
- * \@scene attribute writer.
- *
- * No Ruby usage (internal function)
- *
- * @param imagelist the imagelist
- * @param scene the scene
- * @return the scene
- */
-static VALUE
-imagelist_scene_eq(VALUE imagelist, VALUE scene)
-{
-    rb_check_frozen(imagelist);
-    (void) rb_iv_set(imagelist, "@scene", scene);
-    return scene;
 }
 
 


### PR DESCRIPTION
This patch will eliminate compiler warnings for unused function.

```
$ CFLAGS='-Wall' ruby extconf.rb
$ make
compiling rmagick.c
compiling rmdraw.c
compiling rmenum.c
compiling rmfill.c
compiling rmilist.c
rmilist.c:827:1: warning: unused function 'imagelist_scene_eq' [-Wunused-function]
imagelist_scene_eq(VALUE imagelist, VALUE scene)
^
1 warning generated.
compiling rmimage.c
rmimage.c:16401:21: warning: enumeration value 'StaticGravity' not handled in switch [-Wswitch]
            switch (gravity)
                    ^
rmimage.c:16401:21: note: add missing switch cases
            switch (gravity)
                    ^
1 warning generated.
compiling rminfo.c
compiling rmkinfo.c
compiling rmmain.c
compiling rmmontage.c
compiling rmpixel.c
compiling rmstruct.c
compiling rmutil.c
linking shared-object RMagick2.bundle
```