### PR TITLE
Rubocop: enable MultilineHashKeyLineBreaks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,12 +33,6 @@ Layout/MultilineArrayLineBreaks:
     - 'lib/rmagick_internal.rb'
     - 'lib/rvg/stylable.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Layout/MultilineHashKeyLineBreaks:
-  Exclude:
-    - 'lib/rvg/misc.rb'
-
 # Offense count: 192
 # Cop supports --auto-correct.
 Layout/MultilineMethodArgumentLineBreaks:

--- a/lib/rvg/misc.rb
+++ b/lib/rvg/misc.rb
@@ -478,9 +478,12 @@ module Magick
         }
 
         TEXT_STRATEGIES = {
-          'lr-tb' => LRTextStrategy, 'lr' => LRTextStrategy,
-          'rt-tb' => RLTextStrategy, 'rl' => RLTextStrategy,
-          'tb-rl' => TBTextStrategy, 'tb' => TBTextStrategy
+          'lr-tb' => LRTextStrategy,
+          'lr' => LRTextStrategy,
+          'rt-tb' => RLTextStrategy,
+          'rl' => RLTextStrategy,
+          'tb-rl' => TBTextStrategy,
+          'tb' => TBTextStrategy
         }
 
         def self.degrees_to_radians(deg)


### PR DESCRIPTION
This rule requires that each key-value pair in a multi-line hash is on a
separate line.

https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutmultilinehashkeylinebreaks