### PR TITLE
Rubocop: enable IndentHeredoc

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,24 +20,6 @@ Layout/ClassStructure:
     - 'lib/rvg/rvg.rb'
     - 'lib/rvg/to_c.rb'
 
-# Offense count: 16
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
-  Exclude:
-    - 'Rakefile'
-    - 'examples/describe.rb'
-    - 'examples/histogram.rb'
-    - 'examples/image_opacity.rb'
-    - 'examples/import_export.rb'
-    - 'examples/pattern_fill.rb'
-    - 'examples/rotating_text.rb'
-    - 'examples/spinner.rb'
-    - 'examples/thumbnail.rb'
-    - 'ext/RMagick/extconf.rb'
-    - 'lib/rvg/to_c.rb'
-
 # Offense count: 2312
 # Cop supports --auto-correct.
 Layout/MultilineArrayLineBreaks:

--- a/Rakefile
+++ b/Rakefile
@@ -121,21 +121,21 @@ namespace :legacy do
   task README => 'README.txt' do
     puts "writing #{README}"
     File.open(README, 'w') do |html|
-      html.write <<END_HTML_HEAD
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
-  <head>
-    <title>RMagick #{Magick::VERSION} README</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-    <meta name="GENERATOR" content="RedCloth">
-  </head>
-  <body>
-END_HTML_HEAD
+      html.write <<~END_HTML_HEAD
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+        <html>
+          <head>
+            <title>RMagick #{Magick::VERSION} README</title>
+            <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+            <meta name="GENERATOR" content="RedCloth">
+          </head>
+          <body>
+      END_HTML_HEAD
       html.write File.readlines('README.txt')
-      html.write <<END_HTML_TAIL
-  </body>
-</html>
-END_HTML_TAIL
+      html.write <<~END_HTML_TAIL
+          </body>
+        </html>
+      END_HTML_TAIL
     end
   end
 

--- a/examples/describe.rb
+++ b/examples/describe.rb
@@ -4,9 +4,9 @@
 
 require 'rmagick'
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example shows how to extract attributes from an image.
+  This example shows how to extract attributes from an image.
 
 END_INFO
 

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -152,12 +152,12 @@ module Magick
     def info_text(fg, bg)
       klass = class_type == DirectClass ? 'DirectClass' : 'PsuedoClass'
 
-      text = <<-END_TEXT
-Format: #{format}
-Geometry: #{columns}x#{rows}
-Class: #{klass}
-Depth: #{depth} bits-per-pixel component
-Colors: #{number_colors}
+      text = <<~END_TEXT
+        Format: #{format}
+        Geometry: #{columns}x#{rows}
+        Class: #{klass}
+        Depth: #{depth} bits-per-pixel component
+        Colors: #{number_colors}
       END_TEXT
 
       info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do
@@ -268,10 +268,10 @@ Colors: #{number_colors}
   end
 end
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example shows how to get pixel-level access to an image.
-Usage: histogram.rb <image-filename>
+  This example shows how to get pixel-level access to an image.
+  Usage: histogram.rb <image-filename>
 
 END_INFO
 

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -3,10 +3,10 @@
 require 'rmagick'
 include Magick
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example uses a semi-transparent background color to create a title.
-View the resulting image by entering the command: display image_opacity.miff
+  This example uses a semi-transparent background color to create a title.
+  View the resulting image by entering the command: display image_opacity.miff
 
 END_INFO
 

--- a/examples/import_export.rb
+++ b/examples/import_export.rb
@@ -5,11 +5,11 @@
 require 'rmagick'
 include Magick
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example demonstrates the export_pixels and import_pixels methods
-by copying an image one row at a time. The result is an copy that
-is identical to the original.
+  This example demonstrates the export_pixels and import_pixels methods
+  by copying an image one row at a time. The result is an copy that
+  is identical to the original.
 
 END_INFO
 

--- a/examples/pattern_fill.rb
+++ b/examples/pattern_fill.rb
@@ -7,11 +7,11 @@
 require 'rmagick'
 include Magick
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example demonstrates the PATTERN: image format, which is
-new in ImageMagick 5.5.7. Specify the name of any of the
-supported patterns as an argument. For example, try "checkerboard".
+  This example demonstrates the PATTERN: image format, which is
+  new in ImageMagick 5.5.7. Specify the name of any of the
+  supported patterns as an argument. For example, try "checkerboard".
 
 END_INFO
 

--- a/examples/rotating_text.rb
+++ b/examples/rotating_text.rb
@@ -4,10 +4,10 @@
 require 'rmagick'
 include Magick
 
