### PR TITLE
RSpec: eliminate `let` blocks

### DIFF
--- a/spec/rmagick/draw/class_methods/_dummy_img__spec.rb
+++ b/spec/rmagick/draw/class_methods/_dummy_img__spec.rb
@@ -7,9 +7,9 @@ module Magick
 end
 
 RSpec.describe Magick::Draw, '._dummy_img_' do
-  let(:draw) { described_class.new }
-
   it 'works' do
+    draw = described_class.new
+
     # cause it to become defined. save the object id.
     draw.get_type_metrics('ABCDEF')
     dummy = nil

--- a/spec/rmagick/draw/fill_pattern_writer_spec.rb
+++ b/spec/rmagick/draw/fill_pattern_writer_spec.rb
@@ -1,23 +1,29 @@
 RSpec.describe Magick::Draw, '#fill_pattern' do
-  let(:draw) { described_class.new }
-
   it 'accepts an Image argument' do
+    draw = described_class.new
     img = Magick::Image.new(20, 20)
+
     expect { draw.fill_pattern = img }.not_to raise_error
   end
 
   it 'accepts an ImageList argument' do
+    draw = described_class.new
     img = Magick::Image.new(20, 20)
     ilist = Magick::ImageList.new
     ilist << img
+
     expect { draw.fill_pattern = ilist }.not_to raise_error
   end
 
   it 'does not accept arbitrary arguments' do
+    draw = described_class.new
+
     expect { draw.fill_pattern = 1 }.to raise_error(NoMethodError)
   end
 
   it 'works' do
+    draw = described_class.new
+
     expect { draw.fill_pattern = nil }.not_to raise_error
     expect do
       img1 = Magick::Image.new(10, 10)

--- a/spec/rmagick/draw/interline_spacing_spec.rb
+++ b/spec/rmagick/draw/interline_spacing_spec.rb
@@ -1,16 +1,18 @@
 RSpec.describe Magick::Draw, '#interline_spacing' do
-  let(:draw) { described_class.new }
-
   before do
     @draw = described_class.new
     @img = Magick::Image.new(200, 200)
   end
 
   it 'accepts a valid parameter without raising an error' do
+    draw = described_class.new
+
     expect { draw.interline_spacing(1) }.not_to raise_error
   end
 
   it 'raises an error when given an invalid parameter' do
+    draw = described_class.new
+
     expect { draw.interline_spacing('a') }.to raise_error(ArgumentError)
     expect { draw.interline_spacing([]) }.to raise_error(TypeError)
   end

--- a/spec/rmagick/draw/interline_spacing_writer_spec.rb
+++ b/spec/rmagick/draw/interline_spacing_writer_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe Magick::Draw, '#interline_spacing=' do
-  let(:draw) { described_class.new }
-
   it 'assigns without raising an error' do
+    draw = described_class.new
+
     expect { draw.interline_spacing = 1 }.not_to raise_error
   end
 
   it 'works' do
+    draw = described_class.new
+
     expect { draw.interline_spacing = 2 }.not_to raise_error
     expect { draw.interline_spacing = 'x' }.to raise_error(TypeError)
   end

--- a/spec/rmagick/draw/interword_spacing_spec.rb
+++ b/spec/rmagick/draw/interword_spacing_spec.rb
@@ -1,22 +1,25 @@
 RSpec.describe Magick::Draw, '#interword_spacing' do
-  let(:draw) { described_class.new }
-
   before do
     @draw = described_class.new
     @img = Magick::Image.new(200, 200)
   end
 
   it 'accepts a valid parameter without raising an error' do
+    draw = described_class.new
+
     expect { draw.interword_spacing(1) }.not_to raise_error
   end
 
   it 'raises an error when given an invalid parameter' do
+    draw = described_class.new
+
     expect { draw.interword_spacing('a') }.to raise_error(ArgumentError)
     expect { draw.interword_spacing([]) }.to raise_error(TypeError)
   end
 
   it 'works' do
     draw = described_class.new
+
     draw.interword_spacing(40.5)
     expect(draw.inspect).to eq('interword-spacing 40.5')
     expect { draw.draw(@img) }.not_to raise_error

--- a/spec/rmagick/draw/interword_spacing_writer_spec.rb
+++ b/spec/rmagick/draw/interword_spacing_writer_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe Magick::Draw, '#interword_spacing=' do
-  let(:draw) { described_class.new }
-
   it 'assigns without raising an error' do
+    draw = described_class.new
+
     expect { draw.interword_spacing = 1 }.not_to raise_error
   end
 
   it 'works' do
+    draw = described_class.new
+
     expect { draw.interword_spacing = 2 }.not_to raise_error
     expect { draw.interword_spacing = 'x' }.to raise_error(TypeError)
   end

--- a/spec/rmagick/draw/kerning_spec.rb
+++ b/spec/rmagick/draw/kerning_spec.rb
@@ -1,22 +1,25 @@
 RSpec.describe Magick::Draw, '#kerning' do
-  let(:draw) { described_class.new }
-
   before do
     @draw = described_class.new
     @img = Magick::Image.new(200, 200)
   end
 
   it 'accepts a valid parameter without raising an error' do
+    draw = described_class.new
+
     expect { draw.kerning(1) }.not_to raise_error
   end
 
   it 'raises an error when given an invalid parameter' do
+    draw = described_class.new
+
     expect { draw.kerning('a') }.to raise_error(ArgumentError)
     expect { draw.kerning([]) }.to raise_error(TypeError)
   end
 
   it 'works' do
     draw = described_class.new
+
     draw.kerning(40.5)
     expect(draw.inspect).to eq('kerning 40.5')
     expect { draw.draw(@img) }.not_to raise_error

--- a/spec/rmagick/draw/kerning_writer_spec.rb
+++ b/spec/rmagick/draw/kerning_writer_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe Magick::Draw, '#kerning=' do
-  let(:draw) { described_class.new }
-
   it 'assigns without raising an error' do
+    draw = described_class.new
+
     expect { draw.kerning = 1 }.not_to raise_error
   end
 
   it 'works' do
+    draw = described_class.new
+
     expect { draw.kerning = 2 }.not_to raise_error
     expect { draw.kerning = 'x' }.to raise_error(TypeError)
   end

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Magick::Draw, '#marshal_dump' do
-  let(:draw) { described_class.new }
-
   before do
     @draw = described_class.new
   end
 
   it 'marshals without an error' do
     skip 'this spec fails on some versions of ImageMagick'
+    draw = described_class.new
+
     granite = Magick::Image.read('granite:').first
     s = granite.to_blob { self.format = 'miff' }
     granite = Magick::Image.from_blob(s).first

--- a/spec/rmagick/draw/stroke_pattern_writer_spec.rb
+++ b/spec/rmagick/draw/stroke_pattern_writer_spec.rb
@@ -1,23 +1,29 @@
 RSpec.describe Magick::Draw, '#stroke_pattern' do
-  let(:draw) { described_class.new }
-
   it 'accepts an Image argument' do
+    draw = described_class.new
     img = Magick::Image.new(20, 20)
+
     expect { draw.stroke_pattern = img }.not_to raise_error
   end
 
   it 'accepts an ImageList argument' do
+    draw = described_class.new
     img = Magick::Image.new(20, 20)
     ilist = Magick::ImageList.new
     ilist << img
+
     expect { draw.stroke_pattern = ilist }.not_to raise_error
   end
 
   it 'does not accept arbitrary arguments' do
+    draw = described_class.new
+
     expect { draw.stroke_pattern = 1 }.to raise_error(NoMethodError)
   end
 
   it 'works' do
+    draw = described_class.new
+
     expect { draw.stroke_pattern = nil }.not_to raise_error
     expect do
       img1 = Magick::Image.new(10, 10)

--- a/spec/rmagick/image/blue_shift_spec.rb
+++ b/spec/rmagick/image/blue_shift_spec.rb
@@ -1,18 +1,22 @@
 RSpec.describe Magick::Image, '#blue_shift' do
-  let(:img) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-
   it 'returns a new Image' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     res = img.blue_shift
     expect(res).to be_instance_of(described_class)
     expect(res).not_to eq img
   end
 
   it 'accepts one argument' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     expect { img.blue_shift(2) }.not_to raise_error
     expect { img.blue_shift(2, 3) }.to raise_error(ArgumentError)
   end
 
   it "works" do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     expect(img.blue_shift).not_to be(img)
     expect(img.blue_shift(2.0)).not_to be(img)
     expect { img.blue_shift('x') }.to raise_error(TypeError)

--- a/spec/rmagick/image/channel_entropy_spec.rb
+++ b/spec/rmagick/image/channel_entropy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#channel_entropy' do
-  let(:img) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-
   it 'returns a channel entropy', supported_after('6.9.0') do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     res = img.channel_entropy
     expect(res).to eq([0.5285857222715863])
   end

--- a/spec/rmagick/image/composite_spec.rb
+++ b/spec/rmagick/image/composite_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Magick::Image, '#composite' do
-  let(:img1) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-  let(:img2) { described_class.read(IMAGES_DIR + '/Button_1.gif').first }
-
   it 'raises an error given invalid arguments' do
+    img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
     expect { img1.composite }.to raise_error(ArgumentError)
     expect { img1.composite(img2) }.to raise_error(ArgumentError)
     expect do
@@ -14,6 +14,9 @@ RSpec.describe Magick::Image, '#composite' do
 
   context 'when given 3 arguments' do
     it 'works when 2nd argument is a gravity' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       Magick::CompositeOperator.values do |op|
         Magick::GravityType.values do |grav|
           expect { img1.composite(img2, grav, op) }.not_to raise_error
@@ -22,6 +25,9 @@ RSpec.describe Magick::Image, '#composite' do
     end
 
     it 'raises an error when 2nd argument is not a gravity' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       expect do
         img1.composite(img2, 2, Magick::OverCompositeOp)
       end.to raise_error(TypeError)
@@ -30,6 +36,9 @@ RSpec.describe Magick::Image, '#composite' do
 
   context 'when given 4 arguments' do
     it 'works when 4th argument is a composite operator' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       # there are way too many CompositeOperators to test them all, so just try
       # few representative ops
       Magick::CompositeOperator.values do |op|
@@ -38,17 +47,26 @@ RSpec.describe Magick::Image, '#composite' do
     end
 
     it 'returns a new Magick::Image object' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       res = img1.composite(img2, 0, 0, Magick::OverCompositeOp)
       expect(res).to be_instance_of(described_class)
     end
 
     it 'raises an error when 4th argument is not a composite operator' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       expect { img1.composite(img2, 0, 0, 2) }.to raise_error(TypeError)
     end
   end
 
   context 'when given 5 arguments' do
     it 'works when 2nd argument is gravity and 5th is a composite operator' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       Magick::CompositeOperator.values do |op|
         Magick::GravityType.values do |grav|
           expect { img1.composite(img2, grav, 0, 0, op) }.not_to raise_error
@@ -57,6 +75,9 @@ RSpec.describe Magick::Image, '#composite' do
     end
 
     it 'raises an error when 2nd argument is not a gravity' do
+      img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+      img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
       expect do
         img1.composite(img2, 0, 0, 2, Magick::OverCompositeOp)
       end.to raise_error(TypeError)
@@ -64,6 +85,9 @@ RSpec.describe Magick::Image, '#composite' do
   end
 
   it 'raises an error when the image has been destroyed' do
+    img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
+
     img2.destroy!
     expect do
       img1.composite(img2, Magick::CenterGravity, Magick::OverCompositeOp)

--- a/spec/rmagick/image/constitute_spec.rb
+++ b/spec/rmagick/image/constitute_spec.rb
@@ -1,14 +1,15 @@
 RSpec.describe Magick::Image, '#constitute' do
-  let(:img) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-  let(:pixels) { img.export_pixels(0, 0, img.columns, img.rows, 'RGBA') }
-
   it 'returns an equivalent image to the given pixels' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
