### PR TITLE
RSpec: enable DescribedClass rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,13 +206,6 @@ Performance/FixedSize:
 Performance/RedundantMatch:
   Enabled: false
 
-# Offense count: 517
-# Cop supports --auto-correct.
-# Configuration parameters: SkipBlocks, EnforcedStyle.
-# SupportedStyles: described_class, explicit
-RSpec/DescribedClass:
-  Enabled: false
-
 # Offense count: 359
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/spec/rmagick/image_list_spec.rb
+++ b/spec/rmagick/image_list_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::ImageList do
   before do
-    @list = Magick::ImageList.new(*FILES[0..9])
-    @list2 = Magick::ImageList.new # intersection is 5..9
+    @list = described_class.new(*FILES[0..9])
+    @list2 = described_class.new # intersection is 5..9
     @list2 << @list[5]
     @list2 << @list[6]
     @list2 << @list[7]


### PR DESCRIPTION
This rule requires us to use the `described_class` test helper rather
than explicitly naming the class being tested. The benefit of using
`described_class`, aside from being a little shorter in many cases, is
that it helps prevent false positives when we copy and paste tests if we
forget to change the class name under test.