### PR TITLE
Add __USE_MINGW_ANSI_STDIO definition to avoid `warning: unknown conversion type character 'z' in format’

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -102,6 +102,7 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS = %(-I"#{dir_paths[:include]}")
+        $CPPFLAGS << ' -D__USE_MINGW_ANSI_STDIO=1'
         $LDFLAGS = %(-L"#{dir_paths[:lib]}")
         $LDFLAGS << ' -lucrt' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
 


### PR DESCRIPTION
MinGW platform uses special printf() and it does not recognize `z` format specifier.

Refer https://sourceforge.net/p/mingw-w64/wiki2/gnu%20printf/