### PR TITLE
Get rid of warning “enumeration value ‘StaticGravity’ not handled in switch”

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -16439,6 +16439,11 @@ cropper(int bang, int argc, VALUE *argv, VALUE self)
                     nx = (image->columns - columns) / 2;
                     ny = (image->rows - rows) / 2;
                     break;
+#if defined(IMAGEMAGICK_6)
+                case StaticGravity:
+                    rb_raise(rb_eNotImpError, "`StaticGravity' is not supported");
+                    break;
+#endif
             }
 
             x = ULONG2NUM(nx);


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/pull/965