### PR TITLE
RSpec: remove @list2 from specs where it is unused

### DIFF
--- a/spec/rmagick/image_list/__map___spec.rb
+++ b/spec/rmagick/image_list/__map___spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#__map__' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/all_predicate_spec.rb
+++ b/spec/rmagick/image_list/all_predicate_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#all?' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/any_predicate_spec.rb
+++ b/spec/rmagick/image_list/any_predicate_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#any?' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/at_spec.rb
+++ b/spec/rmagick/image_list/at_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#at' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/braces_equals_spec.rb
+++ b/spec/rmagick/image_list/braces_equals_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#[]=' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/braces_spec.rb
+++ b/spec/rmagick/image_list/braces_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#[]' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/clear_spec.rb
+++ b/spec/rmagick/image_list/clear_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#clear' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/collect_spec.rb
+++ b/spec/rmagick/image_list/collect_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#collect' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/compact_spec.rb
+++ b/spec/rmagick/image_list/compact_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#compact' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/delay_spec.rb
+++ b/spec/rmagick/image_list/delay_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#delay' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/delete_at_spec.rb
+++ b/spec/rmagick/image_list/delete_at_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#delete_at' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/delete_if_spec.rb
+++ b/spec/rmagick/image_list/delete_if_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#delete_if' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/delete_spec.rb
+++ b/spec/rmagick/image_list/delete_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#delete' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/eql_predicate_spec.rb
+++ b/spec/rmagick/image_list/eql_predicate_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#eql?' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/fill_spec.rb
+++ b/spec/rmagick/image_list/fill_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#fill' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/find_all_spec.rb
+++ b/spec/rmagick/image_list/find_all_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#find_all' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/find_spec.rb
+++ b/spec/rmagick/image_list/find_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#find' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/flatten_images_spec.rb
+++ b/spec/rmagick/image_list/flatten_images_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#flatten_images' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/insert_spec.rb
+++ b/spec/rmagick/image_list/insert_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#insert' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/iterations_spec.rb
+++ b/spec/rmagick/image_list/iterations_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#iterations' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/last_spec.rb
+++ b/spec/rmagick/image_list/last_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#last' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/length_spec.rb
+++ b/spec/rmagick/image_list/length_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#length' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/map_bang_spec.rb
+++ b/spec/rmagick/image_list/map_bang_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#map!' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/partition_spec.rb
+++ b/spec/rmagick/image_list/partition_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#partition' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/pop_spec.rb
+++ b/spec/rmagick/image_list/pop_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#pop' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/push_spec.rb
+++ b/spec/rmagick/image_list/push_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#push' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/reject_bang_spec.rb
+++ b/spec/rmagick/image_list/reject_bang_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#reject!' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/reject_spec.rb
+++ b/spec/rmagick/image_list/reject_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#reject' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/reverse_bang_spec.rb
+++ b/spec/rmagick/image_list/reverse_bang_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#reverse!' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/reverse_each_spec.rb
+++ b/spec/rmagick/image_list/reverse_each_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#reverse_each' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/reverse_spec.rb
+++ b/spec/rmagick/image_list/reverse_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#reverse' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/rindex_spec.rb
+++ b/spec/rmagick/image_list/rindex_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#rindex' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/scene_spec.rb
+++ b/spec/rmagick/image_list/scene_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#scene' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/select_spec.rb
+++ b/spec/rmagick/image_list/select_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#select' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/shift_spec.rb
+++ b/spec/rmagick/image_list/shift_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#shift' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/slice_bang_spec.rb
+++ b/spec/rmagick/image_list/slice_bang_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#slice!' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/slice_spec.rb
+++ b/spec/rmagick/image_list/slice_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#slice' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/sort_spec.rb
+++ b/spec/rmagick/image_list/sort_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#sort' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/spaceship_spec.rb
+++ b/spec/rmagick/image_list/spaceship_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#<=>' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/star_spec.rb
+++ b/spec/rmagick/image_list/star_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#*' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/ticks_per_second_spec.rb
+++ b/spec/rmagick/image_list/ticks_per_second_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#ticks_per_second' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/to_a_spec.rb
+++ b/spec/rmagick/image_list/to_a_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#to_a' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/uniq_bang_spec.rb
+++ b/spec/rmagick/image_list/uniq_bang_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#uniq!' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/uniq_spec.rb
+++ b/spec/rmagick/image_list/uniq_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#uniq' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/unshift_spec.rb
+++ b/spec/rmagick/image_list/unshift_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#unshift' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list/values_at_spec.rb
+++ b/spec/rmagick/image_list/values_at_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList, '#values_at' do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'works' do

--- a/spec/rmagick/image_list_spec.rb
+++ b/spec/rmagick/image_list_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe Magick::ImageList do
   before do
     @list = described_class.new(*FILES[0..9])
-    @list2 = described_class.new # intersection is 5..9
-    @list2 << @list[5]
-    @list2 << @list[6]
-    @list2 << @list[7]
-    @list2 << @list[8]
-    @list2 << @list[9]
   end
 
   it 'does not have certain array methods' do


### PR DESCRIPTION
Again, when splitting up the tests, these got copied across all of the
specs, but it's only used in a handful of them. I left it in the tests
where it is used.