### PR TITLE
 Rubocop: move multi-line assignment to next line

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
 #
 ################################################################################
 
+Layout/MultilineAssignmentLayout: { EnforcedStyle: same_line }
 # RSpec/FilePath: { CustomTransform: { Magick: rmagick } }
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,14 +59,6 @@ Layout/MultilineArrayLineBreaks:
     - 'lib/rmagick_internal.rb'
     - 'lib/rvg/stylable.rb'
 
-# Offense count: 94
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedTypes: block, case, class, if, kwbegin, module
-# SupportedStyles: same_line, new_line
-Layout/MultilineAssignmentLayout:
-  Enabled: false
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Layout/MultilineHashKeyLineBreaks:


### PR DESCRIPTION
This rule dictates how we should align assignment across multiple lines.
The default wants us to indent the block on the next line, like so:

```rb
foo =
  if expression
    'bar'
  end
```

There is a configuration for `same_line` which would instead expect us
to format our code like so:

```rb
foo = if expression
  'bar'
end
```

I kind of prefer the first option, but all of our code is in line with
the second option, `same_line`, so I went with that instead. You can see
the impact to our codebase if we were to use the first option in
#971.

rubocop.readthedocs.io/en/stable/cops_layout/#layoutmultilineassignmentlayout