### PR TITLE
RSpec: don't check for errors when assigning res

### DIFF
--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe Magick do
   describe '::Magick_features' do
     it 'works' do
-      res = nil
-      expect { res = Magick::Magick_features }.not_to raise_error
-      expect(res).to be_instance_of(String)
+      expect(Magick::Magick_features).to be_instance_of(String)
     end
   end
 

--- a/spec/rmagick/class_methods/colors_spec.rb
+++ b/spec/rmagick/class_methods/colors_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Magick, '.colors' do
   it 'works' do
-    res = nil
-    expect { res = described_class.colors }.not_to raise_error
+    res = described_class.colors
     expect(res).to be_instance_of(Array)
     res.each do |c|
       expect(c).to be_instance_of(Magick::Color)

--- a/spec/rmagick/class_methods/fonts_spec.rb
+++ b/spec/rmagick/class_methods/fonts_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Magick, '.fonts' do
   it 'works' do
-    res = nil
-    expect { res = described_class.fonts }.not_to raise_error
+    res = described_class.fonts
     expect(res).to be_instance_of(Array)
     res.each do |f|
       expect(f).to be_instance_of(Magick::Font)

--- a/spec/rmagick/image/auto_gamma_channel_spec.rb
+++ b/spec/rmagick/image/auto_gamma_channel_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe Magick::Image, "#auto_gamma_channel" do
   it "works" do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect { res = img.auto_gamma_channel }.not_to raise_error
