### PR TITLE
Rubocop: enable Layout/FirstHashElementLineBreak

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,14 +20,6 @@ Layout/ClassStructure:
     - 'lib/rvg/rvg.rb'
     - 'lib/rvg/to_c.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/FirstHashElementLineBreak:
-  Exclude:
-    - 'doc/ex/writing_mode01.rb'
-    - 'doc/ex/writing_mode02.rb'
-    - 'lib/rmagick_internal.rb'
-
 # Offense count: 21
 # Cop supports --auto-correct.
 Layout/FirstMethodArgumentLineBreak:

--- a/doc/ex/writing_mode01.rb
+++ b/doc/ex/writing_mode01.rb
@@ -2,17 +2,21 @@ require 'rvg/rvg'
 
 Magick::RVG.dpi = 90
 
-TEXT_STYLES = { writing_mode: 'tb',
-                glyph_orientation_vertical: 0,
-                fill: 'red4',
-                font_weight: 'bold',
-                font_size: 16 }
+TEXT_STYLES = {
+  writing_mode: 'tb',
+  glyph_orientation_vertical: 0,
+  fill: 'red4',
+  font_weight: 'bold',
+  font_size: 16
+}
 
-TEXT_STYLES2 = { writing_mode: 'tb',
-                 glyph_orientation_vertical: 90,
-                 fill: 'green',
-                 font_weight: 'bold',
-                 font_size: 16 }
+TEXT_STYLES2 = {
+  writing_mode: 'tb',
+  glyph_orientation_vertical: 90,
+  fill: 'green',
+  font_weight: 'bold',
+  font_size: 16
+}
 
 rvg = Magick::RVG.new(1.25.in, 7.in).viewbox(0, 0, 125, 700) do |canvas|
   canvas.background_fill = 'white'

--- a/doc/ex/writing_mode02.rb
+++ b/doc/ex/writing_mode02.rb
@@ -2,17 +2,21 @@ require 'rvg/rvg'
 
 Magick::RVG.dpi = 90
 
-TEXT_STYLES = { writing_mode: 'lr',
-                glyph_orientation_horizontal: 0,
-                fill: 'red4',
-                font_weight: 'bold',
-                font_size: 16 }
+TEXT_STYLES = {
+  writing_mode: 'lr',
+  glyph_orientation_horizontal: 0,
+  fill: 'red4',
+  font_weight: 'bold',
+  font_size: 16
+}
 
-TEXT_STYLES2 = { writing_mode: 'lr',
-                 glyph_orientation_horizontal: 180,
-                 fill: 'green',
-                 font_weight: 'bold',
-                 font_size: 16 }
+TEXT_STYLES2 = {
+  writing_mode: 'lr',
+  glyph_orientation_horizontal: 180,
+  fill: 'green',
+  font_weight: 'bold',
+  font_size: 16
+}
 
 rvg = Magick::RVG.new(3.in, 1.in).viewbox(0, 0, 300, 100) do |canvas|
   canvas.background_fill = 'white'

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -67,12 +67,14 @@ module Magick
 
   class Geometry
     FLAGS = ['', '%', '!', '<', '>', '@', '^']
-    RFLAGS = { '%' => PercentGeometry,
-               '!' => AspectGeometry,
-               '<' => LessGeometry,
-               '>' => GreaterGeometry,
-               '@' => AreaGeometry,
-               '^' => MinimumGeometry }
+    RFLAGS = {
+      '%' => PercentGeometry,
+      '!' => AspectGeometry,
+      '<' => LessGeometry,
+      '>' => GreaterGeometry,
+      '@' => AreaGeometry,
+      '^' => MinimumGeometry
+    }
 
     attr_accessor :width, :height, :x, :y, :flag
 


### PR DESCRIPTION
This makes us wrap our hashes like so.

https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutfirsthashelementlinebreak