### PR TITLE
CPPCheck: reduce scope of remaining variables

### DIFF
--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -112,7 +112,6 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
 {
     Info *info;
     PixelColor pp;
-    ExceptionInfo *exception;
     MagickBooleanType okay;
 
     Data_Get_Struct(self, Info, info);
@@ -124,6 +123,7 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
     else
     {
         char *name;
+        ExceptionInfo *exception;
 
         name = StringValuePtr(color);
         exception = AcquireExceptionInfo();

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -296,13 +296,14 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
 void
 Color_to_Pixel(Pixel *pp, VALUE color)
 {
-    Pixel *pixel;
     PixelColor pixel_color;
 
     memset(pp, 0, sizeof(*pp));
     // Allow color name or Pixel
     if (CLASS_OF(color) == Class_Pixel)
     {
+        Pixel *pixel;
+
         Data_Get_Struct(color, Pixel, pixel);
         memcpy(pp, pixel, sizeof(Pixel));
     }


### PR DESCRIPTION
I thought there were a bunch more of these, but these are the only ones
that are showing up on Codacy right now.