### PR TITLE
Add test for Image#charcoal with zero arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ AllCops:
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }
+Style/NumericLiterals: { MinDigits: 6 }
 
 ################################################################################
 #

--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe Magick::Image, "#charcoal" do
     expect { @img.charcoal(1.0, 2.0) }.not_to raise_error
     expect { @img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
   end
+
+  it "applies a charcoal effect" do
+    pixels = [45, 98, 156, 209, 171, 11, 239, 236, 2, 8, 65, 247]
+    image = described_class.new(2, 2)
+    image.import_pixels(0, 0, 2, 2, "RGB", pixels)
+    new_image = image.charcoal
+    new_pixels = new_image.export_pixels(0, 0, 2, 2, "RGB")
+    expect(new_pixels).to eq [53736, 53736, 53736, 48703, 48703, 48703, 9953, 9953, 9953, 51857, 51857, 51857]
+  end
 end


### PR DESCRIPTION
Increased min digits on Rubocop rule so that it won't complain about pixel values.