### PR TITLE
Coverage: restore spec for Image#charcoal

### DIFF
--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -1,4 +1,15 @@
 RSpec.describe Magick::Image, "#charcoal" do
+  def expect_im_version(hash)
+    im_major_minor = Magick::IMAGEMAGICK_VERSION.split('.').take(2).join('.')
+
+    hash.each do |key, value|
+      return value if key == im_major_minor
+      return value if key.is_a?(Range) && key.include?(im_major_minor)
+    end
+
+    raise ArgumentError, "no value specified for version: #{im_major_minor}"
+  end
+
   it "works" do
     image = described_class.new(20, 20)
 
@@ -11,12 +22,7 @@ RSpec.describe Magick::Image, "#charcoal" do
   end
 
   it "applies a charcoal effect" do
-    pixels = [
-      45, 98, 156,
-      209, 171, 11,
-      239, 236, 2,
-      8, 65, 247
-    ]
+    pixels = [45, 98, 156, 209, 171, 11, 239, 236, 2, 8, 65, 247]
 
     image = described_class.new(2, 2)
     image.import_pixels(0, 0, 2, 2, "RGB", pixels)
@@ -24,12 +30,11 @@ RSpec.describe Magick::Image, "#charcoal" do
     new_image = image.charcoal
 
     new_pixels = new_image.export_pixels(0, 0, 2, 2, "RGB")
-    expected_pixels = [
-      53736, 53736, 53736,
-      48703, 48703, 48703,
-      9953, 9953, 9953,
-      51857, 51857, 51857
-    ]
+    expected_pixels = expect_im_version(
+      '6.7' => [65535, 65535, 65535, 0, 0, 0, 0, 0, 0, 65535, 65535, 65535],
+      ('6.8'..'7.0') => [53736, 53736, 53736, 48703, 48703, 48703, 9953, 9953, 9953, 51857, 51857, 51857]
+    )
+
     expect(new_pixels).to match_pixels(expected_pixels, delta: 1)
   end
 end

--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -1,15 +1,4 @@
 RSpec.describe Magick::Image, "#charcoal" do
-  def expect_im_version(hash)
-    im_major_minor = Magick::IMAGEMAGICK_VERSION.split('.').take(2).join('.')
-
-    hash.each do |key, value|
-      return value if key == im_major_minor.to_sym
-      return value if key.is_a?(Range) && key.include?(im_major_minor)
-    end
-
-    raise ArgumentError, "no value specified for version: #{im_major_minor}"
-  end
-
   def build_image(width:, height:, pixels:)
     image = Magick::Image.new(width, height)
     image.import_pixels(0, 0, width, height, "RGB", pixels.flatten)
@@ -30,17 +19,14 @@ RSpec.describe Magick::Image, "#charcoal" do
     expect { image.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
   end
 
-  it "applies a charcoal effect" do
+  it "applies a charcoal effect", supported_after('6.8') do
     image = build_image(
       width: 2,
       height: 2,
       pixels: [[45, 98, 156], [209, 171, 11], [239, 236, 2], [8, 65, 247]]
     )
 
-    expected_pixels = expect_im_version(
-      '6.7' => [gray(65535), gray(0), gray(0), gray(65535)],
-      ('6.8'..'7.0') => [gray(53736), gray(48703), gray(9953), gray(51857)]
-    )
+    expected_pixels = [gray(53736), gray(48703), gray(9953), gray(51857)]
 
     expect(image.charcoal).to match_pixels(expected_pixels, delta: 1)
   end

--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -9,4 +9,27 @@ RSpec.describe Magick::Image, "#charcoal" do
     expect { image.charcoal(1.0, 2.0) }.not_to raise_error
     expect { image.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
   end
+
+  it "applies a charcoal effect" do
+    pixels = [
+      45, 98, 156,
+      209, 171, 11,
+      239, 236, 2,
+      8, 65, 247
+    ]
+
+    image = described_class.new(2, 2)
+    image.import_pixels(0, 0, 2, 2, "RGB", pixels)
+
+    new_image = image.charcoal
+
+    new_pixels = new_image.export_pixels(0, 0, 2, 2, "RGB")
+    expected_pixels = [
+      53736, 53736, 53736,
+      48703, 48703, 48703,
+      9953, 9953, 9953,
+      51857, 51857, 51857
+    ]
+    expect(new_pixels).to match_pixels(expected_pixels, delta: 1)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require_relative 'support/simplecov' if ENV['COVERAGE'] == 'true'
+require_relative 'support/matchers'
 
 require 'pry'
 require_relative '../lib/rmagick'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,5 @@
+require_relative 'matchers/match_pixels_matcher'
+
+def match_pixels(expected, delta: 0)
+  Matchers::MatchPixels.new(expected, delta: delta)
+end

--- a/spec/support/matchers/match_pixels_matcher.rb
+++ b/spec/support/matchers/match_pixels_matcher.rb
@@ -1,0 +1,25 @@
+module Matchers
+  class MatchPixels
+    attr_accessor :actual, :expected, :delta
+
+    def initialize(expected, delta:)
+      self.expected = expected
+      self.delta = delta
+    end
+
+    def matches?(actual)
+      self.actual = actual
+      self.delta = delta
+
+      actual.each_with_index.all? do |value, index|
+        expected_value = expected[index]
+        value.between?(expected_value - delta, expected_value + delta)
+      end
+    end
+
+    def failure_message
+      "expected all pixel values to differ by max #{delta}\n" \
+        "\nexpected: #{expected}\n     got: #{actual}\n\n\n"
+    end
+  end
+end


### PR DESCRIPTION
This introduces a new `match_pixels` matcher that checks that all pixels
in the actual are within `delta` of the expected.