### PR TITLE
Rubocop: re-enable RSpec/FilePath

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ AllCops:
 ################################################################################
 
 Layout/MultilineAssignmentLayout: { EnforcedStyle: same_line }
-# RSpec/FilePath: { CustomTransform: { Magick: rmagick } }
+RSpec/FilePath: { CustomTransform: { Magick: rmagick } }
 # we may not need this after finishing RSpec conversion
 # seems like `rubocop-rspec` already excludes the `spec/` directory
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,8 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-RSpec/FilePath: { Enabled: false }
-
 # Offense count: 12
 # Cop supports --auto-correct.
 # Configuration parameters: Categories, ExpectedOrder.


### PR DESCRIPTION
It's passing now. There was some weird stuff with it for a bit.