### PR TITLE
CI: Add Ruby 2.7 into Windows platform

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,6 +39,15 @@ environment:
     - RUBY_VERSION: 26-x64
       IMAGEMAGICK_VERSION: 7.0.9
       PATCH_VERSION: 20
+    - RUBY_VERSION: 27-x64
+      IMAGEMAGICK_VERSION: 6.8.9
+      PATCH_VERSION: 10
+    - RUBY_VERSION: 27-x64
+      IMAGEMAGICK_VERSION: 6.9.10
+      PATCH_VERSION: 90
+    - RUBY_VERSION: 27-x64
+      IMAGEMAGICK_VERSION: 7.0.9
+      PATCH_VERSION: 20
 
 install:
   - appveyor-retry appveyor DownloadFile https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ImageMagick-%IMAGEMAGICK_VERSION%-%PATCH_VERSION%-Q16-x64-dll.exe


### PR DESCRIPTION
RubyInstaller 2.7.0-1 was released.
https://rubyinstaller.org/2020/01/05/rubyinstaller-2.7.0-1-released.html