+    res = img.auto_gamma_channel
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
-    expect { res = img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
-    expect { res = img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+
+    expect { img.auto_gamma_channel Magick::RedChannel }.not_to raise_error
+    expect { img.auto_gamma_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { img.auto_gamma_channel(1) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/auto_level_channel_spec.rb
+++ b/spec/rmagick/image/auto_level_channel_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe Magick::Image, "#auto_level_channel" do
   it "works" do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect { res = img.auto_level_channel }.not_to raise_error
+    res = img.auto_level_channel
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
-    expect { res = img.auto_level_channel Magick::RedChannel }.not_to raise_error
-    expect { res = img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
+
+    expect { img.auto_level_channel Magick::RedChannel }.not_to raise_error
+    expect { img.auto_level_channel Magick::RedChannel, Magick::BlueChannel }.not_to raise_error
     expect { img.auto_level_channel(1) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/clut_channel_spec.rb
+++ b/spec/rmagick/image/clut_channel_spec.rb
@@ -2,9 +2,10 @@ RSpec.describe Magick::Image, "#clut_channel" do
   it "works" do
     img = described_class.new(20, 20) { self.colorspace = Magick::GRAYColorspace }
     clut = described_class.new(20, 1) { self.background_color = 'red' }
-    res = nil
-    expect { res = img.clut_channel(clut) }.not_to raise_error
+
+    res = img.clut_channel(clut)
     expect(res).to be(img)
+
     expect { img.clut_channel(clut, Magick::RedChannel) }.not_to raise_error
     expect { img.clut_channel(clut, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img.clut_channel }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/composite_mathematics_spec.rb
+++ b/spec/rmagick/image/composite_mathematics_spec.rb
@@ -2,13 +2,14 @@ RSpec.describe Magick::Image, '#composite_mathematics' do
   it 'works' do
     bg = described_class.new(50, 50)
     fg = described_class.new(50, 50) { self.background_color = 'black' }
-    res = nil
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity) }.not_to raise_error
+
+    res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity)
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(bg)
     expect(res).not_to be(fg)
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
-    expect { res = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
+
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0, 0.0, 0.0) }.not_to raise_error
+    expect { bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity, 0.0, 0.0) }.not_to raise_error
 
     # too few arguments
     expect { bg.composite_mathematics(fg, 1, 0, 0, 0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/composite_tiled_spec.rb
+++ b/spec/rmagick/image/composite_tiled_spec.rb
@@ -2,13 +2,12 @@ RSpec.describe Magick::Image, '#composite_tiled' do
   it 'works' do
     bg = described_class.new(200, 200)
     fg = described_class.new(50, 100) { self.background_color = 'black' }
-    res = nil
-    expect do
-      res = bg.composite_tiled(fg)
-    end.not_to raise_error
+
+    res = bg.composite_tiled(fg)
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(bg)
     expect(res).not_to be(fg)
+
     expect { bg.composite_tiled!(fg) }.not_to raise_error
     expect { bg.composite_tiled(fg, Magick::AtopCompositeOp) }.not_to raise_error
     expect { bg.composite_tiled(fg, Magick::OverCompositeOp) }.not_to raise_error

--- a/spec/rmagick/image/excerpt_spec.rb
+++ b/spec/rmagick/image/excerpt_spec.rb
@@ -3,13 +3,12 @@ RSpec.describe Magick::Image, '#excerpt' do
     img1 = described_class.new(20, 20)
     img2 = described_class.new(200, 200)
 
-    res = nil
-    expect { res = img1.excerpt(20, 20, 50, 100) }.not_to raise_error
+    res = img1.excerpt(20, 20, 50, 100)
     expect(res).not_to be(img2)
     expect(res.columns).to eq(50)
     expect(res.rows).to eq(100)
 
-    expect { img2.excerpt!(20, 20, 50, 100) }.not_to raise_error
+    img2.excerpt!(20, 20, 50, 100)
     expect(img2.columns).to eq(50)
     expect(img2.rows).to eq(100)
   end

--- a/spec/rmagick/image/level_colors_spec.rb
+++ b/spec/rmagick/image/level_colors_spec.rb
@@ -2,10 +2,7 @@ RSpec.describe Magick::Image, '#level_colors' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect do
-      res = img.level_colors
-    end.not_to raise_error
+    res = img.level_colors
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
 

--- a/spec/rmagick/image/levelize_channel_spec.rb
+++ b/spec/rmagick/image/levelize_channel_spec.rb
@@ -2,10 +2,7 @@ RSpec.describe Magick::Image, '#levelize_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect do
-      res = img.levelize_channel(0, Magick::QuantumRange)
-    end.not_to raise_error
+    res = img.levelize_channel(0, Magick::QuantumRange)
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
 

--- a/spec/rmagick/image/liquid_rescale_spec.rb
+++ b/spec/rmagick/image/liquid_rescale_spec.rb
@@ -10,12 +10,10 @@ describe Magick::Image, '#liquid_rescale' do
       return
     end
 
-    res = nil
-    expect do
-      res = img.liquid_rescale(15, 15)
-    end.not_to raise_error
+    res = img.liquid_rescale(15, 15)
     expect(res.columns).to eq(15)
     expect(res.rows).to eq(15)
+
     expect { img.liquid_rescale(15, 15, 0, 0) }.not_to raise_error
     expect { img.liquid_rescale(15) }.to raise_error(ArgumentError)
     expect { img.liquid_rescale(15, 15, 0, 0, 0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/mask_spec.rb
+++ b/spec/rmagick/image/mask_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe Magick::Image, '#mask' do
     img1 = described_class.new(20, 20)
     cimg = described_class.new(10, 10)
 
-    expect { img1.mask(cimg) }.not_to raise_error
-    res = nil
-    expect { res = img1.mask }.not_to raise_error
+    img1.mask(cimg)
+
+    res = img1.mask
     expect(res).not_to be(nil)
     expect(res).not_to be(cimg)
     expect(res.columns).to eq(20)

--- a/spec/rmagick/image/opaque_channel_spec.rb
+++ b/spec/rmagick/image/opaque_channel_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe Magick::Image, '#opaque_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect { res = img.opaque_channel('white', 'red') }.not_to raise_error
+    res = img.opaque_channel('white', 'red')
     expect(res).not_to be(nil)
     expect(res).to be_instance_of(described_class)
     expect(img).not_to be(res)
+
     expect { img.opaque_channel('red', 'blue', true) }.not_to raise_error
     expect { img.opaque_channel('red', 'blue', true, 50) }.not_to raise_error
     expect { img.opaque_channel('red', 'blue', true, 50, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/paint_transparent_spec.rb
+++ b/spec/rmagick/image/paint_transparent_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe Magick::Image, '#paint_transparent' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect { res = img.paint_transparent('red') }.not_to raise_error
+    res = img.paint_transparent('red')
     expect(res).not_to be(nil)
     expect(res).to be_instance_of(described_class)
     expect(img).not_to be(res)
+
     expect { img.paint_transparent('red', Magick::TransparentAlpha) }.to raise_error(ArgumentError)
     expect { img.paint_transparent('red', alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { img.paint_transparent('red', wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/radial_blur_channel_spec.rb
+++ b/spec/rmagick/image/radial_blur_channel_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe Magick::Image, '#radial_blur_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = nil
-    expect { res = img.radial_blur_channel(30) }.not_to raise_error
+    res = img.radial_blur_channel(30)
     expect(res).not_to be(nil)
     expect(res).to be_instance_of(described_class)
-    expect { res = img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
-    expect { res = img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
+
+    expect { img.radial_blur_channel(30, Magick::RedChannel) }.not_to raise_error
+    expect { img.radial_blur_channel(30, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
 
     expect { img.radial_blur_channel }.to raise_error(ArgumentError)
     expect { img.radial_blur_channel(30, 2) }.to raise_error(TypeError)

--- a/spec/rmagick/image/resize_to_fit_spec.rb
+++ b/spec/rmagick/image/resize_to_fit_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe Magick::Image, '#resize_to_fit' do
   it 'works with two arguments' do
     img = described_class.new(200, 250)
-    res = nil
-    expect { res = img.resize_to_fit(50, 50) }.not_to raise_error
+    res = img.resize_to_fit(50, 50)
     expect(res).not_to be(nil)
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)

--- a/spec/rmagick/image/selective_blur_channel_spec.rb
+++ b/spec/rmagick/image/selective_blur_channel_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe Magick::Image, '#selective_blur_channel' do
   it 'works' do
     img = described_class.new(20, 20)
-    res = nil
 
-    expect { res = img.selective_blur_channel(0, 1, '10%') }.not_to raise_error
+    res = img.selective_blur_channel(0, 1, '10%')
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
     expect([res.columns, res.rows]).to eq([img.columns, img.rows])

--- a/spec/rmagick/image/to_blob_spec.rb
+++ b/spec/rmagick/image/to_blob_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe Magick::Image, '#to_blob' do
   it 'works' do
     img = described_class.new(20, 20)
-    res = nil
 
-    expect { res = img.to_blob { self.format = 'miff' } }.not_to raise_error
+    res = img.to_blob { self.format = 'miff' }
     expect(res).to be_instance_of(String)
     restored = described_class.from_blob(res)
     expect(restored[0]).to eq(img)


### PR DESCRIPTION
`not_to raise_error` is implied, as tests will fail if it raises an
error. So unless we're specifically testing that it doesn't raise an
error, we don't need to do it all over the place.
that a particular action doesn't raise an error, it's not necessary.