### PR TITLE
Replace to correct format specifiers for size_t/ssize_t value

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -318,7 +318,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
         w = FIX2INT(weight);
         if (w < 100 || w > 900)
         {
-            rb_raise(rb_eArgError, "invalid font weight (%zu given)", w);
+            rb_raise(rb_eArgError, "invalid font weight (%"PRIuSIZE" given)", w);
         }
         draw->info->weight = w;
     }

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -318,7 +318,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
         w = FIX2INT(weight);
         if (w < 100 || w > 900)
         {
-            rb_raise(rb_eArgError, "invalid font weight (%ld given)", w);
+            rb_raise(rb_eArgError, "invalid font weight (%zu given)", w);
         }
         draw->info->weight = w;
     }

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3021,7 +3021,7 @@ Image_color_flood_fill( VALUE self, VALUE target_color, VALUE fill_color
     y = NUM2LONG(yv);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -5519,7 +5519,7 @@ Image_display(VALUE self)
 
     if (image->rows == 0 || image->columns == 0)
     {
-        rb_raise(rb_eArgError, "invalid image geometry (%lux%lu)", image->rows, image->columns);
+        rb_raise(rb_eArgError, "invalid image geometry (%zux%zu)", image->rows, image->columns);
     }
 
     info_obj = rm_info_new();
@@ -6542,7 +6542,7 @@ Image_extent(int argc, VALUE *argv, VALUE self)
         }
         else
         {
-            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%ld+%ld"
+            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%zd+%zd"
                      , width, height, geometry.x, geometry.y);
         }
     }
@@ -8027,7 +8027,7 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
         }
         if ((unsigned long)(buffer_l / type_sz) < npixels)
         {
-            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %ld)"
+            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %zu)"
                      , npixels, buffer_l/type_sz);
         }
     }
@@ -8159,7 +8159,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     // Print scene number.
     if ((GetPreviousImageInList(image) != NULL) && (GetNextImageInList(image) != NULL) && image->scene > 0)
     {
-        x += snprintf(buffer+x, len-x, "[%lu]", image->scene);
+        x += snprintf(buffer+x, len-x, "[%zu]", image->scene);
     }
     // Print format
     x += snprintf(buffer+x, len-x, " %s ", image->magick);
@@ -8169,17 +8169,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     {
         if (image->magick_columns != image->columns || image->magick_rows != image->rows)
         {
-            x += snprintf(buffer+x, len-x, "%lux%lu=>", image->magick_columns, image->magick_rows);
+            x += snprintf(buffer+x, len-x, "%zux%zu=>", image->magick_columns, image->magick_rows);
         }
     }
 