+
     result = described_class.constitute(img.columns, img.rows, 'RGBA', pixels)
 
     expect(result.export_pixels).to eq(img.export_pixels)
   end
 
   it 'allows constituting with RGBA quantum (integer) pixel values' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
     # [R, G, B, A, R, G, B, A, ...]
     pixels = [1] * 4 * img.columns * img.rows
 
@@ -19,6 +20,7 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'allows constituting with RGBA scale (float) pixel values' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
     # [R, G, B, A, R, G, B, A, ...]
     pixels = [1.0] * 4 * img.columns * img.rows
 
@@ -29,6 +31,7 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when invalid RGBA pixel values are given' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
     pixels = ['x'] * (4 * img.columns * img.rows)
     expected_message = 'element 0 in pixel array is String, must be numeric'
 
@@ -37,6 +40,8 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when 0 is passed for columns' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
     expected_message = 'width and height must be greater than zero'
 
     expect { described_class.constitute(0, img.rows, 'RGBA', pixels) }
@@ -44,6 +49,8 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when a negative number is passed for columns' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
     expected_message = 'width and height must be greater than zero'
 
     expect { described_class.constitute(-3, img.rows, 'RGBA', pixels) }
@@ -51,6 +58,8 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when 0 is passed for rows' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
     expected_message = 'width and height must be greater than zero'
 
     expect { described_class.constitute(img.columns, 0, 'RGBA', pixels) }
@@ -58,6 +67,8 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error when a negative number is passed for rows' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
     expected_message = 'width and height must be greater than zero'
 
     expect { described_class.constitute(img.columns, -3, 'RGBA', pixels) }
@@ -65,6 +76,8 @@ RSpec.describe Magick::Image, '#constitute' do
   end
 
   it 'raises an error given the wrong number of array elements' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pixels = img.export_pixels(0, 0, img.columns, img.rows, 'RGBA')
     expected_message = 'wrong number of array elements (60960 for 72)'
 
     expect { described_class.constitute(3, 6, 'RGBA', pixels) }

--- a/spec/rmagick/image/dispatch_spec.rb
+++ b/spec/rmagick/image/dispatch_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#dispatch' do
-  let(:img) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-
   it 'expects exactly 5 or 6 arguments' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     expect { img.dispatch }.to raise_error(ArgumentError)
     expect { img.dispatch(0) }.to raise_error(ArgumentError)
     expect { img.dispatch(0, 0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Magick::Image, '#dissolve' do
-  let(:img1) { described_class.new(100, 100) { self.background_color = 'transparent' } }
-  let(:img2) { described_class.new(100, 100) { self.background_color = 'green' }       }
-
   it 'raises an error given invalid arguments' do
+    img1 = described_class.new(100, 100) { self.background_color = 'transparent' }
+    img2 = described_class.new(100, 100) { self.background_color = 'green' }
+
     expect { img1.dissolve }.to raise_error(ArgumentError)
     expect { img1.dissolve(img2, 'x') }.to raise_error(ArgumentError)
     expect { img1.dissolve(img2, 0.50, 'x') }.to raise_error(ArgumentError)
@@ -12,6 +12,9 @@ RSpec.describe Magick::Image, '#dissolve' do
 
   context 'when given 2 arguments' do
     it 'works when alpha is float 0.0 to 1.0' do
+      img1 = described_class.new(100, 100) { self.background_color = 'transparent' }
+      img2 = described_class.new(100, 100) { self.background_color = 'green' }
+
       dissolved = img1.dissolve(img2, 0.50)
       expect(dissolved).to be_instance_of(described_class)
       expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.45, 0.55)
@@ -19,6 +22,9 @@ RSpec.describe Magick::Image, '#dissolve' do
       expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.15, 0.25)
     end
     it 'works when alpha is string percentage' do
+      img1 = described_class.new(100, 100) { self.background_color = 'transparent' }
+      img2 = described_class.new(100, 100) { self.background_color = 'green' }
+
       dissolved = img1.dissolve(img2, '50%')
       expect(dissolved).to be_instance_of(described_class)
       expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.45, 0.55)
