### PR TITLE
Ensure starting simplecov before loading RMagick library in rspec

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -18,10 +18,3 @@ SimpleCov.profiles.define 'rmagick' do
   add_filter 'bundle'
   add_filter 'bin'
 end
-
-## RUN SIMPLECOV
-if ENV['COVERAGE'] =~ /\Atrue\z/i
-  SimpleCov.start 'rmagick'
-  puts '[COVERAGE] Running with SimpleCov HTML Formatter'
-  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
+if ENV['COVERAGE'] =~ /\Atrue\z/i
+  ## RUN SIMPLECOV
+  require 'simplecov'
+  SimpleCov.start 'rmagick'
+  puts '[COVERAGE] Running with SimpleCov HTML Formatter'
+  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
+end
+
 require 'pry'
 require 'rmagick'
 


### PR DESCRIPTION
Fix #889

Now, `simplecov` displays `888 / 1011 LOC (87.83%) covered.` as proper measured value.

### Result

```
$ COVERAGE=true rake
install -c tmp/x86_64-darwin19/RMagick2/2.6.5/RMagick2.bundle lib/RMagick2.bundle
cp tmp/x86_64-darwin19/RMagick2/2.6.5/RMagick2.bundle tmp/x86_64-darwin19/stage/lib/RMagick2.bundle
/Users/watson/.rbenv/versions/2.6.5/bin/ruby -I/Users/watson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.2/lib:/Users/watson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.1/lib /Users/watson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
[COVERAGE] Running with SimpleCov HTML Formatter

Randomized with seed 22005
..................................................................................................................................**..................................................................................................................................................................................................................*.............................................................................................................................................................................*.........................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Magick::Image#read issue #200 raise error with nil argument
     # No reason given
     # ./spec/rmagick/image/read_spec.rb:22

  2) Magick::Image#read issue #200 not hangs with nil argument
     # No reason given
     # ./spec/rmagick/image/read_spec.rb:17

  3) Magick::Draw#marshal_dump marshals without an error
     # this spec fails on some versions of ImageMagick
     # ./spec/rmagick/draw/marshal_dump_spec.rb:8

  4) Magick::Image#liquid_rescale works
     # delegate library support not built-in ''
     # ./spec/rmagick/image/liquid_rescale_spec.rb:4


Finished in 24.58 seconds (files took 0.74367 seconds to load)
638 examples, 0 failures, 4 pending

Randomized with seed 22005

Coverage report generated for RSpec to /Users/watson/prj/rmagick/coverage. 888 / 1011 LOC (87.83%) covered.
```