### PR TITLE
Fix warning of unused variable

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -213,8 +213,9 @@ VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
 {
 #if defined(IMAGEMAGICK_6)
     ChannelType channel;
+    ColorspaceType old_colorspace;
 #endif
-    ColorspaceType colorspace, old_colorspace;
+    ColorspaceType colorspace;
     long len;
     Image *images, *new_image;
     ExceptionInfo *exception;


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/pull/965