-puts <<END_INFO
-Demonstrate the rotation= attribute in the Draw class
-by producing an animated image. View the output image
-by entering the command: animate rotating_text.miff
+puts <<~END_INFO
+  Demonstrate the rotation= attribute in the Draw class
+  by producing an animated image. View the output image
+  by entering the command: animate rotating_text.miff
 END_INFO
 
 text = Draw.new

--- a/examples/spinner.rb
+++ b/examples/spinner.rb
@@ -3,11 +3,11 @@
 
 require 'rmagick'
 
-puts <<END_INFO
-This example creates an animated GIF that resembles the OS X "waiting" icon.
-You can view the GIF with the command
+puts <<~END_INFO
+  This example creates an animated GIF that resembles the OS X "waiting" icon.
+  You can view the GIF with the command
 
-    animate spinner.gif
+      animate spinner.gif
 END_INFO
 
 NFRAMES = 12                    # number of frames in the animation

--- a/examples/thumbnail.rb
+++ b/examples/thumbnail.rb
@@ -1,21 +1,21 @@
 require 'rmagick'
 include Magick
 
-puts <<END_INFO
+puts <<~END_INFO
 
-This example demonstrates how to make a thumbnail of an image.
-An image is resized to the target size (retaining its original
-aspect ratio, of course) and then "mounted" on a square background
-with raised edges.
+  This example demonstrates how to make a thumbnail of an image.
+  An image is resized to the target size (retaining its original
+  aspect ratio, of course) and then "mounted" on a square background
+  with raised edges.
 
-Usage:
+  Usage:
 
-    ruby thumbnail.rb <filename <size>>
+      ruby thumbnail.rb <filename <size>>
 
-where `filename' is the name of an image file and `size' is the
-size of the thumbnail in pixels. The default size is 120 pixels.
-If you don't specify any arguments this script uses a default
-image.
+  where `filename' is the name of an image file and `size' is the
+  size of the thumbnail in pixels. The default size is 120 pixels.
+  If you don't specify any arguments this script uses a default
+  image.
 
 END_INFO
 

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -104,9 +104,9 @@ module RMagick
     def have_enum_value(enum, value, headers = nil, &b)
       checking_for "#{enum}.#{value}" do
         source = <<~"SRC"
