### PR TITLE
RSpec: remove extra spec setup

### DIFF
--- a/spec/rmagick/image/background_color_spec.rb
+++ b/spec/rmagick/image/background_color_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#background_color' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/base_columns_spec.rb
+++ b/spec/rmagick/image/base_columns_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#base_columns' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/base_filename_spec.rb
+++ b/spec/rmagick/image/base_filename_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#base_filename' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/base_rows_spec.rb
+++ b/spec/rmagick/image/base_rows_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#base_rows' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/bias_spec.rb
+++ b/spec/rmagick/image/bias_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#bias' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/black_point_compensation_spec.rb
+++ b/spec/rmagick/image/black_point_compensation_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#black_point_compensation' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/border_color_spec.rb
+++ b/spec/rmagick/image/border_color_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#border_color' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/bounding_box_spec.rb
+++ b/spec/rmagick/image/bounding_box_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Magick::Image, '#bounding_box' do
     gc.stroke_width(5)
     gc.circle(50, 50, 80, 80)
     gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/chromaticity_spec.rb
+++ b/spec/rmagick/image/chromaticity_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#chromaticity' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/class_type_spec.rb
+++ b/spec/rmagick/image/class_type_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#class_type' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/color_profile_spec.rb
+++ b/spec/rmagick/image/color_profile_spec.rb
@@ -1,13 +1,6 @@
 RSpec.describe Magick::Image, '#color_profile' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
     @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 

--- a/spec/rmagick/image/colors_spec.rb
+++ b/spec/rmagick/image/colors_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#colors' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/colorspace_spec.rb
+++ b/spec/rmagick/image/colorspace_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#colorspace' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/columns_spec.rb
+++ b/spec/rmagick/image/columns_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#columns' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/compose_spec.rb
+++ b/spec/rmagick/image/compose_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#compose' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/compression_spec.rb
+++ b/spec/rmagick/image/compression_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#compression' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/delay_spec.rb
+++ b/spec/rmagick/image/delay_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#delay' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/density_spec.rb
+++ b/spec/rmagick/image/density_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#density' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/depth_spec.rb
+++ b/spec/rmagick/image/depth_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Magick::Image, '#depth' do
     gc.stroke_width(5)
     gc.circle(50, 50, 80, 80)
     gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/directory_spec.rb
+++ b/spec/rmagick/image/directory_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#directory' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/dispose_spec.rb
+++ b/spec/rmagick/image/dispose_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#dispose' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/endian_spec.rb
+++ b/spec/rmagick/image/endian_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#endian' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/extract_info_spec.rb
+++ b/spec/rmagick/image/extract_info_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#extract_info' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/filename_spec.rb
+++ b/spec/rmagick/image/filename_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#filename' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/filter_spec.rb
+++ b/spec/rmagick/image/filter_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#filter' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/format_spec.rb
+++ b/spec/rmagick/image/format_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#format' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/freeze_spec.rb
+++ b/spec/rmagick/image/freeze_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#freeze' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/fuzz_spec.rb
+++ b/spec/rmagick/image/fuzz_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#fuzz' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/gamma_spec.rb
+++ b/spec/rmagick/image/gamma_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#gamma' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/geometry_spec.rb
+++ b/spec/rmagick/image/geometry_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#geometry' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/gravity_spec.rb
+++ b/spec/rmagick/image/gravity_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#gravity' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/image_type_spec.rb
+++ b/spec/rmagick/image/image_type_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#image_type' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/interlace_spec.rb
+++ b/spec/rmagick/image/interlace_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#interlace' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/iptc_profile_spec.rb
+++ b/spec/rmagick/image/iptc_profile_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#iptc_profile' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/mean_error_per_pixel_spec.rb
+++ b/spec/rmagick/image/mean_error_per_pixel_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#mean_error_per_pixel' do
   before do
-    @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
     @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/mime_type_spec.rb
+++ b/spec/rmagick/image/mime_type_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#mime_type' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/monitor_spec.rb
+++ b/spec/rmagick/image/monitor_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#monitor' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/montage_spec.rb
+++ b/spec/rmagick/image/montage_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#montage' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/number_colors_spec.rb
+++ b/spec/rmagick/image/number_colors_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#number_colors' do
   before do
-    @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
     @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/offset_spec.rb
+++ b/spec/rmagick/image/offset_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#offset' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/orientation_spec.rb
+++ b/spec/rmagick/image/orientation_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#orientation' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/page_spec.rb
+++ b/spec/rmagick/image/page_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#page' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/pixel_interpolation_method_spec.rb
+++ b/spec/rmagick/image/pixel_interpolation_method_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#pixel_interpolation_method' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/quality_spec.rb
+++ b/spec/rmagick/image/quality_spec.rb
@@ -1,19 +1,11 @@
 RSpec.describe Magick::Image, '#quality' do
   before do
-    @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
     @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do
     expect { @hat.quality }.not_to raise_error
     expect(@hat.quality).to eq(75)
-    expect { @img.quality = 80 }.to raise_error(NoMethodError)
+    expect { @hat.quality = 80 }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image/quantum_depth_spec.rb
+++ b/spec/rmagick/image/quantum_depth_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#quantum_depth' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/rendering_intent_spec.rb
+++ b/spec/rmagick/image/rendering_intent_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#rendering_intent' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/rows_spec.rb
+++ b/spec/rmagick/image/rows_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#rows' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/scene_spec.rb
+++ b/spec/rmagick/image/scene_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#scene' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/start_loop_spec.rb
+++ b/spec/rmagick/image/start_loop_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#start_loop' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/ticks_per_second_spec.rb
+++ b/spec/rmagick/image/ticks_per_second_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#ticks_per_second' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/total_colors_spec.rb
+++ b/spec/rmagick/image/total_colors_spec.rb
@@ -1,19 +1,11 @@
 RSpec.describe Magick::Image, '#total_colors' do
   before do
-    @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
     @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do
     expect { @hat.total_colors }.not_to raise_error
     expect(@hat.total_colors).to be_kind_of(Integer)
-    expect { @img.total_colors = 2 }.to raise_error(NoMethodError)
+    expect { @hat.total_colors = 2 }.to raise_error(NoMethodError)
   end
 end

--- a/spec/rmagick/image/units_spec.rb
+++ b/spec/rmagick/image/units_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#units' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/virtual_pixel_method_spec.rb
+++ b/spec/rmagick/image/virtual_pixel_method_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#virtual_pixel_method' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/x_resolution_spec.rb
+++ b/spec/rmagick/image/x_resolution_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#x_resolution' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do

--- a/spec/rmagick/image/y_resolution_spec.rb
+++ b/spec/rmagick/image/y_resolution_spec.rb
@@ -1,14 +1,6 @@
 RSpec.describe Magick::Image, '#y_resolution' do
   before do
     @img = described_class.new(100, 100)
-    gc = Magick::Draw.new
-
-    gc.stroke_width(5)
-    gc.circle(50, 50, 80, 80)
-    gc.draw(@img)
-
-    @hat = described_class.read(FLOWER_HAT).first
-    @p = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
   end
 
   it 'works' do


### PR DESCRIPTION
When I split up the tests I copied the `before` blocks to each spec.
Some of the logic in the `before` block didn't apply to most specs,
though, so this removes the extra logic from the specs that don't need
them.