### PR TITLE
CI: add timeout-minutes setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.3
@@ -31,6 +32,7 @@ jobs:
 
   test-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
@@ -72,6 +74,7 @@ jobs:
 
   test-windows:
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6]


### PR DESCRIPTION
The default timeout on Github Actions is 360 minutes (6 hours). This
shortens it to 10 minutes so that we don't have to wait forever for
things to fail when they stall.