### PR TITLE
CI: run builds only on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
I think this is all we need. Because I'm pushing to branches on the main
repo, on my branches I see almost 70 checks. 33 for `push` and 33 for
`pull_request`. This will remove the duplicate `push` checks.