### PR TITLE
Rubocop: enable ReturnInVoidContext

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -80,11 +80,6 @@ Lint/RescueException:
     - 'lib/rmagick_internal.rb'
 
 # Offense count: 1
-Lint/ReturnInVoidContext:
-  Exclude:
-    - 'lib/rmagick_internal.rb'
-
-# Offense count: 1
 Lint/UselessComparison:
   Exclude:
     - 'spec/rmagick/enum/case_equality_spec.rb'

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1294,7 +1294,7 @@ module Magick
       if n.nil?
         Kernel.raise IndexError, 'scene number out of bounds' unless @images.length.zero?
         @scene = nil
-        return @scene
+        return
       elsif @images.length.zero?
         Kernel.raise IndexError, 'scene number out of bounds'
       end


### PR DESCRIPTION
This rule disallows returning a value in a context where the return
value will be ignored. In the case of setter methods, Ruby always
returns what was passed into the method, ignoring any return values.

https://rubocop.readthedocs.io/en/stable/cops_lint/#lintreturninvoidcontext