### PR TITLE
Fix memory leak in images_from_imagelist()

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -802,6 +802,9 @@ images_from_imagelist(VALUE imagelist)
         if (head == image || GetPreviousImageInList(image) != NULL)
         {
             image = rm_clone_image(image);
+
+            // Wrap raw ImageMagick object by Ruby object to destroy using Ruby's GC.
+            rm_image_new(image);
         }
         AppendImageToList(&head, image);
     }


### PR DESCRIPTION
`images_from_imagelist()` creates a list to pass ImageMagick API.
When handles Images which appended using `ImageList#<<`, the images will be cloned in some cases.
https://github.com/rmagick/rmagick/blob/ad63bf86df475853a73158369d27be161ee6977f/ext/RMagick/rmilist.c#L804

The list created by `AppendImageToList()` will be finalized in `rm_split()`.
However, cloned images will not be destroyed.

This patch will wrap cloned images with Ruby object.
Then, the wraped images will be destroyed using Ruby's GC if they were wasted.

* Before

```
$ ruby leak.rb
Process: 9392: RSS = 2998 MB
```

* After

```
$ ruby leak.rb
Process: 10240: RSS = 537 MB
```

* Test code

```ruby
require 'rmagick'

1000.times do
  img = Magick::Image.new(500, 500)
  list = Magick::ImageList.new
  list << img
  list << img

  list.append(false)
end

GC.start
rss = `ps -o rss= -p #{Process.pid}`.to_i / 1024
puts "Process: #{Process.pid}: RSS = #{rss} MB"
```