### PR TITLE
Rubocop: enable ExpectActual rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -211,10 +211,6 @@ Performance/RedundantMatch:
 RSpec/ExampleLength:
   Enabled: false
 
-# Offense count: 1
-RSpec/ExpectActual:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 RSpec/HooksBeforeExamples:

--- a/spec/rmagick/image/destroy_bang_spec.rb
+++ b/spec/rmagick/image/destroy_bang_spec.rb
@@ -14,15 +14,16 @@ RSpec.describe Magick::Image, '#destroy!' do
       m = id.split(/ /)
       name = File.basename m[0]
 
-      expect(%i[c d]).to include(which)
-      expect(method).to eq(:destroy!) if which == :d
-
-      if which == :c
+      case which
+      when :c
         expect(images).not_to have_key(addr)
         images[addr] = name
-      else
+      when :d
+        expect(method).to eq(:destroy!)
         expect(images).to have_key(addr)
         expect(images[addr]).to eq(name)
+      else
+        raise ArgumentError, "Unhandled `which`: #{which.inspect}"
       end
     end
 


### PR DESCRIPTION
The `ExpectActual` rule doesn't like a constant being passed into
`expect` while a variable is passed into the test predicate. It wants
the unknown value to be passed to `expect`. It's a bit awkward in this
situation since there's no `be_included_in` matcher. However, I used
this as an excuse to refactor the test for clarity, so the violation is
gone now.