### PR TITLE
Rubocop: enable AutoResourceCleanup rule in specs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -321,7 +321,6 @@ Security/MarshalLoad:
 Style/AutoResourceCleanup:
   Exclude:
     - 'lib/rvg/to_c.rb'
-    - 'spec/rmagick/image_list/from_blob_spec.rb'
 
 # Offense count: 7
 Style/CaseEquality:

--- a/spec/rmagick/image_list/from_blob_spec.rb
+++ b/spec/rmagick/image_list/from_blob_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Magick::ImageList, "#from_blob" do
   end
 
   it "works" do
-    hat = File.open(FLOWER_HAT, 'rb')
-    blob = hat.read
+    blob = File.read(FLOWER_HAT, mode: "rb")
+
     expect { @ilist.from_blob(blob) }.not_to raise_error
     expect(@ilist[0]).to be_instance_of(Magick::Image)
     expect(@ilist.scene).to eq(0)


### PR DESCRIPTION
I left the exclude for `RVG#to_c` because the method isn't currently
under test and I want to make sure I don't break existing logic.