### PR TITLE
Use proper format specifiers within MinGW

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -102,7 +102,6 @@ module RMagick
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS = %(-I"#{dir_paths[:include]}")
-        $CPPFLAGS << ' -D__USE_MINGW_ANSI_STDIO=1'
         $LDFLAGS = %(-L"#{dir_paths[:lib]}")
         $LDFLAGS << ' -lucrt' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
 

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -25,6 +25,23 @@
 #include "ruby.h"
 #include "ruby/io.h"
 
+#if defined(__MINGW32__)
+    // Ruby defines wrong format specifiers for MinGW. So this defines original macro in here.
+    #if SIZEOF_SIZE_T == SIZEOF_LONG
+        #define RMIuSIZE  "lu"
+        #define RMIdSIZE  "ld"
+        #define RMIsVALUE "li\v"
+    #elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
+        #define RMIuSIZE  "I64u"
+        #define RMIdSIZE  "I64d"
+        #define RMIsVALUE "I64i\v"
+    #endif
+#else
+    // Use constants defined in Ruby
+    #define RMIuSIZE  PRIuSIZE
+    #define RMIdSIZE  PRIdSIZE
+    #define RMIsVALUE PRIsVALUE
+#endif
 
 // Undef Ruby's versions of these symbols
 #undef PACKAGE_VERSION

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -318,7 +318,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
         w = FIX2INT(weight);
         if (w < 100 || w > 900)
         {
-            rb_raise(rb_eArgError, "invalid font weight (%"PRIuSIZE" given)", w);
+            rb_raise(rb_eArgError, "invalid font weight (%"RMIuSIZE" given)", w);
         }
         draw->info->weight = w;
     }

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3021,7 +3021,7 @@ Image_color_flood_fill( VALUE self, VALUE target_color, VALUE fill_color
     y = NUM2LONG(yv);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %"PRIuSIZE"x%"PRIuSIZE""
+        rb_raise(rb_eArgError, "target out of range. %lux%lu given, image is %"RMIuSIZE"x%"RMIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -5519,7 +5519,7 @@ Image_display(VALUE self)
 
     if (image->rows == 0 || image->columns == 0)
     {
-        rb_raise(rb_eArgError, "invalid image geometry (%"PRIuSIZE"x%"PRIuSIZE")", image->rows, image->columns);
+        rb_raise(rb_eArgError, "invalid image geometry (%"RMIuSIZE"x%"RMIuSIZE")", image->rows, image->columns);
     }
 
     info_obj = rm_info_new();
@@ -6542,7 +6542,7 @@ Image_extent(int argc, VALUE *argv, VALUE self)
         }
         else
         {
-            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%"PRIdSIZE"+%"PRIdSIZE""
+            rb_raise(rb_eArgError, "invalid extent geometry %ldx%ld+%"RMIdSIZE"+%"RMIdSIZE""
                      , width, height, geometry.x, geometry.y);
         }
     }
@@ -8027,7 +8027,7 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
         }
         if ((unsigned long)(buffer_l / type_sz) < npixels)
         {
-            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %"PRIuSIZE")"
+            rb_raise(rb_eArgError, "pixel buffer too small (need %lu channel values, got %"RMIuSIZE")"
                      , npixels, buffer_l/type_sz);
         }
     }
@@ -8159,7 +8159,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     // Print scene number.
     if ((GetPreviousImageInList(image) != NULL) && (GetNextImageInList(image) != NULL) && image->scene > 0)
     {
-        x += snprintf(buffer+x, len-x, "[%"PRIuSIZE"]", image->scene);
+        x += snprintf(buffer+x, len-x, "[%"RMIuSIZE"]", image->scene);
     }
     // Print format
     x += snprintf(buffer+x, len-x, " %s ", image->magick);
@@ -8169,17 +8169,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
     {
         if (image->magick_columns != image->columns || image->magick_rows != image->rows)
         {
-            x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE"=>", image->magick_columns, image->magick_rows);
+            x += snprintf(buffer+x, len-x, "%"RMIuSIZE"x%"RMIuSIZE"=>", image->magick_columns, image->magick_rows);
         }
     }
 
