### PR TITLE
Rubocop: enable IteratedExpectation rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -211,26 +211,10 @@ Performance/RedundantMatch:
 RSpec/ExampleLength:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-RSpec/HooksBeforeExamples:
-  Exclude:
-    - 'spec/image_2_spec.rb'
-    - 'spec/magick_2_spec.rb'
-
 # Offense count: 2876
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Enabled: false
-
-# Offense count: 1
-RSpec/IteratedExpectation:
-  Enabled: false
-
-# Offense count: 1
-RSpec/MultipleDescribes:
-  Exclude:
-    - 'spec/fill_spec.rb'
 
 # Offense count: 553
 # Configuration parameters: AggregateFailuresByDefault.

--- a/spec/rmagick/image/export_pixels_spec.rb
+++ b/spec/rmagick/image/export_pixels_spec.rb
@@ -9,14 +9,11 @@ RSpec.describe Magick::Image, '#export_pixels' do
   end
 
   it 'works' do
-    expect do
-      res = @img.export_pixels
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
-      res.each do |p|
-        expect(p).to be_kind_of(Integer)
-      end
-    end.not_to raise_error
+    res = @img.export_pixels
+    expect(res).to be_instance_of(Array)
+    expect(res.length).to eq(@img.columns * @img.rows * 'RGB'.length)
+    expect(res).to all(be_kind_of(Integer))
+
     expect { @img.export_pixels(0) }.not_to raise_error
     expect { @img.export_pixels(0, 0) }.not_to raise_error
     expect { @img.export_pixels(0, 0, 10) }.not_to raise_error


### PR DESCRIPTION
`IteratedExpectation` wants us to use `all(some_matcher)` rather than
looping through and matching against each element. Also:

- Removed the outer `not_to raise_error`, as it is implied. The test
  will fail if it raises an error. Also, when one of the expectations
  fails it raises an error, so the `raise_error` matcher makes the
  message more confusing when an internal test fails.
- Enabled the `MultipleDescribes` and `HooksBeforeExamples` rubocop
  rules. These are both passing now after the transition to individual
  spec files.