-        #{COMMON_HEADERS}
-        #{cpp_include(headers)}
-        int main() { #{enum} t = #{value}; t = t; return 0; }
+          #{COMMON_HEADERS}
+          #{cpp_include(headers)}
+          int main() { #{enum} t = #{value}; t = t; return 0; }
         SRC
 
         if try_compile(source, &b)
@@ -270,12 +270,12 @@ module RMagick
       return dir_paths if found_lib
 
       exit_failure <<~END_MINGW
-      Can't install RMagick #{RMAGICK_VERS}.
-      Can't find the ImageMagick library.
-      Retry with '--with-opt-dir' option.
-      Usage: gem install rmagick -- '--with-opt-dir=\"[path to ImageMagick]\"'
-      e.g.
-        gem install rmagick -- '--with-opt-dir=\"C:\Program Files\ImageMagick-6.9.1-Q16\"'
+        Can't install RMagick #{RMAGICK_VERS}.
+        Can't find the ImageMagick library.
+        Retry with '--with-opt-dir' option.
+        Usage: gem install rmagick -- '--with-opt-dir=\"[path to ImageMagick]\"'
+        e.g.
+          gem install rmagick -- '--with-opt-dir=\"C:\Program Files\ImageMagick-6.9.1-Q16\"'
       END_MINGW
     end
 
@@ -298,9 +298,9 @@ module RMagick
 
     def assert_has_dev_libs!
       failure_message = <<~END_FAILURE
-      Can't install RMagick #{RMAGICK_VERS}.
-      Can't find the ImageMagick library or one of the dependent libraries.
-      Check the mkmf.log file for more detailed information.
+        Can't install RMagick #{RMAGICK_VERS}.
+        Can't find the ImageMagick library or one of the dependent libraries.
+        Check the mkmf.log file for more detailed information.
       END_FAILURE
 
       if RUBY_PLATFORM !~ /mswin|mingw/
@@ -390,13 +390,11 @@ module RMagick
 
     def print_summary
       summary = <<~"END_SUMMARY"
-
-
-      #{'=' * 70}
-      #{DateTime.now.strftime('%a %d %b %y %T')}
-      This installation of RMagick #{RMAGICK_VERS} is configured for
-      Ruby #{RUBY_VERSION} (#{RUBY_PLATFORM}) and ImageMagick #{$magick_version}
-      #{'=' * 70}
+          #{'=' * 70}
+        #{DateTime.now.strftime('%a %d %b %y %T')}
+        This installation of RMagick #{RMAGICK_VERS} is configured for
+        Ruby #{RUBY_VERSION} (#{RUBY_PLATFORM}) and ImageMagick #{$magick_version}
+        #{'=' * 70}
 
 
       END_SUMMARY

--- a/lib/rvg/to_c.rb
+++ b/lib/rvg/to_c.rb
@@ -2,28 +2,28 @@ class Magick::RVG
   private
 
   def header_text(pgm, name)
-    pgm.puts <<"END_HEADER"
-/*
-Version: #{Magick_version}
+    pgm.puts <<~"END_HEADER"
+      /*
+      Version: #{Magick_version}
 
-gcc `Magick-config --cflags --cppflags` #{name}.c `Magick-config --ldflags --libs` -o #{name}
-*/
+      gcc `Magick-config --cflags --cppflags` #{name}.c `Magick-config --ldflags --libs` -o #{name}
+      */
 
-#include <stdio.h>
-#include <time.h>
-#include <sys/types.h>
-#include <string.h>
-#include <stdlib.h>
-#include <magick/api.h>
+      #include <stdio.h>
+      #include <time.h>
+      #include <sys/types.h>
+      #include <string.h>
+      #include <stdlib.h>
+      #include <magick/api.h>
 
 
-int main(int argc,char **argv)
-{
-  Image *image;
-  ImageInfo *info;
-  DrawInfo *draw;
-  const char * const primitives =
-END_HEADER
+      int main(int argc,char **argv)
+      {
+        Image *image;
+        ImageInfo *info;
+        DrawInfo *draw;
+        const char * const primitives =
+    END_HEADER
   end
 
   def list_primitives(pgm, gc)
@@ -37,51 +37,51 @@ END_HEADER
   end
 
   def trailer_text(pgm, name)
-    pgm.puts <<"END_TRAILER"
-  ;
+    pgm.puts <<~"END_TRAILER"
+        ;
 
-  InitializeMagick("#{name}");
+        InitializeMagick("#{name}");
 
-  info = CloneImageInfo(NULL);
-  if (!info)
-  {
-    MagickError(ResourceLimitError,"Unable to allocate ImageInfo",
-      "Memory allocation failed");
-  }
+        info = CloneImageInfo(NULL);
+        if (!info)
+        {
+          MagickError(ResourceLimitError,"Unable to allocate ImageInfo",
+            "Memory allocation failed");
+        }
 
-  info->size = AcquireMagickMemory(20);
-  sprintf(info->size, "%dx%d", #{@width.to_i}, #{@height.to_i});
+        info->size = AcquireMagickMemory(20);
+        sprintf(info->size, "%dx%d", #{@width.to_i}, #{@height.to_i});
 
-  image = AllocateImage(info);
-  if (!image)
-  {
-    MagickError(ResourceLimitError,"Unable to allocate Image",
-      "Memory allocation failed");
-  }
+        image = AllocateImage(info);
+        if (!image)
+        {
+          MagickError(ResourceLimitError,"Unable to allocate Image",
+            "Memory allocation failed");
+        }
 
-  SetImage(image, OpaqueOpacity);
+        SetImage(image, OpaqueOpacity);
 
-  draw = CloneDrawInfo(info, NULL);
-  CloneString(&(draw->primitive), primitives);
-  DrawImage(image, draw);
+        draw = CloneDrawInfo(info, NULL);
+        CloneString(&(draw->primitive), primitives);
+        DrawImage(image, draw);
 
-  if (image->exception.severity != UndefinedException)
-  {
-        printf("%s: %s", image->exception.reason, image->exception.description);
-        exit(1);
-  }
+        if (image->exception.severity != UndefinedException)
+        {
+              printf("%s: %s", image->exception.reason, image->exception.description);
+              exit(1);
+        }
 
-  strcpy(image->filename, "#{name + '.gif'}");
-  WriteImage(info, image);
+        strcpy(image->filename, "#{name + '.gif'}");
+        WriteImage(info, image);
 
-  DestroyDrawInfo(draw);
-  DestroyImage(image);
-  DestroyImageInfo(info);
-  DestroyMagick();
+        DestroyDrawInfo(draw);
+        DestroyImage(image);
+        DestroyImageInfo(info);
+        DestroyMagick();
 
-  return 0;
-}
-END_TRAILER
+        return 0;
+      }
+    END_TRAILER
   end
 
   public


### PR DESCRIPTION
This rule requires that we use the "squiggly" heredoc (`<<~`), which
allows us to indent the heredoc. It will trim left spacing in the
heredoc.

https://infinum.com/the-capsized-eight/multiline-strings-ruby-2-3-0-the-squiggly-heredoc
https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutheredocindentation