### PR TITLE
RSpec: number repeated test variables

### DIFF
--- a/spec/rmagick/draw/draw_spec.rb
+++ b/spec/rmagick/draw/draw_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Magick::Draw, '#draw' do
   end
 
   it 'works' do
-    draw = @draw.dup
+    draw2 = @draw.dup
 
     img = Magick::Image.new(10, 10)
     @draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     expect { @draw.draw(img) }.not_to raise_error
 
-    expect { draw.draw(img) }.to raise_error(ArgumentError)
-    expect { draw.draw('x') }.to raise_error(NoMethodError)
+    expect { draw2.draw(img) }.to raise_error(ArgumentError)
+    expect { draw2.draw('x') }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -43,37 +43,37 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
   end
 
   it 'works' do
-    draw = @draw.dup
-    draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
-    draw.decorate = Magick::LineThroughDecoration
-    draw.encoding = 'AdobeCustom'
-    draw.gravity = Magick::CenterGravity
-    draw.fill = Magick::Pixel.from_color('red')
-    draw.fill_pattern = Magick::Image.new(10, 10) { self.format = 'miff' }
-    draw.stroke = Magick::Pixel.from_color('blue')
-    draw.stroke_width = 5
-    draw.text_antialias = true
-    draw.font = 'Arial-Bold'
-    draw.font_family = 'arial'
-    draw.font_style = Magick::ItalicStyle
-    draw.font_stretch = Magick::CondensedStretch
-    draw.font_weight = Magick::BoldWeight
-    draw.pointsize = 12
-    draw.density = '72x72'
-    draw.align = Magick::CenterAlign
-    draw.undercolor = Magick::Pixel.from_color('green')
-    draw.kerning = 10.5
-    draw.interword_spacing = 3.75
+    draw2 = @draw.dup
+    draw2.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
+    draw2.decorate = Magick::LineThroughDecoration
+    draw2.encoding = 'AdobeCustom'
+    draw2.gravity = Magick::CenterGravity
+    draw2.fill = Magick::Pixel.from_color('red')
+    draw2.fill_pattern = Magick::Image.new(10, 10) { self.format = 'miff' }
+    draw2.stroke = Magick::Pixel.from_color('blue')
+    draw2.stroke_width = 5
+    draw2.text_antialias = true
+    draw2.font = 'Arial-Bold'
+    draw2.font_family = 'arial'
+    draw2.font_style = Magick::ItalicStyle
+    draw2.font_stretch = Magick::CondensedStretch
+    draw2.font_weight = Magick::BoldWeight
+    draw2.pointsize = 12
+    draw2.density = '72x72'
+    draw2.align = Magick::CenterAlign
+    draw2.undercolor = Magick::Pixel.from_color('green')
+    draw2.kerning = 10.5
+    draw2.interword_spacing = 3.75
 
-    draw.circle(20, 25, 20, 28)
+    draw2.circle(20, 25, 20, 28)
 
     dumped = nil
-    expect { dumped = draw.marshal_dump }.not_to raise_error
+    expect { dumped = draw2.marshal_dump }.not_to raise_error
 
-    draw2 = @draw.dup
+    draw3 = @draw.dup
     expect do
-      draw2.marshal_load(dumped)
+      draw3.marshal_load(dumped)
     end.not_to raise_error
-    expect(draw2.inspect).to eq(draw.inspect)
+    expect(draw3.inspect).to eq(draw2.inspect)
   end
 end

--- a/spec/rmagick/image/colors_spec.rb
+++ b/spec/rmagick/image/colors_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Magick::Image, '#colors' do
   it 'works' do
     expect { @img.colors }.not_to raise_error
     expect(@img.colors).to eq(0)
-    img = @img.copy
-    img.class_type = Magick::PseudoClass
-    expect(img.colors).to be_kind_of(Integer)
-    expect { img.colors = 2 }.to raise_error(NoMethodError)
+    img2 = @img.copy
+    img2.class_type = Magick::PseudoClass
+    expect(img2.colors).to be_kind_of(Integer)
+    expect { img2.colors = 2 }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image/colorspace_spec.rb
+++ b/spec/rmagick/image/colorspace_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Magick::Image, '#colorspace' do
     expect { @img.colorspace }.not_to raise_error
     expect(@img.colorspace).to be_instance_of(Magick::ColorspaceType)
     expect(@img.colorspace).to eq(Magick::SRGBColorspace)
-    img = @img.copy
+    img2 = @img.copy
 
     Magick::ColorspaceType.values do |colorspace|