-    x += snprintf(buffer+x, len-x, "%lux%lu ", image->columns, image->rows);
+    x += snprintf(buffer+x, len-x, "%zux%zu ", image->columns, image->rows);
 
     // Print current columnsXrows
     if (   image->page.width != 0 || image->page.height != 0
            || image->page.x != 0     || image->page.y != 0)
     {
-        x += snprintf(buffer+x, len-x, "%lux%lu%+ld%+ld ", image->page.width, image->page.height
+        x += snprintf(buffer+x, len-x, "%zux%zu+%zd+%zd ", image->page.width, image->page.height
                      , image->page.x, image->page.y);
     }
 
@@ -8190,17 +8190,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         {
             if (image->total_colors >= (unsigned long)(1 << 24))
             {
-                x += snprintf(buffer+x, len-x, "%lumc ", image->total_colors/1024/1024);
+                x += snprintf(buffer+x, len-x, "%zumc ", image->total_colors/1024/1024);
             }
             else
             {
                 if (image->total_colors >= (unsigned long)(1 << 16))
                 {
-                    x += snprintf(buffer+x, len-x, "%lukc ", image->total_colors/1024);
+                    x += snprintf(buffer+x, len-x, "%zukc ", image->total_colors/1024);
                 }
                 else
                 {
-                    x += snprintf(buffer+x, len-x, "%luc ", image->total_colors);
+                    x += snprintf(buffer+x, len-x, "%zuc ", image->total_colors);
                 }
             }
         }
@@ -8215,7 +8215,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         }
         else
         {
-            x += snprintf(buffer+x, len-x, "PseudoClass %lu=>%ldc ", image->total_colors
+            x += snprintf(buffer+x, len-x, "PseudoClass %zu=>%zuc ", image->total_colors
                          , (long)image->colors);
             if (image->error.mean_error_per_pixel != 0.0)
             {
@@ -9338,7 +9338,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
     y = NUM2LONG(argv[2]);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -14260,7 +14260,7 @@ Image_texture_flood_fill(VALUE self, VALUE color_obj, VALUE texture_obj
 
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %lux%lu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
                  , x, y, image->columns, image->rows);
     }
 
@@ -14738,7 +14738,7 @@ Image_to_blob(VALUE self)
                || !rm_strcasecmp(magick_info->name, "JPG"))
               && (image->rows == 0 || image->columns == 0))
         {
-            rb_raise(rb_eRuntimeError, "Can't convert %lux%lu %.4s image to a blob"
+            rb_raise(rb_eRuntimeError, "Can't convert %zux%zu %.4s image to a blob"
                      , image->columns, image->rows, magick_info->name);
         }
     }

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3021,7 +3021,7 @@ Image_color_flood_fill( VALUE self, VALUE target_color, VALUE fill_color
     y = NUM2LONG(yv);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %zux%zu"
+        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %"PRIuSIZE"x%"PRIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -5519,7 +5519,7 @@ Image_display(VALUE self)
 
     if (image->rows == 0 || image->columns == 0)
     {
-        rb_raise(rb_eArgError, "invalid image geometry (%zux%zu)", image->rows, image->columns);
+        rb_raise(rb_eArgError, "invalid image geometry (%"PRIuSIZE"x%"PRIuSIZE")", image->rows, image->columns);
     }
 
     info_obj = rm_info_new();
@@ -6542,7 +6542,7 @@ Image_extent(int argc, VALUE *argv, VALUE self)
         }
         else
         {
-            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%zd+%zd"
+            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%"PRIdSIZE"+%"PRIdSIZE""
                      , width, height, geometry.x, geometry.y);
         }
     }
@@ -8027,7 +8027,7 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
         }
         if ((unsigned long)(buffer_l / type_sz) < npixels)
         {
-            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %zu)"
+            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %"PRIuSIZE")"
                      , npixels, buffer_l/type_sz);
         }
     }
@@ -8159,7 +8159,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     // Print scene number.
     if ((GetPreviousImageInList(image) != NULL) && (GetNextImageInList(image) != NULL) && image->scene > 0)
     {
-        x += snprintf(buffer+x, len-x, "[%zu]", image->scene);
+        x += snprintf(buffer+x, len-x, "[%"PRIuSIZE"]", image->scene);
     }
     // Print format
     x += snprintf(buffer+x, len-x, " %s ", image->magick);
@@ -8169,17 +8169,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     {
         if (image->magick_columns != image->columns || image->magick_rows != image->rows)
         {
-            x += snprintf(buffer+x, len-x, "%zux%zu=>", image->magick_columns, image->magick_rows);
+            x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE"=>", image->magick_columns, image->magick_rows);
         }
     }
 
-    x += snprintf(buffer+x, len-x, "%zux%zu ", image->columns, image->rows);
+    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE" ", image->columns, image->rows);
 
     // Print current columnsXrows
     if (   image->page.width != 0 || image->page.height != 0
            || image->page.x != 0     || image->page.y != 0)
     {
-        x += snprintf(buffer+x, len-x, "%zux%zu+%zd+%zd ", image->page.width, image->page.height
+        x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE"+%"PRIdSIZE"+%"PRIdSIZE" ", image->page.width, image->page.height
                      , image->page.x, image->page.y);
     }
 
@@ -8190,17 +8190,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         {
             if (image->total_colors >= (unsigned long)(1 << 24))
             {
-                x += snprintf(buffer+x, len-x, "%zumc ", image->total_colors/1024/1024);
+                x += snprintf(buffer+x, len-x, "%"PRIuSIZE"mc ", image->total_colors/1024/1024);
             }
             else
             {
                 if (image->total_colors >= (unsigned long)(1 << 16))
                 {
-                    x += snprintf(buffer+x, len-x, "%zukc ", image->total_colors/1024);
+                    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"kc ", image->total_colors/1024);
                 }
                 else
                 {
-                    x += snprintf(buffer+x, len-x, "%zuc ", image->total_colors);
+                    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"c ", image->total_colors);
                 }
             }
         }
