### PR TITLE
Rubocop: enable HeredocArgumentClosingParenthesis

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,12 +20,6 @@ Layout/ClassStructure:
     - 'lib/rvg/rvg.rb'
     - 'lib/rvg/to_c.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/HeredocArgumentClosingParenthesis:
-  Exclude:
-    - 'doc/ex/arcs01.rb'
-
 # Offense count: 16
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/doc/ex/arcs01.rb
+++ b/doc/ex/arcs01.rb
@@ -15,14 +15,14 @@ rvg = Magick::RVG.new(12.cm, 5.25.cm).viewbox(0, 0, 1200, 400) do |canvas|
         .styles(fill: 'red', stroke: 'blue', stroke_width: 5)
   canvas.path('M275,175 v-150 a150,150 0 0,0 -150,150 z')
         .styles(fill: 'yellow', stroke: 'blue', stroke_width: 5)
-  canvas.path(<<-END_PATH
+  canvas.path(<<-END_PATH)
            M600,350 l 50,-25
            a25,25 -30 0,1 50,-25 l 50,-25
            a25,50 -30 0,1 50,-25 l 50,-25
            a25,75 -30 0,1 50,-25 l 50,-25
            a25,100 -30 0,1 50,-25 l 50,-25
   END_PATH
-             ).styles(fill: 'none', stroke: 'red', stroke_width: 5)
+        .styles(fill: 'none', stroke: 'red', stroke_width: 5)
 end
 
 rvg.draw.write('arcs01.gif')


### PR DESCRIPTION
This rule requires that the closing paren is after the opening heredoc
tag.

https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutheredocargumentclosingparenthesis