### PR TITLE
CI: Remove unnecessary "gem install bundler"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           v1-linux-2.3-{{ checksum rmagick.gemspec }}
     - name: Build and test with Rake
       run: |
-        gem install bundler
         bundle install --path=vendor/bundle --jobs 4 --retry 3
         STYLE_CHECKS=true bundle exec rubocop
 
@@ -68,7 +67,6 @@ jobs:
           v1-linux-${{ matrix.ruby-version }}-{{ checksum rmagick.gemspec }}
     - name: Build and test with Rake
       run: |
-        gem install bundler
         bundle install --path=vendor/bundle --jobs 4 --retry 3
         bundle exec rake
 


### PR DESCRIPTION
`bundler` will be installed at https://github.com/rmagick/rmagick/blob/e48d78ab81f6d3fab502a8c24ca9edb65921c87c/before_install_linux.sh#L5