### PR TITLE
Replace to correct format specifiers for size_t value

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -120,7 +120,7 @@ module RMagick
 
       end
 
-      $CFLAGS << (have_macro('__GNUC__') ? ' -std=gnu99' : ' -std=c99')
+      $CFLAGS << (have_macro('__GNUC__') && !(RUBY_PLATFORM =~ /mingw/) ? ' -std=gnu99' : ' -std=c99')
     end
 
     # Test for a specific value in an enum type

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -15,6 +15,7 @@
 
 //! Suppress warnings about deprecated functions on Windows
 #define _CRT_SECURE_NO_DEPRECATE 1
+#define __USE_MINGW_ANSI_STDIO 1
 
 #include <assert.h>
 #include <stdio.h>

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -318,7 +318,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
         w = FIX2INT(weight);
         if (w < 100 || w > 900)
         {
-            rb_raise(rb_eArgError, "invalid font weight (%ld given)", w);
+            rb_raise(rb_eArgError, "invalid font weight (%zu given)", w);
         }
         draw->info->weight = w;
     }

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3020,7 +3020,7 @@ Image_color_flood_fill( VALUE self, VALUE target_color, VALUE fill_color
     y = NUM2LONG(yv);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -5518,7 +5518,7 @@ Image_display(VALUE self)
 
     if (image->rows == 0 || image->columns == 0)
     {
-        rb_raise(rb_eArgError, "invalid image geometry (%lux%lu)", image->rows, image->columns);
+        rb_raise(rb_eArgError, "invalid image geometry (%zux%zu)", image->rows, image->columns);
     }
 
     info_obj = rm_info_new();
@@ -6541,7 +6541,7 @@ Image_extent(int argc, VALUE *argv, VALUE self)
         }
         else
         {
-            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%ld+%ld"
+            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%zu+%zu"
                      , width, height, geometry.x, geometry.y);
         }
     }
@@ -8026,7 +8026,7 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
         }
         if ((unsigned long)(buffer_l / type_sz) < npixels)
         {
-            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %ld)"
+            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %zu)"
                      , npixels, buffer_l/type_sz);
         }
     }
@@ -8158,7 +8158,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     // Print scene number.
     if ((GetPreviousImageInList(image) != NULL) && (GetNextImageInList(image) != NULL) && image->scene > 0)
     {
-        x += snprintf(buffer+x, len-x, "[%lu]", image->scene);
+        x += snprintf(buffer+x, len-x, "[%zu]", image->scene);
     }
     // Print format
     x += snprintf(buffer+x, len-x, " %s ", image->magick);
@@ -8168,17 +8168,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     {
         if (image->magick_columns != image->columns || image->magick_rows != image->rows)
         {
-            x += snprintf(buffer+x, len-x, "%lux%lu=>", image->magick_columns, image->magick_rows);
+            x += snprintf(buffer+x, len-x, "%zux%zu=>", image->magick_columns, image->magick_rows);
         }
     }
 
-    x += snprintf(buffer+x, len-x, "%lux%lu ", image->columns, image->rows);
+    x += snprintf(buffer+x, len-x, "%zux%zu ", image->columns, image->rows);
 
     // Print current columnsXrows
     if (   image->page.width != 0 || image->page.height != 0
            || image->page.x != 0     || image->page.y != 0)
     {
-        x += snprintf(buffer+x, len-x, "%lux%lu%+ld%+ld ", image->page.width, image->page.height
+        x += snprintf(buffer+x, len-x, "%zux%zu+%zu+%zu ", image->page.width, image->page.height
                      , image->page.x, image->page.y);
     }
 
@@ -8189,17 +8189,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         {
             if (image->total_colors >= (unsigned long)(1 << 24))
             {
-                x += snprintf(buffer+x, len-x, "%lumc ", image->total_colors/1024/1024);
+                x += snprintf(buffer+x, len-x, "%zumc ", image->total_colors/1024/1024);
             }
             else
             {
                 if (image->total_colors >= (unsigned long)(1 << 16))
                 {
-                    x += snprintf(buffer+x, len-x, "%lukc ", image->total_colors/1024);
+                    x += snprintf(buffer+x, len-x, "%zukc ", image->total_colors/1024);
                 }
                 else
                 {
-                    x += snprintf(buffer+x, len-x, "%luc ", image->total_colors);
+                    x += snprintf(buffer+x, len-x, "%zuc ", image->total_colors);
                 }
             }
         }
@@ -8214,7 +8214,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         }
         else
         {
-            x += snprintf(buffer+x, len-x, "PseudoClass %lu=>%ldc ", image->total_colors
+            x += snprintf(buffer+x, len-x, "PseudoClass %zu=>%ldc ", image->total_colors
                          , (long)image->colors);
             if (image->error.mean_error_per_pixel != 0.0)
             {
@@ -9337,7 +9337,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
     y = NUM2LONG(argv[2]);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -14260,7 +14260,7 @@ Image_texture_flood_fill(VALUE self, VALUE color_obj, VALUE texture_obj
 
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -14738,7 +14738,7 @@ Image_to_blob(VALUE self)
                || !rm_strcasecmp(magick_info->name, "JPG"))
               && (image->rows == 0 || image->columns == 0))
         {
-            rb_raise(rb_eRuntimeError, "Can't convert %lux%lu %.4s image to a blob"
+            rb_raise(rb_eRuntimeError, "Can't convert %zux%zu %.4s image to a blob"
                      , image->columns, image->rows, magick_info->name);
         }
     }

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2029,7 +2029,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Data_Get_Struct(self, Info, info);
     info->scene = NUM2ULONG(scene);
 
-    (void) snprintf(buf, sizeof(buf), "%-ld", info->scene);
+    (void) snprintf(buf, sizeof(buf), "%zu", info->scene);
     (void) SetImageOption(info, "scene", buf);
 
     return scene;

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -537,7 +537,7 @@ Font_to_s(VALUE self)
             strcpy(weight, "BoldWeight");
             break;
         default:
-            snprintf(weight, sizeof(weight), "%lu", ti.weight);
+            snprintf(weight, sizeof(weight), "%zu", ti.weight);
             break;
     }
 
@@ -753,7 +753,7 @@ RectangleInfo_to_s(VALUE self)
     char buff[100];
 
     Export_RectangleInfo(&rect, self);
-    snprintf(buff, sizeof(buff), "width=%lu, height=%lu, x=%ld, y=%ld"
+    snprintf(buff, sizeof(buff), "width=%zu, height=%zu, x=%zu, y=%zu"
           , rect.width, rect.height, rect.x, rect.y);
     return rb_str_new2(buff);
 }


### PR DESCRIPTION
If the wrong format specifier is used, the correct value may not be output and cause a problem.