### PR TITLE
Remove unnecessary `extconf.rb’ require

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require_relative 'support/simplecov' if ENV['COVERAGE'] == 'true'
 
 require 'pry'
-require_relative '../ext/RMagick/extconf'
 require_relative '../lib/rmagick'
 require_relative '../lib/rvg/rvg'
 


### PR DESCRIPTION
Because when run spec on CI, `rake` generate Makefile twice.

```
$ rake
mkdir -p tmp/x86_64-darwin19/RMagick2/2.3.8
cd tmp/x86_64-darwin19/RMagick2/2.3.8
/Users/watson/.rbenv/versions/2.3.8/bin/ruby -I. ../../../../ext/RMagick/extconf.rb
checking for brew... yes
checking for clang... yes
checking for pkg-config... yes
checking for outdated ImageMagick version (<= 6.7.7)... no
checking for __GNUC__... yes
checking for Ruby version >= 2.3.0... yes
checking for MagickCore/MagickCore.h... no
checking for magick/MagickCore.h... yes
checking for rb_gc_adjust_memory_usage() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... no
checking for GetImageChannelEntropy() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for SetImageGray() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for SetMagickAlignedMemoryMethods() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for posix_memalign() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for malloc_usable_size() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... no
checking for malloc_size() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
creating extconf.h
creating Makefile

======================================================================
Tue 04 Feb 20 00:21:35
This installation of RMagick 4.1.0.rc2 is configured for
Ruby 2.3.8 (x86_64-darwin19) and ImageMagick 6.9.10
======================================================================

Configured compile options: {:magick_version=>"6.9.10", :local_libs=>" -L/Users/watson/imagemagick6.9/lib -lMagickCore-6.Q16", :cflags=>" -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/Users/watson/imagemagick6.9/include/ImageMagick-6 -std=gnu99", :cppflags=>" -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/Users/watson/imagemagick6.9/include/ImageMagick-6", :ldflags=>" -L/Users/watson/imagemagick6.9/lib -lMagickCore-6.Q16", :defs=>[], :config_h=>"Makefile rmagick.h"}
cd -
cd tmp/x86_64-darwin19/RMagick2/2.3.8
/usr/bin/make
compiling ../../../../ext/RMagick/rmagick.c
compiling ../../../../ext/RMagick/rmdraw.c
compiling ../../../../ext/RMagick/rmenum.c
compiling ../../../../ext/RMagick/rmfill.c
compiling ../../../../ext/RMagick/rmilist.c
compiling ../../../../ext/RMagick/rmimage.c
../../../../ext/RMagick/rmimage.c:16405:21: warning: enumeration value 'StaticGravity' not handled in switch [-Wswitch]
            switch (gravity)
                    ^
../../../../ext/RMagick/rmimage.c:16405:21: note: add missing switch cases
            switch (gravity)
                    ^
1 warning generated.
compiling ../../../../ext/RMagick/rminfo.c
compiling ../../../../ext/RMagick/rmkinfo.c
compiling ../../../../ext/RMagick/rmmain.c
compiling ../../../../ext/RMagick/rmmontage.c
compiling ../../../../ext/RMagick/rmpixel.c
compiling ../../../../ext/RMagick/rmstruct.c
compiling ../../../../ext/RMagick/rmutil.c
linking shared-object RMagick2.bundle
cd -
mkdir -p tmp/x86_64-darwin19/stage/lib
install -c tmp/x86_64-darwin19/RMagick2/2.3.8/RMagick2.bundle lib/RMagick2.bundle
cp tmp/x86_64-darwin19/RMagick2/2.3.8/RMagick2.bundle tmp/x86_64-darwin19/stage/lib/RMagick2.bundle
/Users/watson/.rbenv/versions/2.3.8/bin/ruby -I/Users/watson/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/rspec-support-3.9.2/lib:/Users/watson/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/rspec-core-3.9.1/lib /Users/watson/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
checking for brew... yes
checking for clang... yes
checking for pkg-config... yes
checking for outdated ImageMagick version (<= 6.7.7)... no
checking for __GNUC__... yes
checking for Ruby version >= 2.3.0... yes
checking for MagickCore/MagickCore.h... no
checking for magick/MagickCore.h... yes
checking for rb_gc_adjust_memory_usage() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... no
checking for GetImageChannelEntropy() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for SetImageGray() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for SetMagickAlignedMemoryMethods() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for posix_memalign() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
checking for malloc_usable_size() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... no
checking for malloc_size() in assert.h,ctype.h,stdio.h,stdlib.h,math.h,time.h,sys/types.h,magick/MagickCore.h... yes
creating extconf.h
creating Makefile

======================================================================
Tue 04 Feb 20 00:21:39
This installation of RMagick 4.1.0.rc2 is configured for
Ruby 2.3.8 (x86_64-darwin19) and ImageMagick 6.9.10
======================================================================

…
```