### PR TITLE
Eliminate compiler warnings on Windows

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -124,7 +124,7 @@ rm_aligned_malloc_size(void *ptr)
 // Refered to https://github.com/ImageMagick/ImageMagick/blob/master/MagickCore/memory-private.h
 #define MAGICKCORE_SIZEOF_VOID_P 8
 #define CACHE_LINE_SIZE  (8 * MAGICKCORE_SIZEOF_VOID_P)
-
+    size_t _aligned_msize(void *memblock, size_t alignment, size_t offset);
     return _aligned_msize(ptr, CACHE_LINE_SIZE, 0);
 #endif
 }


### PR DESCRIPTION
This patch will eliminate following warning message.

```
../../../../ext/RMagick/rmmain.c:128:12: warning: implicit declaration of function '_aligned_msize'; did you mean '_aligned_free'? [-Wimplicit-function-declaration]
 128 |     return _aligned_msize(ptr, CACHE_LINE_SIZE, 0);
     |            ^~~~~~~~~~~~~~
     |            _aligned_free
```