### PR TITLE
CI: use object syntax in matrix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,24 +35,30 @@ jobs:
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
-        imagemagick-version: [6.7.7-10, 6.8.9-10, 6.9.10-90, 7.0.9-20]
+        imagemagick-version:
+          - { full: 6.7.7-10, major-minor: '6.7' }
+          - { full: 6.8.9-10, major-minor: '6.8' }
+          - { full: 6.9.10-90, major-minor: '6.9' }
+          - { full: 7.0.9-20, major-minor: '7.0' }
 
+    name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v2
     - name: Cache ImageMagick
       uses: actions/cache@v1
       with:
         path: ./build-ImageMagick
-        key: v1-imagemagick-${{ matrix.imagemagick-version }}
+        key: v1-imagemagick-${{ matrix.imagemagick-version.full }}
         restore-keys: |
-          v1-imagemagick-${{ matrix.imagemagick-version }}
+          v1-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@master
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Update/Install packages
       run: |
-        IMAGEMAGICK_VERSION=${{ matrix.imagemagick-version }} ./before_install_linux.sh
+        export IMAGEMAGICK_VERSION=${{ matrix.imagemagick-version.full }}
+        ./before_install_linux.sh
     - name: Cache Ruby dependencies
       uses: actions/cache@v1
       with:
@@ -70,8 +76,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby-version: [2.3.3, 2.4.9, 2.5.7, 2.6.5]
-        imagemagick-version: [6.8.9-10, 6.9.10-90, 7.0.9-20]
+        ruby-version: [2.3, 2.4, 2.5, 2.6]
+        imagemagick-version:
+          - { full: 6.8.9-10, major-minor: '6.8' }
+          - { full: 6.9.10-90, major-minor: '6.9' }
+          - { full: 7.0.9-20, major-minor: '7.0' }
+    name: MSWin, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -80,7 +90,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Install ImageMagick
       run: |
-        $imagemagick_version = "${{ matrix.imagemagick-version }}"
+        $imagemagick_version = "${{ matrix.imagemagick-version.full }}"
         $imagemagick_version_without_patch = $imagemagick_version.split("-")[0]
         $installer_name = "ImageMagick-$($imagemagick_version)-Q16-x64-dll.exe"
         $url = "https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/$($installer_name)"


### PR DESCRIPTION
This changes the `matrix` options for `imagemagick-version` to be
structured as an object. The goal of using this approach is that the job
name can be consistent when we increase the patch or build numbers. This
will allow us to make the build steps required without needing to update
the required steps every time we update them.