-      expect { img.colorspace = colorspace }.not_to raise_error
+      expect { img2.colorspace = colorspace }.not_to raise_error
     end
     expect { @img.colorspace = 2 }.to raise_error(TypeError)
     Magick::ColorspaceType.values.each do |cs|
-      expect { img.colorspace = cs }.not_to raise_error
+      expect { img2.colorspace = cs }.not_to raise_error
     end
   end
 end

--- a/spec/rmagick/image/mask_spec.rb
+++ b/spec/rmagick/image/mask_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Magick::Image, '#mask' do
     # mask expects an Image and calls `cur_image'
     expect { @img.mask = 2 }.to raise_error(NoMethodError)
 
-    img = @img.copy.freeze
-    expect { img.mask cimg }.to raise_error(FreezeError)
+    img2 = @img.copy.freeze
+    expect { img2.mask cimg }.to raise_error(FreezeError)
 
     @img.destroy!
     expect { @img.mask cimg }.to raise_error(Magick::DestroyedImageError)

--- a/spec/rmagick/image/mean_error_per_pixel_spec.rb
+++ b/spec/rmagick/image/mean_error_per_pixel_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Magick::Image, '#mean_error_per_pixel' do
     expect(@hat.normalized_mean_error).to eq(0.0)
     expect(@hat.normalized_maximum_error).to eq(0.0)
 
-    hat = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
+    hat2 = @hat.quantize(16, Magick::RGBColorspace, true, 0, true)
 
