### PR TITLE
Rubocop: enable RSpec/PredicateMatcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,12 @@ AllCops:
     - 'vendor/bundle/**/*'
     - '**/*\.spec'
 
+################################################################################
+#
+# Rules that depart from rubocop defaults
+#
+################################################################################
+
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -307,14 +307,6 @@ RSpec/MultipleExpectations:
 RSpec/Pending:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: Strict, EnforcedStyle.
-# SupportedStyles: inflected, explicit
-RSpec/PredicateMatcher:
-  Exclude:
-    - 'spec/rmagick/image/read_spec.rb'
-
 RSpec/RepeatedDescription:
   Enabled: false
 

--- a/spec/rmagick/image/read_spec.rb
+++ b/spec/rmagick/image/read_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Magick::Image, '#read' do
 
     it 'not hangs with nil argument' do
       skip
-      expect(@status.signaled?).to be_falsey
+      expect(@status.signaled?).to be(false)
     end
 
     it 'raise error with nil argument' do
       skip
-      expect(@status.success?).to be_truthy
+      expect(@status.success?).to be(true)
       expect { Magick::Image.read(nil) }.to raise_error(Magick::ImageMagickError, /unable to open image nil/)
     end
   end


### PR DESCRIPTION
This rule requires that we use `be(true)` instead of `be_truthy`.
`be_truthy` allows *any* truthy value, such as `0`, `[]` or `fie`, as
opposed to `be(true)`, which ensures that the value is, in fact, `true`.

https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecpredicatematcher