### PR TITLE
RSpec: disable LetBrace rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,13 @@ AllCops:
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }
+
+
+################################################################################
+#
+# Rules we don't want to enable
+#
+################################################################################
+
+RSpec/AlignLeftLetBrace: { Enabled: false }
+RSpec/AlignRightLetBrace: { Enabled: false }

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,20 +206,6 @@ Performance/FixedSize:
 Performance/RedundantMatch:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-RSpec/AlignLeftLetBrace:
-  Exclude:
-    - 'spec/rmagick/image/constitute_spec.rb'
-    - 'spec/rmagick/image/from_blob_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-RSpec/AlignRightLetBrace:
-  Exclude:
-    - 'spec/rmagick/image/constitute_spec.rb'
-    - 'spec/rmagick/image/from_blob_spec.rb'
-
 # Offense count: 517
 # Cop supports --auto-correct.
 # Configuration parameters: SkipBlocks, EnforcedStyle.


### PR DESCRIPTION
The `AlignLeftLetBrace` and `AlignRightLetBrace` rules require that when
there are multiple `let` blocks that they align their braces like so:

```rb
let(:one_thing)     { make_a_thing       }
let(:another_thing) { make_another_thing }
```

This looks more tidy, but it can cause diff churn when we add or remove
a line:

```diff
- let(:one_thing)     { make_a_thing       }
- let(:another_thing) { make_another_thing }
+ let(:one_thing)            { make_a_thing              }
+ let(:another_thing)        { make_another_thing        }
+ let(:another_longer_thing) { make_another_longer_thing }
```

For the sake of having a clean history, it's probably better not
to align things.