-    expect(hat.mean_error_per_pixel).not_to eq(0.0)
-    expect(hat.normalized_mean_error).not_to eq(0.0)
-    expect(hat.normalized_maximum_error).not_to eq(0.0)
-    expect { hat.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
-    expect { hat.normalized_mean_error = 1 }.to raise_error(NoMethodError)
-    expect { hat.normalized_maximum_error = 1 }.to raise_error(NoMethodError)
+    expect(hat2.mean_error_per_pixel).not_to eq(0.0)
+    expect(hat2.normalized_mean_error).not_to eq(0.0)
+    expect(hat2.normalized_maximum_error).not_to eq(0.0)
+    expect { hat2.mean_error_per_pixel = 1 }.to raise_error(NoMethodError)
+    expect { hat2.normalized_mean_error = 1 }.to raise_error(NoMethodError)
+    expect { hat2.normalized_maximum_error = 1 }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image/mime_type_spec.rb
+++ b/spec/rmagick/image/mime_type_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Magick::Image, '#mime_type' do
   end
 
   it 'works' do
-    img = @img.copy
-    img.format = 'GIF'
-    expect { img.mime_type }.not_to raise_error
-    expect(img.mime_type).to eq('image/gif')
-    img.format = 'JPG'
-    expect(img.mime_type).to eq('image/jpeg')
-    expect { img.mime_type = 'image/jpeg' }.to raise_error(NoMethodError)
+    img2 = @img.copy
+    img2.format = 'GIF'
+    expect { img2.mime_type }.not_to raise_error
+    expect(img2.mime_type).to eq('image/gif')
+    img2.format = 'JPG'
+    expect(img2.mime_type).to eq('image/jpeg')
+    expect { img2.mime_type = 'image/jpeg' }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image/scene_spec.rb
+++ b/spec/rmagick/image/scene_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Magick::Image, '#scene' do
   it 'works' do
     ilist = Magick::ImageList.new
     ilist << @img
-    img = @img.copy
-    ilist << img
+    img2 = @img.copy
+    ilist << img2
     ilist.write('temp.gif')
     FileUtils.rm('temp.gif')
 
-    expect { img.scene }.not_to raise_error
+    expect { img2.scene }.not_to raise_error
     expect(@img.scene).to eq(0)
-    expect(img.scene).to eq(1)
-    expect { img.scene = 2 }.to raise_error(NoMethodError)
+    expect(img2.scene).to eq(1)
+    expect { img2.scene = 2 }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image_list/coalesce_spec.rb
+++ b/spec/rmagick/image_list/coalesce_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Magick::ImageList, "#coalesce" do
 
   it "works" do
     @ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    ilist = nil
-    expect { ilist = @ilist.coalesce }.not_to raise_error
-    expect(ilist).to be_instance_of(described_class)
-    expect(ilist.length).to eq(2)
-    expect(ilist.scene).to eq(0)
+    ilist2 = nil
+    expect { ilist2 = @ilist.coalesce }.not_to raise_error
+    expect(ilist2).to be_instance_of(described_class)
+    expect(ilist2.length).to eq(2)
+    expect(ilist2.scene).to eq(0)
   end
 end

--- a/spec/rmagick/image_list/fill_spec.rb
+++ b/spec/rmagick/image_list/fill_spec.rb
@@ -10,29 +10,29 @@ RSpec.describe Magick::ImageList, '#fill' do
   end
 
   it 'works' do
-    list = @list.copy
-    img = list[0].copy
+    list2 = @list.copy
+    img = list2[0].copy
     expect do
-      expect(list.fill(img)).to be_instance_of(described_class)
+      expect(list2.fill(img)).to be_instance_of(described_class)
     end.not_to raise_error
-    list.each { |el| expect(img).to be(el) }
+    list2.each { |el| expect(img).to be(el) }
 
-    list = @list.copy
-    list.fill(img, 0, 3)
-    0.upto(2) { |i| expect(list[i]).to be(img) }
+    list2 = @list.copy
+    list2.fill(img, 0, 3)
+    0.upto(2) { |i| expect(list2[i]).to be(img) }
 
-    list = @list.copy
-    list.fill(img, 4..7)
-    4.upto(7) { |i| expect(list[i]).to be(img) }
+    list2 = @list.copy
+    list2.fill(img, 4..7)
+    4.upto(7) { |i| expect(list2[i]).to be(img) }
 
-    list = @list.copy
-    list.fill { |i| list[i] = img }
-    list.each { |el| expect(img).to be(el) }
+    list2 = @list.copy
+    list2.fill { |i| list2[i] = img }
+    list2.each { |el| expect(img).to be(el) }
 
-    list = @list.copy
-    list.fill(0, 3) { |i| list[i] = img }
-    0.upto(2) { |i| expect(list[i]).to be(img) }
+    list2 = @list.copy
+    list2.fill(0, 3) { |i| list2[i] = img }
+    0.upto(2) { |i| expect(list2[i]).to be(img) }
 
-    expect { list.fill('x', 0) }.to raise_error(ArgumentError)
+    expect { list2.fill('x', 0) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image_list/last_spec.rb
+++ b/spec/rmagick/image_list/last_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe Magick::ImageList, '#last' do
     expect(img).to eq(img2)
     img2 = Magick::Image.new(5, 5)
     @list << img2
-    ilist = nil
-    expect { ilist = @list.last(2) }.not_to raise_error
-    expect(ilist).to be_instance_of(described_class)
-    expect(ilist.length).to eq(2)
-    expect(ilist.scene).to eq(1)
-    expect(ilist[0]).to eq(img)
-    expect(ilist[1]).to eq(img2)
+    ilist2 = nil
+    expect { ilist2 = @list.last(2) }.not_to raise_error
+    expect(ilist2).to be_instance_of(described_class)
+    expect(ilist2.length).to eq(2)
+    expect(ilist2.scene).to eq(1)
+    expect(ilist2[0]).to eq(img)
+    expect(ilist2[1]).to eq(img2)
   end
 end

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Magick::ImageList, "#montage" do
 
   it "works" do
     @ilist.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
-    ilist = @ilist.copy
+    ilist2 = @ilist.copy
     montage = nil
     expect do
-      montage = ilist.montage do
+      montage = ilist2.montage do
         self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
         self.background_color = 'blue'
         self.border_color = Magick::Pixel.new(0, 0, 0)
@@ -41,7 +41,7 @@ RSpec.describe Magick::ImageList, "#montage" do
         self.title = 'sample'
       end
       expect(montage).to be_instance_of(described_class)
-      expect(ilist).to eq(@ilist)
+      expect(ilist2).to eq(@ilist)
 
       montage_image = montage.first
       expect(montage_image.background_color).to eq('blue')
@@ -52,52 +52,52 @@ RSpec.describe Magick::ImageList, "#montage" do
     # looks like IM doesn't diagnose invalid geometry args
     # to tile= and geometry=
     expect do
-      montage = ilist.montage { self.background_color = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.background_color = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.border_color = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.border_color = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.border_width = [2] }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.border_width = [2] }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.compose = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.compose = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.filename = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.filename = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.fill = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.fill = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.font = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.font = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.gravity = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.gravity = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.matte_color = 2 }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.matte_color = 2 }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.pointsize = 'x' }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.pointsize = 'x' }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(TypeError)
     expect do
-      montage = ilist.montage { self.stroke = 'x' }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.stroke = 'x' }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(ArgumentError)
     expect do
