### PR TITLE
CI: Set `MAKE` environment variable to avoid build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
           v1-windows-${{ matrix.ruby-version }}-{{ checksum rmagick.gemspec }}
     - name: Build and test with Rake
       run: |
-        cmd.exe /D /S /C "SET PATH=D:\ImageMagick;%PATH% & bundle install --path=vendor/bundle --retry 3 & bundle exec rake"
+        cmd.exe /D /S /C "SET MAKE=make & SET PATH=D:\ImageMagick;%PATH% & bundle install --path=vendor/bundle --retry 3 & bundle exec rake"


### PR DESCRIPTION
Recently, `C:\Strawberry\c\bin/gmake.exe` has been used in Windows platform.
It is one of Perl platform in Windows (http://strawberryperl.com) and its make command (`gmake`) will fail to compile Ruby extension.

To ensure using `make` command in msys/MinGW, this PR set `MAKE` environment variable.
(Refer https://github.com/rmagick/rmagick/pull/1020)