@@ -8215,8 +8215,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         }
         else
         {
-            x += snprintf(buffer+x, len-x, "PseudoClass %zu=>%zuc ", image->total_colors
-                         , (long)image->colors);
+            x += snprintf(buffer+x, len-x, "PseudoClass %"PRIuSIZE"=>%"PRIuSIZE"c ", image->total_colors, image->colors);
             if (image->error.mean_error_per_pixel != 0.0)
             {
                 x += snprintf(buffer+x, len-x, "%ld/%.6f/%.6fdb "
@@ -9338,7 +9337,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
     y = NUM2LONG(argv[2]);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"PRIuSIZE"x%"PRIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -14260,7 +14259,7 @@ Image_texture_flood_fill(VALUE self, VALUE color_obj, VALUE texture_obj
 
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %zux%zu"
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"PRIuSIZE"x%"PRIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -14738,7 +14737,7 @@ Image_to_blob(VALUE self)
                || !rm_strcasecmp(magick_info->name, "JPG"))
               && (image->rows == 0 || image->columns == 0))
         {
-            rb_raise(rb_eRuntimeError, "Can't convert %zux%zu %.4s image to a blob"
+            rb_raise(rb_eRuntimeError, "Can't convert %"PRIuSIZE"x%"PRIuSIZE" %.4s image to a blob"
                      , image->columns, image->rows, magick_info->name);
         }
     }

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2029,7 +2029,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Data_Get_Struct(self, Info, info);
     info->scene = NUM2ULONG(scene);
 
-    (void) snprintf(buf, sizeof(buf), "%-ld", info->scene);
+    (void) snprintf(buf, sizeof(buf), "%zu", info->scene);
     (void) SetImageOption(info, "scene", buf);
 
     return scene;

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2029,7 +2029,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Data_Get_Struct(self, Info, info);
     info->scene = NUM2ULONG(scene);
 
-    (void) snprintf(buf, sizeof(buf), "%zu", info->scene);
+    (void) snprintf(buf, sizeof(buf), "%"PRIuSIZE"", info->scene);
     (void) SetImageOption(info, "scene", buf);
 
     return scene;

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -537,7 +537,7 @@ Font_to_s(VALUE self)
             strcpy(weight, "BoldWeight");
             break;
         default:
-            snprintf(weight, sizeof(weight), "%lu", ti.weight);
+            snprintf(weight, sizeof(weight), "%zu", ti.weight);
             break;
     }
 
@@ -753,7 +753,7 @@ RectangleInfo_to_s(VALUE self)
     char buff[100];
 
     Export_RectangleInfo(&rect, self);
-    snprintf(buff, sizeof(buff), "width=%lu, height=%lu, x=%ld, y=%ld"
+    snprintf(buff, sizeof(buff), "width=%zu, height=%zu, x=%zd, y=%zd"
           , rect.width, rect.height, rect.x, rect.y);
     return rb_str_new2(buff);
 }

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -537,7 +537,7 @@ Font_to_s(VALUE self)
             strcpy(weight, "BoldWeight");
             break;
         default:
-            snprintf(weight, sizeof(weight), "%zu", ti.weight);
+            snprintf(weight, sizeof(weight), "%"PRIuSIZE"", ti.weight);
             break;
     }
 
@@ -753,7 +753,7 @@ RectangleInfo_to_s(VALUE self)
     char buff[100];
 
     Export_RectangleInfo(&rect, self);
-    snprintf(buff, sizeof(buff), "width=%zu, height=%zu, x=%zd, y=%zd"
+    snprintf(buff, sizeof(buff), "width=%"PRIuSIZE", height=%"PRIuSIZE", x=%"PRIdSIZE", y=%"PRIdSIZE""
           , rect.width, rect.height, rect.x, rect.y);
     return rb_str_new2(buff);
 }


### PR DESCRIPTION
If the wrong format specifier is used, the correct value may not be output and cause a problem.

Related to https://github.com/rmagick/rmagick/pull/965