### PR TITLE
Pass caption value into ImageMagick 7 API in Image#polaroid

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10889,7 +10889,7 @@ Image_polaroid(int argc, VALUE *argv, VALUE self)
     Draw *draw;
     ExceptionInfo *exception;
 #if defined(IMAGEMAGICK_7)
-    char *caption = (char *) NULL;
+    const char *caption;
 #endif
 
     image = rm_check_destroyed(self);
@@ -10914,6 +10914,7 @@ Image_polaroid(int argc, VALUE *argv, VALUE self)
 
     exception = AcquireExceptionInfo();
 #if defined(IMAGEMAGICK_7)
+    caption = GetImageProperty(clone, "Caption", exception);
     new_image = PolaroidImage(clone, draw->info, caption, angle, image->interpolate, exception);
 #else
     new_image = PolaroidImage(clone, draw->info, angle, exception);


### PR DESCRIPTION
Fix #897

In ImageMagick 6, `PolaroidImage()` retrives caption value in inside.

```c
  value=GetImageProperty(image,"Caption");
```
https://github.com/ImageMagick/ImageMagick6/blob/4dc6b70d5d24653468d474ab2d1c184f05edcfab/magick/fx.c#L4226