### PR TITLE
Detect the proper ARCHFLAGS on macOS

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -90,7 +90,7 @@ module RMagick
         $LDFLAGS = ENV['LDFLAGS'].to_s + ' ' + `pkg-config --libs #{magick_package}`.chomp
         $LOCAL_LIBS = ENV['LIBS'].to_s + ' ' + `pkg-config --libs #{magick_package}`.chomp
 
-        set_archflags_for_osx(magick_package) if RUBY_PLATFORM =~ /darwin/ # osx
+        configure_archflags_for_osx(magick_package) if RUBY_PLATFORM =~ /darwin/ # osx
 
       elsif RUBY_PLATFORM =~ /mingw/ # mingw
 
@@ -254,7 +254,7 @@ SRC
 
     # issue #169
     # set ARCHFLAGS appropriately for OSX
-    def set_archflags_for_osx(magick_package)
+    def configure_archflags_for_osx(magick_package)
       return unless `pkg-config #{magick_package} --libs-only-L`.match(%r{-L(.+)/lib})
 
       imagemagick_dir = Regexp.last_match(1)


### PR DESCRIPTION
When run `ruby extconf.rb` on macOS,  it did not specify an appropriate file with `file` command.

it just shown the help message.

```
Usage: file [bcCdEhikLlNnprsvzZ0] [-e test] [-f namefile] [-F separator] [-m magicfiles] [-M magicfiles] file...
       file -C -m magicfiles
Try `file --help' for more information.
```