-    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE" ", image->columns, image->rows);
+    x += snprintf(buffer+x, len-x, "%"RMIuSIZE"x%"RMIuSIZE" ", image->columns, image->rows);
 
     // Print current columnsXrows
     if (   image->page.width != 0 || image->page.height != 0
            || image->page.x != 0     || image->page.y != 0)
     {
-        x += snprintf(buffer+x, len-x, "%"PRIuSIZE"x%"PRIuSIZE"+%"PRIdSIZE"+%"PRIdSIZE" ", image->page.width, image->page.height
+        x += snprintf(buffer+x, len-x, "%"RMIuSIZE"x%"RMIuSIZE"+%"RMIdSIZE"+%"RMIdSIZE" ", image->page.width, image->page.height
                      , image->page.x, image->page.y);
     }
 
@@ -8190,17 +8190,17 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         {
             if (image->total_colors >= (unsigned long)(1 << 24))
             {
-                x += snprintf(buffer+x, len-x, "%"PRIuSIZE"mc ", image->total_colors/1024/1024);
+                x += snprintf(buffer+x, len-x, "%"RMIuSIZE"mc ", image->total_colors/1024/1024);
             }
             else
             {
                 if (image->total_colors >= (unsigned long)(1 << 16))
                 {
-                    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"kc ", image->total_colors/1024);
+                    x += snprintf(buffer+x, len-x, "%"RMIuSIZE"kc ", image->total_colors/1024);
                 }
                 else
                 {
-                    x += snprintf(buffer+x, len-x, "%"PRIuSIZE"c ", image->total_colors);
+                    x += snprintf(buffer+x, len-x, "%"RMIuSIZE"c ", image->total_colors);
                 }
             }
         }
@@ -8215,7 +8215,7 @@ build_inspect_string(Image *image, char *buffer, size_t len)
         }
         else
         {
-            x += snprintf(buffer+x, len-x, "PseudoClass %"PRIuSIZE"=>%"PRIuSIZE"c ", image->total_colors, image->colors);
+            x += snprintf(buffer+x, len-x, "PseudoClass %"RMIuSIZE"=>%"RMIuSIZE"c ", image->total_colors, image->colors);
             if (image->error.mean_error_per_pixel != 0.0)
             {
                 x += snprintf(buffer+x, len-x, "%ld/%.6f/%.6fdb "
@@ -9337,7 +9337,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
     y = NUM2LONG(argv[2]);
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"PRIuSIZE"x%"PRIuSIZE""
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"RMIuSIZE"x%"RMIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -14259,7 +14259,7 @@ Image_texture_flood_fill(VALUE self, VALUE color_obj, VALUE texture_obj
 
     if ((unsigned long)x > image->columns || (unsigned long)y > image->rows)
     {
-        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"PRIuSIZE"x%"PRIuSIZE""
+        rb_raise(rb_eArgError, "target out of range. %ldx%ld given, image is %"RMIuSIZE"x%"RMIuSIZE""
                  , x, y, image->columns, image->rows);
     }
 
@@ -14737,7 +14737,7 @@ Image_to_blob(VALUE self)
                || !rm_strcasecmp(magick_info->name, "JPG"))
               && (image->rows == 0 || image->columns == 0))
         {
-            rb_raise(rb_eRuntimeError, "Can't convert %"PRIuSIZE"x%"PRIuSIZE" %.4s image to a blob"
+            rb_raise(rb_eRuntimeError, "Can't convert %"RMIuSIZE"x%"RMIuSIZE" %.4s image to a blob"
                      , image->columns, image->rows, magick_info->name);
         }
     }

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2029,7 +2029,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Data_Get_Struct(self, Info, info);
     info->scene = NUM2ULONG(scene);
 
-    (void) snprintf(buf, sizeof(buf), "%"PRIuSIZE"", info->scene);
+    (void) snprintf(buf, sizeof(buf), "%"RMIuSIZE"", info->scene);
     (void) SetImageOption(info, "scene", buf);
 
     return scene;

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -537,7 +537,7 @@ Font_to_s(VALUE self)
             strcpy(weight, "BoldWeight");
             break;
         default:
-            snprintf(weight, sizeof(weight), "%"PRIuSIZE"", ti.weight);
+            snprintf(weight, sizeof(weight), "%"RMIuSIZE"", ti.weight);
             break;
     }
 
@@ -753,7 +753,7 @@ RectangleInfo_to_s(VALUE self)
     char buff[100];
 
     Export_RectangleInfo(&rect, self);
-    snprintf(buff, sizeof(buff), "width=%"PRIuSIZE", height=%"PRIuSIZE", x=%"PRIdSIZE", y=%"PRIdSIZE""
+    snprintf(buff, sizeof(buff), "width=%"RMIuSIZE", height=%"RMIuSIZE", x=%"RMIdSIZE", y=%"RMIdSIZE""
           , rect.width, rect.height, rect.x, rect.y);
     return rb_str_new2(buff);
 }

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -266,7 +266,7 @@ rm_check_ary_type(VALUE ary)
     VALUE checked = rb_check_array_type(ary);
     if (NIL_P(checked))
     {
-        rb_raise(rb_eTypeError, "wrong argument type %"PRIsVALUE" was given. (must respond to :to_ary)", rb_obj_class(ary));
+        rb_raise(rb_eTypeError, "wrong argument type %"RMIsVALUE" was given. (must respond to :to_ary)", rb_obj_class(ary));
     }
     return checked;
 }


### PR DESCRIPTION
Seems Ruby's printf() format specifiers are wrong for old MinGW platform.
This PR uses  proper format specifiers for MinGW.

Related to https://github.com/rmagick/rmagick/pull/965