-      montage = ilist.montage { self.texture = 'x' }
-      expect(ilist).to eq(@ilist)
+      montage = ilist2.montage { self.texture = 'x' }
+      expect(ilist2).to eq(@ilist)
     end.to raise_error(NoMethodError)
   end
 

--- a/spec/rmagick/image_list/push_spec.rb
+++ b/spec/rmagick/image_list/push_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Magick::ImageList, '#push' do
   end
 
   it 'works' do
-    list = @list
+    list2 = @list
     img1 = @list[0]
     img2 = @list[1]
     expect { @list.push(img1, img2) }.not_to raise_error
-    expect(@list).to be(list) # push returns self
+    expect(@list).to be(list2) # push returns self
     expect(@list.cur_image).to be(img2)
   end
 end

--- a/spec/rmagick/image_list/reject_spec.rb
+++ b/spec/rmagick/image_list/reject_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Magick::ImageList, '#reject' do
   it 'works' do
     @list.scene = 7
     cur = @list.cur_image
-    list = @list
+    list2 = @list
     expect do
       res = @list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
       expect(res.length).to eq(9)
       expect(res).to be_instance_of(described_class)
       expect(res.cur_image).to be(cur)
     end.not_to raise_error
-    expect(@list).to be(list)
+    expect(@list).to be(list2)
     expect(@list.cur_image).to be(cur)
 
     # Omit current image from result list - result cur_image s/b last image

--- a/spec/rmagick/image_list/reverse_bang_spec.rb
+++ b/spec/rmagick/image_list/reverse_bang_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Magick::ImageList, '#reverse!' do
   end
 
   it 'works' do
-    list = @list
+    list2 = @list
     cur = @list.cur_image
     expect { @list.reverse! }.not_to raise_error
-    expect(@list).to be(list)
+    expect(@list).to be(list2)
     expect(@list.cur_image).to be(cur)
   end
 end

--- a/spec/rmagick/image_list/reverse_spec.rb
+++ b/spec/rmagick/image_list/reverse_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Magick::ImageList, '#reverse' do
   end
 
   it 'works' do
-    list = nil
+    list2 = nil
     cur = @list.cur_image
-    expect { list = @list.reverse }.not_to raise_error
-    expect(@list.length).to eq(list.length)
+    expect { list2 = @list.reverse }.not_to raise_error
+    expect(@list.length).to eq(list2.length)
     expect(@list.cur_image).to be(cur)
   end
 end

--- a/spec/rmagick/image_list/uniq_bang_spec.rb
+++ b/spec/rmagick/image_list/uniq_bang_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Magick::ImageList, '#uniq!' do
     @list[1] = @list[0]
     @list.scene = 7
     cur = @list.cur_image
-    list = @list
+    list2 = @list
     @list.uniq!
-    expect(@list).to be(list)
+    expect(@list).to be(list2)
     expect(@list.cur_image).to be(cur)
     expect(@list.scene).to eq(6)
     @list[5] = @list[6]

--- a/spec/rmagick/image_list/uniq_spec.rb
+++ b/spec/rmagick/image_list/uniq_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Magick::ImageList, '#uniq' do
     expect(@list.uniq).to be_instance_of(described_class)
     @list[1] = @list[0]
     @list.scene = 7
-    list = @list.uniq
-    expect(list.length).to eq(9)
-    expect(list.scene).to eq(6)
+    list2 = @list.uniq
+    expect(list2.length).to eq(9)
+    expect(list2.scene).to eq(6)
     expect(@list.scene).to eq(7)
     @list[6] = @list[7]
-    list = @list.uniq
-    expect(list.length).to eq(8)
-    expect(list.scene).to eq(5)
+    list2 = @list.uniq
+    expect(list2.length).to eq(8)
+    expect(list2.scene).to eq(5)
     expect(@list.scene).to eq(7)
   end
 end

--- a/spec/rmagick/image_list/values_at_spec.rb
+++ b/spec/rmagick/image_list/values_at_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Magick::ImageList, '#values_at' do
   end
 
   it 'works' do
-    ilist = nil
-    expect { ilist = @list.values_at(1, 3, 5) }.not_to raise_error
-    expect(ilist).to be_instance_of(described_class)
-    expect(ilist.length).to eq(3)
-    expect(ilist.scene).to eq(2)
+    list2 = nil
+    expect { list2 = @list.values_at(1, 3, 5) }.not_to raise_error
+    expect(list2).to be_instance_of(described_class)
+    expect(list2.length).to eq(3)
+    expect(list2.scene).to eq(2)
   end
 end