@@ -36,18 +42,23 @@ RSpec.describe Magick::Image, '#dissolve' do
     d.draw(wk)
 
     it 'works on colored background' do
+      img = described_class.new(100, 100) { self.background_color = 'green' }
+
       # generate an image to use with gravity
-      dissolved = img2.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
+      dissolved = img.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
       expect(dissolved).to be_instance_of(described_class)
-      expect(dissolved.pixel_color(10, 10)).to eq(img2.pixel_color(10, 10))
+      expect(dissolved.pixel_color(10, 10)).to eq(img.pixel_color(10, 10))
       expect(Float(dissolved.pixel_color(50, 50).blue) / Magick::QuantumRange).to be_between(0.45, 0.55)
-      expect(Float(dissolved.pixel_color(50, 50).green)).to be_between(0, img2.pixel_color(2, 2).green).exclusive
+      expect(Float(dissolved.pixel_color(50, 50).green)).to be_between(0, img.pixel_color(2, 2).green).exclusive
     end
   end
 
   # still need to test with destination percentage, offsets
 
   it 'raises an error when the image has been destroyed' do
+    img1 = described_class.new(100, 100) { self.background_color = 'transparent' }
+    img2 = described_class.new(100, 100) { self.background_color = 'green' }
+
     img1.destroy!
     expect { img1.dissolve(img2, 0.50) }.to raise_error(Magick::DestroyedImageError)
   end

--- a/spec/rmagick/image/element_assignment_spec.rb
+++ b/spec/rmagick/image/element_assignment_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#[]=' do
-  let(:img) { described_class.new(20, 20) }
-
   it 'allows assignment of arbitrary properties' do
+    img = described_class.new(20, 20)
+
     img['comment'] = 'str_1'
     img['label'] = 'str_2'
     img['jpeg:sampling-factor'] = '2x1,1x1,1x1'
@@ -12,6 +12,8 @@ RSpec.describe Magick::Image, '#[]=' do
   end
 
   it 'raises an error when trying to assign properties to a frozen image' do
+    img = described_class.new(20, 20)
+
     img.freeze
 
     expect { img['comment'] = 'str_4' }.to raise_error(RuntimeError)

--- a/spec/rmagick/image/element_reference_spec.rb
+++ b/spec/rmagick/image/element_reference_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#[]' do
-  let(:img) { described_class.new(20, 20) }
-
   it 'allows accessing arbitrary properties' do
+    img = described_class.new(20, 20)
+
     img['comment'] = 'str_1'
     img['label'] = 'str_2'
     img['jpeg:sampling-factor'] = '2x1,1x1,1x1'

--- a/spec/rmagick/image/from_blob_spec.rb
+++ b/spec/rmagick/image/from_blob_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Magick::Image, '#from_blob' do
-  let(:img) { described_class.read(IMAGES_DIR + '/Button_0.gif').first }
-  let(:blob) { img.to_blob }
-
   it 'returns an image equal to the original' do
+    img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    blob = img.to_blob
+
     expect(blob).to be_instance_of(String)
     res = described_class.from_blob(blob)
     expect(res).to be_instance_of(Array)

--- a/spec/rmagick/image/properties_spec.rb
+++ b/spec/rmagick/image/properties_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#properties' do
-  let(:img) { described_class.new(20, 20) }
-
   it 'returns a hash of assigned properties' do
+    img = described_class.new(20, 20)
+
     img['comment'] = 'str_1'
     img['label'] = 'str_2'
     img['jpeg:sampling-factor'] = '2x1,1x1,1x1'


### PR DESCRIPTION
I've been moving in the  direction of avoiding `let` blocks as they
create indirection in the tests that can make it hard to fully
understand what the test is testing. Instead, I will err on the side of
a little more duplication in the tests. In cases where there is a lot of
setup logic to use over and over, I will often pull it out into helper
methods either in the specific test file, or in a higher level file for
use across multiple specs. More detailed argument against `let` blocks
in [this thoughtbot article][1].

[1]: https://thoughtbot.com/blog/lets-not