### PR TITLE
Skip BlurCompositeOp in unit test.

### DIFF
--- a/spec/rmagick/draw/image_spec.rb
+++ b/spec/rmagick/draw/image_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Draw, '#image' do
 
   it 'works' do
     Magick::CompositeOperator.values do |composite|
-      next if [Magick::CopyAlphaCompositeOp, Magick::NoCompositeOp].include?(composite)
+      next if [Magick::BlurCompositeOp, Magick::CopyAlphaCompositeOp, Magick::NoCompositeOp].include?(composite)
 
       draw = Magick::Draw.new
       draw.image(composite, 10, 10, 200, 100, "#{IMAGES_DIR}/Flower_Hat.jpg")


### PR DESCRIPTION
The unit test fails with recent versions of ImageMagick because `BlurCompositeOp` needs `compose:args` to work. This did not fail with earlier version of ImageMagick because we recently improved the error reporting. This PR will change the unit test to skip `BlurCompositeOp`.