### PR TITLE
Example: Fix “undefined method `opacity’”

### DIFF
--- a/doc/ex/colors.rb
+++ b/doc/ex/colors.rb
@@ -20,7 +20,7 @@ colors do |c|
       self.border_color = 'gray50'
     end
     rgb  = format('#%02x%02x%02x', c.color.red & 0xff, c.color.green & 0xff, c.color.blue & 0xff)
-    rgb += format('%02x', c.color.opacity & 0xff) if c.color.opacity != 0
+    rgb += format('%02x', c.color.alpha & 0xff) if c.color.alpha != Magick::QuantumRange
     m = /(.*?)Compliance/.match c.compliance.to_s
     colors.cur_image['Label'] = "#{c.name} (#{rgb}) #{m[1]}"
   end


### PR DESCRIPTION
This patch will fix following error in example.

```sh
$ ruby colors.rb
Creating colors.miff. This may take a few seconds...
	Creating color swatches...
colors.rb:23:in `block in <main>': undefined method `opacity' for #<Magick::Pixel:0x00007fe243940cf0> (NoMethodError)
	from colors.rb:16:in `colors'
	from colors.rb:16:in `<main>’
```