### PR TITLE
Example: Fix “uninitialized constant Magick::TransparentOpacity” error

### DIFF
--- a/doc/ex/transparent.rb
+++ b/doc/ex/transparent.rb
@@ -24,7 +24,7 @@ before.compression = Magick::LZWCompression
 before.write('transparent_before.gif')
 
 before.fuzz = 100
-after = before.transparent('black', Magick::TransparentOpacity)
+after = before.transparent('black', alpha: Magick::TransparentAlpha)
 
 # Different way of reading an image - start with an imagelist.
 # Use the plasma image as a background so we can see that


### PR DESCRIPTION
This patch should fix following error in example of transparent.rb.

```
$ ruby transparent.rb
Traceback (most recent call last):
transparent.rb:27:in `<main>': uninitialized constant Magick::TransparentOpacity (NameError)
Did you mean?  Magick::TransparentColorspace
```