--- a/spec/rmagick/pixel/clone_spec.rb
+++ b/spec/rmagick/pixel/clone_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Magick::Pixel, '#clone' do
   end
 
   it 'works' do
-    pixel = @pixel.clone
-    expect(pixel).to eq(@pixel)
-    expect(pixel.object_id).not_to eq(@pixel.object_id)
+    pixel2 = @pixel.clone
+    expect(pixel2).to eq(@pixel)
+    expect(pixel2.object_id).not_to eq(@pixel.object_id)
 
-    pixel = @pixel.freeze.clone
-    expect(pixel.frozen?).to be(true)
+    pixel2 = @pixel.freeze.clone
+    expect(pixel2.frozen?).to be(true)
   end
 end

--- a/spec/rmagick/pixel/dup_spec.rb
+++ b/spec/rmagick/pixel/dup_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Magick::Pixel, '#dup' do
   end
 
   it 'works' do
-    pixel = @pixel.dup
-    expect(@pixel === pixel).to be(true)
-    expect(pixel.object_id).not_to eq(@pixel.object_id)
+    pixel2 = @pixel.dup
+    expect(@pixel === pixel2).to be(true)
+    expect(pixel2.object_id).not_to eq(@pixel.object_id)
 
-    pixel = @pixel.freeze.dup
-    expect(pixel.frozen?).to be(false)
+    pixel2 = @pixel.freeze.dup
+    expect(pixel2.frozen?).to be(false)
   end
 end

--- a/spec/rmagick/pixel/eql_predicate_spec.rb
+++ b/spec/rmagick/pixel/eql_predicate_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Magick::Pixel, '#eql?' do
   end
 
   it 'works' do
-    p = @pixel
-    expect(@pixel.eql?(p)).to be(true)
-    p = described_class.new
-    expect(@pixel.eql?(p)).to be(false)
+    pixel2 = @pixel
+    expect(@pixel.eql?(pixel2)).to be(true)
+    pixel2 = described_class.new
+    expect(@pixel.eql?(pixel2)).to be(false)
   end
 end

--- a/spec/rmagick/pixel/spaceship_spec.rb
+++ b/spec/rmagick/pixel/spaceship_spec.rb
@@ -5,33 +5,33 @@ RSpec.describe Magick::Pixel, '#<=>' do
 
   it 'works' do
     @pixel.red = 100
-    pixel = @pixel.dup
-    expect(@pixel <=> pixel).to eq(0)
+    pixel2 = @pixel.dup
+    expect(@pixel <=> pixel2).to eq(0)
 
-    pixel.red -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.red += 20
-    expect(@pixel <=> pixel).to eq(-1)
+    pixel2.red -= 10
+    expect(@pixel <=> pixel2).to eq(1)
+    pixel2.red += 20
+    expect(@pixel <=> pixel2).to eq(-1)
 
     @pixel.green = 100
-    pixel = @pixel.dup
-    pixel.green -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.green += 20
-    expect(@pixel <=> pixel).to eq(-1)
+    pixel2 = @pixel.dup
+    pixel2.green -= 10
+    expect(@pixel <=> pixel2).to eq(1)
+    pixel2.green += 20
+    expect(@pixel <=> pixel2).to eq(-1)
 
     @pixel.blue = 100
-    pixel = @pixel.dup
-    pixel.blue -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.blue += 20
-    expect(@pixel <=> pixel).to eq(-1)
+    pixel2 = @pixel.dup
+    pixel2.blue -= 10
+    expect(@pixel <=> pixel2).to eq(1)
+    pixel2.blue += 20
+    expect(@pixel <=> pixel2).to eq(-1)
 
     @pixel.alpha = 100
-    pixel = @pixel.dup
-    pixel.alpha -= 10
-    expect(@pixel <=> pixel).to eq(1)
-    pixel.alpha += 20
-    expect(@pixel <=> pixel).to eq(-1)
+    pixel2 = @pixel.dup
+    pixel2.alpha -= 10
+    expect(@pixel <=> pixel2).to eq(1)
+    pixel2.alpha += 20
+    expect(@pixel <=> pixel2).to eq(-1)
   end
 end


### PR DESCRIPTION
This adds a number in situations where we assign a new variable based on
an instance variable with the same name. So something like:

```rb
list = @list.clone
```

changes to:

```rb
list2 = @list.clone
```

The reason for this, aside from greater clarity, is that I want to
remove the instance variables. Instead, we will instantiate them locally
in the test, or use `let` blocks where appropriate.