### PR TITLE
CI: don't specify ruby patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3.8, 2.4.9, 2.5.7, 2.6.5, 2.7.0]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
         imagemagick-version: [6.7.7-10, 6.8.9-10, 6.9.10-90, 7.0.9-20]
 
     steps:


### PR DESCRIPTION
I'd like to make the builds required, but it's kind of tricky if the
patch version changes, since each version check is a separate build
requirement. Removing the patch version for Ruby at least makes that a
little less painful. It'll still be a problem with ImageMagick patch
versions, but I'll continue to think on it.