### PR TITLE
RSpec: remove `not_to raise_error` blocks

### DIFF
--- a/spec/rmagick/draw/annotate_spec.rb
+++ b/spec/rmagick/draw/annotate_spec.rb
@@ -2,16 +2,14 @@ RSpec.describe Magick::Draw, '#annotate' do
   it 'works' do
     draw = described_class.new
 
-    expect do
-      img = Magick::Image.new(10, 10)
-      draw.annotate(img, 0, 0, 0, 20, 'Hello world')
+    img = Magick::Image.new(10, 10)
+    draw.annotate(img, 0, 0, 0, 20, 'Hello world')
 
-      yield_obj = nil
-      draw.annotate(img, 100, 100, 20, 20, 'Hello world 2') do |draw2|
-        yield_obj = draw2
-      end
-      expect(yield_obj).to be_instance_of(described_class)
-    end.not_to raise_error
+    yield_obj = nil
+    draw.annotate(img, 100, 100, 20, 20, 'Hello world 2') do |draw2|
+      yield_obj = draw2
+    end
+    expect(yield_obj).to be_instance_of(described_class)
 
     expect do
       img = Magick::Image.new(10, 10)

--- a/spec/rmagick/draw/initialize_spec.rb
+++ b/spec/rmagick/draw/initialize_spec.rb
@@ -1,12 +1,10 @@
 RSpec.describe Magick::Draw, '#initialize' do
   it 'works' do
-    expect do
-      yield_obj = nil
+    yield_obj = nil
 
-      described_class.new do |option|
-        yield_obj = option
-      end
-      expect(yield_obj).to be_instance_of(Magick::Image::DrawOptions)
-    end.not_to raise_error
+    described_class.new do |option|
+      yield_obj = option
+    end
+    expect(yield_obj).to be_instance_of(Magick::Image::DrawOptions)
   end
 end

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -68,9 +68,7 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     expect { dumped = draw2.marshal_dump }.not_to raise_error
 
     draw3 = draw1.dup
-    expect do
-      draw3.marshal_load(dumped)
-    end.not_to raise_error
+    draw3.marshal_load(dumped)
     expect(draw3.inspect).to eq(draw2.inspect)
   end
 end

--- a/spec/rmagick/gradient_fill/fill_spec.rb
+++ b/spec/rmagick/gradient_fill/fill_spec.rb
@@ -2,58 +2,40 @@ RSpec.describe Magick::GradientFill, '#fill' do
   it 'works' do
     img = Magick::Image.new(10, 10)
 
-    expect do
-      gradient = described_class.new(0, 0, 0, 0, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 0, 0, 0, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, 0, 0, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 0, 0, 10, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, 0, 10, 0, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 0, 10, 0, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, 0, 10, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 0, 10, 10, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, 0, 5, 20, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 0, 5, 20, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(-10, 0, -10, 10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(-10, 0, -10, 10, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, -10, 10, -10, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, -10, 10, -10, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, -10, 10, -20, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, -10, 10, -20, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
 
-    expect do
-      gradient = described_class.new(0, 100, 100, 200, '#900', '#000')
-      obj = gradient.fill(img)
-      expect(obj).to eq(gradient)
-    end.not_to raise_error
+    gradient = described_class.new(0, 100, 100, 200, '#900', '#000')
+    obj = gradient.fill(img)
+    expect(obj).to eq(gradient)
   end
 end

--- a/spec/rmagick/image/adaptive_blur_channel_spec.rb
+++ b/spec/rmagick/image/adaptive_blur_channel_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_blur_channel" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_blur_channel
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_blur_channel
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_blur_channel(2) }.not_to raise_error
     expect { img.adaptive_blur_channel(3, 2) }.not_to raise_error
     expect { img.adaptive_blur_channel(3, 2, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/adaptive_blur_spec.rb
+++ b/spec/rmagick/image/adaptive_blur_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_blur" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_blur
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_blur
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_blur(2) }.not_to raise_error
     expect { img.adaptive_blur(3, 2) }.not_to raise_error
     expect { img.adaptive_blur(3, 2, 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/adaptive_resize_spec.rb
+++ b/spec/rmagick/image/adaptive_resize_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_resize" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_resize(10, 10)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_resize(10, 10)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_resize(2) }.not_to raise_error
     expect { img.adaptive_resize(-1.0) }.to raise_error(ArgumentError)
     expect { img.adaptive_resize(10, 10, 10) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/adaptive_sharpen_channel_spec.rb
+++ b/spec/rmagick/image/adaptive_sharpen_channel_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_sharpen_channel" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_sharpen_channel
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_sharpen_channel
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_sharpen_channel(2) }.not_to raise_error
     expect { img.adaptive_sharpen_channel(3, 2) }.not_to raise_error
     expect { img.adaptive_sharpen_channel(3, 2, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/adaptive_sharpen_spec.rb
+++ b/spec/rmagick/image/adaptive_sharpen_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_sharpen" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_sharpen
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_sharpen
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_sharpen(2) }.not_to raise_error
     expect { img.adaptive_sharpen(3, 2) }.not_to raise_error
     expect { img.adaptive_sharpen(3, 2, 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/adaptive_threshold_spec.rb
+++ b/spec/rmagick/image/adaptive_threshold_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#adaptive_threshold" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.adaptive_threshold
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.adaptive_threshold
+    expect(res).to be_instance_of(described_class)
+
     expect { img.adaptive_threshold(2) }.not_to raise_error
     expect { img.adaptive_threshold(2, 4) }.not_to raise_error
     expect { img.adaptive_threshold(2, 4, 1) }.not_to raise_error

--- a/spec/rmagick/image/auto_orient_spec.rb
+++ b/spec/rmagick/image/auto_orient_spec.rb
@@ -1,21 +1,17 @@
 RSpec.describe Magick::Image, "#auto_orient" do
   it "works" do
     Magick::OrientationType.values.each do |v|
-      expect do
-        img = described_class.new(10, 10)
-        img.orientation = v
-        res = img.auto_orient
-        expect(res).to be_instance_of(described_class)
-        expect(res).not_to be(img)
-      end.not_to raise_error
+      img = described_class.new(10, 10)
+      img.orientation = v
+      res = img.auto_orient
+      expect(res).to be_instance_of(described_class)
+      expect(res).not_to be(img)
     end
 
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.auto_orient!
-      # When not changed, returns nil
-      expect(res).to be(nil)
-    end.not_to raise_error
+    res = img.auto_orient!
+    # When not changed, returns nil
+    expect(res).to be(nil)
   end
 end

--- a/spec/rmagick/image/change_geometry_spec.rb
+++ b/spec/rmagick/image/change_geometry_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Magick::Image, "#change_geometry" do
 
     expect { img.change_geometry('sss') }.to raise_error(ArgumentError)
     expect { img.change_geometry('100x100') }.to raise_error(LocalJumpError)
-    expect do
-      res = img.change_geometry('100x100') { 1 }
-      expect(res).to eq(1)
-    end.not_to raise_error
+
+    res = img.change_geometry('100x100') { 1 }
+    expect(res).to eq(1)
+
     expect { img.change_geometry([]) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image/channel_extrema_spec.rb
+++ b/spec/rmagick/image/channel_extrema_spec.rb
@@ -2,13 +2,12 @@ RSpec.describe Magick::Image, "#channel_extrema" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.channel_extrema
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(2)
-      expect(res[0]).to be_kind_of(Integer)
-      expect(res[1]).to be_kind_of(Integer)
-    end.not_to raise_error
+    res = img.channel_extrema
+    expect(res).to be_instance_of(Array)
+    expect(res.length).to eq(2)
+    expect(res[0]).to be_kind_of(Integer)
+    expect(res[1]).to be_kind_of(Integer)
+
     expect { img.channel_extrema(Magick::RedChannel) }.not_to raise_error
     expect { img.channel_extrema(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img.channel_extrema(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error

--- a/spec/rmagick/image/channel_mean_spec.rb
+++ b/spec/rmagick/image/channel_mean_spec.rb
@@ -2,13 +2,12 @@ RSpec.describe Magick::Image, "#channel_mean" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.channel_mean
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(2)
-      expect(res[0]).to be_instance_of(Float)
-      expect(res[1]).to be_instance_of(Float)
-    end.not_to raise_error
+    res = img.channel_mean
+    expect(res).to be_instance_of(Array)
+    expect(res.length).to eq(2)
+    expect(res[0]).to be_instance_of(Float)
+    expect(res[1]).to be_instance_of(Float)
+
     expect { img.channel_mean(Magick::RedChannel) }.not_to raise_error
     expect { img.channel_mean(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img.channel_mean(Magick::GreenChannel, Magick::OpacityChannel) }.not_to raise_error

--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#charcoal" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.charcoal
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.charcoal
+    expect(res).to be_instance_of(described_class)
+
     expect { img.charcoal(1.0) }.not_to raise_error
     expect { img.charcoal(1.0, 2.0) }.not_to raise_error
     expect { img.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/chop_spec.rb
+++ b/spec/rmagick/image/chop_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, "#chop" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.chop(10, 10, 10, 10)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.chop(10, 10, 10, 10)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/class_type_spec.rb
+++ b/spec/rmagick/image/class_type_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe Magick::Image, '#class_type' do
     expect(img.class_type).to eq(Magick::PseudoClass)
     expect { img.class_type = 2 }.to raise_error(TypeError)
 
-    expect do
-      img.class_type = Magick::PseudoClass
-      img.class_type = Magick::DirectClass
-      expect(img.class_type).to eq(Magick::DirectClass)
-    end.not_to raise_error
+    img.class_type = Magick::PseudoClass
+    img.class_type = Magick::DirectClass
+    expect(img.class_type).to eq(Magick::DirectClass)
   end
 end

--- a/spec/rmagick/image/clone_spec.rb
+++ b/spec/rmagick/image/clone_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, "#clone" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.clone
-      expect(res).to be_instance_of(described_class)
-      expect(img).to eq(res)
-    end.not_to raise_error
+    res = img.clone
+    expect(res).to be_instance_of(described_class)
+    expect(img).to eq(res)
+
     res = img.clone
     expect(img.frozen?).to eq(res.frozen?)
     img.freeze

--- a/spec/rmagick/image/color_fill_to_border_spec.rb
+++ b/spec/rmagick/image/color_fill_to_border_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Magick::Image, "#color_fill_to_border" do
 
     expect { img.color_fill_to_border(-1, 1, 'red') }.to raise_error(ArgumentError)
     expect { img.color_fill_to_border(1, 100, 'red') }.to raise_error(ArgumentError)
-    expect do
-      res = img.color_fill_to_border(img.columns / 2, img.rows / 2, 'red')
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+
+    res = img.color_fill_to_border(img.columns / 2, img.rows / 2, 'red')
+    expect(res).to be_instance_of(described_class)
+
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.color_fill_to_border(img.columns / 2, img.rows / 2, pixel) }.not_to raise_error
   end

--- a/spec/rmagick/image/color_floodfill_spec.rb
+++ b/spec/rmagick/image/color_floodfill_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Magick::Image, "#color_floodfill" do
 
     expect { img.color_floodfill(-1, 1, 'red') }.to raise_error(ArgumentError)
     expect { img.color_floodfill(1, 100, 'red') }.to raise_error(ArgumentError)
-    expect do
-      res = img.color_floodfill(img.columns / 2, img.rows / 2, 'red')
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+
+    res = img.color_floodfill(img.columns / 2, img.rows / 2, 'red')
+    expect(res).to be_instance_of(described_class)
+
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.color_floodfill(img.columns / 2, img.rows / 2, pixel) }.not_to raise_error
   end

--- a/spec/rmagick/image/color_histogram_spec.rb
+++ b/spec/rmagick/image/color_histogram_spec.rb
@@ -2,15 +2,12 @@ RSpec.describe Magick::Image, "#color_histogram" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.color_histogram
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
-    expect do
-      img.class_type = Magick::PseudoClass
-      res = img.color_histogram
-      expect(img.class_type).to eq(Magick::PseudoClass)
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
+    res = img.color_histogram
+    expect(res).to be_instance_of(Hash)
+
+    img.class_type = Magick::PseudoClass
+    res = img.color_histogram
+    expect(img.class_type).to eq(Magick::PseudoClass)
+    expect(res).to be_instance_of(Hash)
   end
 end

--- a/spec/rmagick/image/color_point_spec.rb
+++ b/spec/rmagick/image/color_point_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, "#color_point" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.color_point(0, 0, 'red')
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.color_point(0, 0, 'red')
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.color_point(0, 0, pixel) }.not_to raise_error
   end

--- a/spec/rmagick/image/color_reset_bang_spec.rb
+++ b/spec/rmagick/image/color_reset_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#color_reset!" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.color_reset!('red')
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.color_reset!('red')
+    expect(res).to be(img)
+
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.color_reset!(pixel) }.not_to raise_error
     expect { img.color_reset!([2]) }.to raise_error(TypeError)

--- a/spec/rmagick/image/colorize_spec.rb
+++ b/spec/rmagick/image/colorize_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, "#colorize" do
   it "works" do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.colorize(0.25, 0.25, 0.25, 'red')
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.colorize(0.25, 0.25, 0.25, 'red')
+    expect(res).to be_instance_of(described_class)
+
     expect { img.colorize(0.25, 0.25, 0.25, 0.25, 'red') }.not_to raise_error
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.colorize(0.25, 0.25, 0.25, pixel) }.not_to raise_error

--- a/spec/rmagick/image/colormap_spec.rb
+++ b/spec/rmagick/image/colormap_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe Magick::Image, "#colormap" do
     expect(res).to be_instance_of(String)
 
     # test 'set' operation
-    expect do
-      old_color = pc_img.colormap(0)
-      res = pc_img.colormap(0, 'red')
-      expect(res).to eq(old_color)
-      res = pc_img.colormap(0)
-      expect(res).to eq('red')
-    end.not_to raise_error
+    old_color = pc_img.colormap(0)
+    res = pc_img.colormap(0, 'red')
+    expect(res).to eq(old_color)
+    res = pc_img.colormap(0)
+    expect(res).to eq('red')
+
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { pc_img.colormap(0, pixel) }.not_to raise_error
     expect { pc_img.colormap }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/composite_affine_spec.rb
+++ b/spec/rmagick/image/composite_affine_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe Magick::Image, '#composite_affine' do
     img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
     img1.define('compose:args', '1x1')
     img2.define('compose:args', '1x1')
-    expect do
-      res = img1.composite_affine(img2, affine)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img1)
-    end.not_to raise_error
+
+    res = img1.composite_affine(img2, affine)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img1)
   end
 end

--- a/spec/rmagick/image/composite_bang_spec.rb
+++ b/spec/rmagick/image/composite_bang_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Magick::Image, '#composite!' do
     img2.define('compose:args', '1x1')
     Magick::CompositeOperator.values do |op|
       Magick::GravityType.values do |gravity|
-        expect do
-          res = img1.composite!(img2, gravity, op)
-          expect(res).to be(img1)
-        end.not_to raise_error
+        res = img1.composite!(img2, gravity, op)
+        expect(res).to be(img1)
       end
     end
     img1.freeze

--- a/spec/rmagick/image/composite_channel_spec.rb
+++ b/spec/rmagick/image/composite_channel_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Magick::Image, '#composite_channel' do
     img2.define('compose:args', '1x1')
     Magick::CompositeOperator.values do |op|
       Magick::GravityType.values do |gravity|
-        expect do
-          res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
-          expect(res).not_to be(img1)
-        end.not_to raise_error
+        res = img1.composite_channel(img2, gravity, 5, 5, op, Magick::BlueChannel)
+        expect(res).not_to be(img1)
       end
     end
 

--- a/spec/rmagick/image/contrast_spec.rb
+++ b/spec/rmagick/image/contrast_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#contrast' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.contrast
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.contrast
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.contrast(true) }.not_to raise_error
     expect { img.contrast(true, 2) }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image/contrast_stretch_channel_spec.rb
+++ b/spec/rmagick/image/contrast_stretch_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#contrast_stretch_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.contrast_stretch_channel(25)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.contrast_stretch_channel(25)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.contrast_stretch_channel(25, 50) }.not_to raise_error
     expect { img.contrast_stretch_channel('10%') }.not_to raise_error
     expect { img.contrast_stretch_channel('10%', '50%') }.not_to raise_error

--- a/spec/rmagick/image/convolve_channel_spec.rb
+++ b/spec/rmagick/image/convolve_channel_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe Magick::Image, '#convolve_channel' do
     expect { img.convolve_channel(3) }.to raise_error(ArgumentError)
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3
-    expect do
-      res = img.convolve_channel(order, kernel, Magick::RedChannel)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+
+    res = img.convolve_channel(order, kernel, Magick::RedChannel)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     expect { img.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
     expect { img.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)

--- a/spec/rmagick/image/convolve_spec.rb
+++ b/spec/rmagick/image/convolve_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe Magick::Image, '#convolve' do
     kernel = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     order = 3
 
-    expect do
-      res = img.convolve(order, kernel)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.convolve(order, kernel)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.convolve }.to raise_error(ArgumentError)
     expect { img.convolve(0) }.to raise_error(ArgumentError)
     expect { img.convolve(-1) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/copy_spec.rb
+++ b/spec/rmagick/image/copy_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#copy' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      ditto = img.copy
-      expect(ditto).to eq(img)
-    end.not_to raise_error
+    ditto = img.copy
+    expect(ditto).to eq(img)
   end
 end

--- a/spec/rmagick/image/crop_bang_spec.rb
+++ b/spec/rmagick/image/crop_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#crop!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.crop!(0, 0, img.columns / 2, img.rows / 2)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.crop!(0, 0, img.columns / 2, img.rows / 2)
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/crop_spec.rb
+++ b/spec/rmagick/image/crop_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe Magick::Image, '#crop' do
 
     expect { img.crop }.to raise_error(ArgumentError)
     expect { img.crop(0, 0) }.to raise_error(ArgumentError)
-    expect do
-      res = img.crop(0, 0, img.columns / 2, img.rows / 2)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+
+    res = img.crop(0, 0, img.columns / 2, img.rows / 2)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     # 3-argument form
     Magick::GravityType.values do |grav|

--- a/spec/rmagick/image/cycle_colormap_spec.rb
+++ b/spec/rmagick/image/cycle_colormap_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#cycle_colormap' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.cycle_colormap(5)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-      expect(res.class_type).to eq(Magick::PseudoClass)
-    end.not_to raise_error
+    res = img.cycle_colormap(5)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+    expect(res.class_type).to eq(Magick::PseudoClass)
   end
 end

--- a/spec/rmagick/image/decipher_spec.rb
+++ b/spec/rmagick/image/decipher_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#decipher' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    res = res2 = nil
-    expect do
-      res = img.encipher 'passphrase'
-      res2 = res.decipher 'passphrase'
-    end.not_to raise_error
+    res = img.encipher 'passphrase'
+    res2 = res.decipher 'passphrase'
+
     expect(res).to be_instance_of(described_class)
     expect(res).not_to be(img)
     expect(res.columns).to eq(img.columns)

--- a/spec/rmagick/image/deskew_spec.rb
+++ b/spec/rmagick/image/deskew_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#deskew' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.deskew
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.deskew
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     expect { img.deskew(0.10) }.not_to raise_error
     expect { img.deskew('95%') }.not_to raise_error

--- a/spec/rmagick/image/despeckle_spec.rb
+++ b/spec/rmagick/image/despeckle_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#despeckle' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.despeckle
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.despeckle
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/difference_spec.rb
+++ b/spec/rmagick/image/difference_spec.rb
@@ -2,14 +2,13 @@ RSpec.describe Magick::Image, '#difference' do
   it 'works' do
     img1 = described_class.read(IMAGES_DIR + '/Button_0.gif').first
     img2 = described_class.read(IMAGES_DIR + '/Button_1.gif').first
-    expect do
-      res = img1.difference(img2)
-      expect(res).to be_instance_of(Array)
-      expect(res.length).to eq(3)
-      expect(res[0]).to be_instance_of(Float)
-      expect(res[1]).to be_instance_of(Float)
-      expect(res[2]).to be_instance_of(Float)
-    end.not_to raise_error
+
+    res = img1.difference(img2)
+    expect(res).to be_instance_of(Array)
+    expect(res.length).to eq(3)
+    expect(res[0]).to be_instance_of(Float)
+    expect(res[1]).to be_instance_of(Float)
+    expect(res[2]).to be_instance_of(Float)
 
     expect { img1.difference(2) }.to raise_error(NoMethodError)
     img2.destroy!

--- a/spec/rmagick/image/distortion_channel_spec.rb
+++ b/spec/rmagick/image/distortion_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#distortion_channel' do
   it 'works' do
     img1 = described_class.new(20, 20)
 
-    expect do
-      metric = img1.distortion_channel(img1, Magick::MeanAbsoluteErrorMetric)
-      expect(metric).to be_instance_of(Float)
-      expect(metric).to eq(0.0)
-    end.not_to raise_error
+    metric = img1.distortion_channel(img1, Magick::MeanAbsoluteErrorMetric)
+    expect(metric).to be_instance_of(Float)
+    expect(metric).to eq(0.0)
+
     expect { img1.distortion_channel(img1, Magick::MeanSquaredErrorMetric) }.not_to raise_error
     expect { img1.distortion_channel(img1, Magick::PeakAbsoluteErrorMetric) }.not_to raise_error
     expect { img1.distortion_channel(img1, Magick::PeakSignalToNoiseRatioErrorMetric) }.not_to raise_error

--- a/spec/rmagick/image/dup_spec.rb
+++ b/spec/rmagick/image/dup_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#dup' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      ditto = img.dup
-      expect(ditto).to eq(img)
-    end.not_to raise_error
+    ditto = img.dup
+    expect(ditto).to eq(img)
   end
 end

--- a/spec/rmagick/image/each_profile_spec.rb
+++ b/spec/rmagick/image/each_profile_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe Magick::Image, '#each_profile' do
     expect(img.each_profile {}).to be(nil)
 
     img.iptc_profile = 'test profile'
-    expect do
-      img.each_profile do |name, value|
-        expect(name).to eq('iptc')
-        expect(value).to eq('test profile')
-      end
-    end.not_to raise_error
+    img.each_profile do |name, value|
+      expect(name).to eq('iptc')
+      expect(value).to eq('test profile')
+    end
   end
 end

--- a/spec/rmagick/image/edge_spec.rb
+++ b/spec/rmagick/image/edge_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#edge' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.edge
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.edge
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.edge(2.0) }.not_to raise_error
     expect { img.edge(2.0, 2) }.to raise_error(ArgumentError)
     expect { img.edge('x') }.to raise_error(TypeError)

--- a/spec/rmagick/image/emboss_spec.rb
+++ b/spec/rmagick/image/emboss_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#emboss' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.emboss
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.emboss
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.emboss(1.0) }.not_to raise_error
     expect { img.emboss(1.0, 0.5) }.not_to raise_error
     expect { img.emboss(1.0, 0.5, 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/enhance_spec.rb
+++ b/spec/rmagick/image/enhance_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#enhance' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.enhance
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.enhance
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/equalize_channel_spec.rb
+++ b/spec/rmagick/image/equalize_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#equalize_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.equalize_channel
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.equalize_channel
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.equalize_channel }.not_to raise_error
     expect { img.equalize_channel(Magick::RedChannel) }.not_to raise_error
     expect { img.equalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error

--- a/spec/rmagick/image/equalize_spec.rb
+++ b/spec/rmagick/image/equalize_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#equalize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.equalize
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.equalize
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/erase_bang_spec.rb
+++ b/spec/rmagick/image/erase_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#erase!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.erase!
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.erase!
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/export_pixels_spec.rb
+++ b/spec/rmagick/image/export_pixels_spec.rb
@@ -18,14 +18,12 @@ RSpec.describe Magick::Image, '#export_pixels' do
     expect { img.export_pixels(0, 0) }.not_to raise_error
     expect { img.export_pixels(0, 0, 10) }.not_to raise_error
     expect { img.export_pixels(0, 0, 10, 10) }.not_to raise_error
-    expect do
-      res = img.export_pixels(0, 0, 10, 10, 'RGBA')
-      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels(0, 0, 10, 10, 'I')
-      expect(res.length).to eq(10 * 10 * 'I'.length)
-    end.not_to raise_error
+
+    res = img.export_pixels(0, 0, 10, 10, 'RGBA')
+    expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+
+    res = img.export_pixels(0, 0, 10, 10, 'I')
+    expect(res.length).to eq(10 * 10 * 'I'.length)
 
     # too many arguments
     expect { img.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/export_pixels_to_str_spec.rb
+++ b/spec/rmagick/image/export_pixels_to_str_spec.rb
@@ -2,44 +2,36 @@ RSpec.describe Magick::Image, '#export_pixels_to_str' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.export_pixels_to_str
-      expect(res).to be_instance_of(String)
-      expect(res.length).to eq(img.columns * img.rows * 'RGB'.length)
-    end.not_to raise_error
+    res = img.export_pixels_to_str
+    expect(res).to be_instance_of(String)
+    expect(res.length).to eq(img.columns * img.rows * 'RGB'.length)
+
     expect { img.export_pixels_to_str(0) }.not_to raise_error
     expect { img.export_pixels_to_str(0, 0) }.not_to raise_error
     expect { img.export_pixels_to_str(0, 0, 10) }.not_to raise_error
     expect { img.export_pixels_to_str(0, 0, 10, 10) }.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
-      expect(res.length).to eq(10 * 10 * 'RGBA'.length)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I')
-      expect(res.length).to eq(10 * 10 * 'I'.length)
-    end.not_to raise_error
 
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
-      expect(res.length).to eq(10 * 10 * 1)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
-      expect(res.length).to eq(10 * 10 * 2)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
-      expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
-      expect(res.length).to eq(10 * 10 * 4)
-    end.not_to raise_error
-    expect do
-      res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
-      expect(res.length).to eq(10 * 10 * 8)
-    end.not_to raise_error
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'RGBA')
+    expect(res.length).to eq(10 * 10 * 'RGBA'.length)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I')
+    expect(res.length).to eq(10 * 10 * 'I'.length)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::CharPixel)
+    expect(res.length).to eq(10 * 10 * 1)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::ShortPixel)
+    expect(res.length).to eq(10 * 10 * 2)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::LongPixel)
+    expect(res.length).to eq(10 * 10 * [1].pack('L!').length)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::FloatPixel)
+    expect(res.length).to eq(10 * 10 * 4)
+
+    res = img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::DoublePixel)
+    expect(res.length).to eq(10 * 10 * 8)
+
     expect { img.export_pixels_to_str(0, 0, 10, 10, 'I', Magick::QuantumPixel) }.not_to raise_error
 
     # too many arguments

--- a/spec/rmagick/image/find_similar_region_spec.rb
+++ b/spec/rmagick/image/find_similar_region_spec.rb
@@ -4,31 +4,26 @@ RSpec.describe Magick::Image, '#find_similar_region' do
     girl = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
     region = girl.crop(10, 10, 50, 50)
 
-    expect do
-      x, y = girl.find_similar_region(region)
-      expect(x).not_to be(nil)
-      expect(y).not_to be(nil)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-    expect do
-      x, y = girl.find_similar_region(region, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
-    expect do
-      x, y = girl.find_similar_region(region, 0, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
+    x, y = girl.find_similar_region(region)
+    expect(x).not_to be(nil)
+    expect(y).not_to be(nil)
+    expect(x).to eq(10)
+    expect(y).to eq(10)
+
+    x, y = girl.find_similar_region(region, 0)
+    expect(x).to eq(10)
+    expect(y).to eq(10)
+
+    x, y = girl.find_similar_region(region, 0, 0)
+    expect(x).to eq(10)
+    expect(y).to eq(10)
 
     list = Magick::ImageList.new
     list << region
-    expect do
-      x, y = girl.find_similar_region(list, 0, 0)
-      expect(x).to eq(10)
-      expect(y).to eq(10)
-    end.not_to raise_error
+
+    x, y = girl.find_similar_region(list, 0, 0)
+    expect(x).to eq(10)
+    expect(y).to eq(10)
 
     x = girl.find_similar_region(img)
     expect(x).to be(nil)

--- a/spec/rmagick/image/flip_bang_spec.rb
+++ b/spec/rmagick/image/flip_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#flip!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.flip!
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.flip!
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/flip_spec.rb
+++ b/spec/rmagick/image/flip_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#flip' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.flip
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.flip
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/flop_bang_spec.rb
+++ b/spec/rmagick/image/flop_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#flop!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.flop!
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.flop!
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/flop_spec.rb
+++ b/spec/rmagick/image/flop_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#flop' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.flop
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.flop
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/frame_spec.rb
+++ b/spec/rmagick/image/frame_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#frame' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.frame
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.frame
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.frame(50) }.not_to raise_error
     expect { img.frame(50, 50) }.not_to raise_error
     expect { img.frame(50, 50, 25) }.not_to raise_error

--- a/spec/rmagick/image/gamma_channel_spec.rb
+++ b/spec/rmagick/image/gamma_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#gamma_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.gamma_channel(0.8)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.gamma_channel(0.8)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.gamma_channel }.to raise_error(ArgumentError)
     expect { img.gamma_channel(0.8, Magick::RedChannel) }.not_to raise_error
     expect { img.gamma_channel(0.8, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error

--- a/spec/rmagick/image/gamma_correct_spec.rb
+++ b/spec/rmagick/image/gamma_correct_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Magick::Image, '#gamma_correct' do
     img = described_class.new(20, 20)
 
     expect { img.gamma_correct }.to raise_error(ArgumentError)
-    expect do
-      res = img.gamma_correct(0.8)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+
+    res = img.gamma_correct(0.8)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.gamma_correct(0.8, 0.9) }.not_to raise_error
     expect { img.gamma_correct(0.8, 0.9, 1.0) }.not_to raise_error
     expect { img.gamma_correct(0.8, 0.9, 1.0, 1.1) }.not_to raise_error

--- a/spec/rmagick/image/gaussian_blur_channel_spec.rb
+++ b/spec/rmagick/image/gaussian_blur_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#gaussian_blur_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.gaussian_blur_channel
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.gaussian_blur_channel
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.gaussian_blur_channel(0.0) }.not_to raise_error
     expect { img.gaussian_blur_channel(0.0, 3.0) }.not_to raise_error
     expect { img.gaussian_blur_channel(0.0, 3.0, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/gaussian_blur_spec.rb
+++ b/spec/rmagick/image/gaussian_blur_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#gaussian_blur' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.gaussian_blur
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.gaussian_blur
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.gaussian_blur(0.0) }.not_to raise_error
     expect { img.gaussian_blur(0.0, 3.0) }.not_to raise_error
     # sigma must be != 0.0

--- a/spec/rmagick/image/get_exif_by_entry_spec.rb
+++ b/spec/rmagick/image/get_exif_by_entry_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#get_exif_by_entry' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.get_exif_by_entry
-      expect(res).to be_instance_of(Array)
-    end.not_to raise_error
+    res = img.get_exif_by_entry
+    expect(res).to be_instance_of(Array)
   end
 end

--- a/spec/rmagick/image/get_exif_by_number_spec.rb
+++ b/spec/rmagick/image/get_exif_by_number_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#get_exif_by_number' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.get_exif_by_number
-      expect(res).to be_instance_of(Hash)
-    end.not_to raise_error
+    res = img.get_exif_by_number
+    expect(res).to be_instance_of(Hash)
   end
 end

--- a/spec/rmagick/image/get_pixels_spec.rb
+++ b/spec/rmagick/image/get_pixels_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe Magick::Image, '#get_pixels' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      pixels = img.get_pixels(0, 0, img.columns, 1)
-      expect(pixels).to be_instance_of(Array)
-      expect(pixels.length).to eq(img.columns)
-      expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
-    end.not_to raise_error
+    pixels = img.get_pixels(0, 0, img.columns, 1)
+    expect(pixels).to be_instance_of(Array)
+    expect(pixels.length).to eq(img.columns)
+    expect(pixels.all? { |p| p.is_a? Magick::Pixel }).to be(true)
+
     expect { img.get_pixels(0,  0, -1, 1) }.to raise_error(RangeError)
     expect { img.get_pixels(0,  0, img.columns, -1) }.to raise_error(RangeError)
     expect { img.get_pixels(0,  0, img.columns + 1, 1) }.to raise_error(RangeError)

--- a/spec/rmagick/image/implode_spec.rb
+++ b/spec/rmagick/image/implode_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#implode' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.implode(0.5)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.implode(0.5)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.implode(0.5, 0.5) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image/import_pixels_spec.rb
+++ b/spec/rmagick/image/import_pixels_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe Magick::Image, '#import_pixels' do
     img = described_class.new(20, 20)
     pixels = img.export_pixels(0, 0, img.columns, 1, 'RGB')
 
-    expect do
-      res = img.import_pixels(0, 0, img.columns, 1, 'RGB', pixels)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.import_pixels(0, 0, img.columns, 1, 'RGB', pixels)
+    expect(res).to be(img)
+
     expect { img.import_pixels }.to raise_error(ArgumentError)
     expect { img.import_pixels(0) }.to raise_error(ArgumentError)
     expect { img.import_pixels(0, 0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/level_channel_spec.rb
+++ b/spec/rmagick/image/level_channel_spec.rb
@@ -3,11 +3,10 @@ RSpec.describe Magick::Image, '#level_channel' do
     img = described_class.new(20, 20)
 
     expect { img.level_channel }.to raise_error(ArgumentError)
-    expect do
-      res = img.level_channel(Magick::RedChannel)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+
+    res = img.level_channel(Magick::RedChannel)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     expect { img.level_channel(Magick::RedChannel, 0.0) }.not_to raise_error
     expect { img.level_channel(Magick::RedChannel, 0.0, 1.0) }.not_to raise_error

--- a/spec/rmagick/image/level_spec.rb
+++ b/spec/rmagick/image/level_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#level' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.level
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.level
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.level(0.0) }.not_to raise_error
     expect { img.level(0.0, 1.0) }.not_to raise_error
     expect { img.level(0.0, 1.0, Magick::QuantumRange) }.not_to raise_error

--- a/spec/rmagick/image/magnify_spec.rb
+++ b/spec/rmagick/image/magnify_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#magnify' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.magnify
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.magnify
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     res = img.magnify!
     expect(res).to be(img)

--- a/spec/rmagick/image/matte_fill_to_border_spec.rb
+++ b/spec/rmagick/image/matte_fill_to_border_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#matte_fill_to_border' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.matte_fill_to_border(img.columns / 2, img.rows / 2)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.matte_fill_to_border(img.columns / 2, img.rows / 2)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.matte_fill_to_border(img.columns, img.rows) }.not_to raise_error
     expect { img.matte_fill_to_border(img.columns + 1, img.rows) }.to raise_error(ArgumentError)
     expect { img.matte_fill_to_border(img.columns, img.rows + 1) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/matte_floodfill_spec.rb
+++ b/spec/rmagick/image/matte_floodfill_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#matte_floodfill' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.matte_floodfill(img.columns / 2, img.rows / 2)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.matte_floodfill(img.columns / 2, img.rows / 2)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.matte_floodfill(img.columns, img.rows) }.not_to raise_error
 
     Magick::PaintMethod.values do |method|

--- a/spec/rmagick/image/matte_replace_spec.rb
+++ b/spec/rmagick/image/matte_replace_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#matte_replace' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.matte_replace(img.columns / 2, img.rows / 2)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.matte_replace(img.columns / 2, img.rows / 2)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/matte_reset_bang_spec.rb
+++ b/spec/rmagick/image/matte_reset_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#matte_reset!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.matte_reset!
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.matte_reset!
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/median_filter_spec.rb
+++ b/spec/rmagick/image/median_filter_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#median_filter' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.median_filter
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.median_filter
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.median_filter(0.5) }.not_to raise_error
     expect { img.median_filter(0.5, 'x') }.to raise_error(ArgumentError)
     expect { img.median_filter('x') }.to raise_error(TypeError)

--- a/spec/rmagick/image/minify_spec.rb
+++ b/spec/rmagick/image/minify_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#minify' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.minify
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.minify
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
 
     res = img.minify!
     expect(res).to be(img)

--- a/spec/rmagick/image/modulate_spec.rb
+++ b/spec/rmagick/image/modulate_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#modulate' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.modulate
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.modulate
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.modulate(0.5) }.not_to raise_error
     expect { img.modulate(0.5, 0.5) }.not_to raise_error
     expect { img.modulate(0.5, 0.5, 0.5) }.not_to raise_error

--- a/spec/rmagick/image/morphology_channel_spec.rb
+++ b/spec/rmagick/image/morphology_channel_spec.rb
@@ -9,10 +9,9 @@ RSpec.describe Magick::Image, '#morphology_channel' do
     expect { img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, :not_kernel_info) }.to raise_error(ArgumentError)
 
     kernel = Magick::KernelInfo.new('Octagon')
-    expect do
-      res = img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+
+    res = img.morphology_channel(Magick::RedChannel, Magick::EdgeOutMorphology, 2, kernel)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/morphology_spec.rb
+++ b/spec/rmagick/image/morphology_spec.rb
@@ -4,11 +4,9 @@ RSpec.describe Magick::Image, '#morphology' do
     kernel = Magick::KernelInfo.new('Octagon')
 
     Magick::MorphologyMethod.values do |method|
-      expect do
-        res = img.morphology(method, 2, kernel)
-        expect(res).to be_instance_of(described_class)
-        expect(res).not_to be(img)
-      end.not_to raise_error
+      res = img.morphology(method, 2, kernel)
+      expect(res).to be_instance_of(described_class)
+      expect(res).not_to be(img)
     end
   end
 end

--- a/spec/rmagick/image/motion_blur_spec.rb
+++ b/spec/rmagick/image/motion_blur_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#motion_blur' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.motion_blur(1.0, 7.0, 180)
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.motion_blur(1.0, 7.0, 180)
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.motion_blur(1.0, 0.0, 180) }.to raise_error(ArgumentError)
     expect { img.motion_blur(1.0, -1.0, 180) }.not_to raise_error
   end

--- a/spec/rmagick/image/negate_channel_spec.rb
+++ b/spec/rmagick/image/negate_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#negate_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.negate_channel
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.negate_channel
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.negate_channel(true) }.not_to raise_error
     expect { img.negate_channel(true, Magick::RedChannel) }.not_to raise_error
     expect { img.negate_channel(true, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error

--- a/spec/rmagick/image/negate_spec.rb
+++ b/spec/rmagick/image/negate_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#negate' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.negate
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.negate
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.negate(true) }.not_to raise_error
     expect { img.negate(true, 2) }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image/normalize_channel_spec.rb
+++ b/spec/rmagick/image/normalize_channel_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#normalize_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.normalize_channel
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.normalize_channel
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.normalize_channel(Magick::RedChannel) }.not_to raise_error
     expect { img.normalize_channel(Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { img.normalize_channel(Magick::RedChannel, 2) }.to raise_error(TypeError)

--- a/spec/rmagick/image/normalize_spec.rb
+++ b/spec/rmagick/image/normalize_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#normalize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.normalize
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.normalize
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
   end
 end

--- a/spec/rmagick/image/oil_paint_spec.rb
+++ b/spec/rmagick/image/oil_paint_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#oil_paint' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.oil_paint
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.oil_paint
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.oil_paint(2.0) }.not_to raise_error
     expect { img.oil_paint(2.0, 1.0) }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image/opaque_predicate_spec.rb
+++ b/spec/rmagick/image/opaque_predicate_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Magick::Image, '#opaque?' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      expect(img.opaque?).to be(true)
-    end.not_to raise_error
+    expect(img.opaque?).to be(true)
+
     img.alpha(Magick::TransparentAlphaChannel)
+
     expect(img.opaque?).to be(false)
   end
 end

--- a/spec/rmagick/image/opaque_spec.rb
+++ b/spec/rmagick/image/opaque_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#opaque' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.opaque('white', 'red')
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.opaque('white', 'red')
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     red = Magick::Pixel.new(Magick::QuantumRange)
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     expect { img.opaque(red, blue) }.not_to raise_error

--- a/spec/rmagick/image/ordered_dither_spec.rb
+++ b/spec/rmagick/image/ordered_dither_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#ordered_dither' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.ordered_dither
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.ordered_dither
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.ordered_dither('3x3') }.not_to raise_error
     expect { img.ordered_dither(2) }.not_to raise_error
     expect { img.ordered_dither(3) }.not_to raise_error

--- a/spec/rmagick/image/palette_predicate_spec.rb
+++ b/spec/rmagick/image/palette_predicate_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe Magick::Image, '#palette?' do
   it 'works' do
     img = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      expect(img.palette?).to be(false)
-    end.not_to raise_error
+
+    expect(img.palette?).to be(false)
+
     img = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+
     expect(img.palette?).to be(true)
   end
 end

--- a/spec/rmagick/image/pixel_color_spec.rb
+++ b/spec/rmagick/image/pixel_color_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#pixel_color' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.pixel_color(0, 0)
-      expect(res).to be_instance_of(Magick::Pixel)
-    end.not_to raise_error
+    res = img.pixel_color(0, 0)
+    expect(res).to be_instance_of(Magick::Pixel)
+
     res = img.pixel_color(0, 0)
     expect(res.to_color).to eq(img.background_color)
     res = img.pixel_color(0, 0, 'red')
@@ -19,11 +18,9 @@ RSpec.describe Magick::Image, '#pixel_color' do
     img = described_class.new(10, 10) { self.background_color = 'blue' }
     expect(img.pixel_color(50, 50).to_color).to eq('blue')
 
-    expect do
-      img.class_type = Magick::PseudoClass
-      res = img.pixel_color(0, 0, 'red')
-      expect(res.to_color).to eq('blue')
-    end.not_to raise_error
+    img.class_type = Magick::PseudoClass
+    res = img.pixel_color(0, 0, 'red')
+    expect(res.to_color).to eq('blue')
   end
 
   it 'get/set CYMK color', supported_after('6.8.0') do

--- a/spec/rmagick/image/posterize_spec.rb
+++ b/spec/rmagick/image/posterize_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#posterize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.posterize
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
+    res = img.posterize
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
     expect { img.posterize(5) }.not_to raise_error
     expect { img.posterize(5, true) }.not_to raise_error
     expect { img.posterize(5, true, 'x') }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/preview_spec.rb
+++ b/spec/rmagick/image/preview_spec.rb
@@ -1,10 +1,10 @@
 describe Magick::Image, '#preview' do
   it 'works' do
     hat = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      prev = hat.preview(Magick::RotatePreview)
-      expect(prev).to be_instance_of(described_class)
-    end.not_to raise_error
+
+    prev = hat.preview(Magick::RotatePreview)
+    expect(prev).to be_instance_of(described_class)
+
     Magick::PreviewType.values do |type|
       expect { hat.preview(type) }.not_to raise_error
     end

--- a/spec/rmagick/image/profile_bang_spec.rb
+++ b/spec/rmagick/image/profile_bang_spec.rb
@@ -3,10 +3,9 @@ RSpec.describe Magick::Image, '#profile!' do
     img = described_class.new(20, 20)
     profile = described_class.read(IMAGE_WITH_PROFILE).first.color_profile
 
-    expect do
-      res = img.profile!('*', nil)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.profile!('*', nil)
+    expect(res).to be(img)
+
     expect { img.profile!('icc', profile) }.not_to raise_error
     expect { img.profile!('iptc', 'xxx') }.not_to raise_error
     expect { img.profile!('icc', nil) }.not_to raise_error

--- a/spec/rmagick/image/quantize_spec.rb
+++ b/spec/rmagick/image/quantize_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#quantize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.quantize
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.quantize
+    expect(res).to be_instance_of(described_class)
 
     Magick::ColorspaceType.values do |cs|
       expect { img.quantize(256, cs) }.not_to raise_error

--- a/spec/rmagick/image/quantum_operator_spec.rb
+++ b/spec/rmagick/image/quantum_operator_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#quantum_operator' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.quantum_operator(Magick::AddQuantumOperator, 2)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.quantum_operator(Magick::AddQuantumOperator, 2)
+    expect(res).to be_instance_of(described_class)
+
     Magick::QuantumExpressionOperator.values do |op|
       expect { img.quantum_operator(op, 2) }.not_to raise_error
     end

--- a/spec/rmagick/image/radial_blur_spec.rb
+++ b/spec/rmagick/image/radial_blur_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#radial_blur' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.radial_blur(30)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.radial_blur(30)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/raise_spec.rb
+++ b/spec/rmagick/image/raise_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#raise' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.raise
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.raise
+    expect(res).to be_instance_of(described_class)
+
     expect { img.raise(4) }.not_to raise_error
     expect { img.raise(4, 4) }.not_to raise_error
     expect { img.raise(4, 4, false) }.not_to raise_error

--- a/spec/rmagick/image/random_threshold_channel_spec.rb
+++ b/spec/rmagick/image/random_threshold_channel_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#random_threshold_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.random_threshold_channel('20%')
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.random_threshold_channel('20%')
+    expect(res).to be_instance_of(described_class)
+
     threshold = Magick::Geometry.new(20)
     expect { img.random_threshold_channel(threshold) }.not_to raise_error
     expect { img.random_threshold_channel(threshold, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/reduce_noise_spec.rb
+++ b/spec/rmagick/image/reduce_noise_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#reduce_noise' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.reduce_noise(0)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.reduce_noise(0)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.reduce_noise(4) }.not_to raise_error
   end
 end

--- a/spec/rmagick/image/resample_bang_spec.rb
+++ b/spec/rmagick/image/resample_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#resample!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.resample!(50)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.resample!(50)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.resample!(50) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/resize_bang_spec.rb
+++ b/spec/rmagick/image/resize_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#resize!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.resize!(2)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.resize!(2)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.resize!(0.50) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/resize_spec.rb
+++ b/spec/rmagick/image/resize_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#resize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.resize(2)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.resize(2)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.resize(50, 50) }.not_to raise_error
 
     Magick::FilterType.values do |filter|

--- a/spec/rmagick/image/roll_spec.rb
+++ b/spec/rmagick/image/roll_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#roll' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.roll(5, 5)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.roll(5, 5)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/rotate_bang_spec.rb
+++ b/spec/rmagick/image/rotate_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#rotate!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.rotate!(45)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.rotate!(45)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.rotate!(45) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/rotate_spec.rb
+++ b/spec/rmagick/image/rotate_spec.rb
@@ -2,23 +2,21 @@ RSpec.describe Magick::Image, '#rotate' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.rotate(45)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.rotate(45)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.rotate(-45) }.not_to raise_error
 
     img = described_class.new(100, 50)
-    expect do
-      res = img.rotate(90, '>')
-      expect(res).to be_instance_of(described_class)
-      expect(res.columns).to eq(50)
-      expect(res.rows).to eq(100)
-    end.not_to raise_error
-    expect do
-      res = img.rotate(90, '<')
-      expect(res).to be(nil)
-    end.not_to raise_error
+
+    res = img.rotate(90, '>')
+    expect(res).to be_instance_of(described_class)
+    expect(res.columns).to eq(50)
+    expect(res.rows).to eq(100)
+
+    res = img.rotate(90, '<')
+    expect(res).to be(nil)
+
     expect { img.rotate(90, 't') }.to raise_error(ArgumentError)
     expect { img.rotate(90, []) }.to raise_error(TypeError)
   end

--- a/spec/rmagick/image/sample_bang_spec.rb
+++ b/spec/rmagick/image/sample_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sample!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sample!(2)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.sample!(2)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.sample!(0.50) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/sample_spec.rb
+++ b/spec/rmagick/image/sample_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sample' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sample(10, 10)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.sample(10, 10)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.sample(2) }.not_to raise_error
     expect { img.sample }.to raise_error(ArgumentError)
     expect { img.sample(0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/scale_bang_spec.rb
+++ b/spec/rmagick/image/scale_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#scale!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.scale!(2)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.scale!(2)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.scale!(0.50) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/scale_spec.rb
+++ b/spec/rmagick/image/scale_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#scale' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.scale(10, 10)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.scale(10, 10)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.scale(2) }.not_to raise_error
     expect { img.scale }.to raise_error(ArgumentError)
     expect { img.scale(25, 25, 25) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/segment_spec.rb
+++ b/spec/rmagick/image/segment_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#segment' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.segment
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.segment
+    expect(res).to be_instance_of(described_class)
 
     # Don't test colorspaces that require PsuedoColor images
     (Magick::ColorspaceType.values - [

--- a/spec/rmagick/image/sepiatone_spec.rb
+++ b/spec/rmagick/image/sepiatone_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sepiatone' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sepiatone
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.sepiatone
+    expect(res).to be_instance_of(described_class)
+
     expect { img.sepiatone(Magick::QuantumRange * 0.80) }.not_to raise_error
     expect { img.sepiatone(Magick::QuantumRange, 2) }.to raise_error(ArgumentError)
     expect { img.sepiatone('x') }.to raise_error(TypeError)

--- a/spec/rmagick/image/shade_spec.rb
+++ b/spec/rmagick/image/shade_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#shade' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.shade
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.shade
+    expect(res).to be_instance_of(described_class)
+
     expect { img.shade(true) }.not_to raise_error
     expect { img.shade(true, 30) }.not_to raise_error
     expect { img.shade(true, 30, 30) }.not_to raise_error

--- a/spec/rmagick/image/shadow_spec.rb
+++ b/spec/rmagick/image/shadow_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#shadow' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.shadow
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.shadow
+    expect(res).to be_instance_of(described_class)
+
     expect { img.shadow(5) }.not_to raise_error
     expect { img.shadow(5, 5) }.not_to raise_error
     expect { img.shadow(5, 5, 3.0) }.not_to raise_error

--- a/spec/rmagick/image/sharpen_channel_spec.rb
+++ b/spec/rmagick/image/sharpen_channel_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sharpen_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sharpen_channel
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.sharpen_channel
+    expect(res).to be_instance_of(described_class)
+
     expect { img.sharpen_channel(2.0) }.not_to raise_error
     expect { img.sharpen_channel(2.0, 1.0) }.not_to raise_error
     expect { img.sharpen_channel(2.0, 1.0, Magick::RedChannel) }.not_to raise_error

--- a/spec/rmagick/image/sharpen_spec.rb
+++ b/spec/rmagick/image/sharpen_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sharpen' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sharpen
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.sharpen
+    expect(res).to be_instance_of(described_class)
+
     expect { img.sharpen(2.0) }.not_to raise_error
     expect { img.sharpen(2.0, 1.0) }.not_to raise_error
     expect { img.sharpen(2.0, 1.0, 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/shave_bang_spec.rb
+++ b/spec/rmagick/image/shave_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#shave' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.shave!(5, 5)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.shave!(5, 5)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.shave!(2, 2) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/shave_spec.rb
+++ b/spec/rmagick/image/shave_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#shave' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.shave(5, 5)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.shave(5, 5)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/shear_spec.rb
+++ b/spec/rmagick/image/shear_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#shear' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.shear(30, 30)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.shear(30, 30)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/sigmoidal_contrast_channel_spec.rb
+++ b/spec/rmagick/image/sigmoidal_contrast_channel_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#sigmoidal_contrast_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.sigmoidal_contrast_channel
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.sigmoidal_contrast_channel
+    expect(res).to be_instance_of(described_class)
+
     expect { img.sigmoidal_contrast_channel(3.0) }.not_to raise_error
     expect { img.sigmoidal_contrast_channel(3.0, 50.0) }.not_to raise_error
     expect { img.sigmoidal_contrast_channel(3.0, 50.0, true) }.not_to raise_error

--- a/spec/rmagick/image/signature_spec.rb
+++ b/spec/rmagick/image/signature_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#signature' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.signature
-      expect(res).to be_instance_of(String)
-    end.not_to raise_error
+    res = img.signature
+    expect(res).to be_instance_of(String)
   end
 end

--- a/spec/rmagick/image/solarize_spec.rb
+++ b/spec/rmagick/image/solarize_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#solarize' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.solarize
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.solarize
+    expect(res).to be_instance_of(described_class)
+
     expect { img.solarize(100) }.not_to raise_error
     expect { img.solarize(-100) }.to raise_error(ArgumentError)
     expect { img.solarize(Magick::QuantumRange + 1) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/splice_spec.rb
+++ b/spec/rmagick/image/splice_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#splice' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.splice(0, 0, 2, 2)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.splice(0, 0, 2, 2)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.splice(0, 0, 2, 2, 'red') }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { img.splice(0, 0, 2, 2, red) }.not_to raise_error

--- a/spec/rmagick/image/spread_spec.rb
+++ b/spec/rmagick/image/spread_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#spread' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.spread
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.spread
+    expect(res).to be_instance_of(described_class)
+
     expect { img.spread(3.0) }.not_to raise_error
     expect { img.spread(3.0, 2) }.to raise_error(ArgumentError)
     expect { img.spread('x') }.to raise_error(TypeError)

--- a/spec/rmagick/image/stegano_spec.rb
+++ b/spec/rmagick/image/stegano_spec.rb
@@ -3,10 +3,8 @@ RSpec.describe Magick::Image, '#stegano' do
     img = described_class.new(100, 100) { self.background_color = 'black' }
     watermark = described_class.new(10, 10) { self.background_color = 'white' }
 
-    expect do
-      res = img.stegano(watermark, 0)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.stegano(watermark, 0)
+    expect(res).to be_instance_of(described_class)
 
     watermark.destroy!
     expect { img.stegano(watermark, 0) }.to raise_error(Magick::DestroyedImageError)

--- a/spec/rmagick/image/stereo_spec.rb
+++ b/spec/rmagick/image/stereo_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#stereo' do
   it 'works' do
     img1 = described_class.new(20, 20)
 
-    expect do
-      res = img1.stereo(img1)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img1.stereo(img1)
+    expect(res).to be_instance_of(described_class)
 
     img2 = described_class.new(20, 20)
     img2.destroy!

--- a/spec/rmagick/image/store_pixels_spec.rb
+++ b/spec/rmagick/image/store_pixels_spec.rb
@@ -5,10 +5,8 @@ RSpec.describe Magick::Image, '#store_pixels' do
     img = described_class.new(20, 20)
     pixels = img.get_pixels(0, 0, img.columns, 1)
 
-    expect do
-      res = img.store_pixels(0, 0, img.columns, 1, pixels)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.store_pixels(0, 0, img.columns, 1, pixels)
+    expect(res).to be(img)
 
     pixels[0] = 'x'
     expect { img.store_pixels(0, 0, img.columns, 1, pixels) }.to raise_error(TypeError)

--- a/spec/rmagick/image/strip_bang_spec.rb
+++ b/spec/rmagick/image/strip_bang_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#strip!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.strip!
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.strip!
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/swirl_spec.rb
+++ b/spec/rmagick/image/swirl_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#swirl' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.swirl(30)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.swirl(30)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/texture_fill_to_border_spec.rb
+++ b/spec/rmagick/image/texture_fill_to_border_spec.rb
@@ -3,10 +3,9 @@ RSpec.describe Magick::Image, '#texture_fill_to_border' do
     img = described_class.new(20, 20)
     texture = described_class.read('granite:').first
 
-    expect do
-      res = img.texture_fill_to_border(img.columns / 2, img.rows / 2, texture)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.texture_fill_to_border(img.columns / 2, img.rows / 2, texture)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.texture_fill_to_border(img.columns / 2, img.rows / 2, 'x') }.to raise_error(NoMethodError)
     expect { img.texture_fill_to_border(img.columns * 2, img.rows, texture) }.to raise_error(ArgumentError)
     expect { img.texture_fill_to_border(img.columns, img.rows * 2, texture) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/texture_floodfill_spec.rb
+++ b/spec/rmagick/image/texture_floodfill_spec.rb
@@ -3,10 +3,9 @@ RSpec.describe Magick::Image, '#texture_floodfill' do
     img = described_class.new(20, 20)
     texture = described_class.read('granite:').first
 
-    expect do
-      res = img.texture_floodfill(img.columns / 2, img.rows / 2, texture)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.texture_floodfill(img.columns / 2, img.rows / 2, texture)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.texture_floodfill(img.columns / 2, img.rows / 2, 'x') }.to raise_error(NoMethodError)
     texture.destroy!
     expect { img.texture_floodfill(img.columns / 2, img.rows / 2, texture) }.to raise_error(Magick::DestroyedImageError)

--- a/spec/rmagick/image/threshold_spec.rb
+++ b/spec/rmagick/image/threshold_spec.rb
@@ -2,9 +2,7 @@ RSpec.describe Magick::Image, '#threshold' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.threshold(100)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.threshold(100)
+    expect(res).to be_instance_of(described_class)
   end
 end

--- a/spec/rmagick/image/thumbnail_bang_spec.rb
+++ b/spec/rmagick/image/thumbnail_bang_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#thumbnail!' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.thumbnail!(2)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.thumbnail!(2)
+    expect(res).to be(img)
+
     img.freeze
     expect { img.thumbnail!(0.50) }.to raise_error(FreezeError)
   end

--- a/spec/rmagick/image/thumbnail_spec.rb
+++ b/spec/rmagick/image/thumbnail_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#thumbnail' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.thumbnail(10, 10)
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.thumbnail(10, 10)
+    expect(res).to be_instance_of(described_class)
+
     expect { img.thumbnail(2) }.not_to raise_error
     expect { img.thumbnail }.to raise_error(ArgumentError)
     expect { img.thumbnail(-1.0) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/to_color_spec.rb
+++ b/spec/rmagick/image/to_color_spec.rb
@@ -3,9 +3,7 @@ RSpec.describe Magick::Image, '#to_color' do
     img = described_class.new(20, 20)
     red = Magick::Pixel.new(Magick::QuantumRange)
 
-    expect do
-      res = img.to_color(red)
-      expect(res).to eq('red')
-    end.not_to raise_error
+    res = img.to_color(red)
+    expect(res).to eq('red')
   end
 end

--- a/spec/rmagick/image/transparent_spec.rb
+++ b/spec/rmagick/image/transparent_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#transparent' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.transparent('white')
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.transparent('white')
+    expect(res).to be_instance_of(described_class)
+
     pixel = Magick::Pixel.new
     expect { img.transparent(pixel) }.not_to raise_error
     expect { img.transparent('white', Magick::TransparentAlpha) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image/transpose_spec.rb
+++ b/spec/rmagick/image/transpose_spec.rb
@@ -2,15 +2,12 @@ RSpec.describe Magick::Image, '#transpose' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.transpose
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
-    expect do
-      res = img.transpose!
-      expect(res).to be_instance_of(described_class)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.transpose
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
+    res = img.transpose!
+    expect(res).to be_instance_of(described_class)
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/transverse_spec.rb
+++ b/spec/rmagick/image/transverse_spec.rb
@@ -2,15 +2,12 @@ RSpec.describe Magick::Image, '#transverse' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.transverse
-      expect(res).to be_instance_of(described_class)
-      expect(res).not_to be(img)
-    end.not_to raise_error
-    expect do
-      res = img.transverse!
-      expect(res).to be_instance_of(described_class)
-      expect(res).to be(img)
-    end.not_to raise_error
+    res = img.transverse
+    expect(res).to be_instance_of(described_class)
+    expect(res).not_to be(img)
+
+    res = img.transverse!
+    expect(res).to be_instance_of(described_class)
+    expect(res).to be(img)
   end
 end

--- a/spec/rmagick/image/trim_bang_spec.rb
+++ b/spec/rmagick/image/trim_bang_spec.rb
@@ -1,13 +1,12 @@
 RSpec.describe Magick::Image, '#trim!' do
   it 'works' do
     hat = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      res = hat.trim!
-      expect(res).to be(hat)
+    res = hat.trim!
+    expect(res).to be(hat)
 
-      res = hat.trim!(10)
-      expect(res).to be(hat)
-    end.not_to raise_error
+    res = hat.trim!(10)
+    expect(res).to be(hat)
+
     expect { hat.trim!(10, 10) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image/trim_spec.rb
+++ b/spec/rmagick/image/trim_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Magick::Image, '#trim' do
   it 'works' do
     # Can't use the default image because it's a solid color
     hat = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
-    expect do
-      expect(hat.trim).to be_instance_of(described_class)
-      expect(hat.trim(10)).to be_instance_of(described_class)
-    end.not_to raise_error
+
+    expect(hat.trim).to be_instance_of(described_class)
+    expect(hat.trim(10)).to be_instance_of(described_class)
+
     expect { hat.trim(10, 10) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image/unique_colors_spec.rb
+++ b/spec/rmagick/image/unique_colors_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::Image, '#unique_colors' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.unique_colors
-      expect(res).to be_instance_of(described_class)
-      expect(res.columns).to eq(1)
-      expect(res.rows).to eq(1)
-    end.not_to raise_error
+    res = img.unique_colors
+    expect(res).to be_instance_of(described_class)
+    expect(res.columns).to eq(1)
+    expect(res.rows).to eq(1)
   end
 end

--- a/spec/rmagick/image/unsharp_mask_channel_spec.rb
+++ b/spec/rmagick/image/unsharp_mask_channel_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#unsharp_mask_channel' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.unsharp_mask_channel
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.unsharp_mask_channel
+    expect(res).to be_instance_of(described_class)
 
     expect { img.unsharp_mask_channel(2.0) }.not_to raise_error
     expect { img.unsharp_mask_channel(2.0, 1.0) }.not_to raise_error

--- a/spec/rmagick/image/unsharp_mask_spec.rb
+++ b/spec/rmagick/image/unsharp_mask_spec.rb
@@ -2,10 +2,8 @@ RSpec.describe Magick::Image, '#unsharp_mask' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.unsharp_mask
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.unsharp_mask
+    expect(res).to be_instance_of(described_class)
 
     expect { img.unsharp_mask(2.0) }.not_to raise_error
     expect { img.unsharp_mask(2.0, 1.0) }.not_to raise_error

--- a/spec/rmagick/image/view_spec.rb
+++ b/spec/rmagick/image/view_spec.rb
@@ -2,13 +2,11 @@ RSpec.describe Magick::Image, '#view' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.view(0, 0, 5, 5)
-      expect(res).to be_instance_of(Magick::Image::View)
-    end.not_to raise_error
-    expect do
-      img.view(0, 0, 5, 5) { |v| expect(v).to be_instance_of(Magick::Image::View) }
-    end.not_to raise_error
+    res = img.view(0, 0, 5, 5)
+    expect(res).to be_instance_of(Magick::Image::View)
+
+    img.view(0, 0, 5, 5) { |v| expect(v).to be_instance_of(Magick::Image::View) }
+
     expect { img.view(-1, 0, 5, 5) }.to raise_error(RangeError)
     expect { img.view(0, -1, 5, 5) }.to raise_error(RangeError)
     expect { img.view(1, 0, img.columns, 5) }.to raise_error(RangeError)

--- a/spec/rmagick/image/vignette_spec.rb
+++ b/spec/rmagick/image/vignette_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe Magick::Image, '#vignette' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.vignette
-      expect(res).to be_instance_of(described_class)
-      expect(img).not_to be(res)
-    end.not_to raise_error
+    res = img.vignette
+    expect(res).to be_instance_of(described_class)
+    expect(img).not_to be(res)
+
     expect { img.vignette(0) }.not_to raise_error
     expect { img.vignette(0, 0) }.not_to raise_error
     expect { img.vignette(0, 0, 0) }.not_to raise_error

--- a/spec/rmagick/image/wave_spec.rb
+++ b/spec/rmagick/image/wave_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe Magick::Image, '#wave' do
   it 'works' do
     img = described_class.new(20, 20)
 
-    expect do
-      res = img.wave
-      expect(res).to be_instance_of(described_class)
-    end.not_to raise_error
+    res = img.wave
+    expect(res).to be_instance_of(described_class)
+
     expect { img.wave(25) }.not_to raise_error
     expect { img.wave(25, 200) }.not_to raise_error
     expect { img.wave(25, 200, 2) }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/ampersand_spec.rb
+++ b/spec/rmagick/image_list/ampersand_spec.rb
@@ -10,23 +10,21 @@ RSpec.describe Magick::ImageList, '#&' do
 
     list.scene = 7
     cur = list.cur_image
-    expect do
-      res = list & list2
-      expect(res).to be_instance_of(described_class)
-      expect(list).not_to be(res)
-      expect(list2).not_to be(res)
-      expect(res.length).to eq(5)
-      expect(res.scene).to eq(2)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
+
+    res = list & list2
+    expect(res).to be_instance_of(described_class)
+    expect(list).not_to be(res)
+    expect(list2).not_to be(res)
+    expect(res.length).to eq(5)
+    expect(res.scene).to eq(2)
+    expect(res.cur_image).to be(cur)
 
     # current scene not in the result, set result scene to last image in result
     list.scene = 2
-    expect do
-      res = list & list2
-      expect(res).to be_instance_of(described_class)
-      expect(res.scene).to eq(4)
-    end.not_to raise_error
+
+    res = list & list2
+    expect(res).to be_instance_of(described_class)
+    expect(res.scene).to eq(4)
 
     expect { list & 2 }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image_list/append_spec.rb
+++ b/spec/rmagick/image_list/append_spec.rb
@@ -13,14 +13,13 @@ RSpec.describe Magick::ImageList, '#<<' do
   it "works" do
     ilist = described_class.new
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    expect do
-      img = ilist.append(true)
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
-    expect do
-      img = ilist.append(false)
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
+
+    img = ilist.append(true)
+    expect(img).to be_instance_of(Magick::Image)
+
+    img = ilist.append(false)
+    expect(img).to be_instance_of(Magick::Image)
+
     expect { ilist.append }.to raise_error(ArgumentError)
     expect { ilist.append(true, 1) }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image_list/at_spec.rb
+++ b/spec/rmagick/image_list/at_spec.rb
@@ -2,17 +2,17 @@ RSpec.describe Magick::ImageList, '#at' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      cur = list.cur_image
-      img = list.at(7)
-      expect(list[7]).to be(img)
-      expect(list.cur_image).to be(cur)
-      img = list.at(10)
-      expect(img).to be(nil)
-      expect(list.cur_image).to be(cur)
-      img = list.at(-1)
-      expect(list[9]).to be(img)
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+    cur = list.cur_image
+    img = list.at(7)
+    expect(list[7]).to be(img)
+    expect(list.cur_image).to be(cur)
+
+    img = list.at(10)
+    expect(img).to be(nil)
+    expect(list.cur_image).to be(cur)
+
+    img = list.at(-1)
+    expect(list[9]).to be(img)
+    expect(list.cur_image).to be(cur)
   end
 end

--- a/spec/rmagick/image_list/average_spec.rb
+++ b/spec/rmagick/image_list/average_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Magick::ImageList, "#average" do
     ilist = described_class.new
 
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_0.gif')
-    expect do
-      img = ilist.average
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
+
+    img = ilist.average
+    expect(img).to be_instance_of(Magick::Image)
+
     expect { ilist.average(1) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image_list/braces_equals_spec.rb
+++ b/spec/rmagick/image_list/braces_equals_spec.rb
@@ -3,62 +3,50 @@ RSpec.describe Magick::ImageList, '#[]=' do
     list = described_class.new(*FILES[0..9])
     img = Magick::Image.new(5, 5)
 
-    expect do
-      rv = list[0] = img
-      expect(rv).to be(img)
-      expect(list[0]).to be(img)
-      expect(list.scene).to eq(0)
-    end.not_to raise_error
+    rv = list[0] = img
+    expect(rv).to be(img)
+    expect(list[0]).to be(img)
+    expect(list.scene).to eq(0)
 
     # replace 2 images with 1
-    expect do
-      img = Magick::Image.new(5, 5)
-      rv = list[1, 2] = img
-      expect(rv).to be(img)
-      expect(list.length).to eq(9)
-      expect(list[1]).to be(img)
-      expect(list.scene).to eq(1)
-    end.not_to raise_error
+    img = Magick::Image.new(5, 5)
+    rv = list[1, 2] = img
+    expect(rv).to be(img)
+    expect(list.length).to eq(9)
+    expect(list[1]).to be(img)
+    expect(list.scene).to eq(1)
 
     # replace 1 image with 2
-    expect do
-      img = Magick::Image.new(5, 5)
-      img2 = Magick::Image.new(5, 5)
-      ary = [img, img2]
-      rv = list[3, 1] = ary
-      expect(rv).to be(ary)
-      expect(list.length).to eq(10)
-      expect(list[3]).to be(img)
-      expect(list[4]).to be(img2)
-      expect(list.scene).to eq(4)
-    end.not_to raise_error
+    img = Magick::Image.new(5, 5)
+    img2 = Magick::Image.new(5, 5)
+    ary = [img, img2]
+    rv = list[3, 1] = ary
+    expect(rv).to be(ary)
+    expect(list.length).to eq(10)
+    expect(list[3]).to be(img)
+    expect(list[4]).to be(img2)
+    expect(list.scene).to eq(4)
 
-    expect do
-      img = Magick::Image.new(5, 5)
-      rv = list[5..6] = img
-      expect(rv).to be(img)
-      expect(list.length).to eq(9)
-      expect(list[5]).to be(img)
-      expect(list.scene).to eq(5)
-    end.not_to raise_error
+    img = Magick::Image.new(5, 5)
+    rv = list[5..6] = img
+    expect(rv).to be(img)
+    expect(list.length).to eq(9)
+    expect(list[5]).to be(img)
+    expect(list.scene).to eq(5)
 
-    expect do
-      ary = [img, img]
-      rv = list[7..8] = ary
-      expect(rv).to be(ary)
-      expect(list.length).to eq(9)
-      expect(list[7]).to be(img)
-      expect(list[8]).to be(img)
-      expect(list.scene).to eq(8)
-    end.not_to raise_error
+    ary = [img, img]
+    rv = list[7..8] = ary
+    expect(rv).to be(ary)
+    expect(list.length).to eq(9)
+    expect(list[7]).to be(img)
+    expect(list[8]).to be(img)
+    expect(list.scene).to eq(8)
 
-    expect do
-      rv = list[-1] = img
-      expect(rv).to be(img)
-      expect(list.length).to eq(9)
-      expect(list[8]).to be(img)
-      expect(list.scene).to eq(8)
-    end.not_to raise_error
+    rv = list[-1] = img
+    expect(rv).to be(img)
+    expect(list.length).to eq(9)
+    expect(list[8]).to be(img)
+    expect(list.scene).to eq(8)
 
     expect { list[0] = 1 }.to raise_error(ArgumentError)
     expect { list[0, 1] = [1, 2] }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/collect_spec.rb
+++ b/spec/rmagick/image_list/collect_spec.rb
@@ -2,18 +2,15 @@ RSpec.describe Magick::ImageList, '#collect' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      scene = list.scene
-      res = list.collect(&:negate)
-      expect(res).to be_instance_of(described_class)
-      expect(list).not_to be(res)
-      expect(res.scene).to eq(scene)
-    end.not_to raise_error
-    expect do
-      scene = list.scene
-      list.collect!(&:negate)
-      expect(list).to be_instance_of(described_class)
-      expect(list.scene).to eq(scene)
-    end.not_to raise_error
+    scene = list.scene
+    res = list.collect(&:negate)
+    expect(res).to be_instance_of(described_class)
+    expect(list).not_to be(res)
+    expect(res.scene).to eq(scene)
+
+    scene = list.scene
+    list.collect!(&:negate)
+    expect(list).to be_instance_of(described_class)
+    expect(list.scene).to eq(scene)
   end
 end

--- a/spec/rmagick/image_list/compact_spec.rb
+++ b/spec/rmagick/image_list/compact_spec.rb
@@ -2,17 +2,14 @@ RSpec.describe Magick::ImageList, '#compact' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      res = list.compact
-      expect(list).not_to be(res)
-      expect(list).to eq(res)
-    end.not_to raise_error
-    expect do
-      res = list
-      list.compact!
-      expect(list).to be_instance_of(described_class)
-      expect(list).to eq(res)
-      expect(list).to be(res)
-    end.not_to raise_error
+    res = list.compact
+    expect(list).not_to be(res)
+    expect(list).to eq(res)
+
+    res = list
+    list.compact!
+    expect(list).to be_instance_of(described_class)
+    expect(list).to eq(res)
+    expect(list).to be(res)
   end
 end

--- a/spec/rmagick/image_list/concat_spec.rb
+++ b/spec/rmagick/image_list/concat_spec.rb
@@ -20,12 +20,11 @@ RSpec.describe Magick::ImageList, '#concat' do
     list2 << list[8]
     list2 << list[9]
 
-    expect do
-      res = list.concat(list2)
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(15)
-      expect(res.cur_image).to be(res[14])
-    end.not_to raise_error
+    res = list.concat(list2)
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(15)
+    expect(res.cur_image).to be(res[14])
+
     expect { list.concat(2) }.to raise_error(ArgumentError)
     expect { list.concat([2]) }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image_list/delete_if_spec.rb
+++ b/spec/rmagick/image_list/delete_if_spec.rb
@@ -4,19 +4,16 @@ RSpec.describe Magick::ImageList, '#delete_if' do
 
     list.scene = 7
     cur = list.cur_image
-    expect do
-      list.delete_if { |img| File.basename(img.filename) =~ /5/ }
-      expect(list).to be_instance_of(described_class)
-      expect(list.length).to eq(9)
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+
+    list.delete_if { |img| File.basename(img.filename) =~ /5/ }
+    expect(list).to be_instance_of(described_class)
+    expect(list.length).to eq(9)
+    expect(list.cur_image).to be(cur)
 
     # Delete the current image
-    expect do
-      list.delete_if { |img| File.basename(img.filename) =~ /7/ }
-      expect(list).to be_instance_of(described_class)
-      expect(list.length).to eq(8)
-      expect(list.cur_image).to be(list[-1])
-    end.not_to raise_error
+    list.delete_if { |img| File.basename(img.filename) =~ /7/ }
+    expect(list).to be_instance_of(described_class)
+    expect(list.length).to eq(8)
+    expect(list.cur_image).to be(list[-1])
   end
 end

--- a/spec/rmagick/image_list/delete_spec.rb
+++ b/spec/rmagick/image_list/delete_spec.rb
@@ -2,27 +2,23 @@ RSpec.describe Magick::ImageList, '#delete' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      cur = list.cur_image
-      img = list[7]
-      expect(list.delete(img)).to be(img)
-      expect(list.length).to eq(9)
-      expect(list.cur_image).to be(cur)
+    cur = list.cur_image
+    img = list[7]
+    expect(list.delete(img)).to be(img)
+    expect(list.length).to eq(9)
+    expect(list.cur_image).to be(cur)
 
-      # Try deleting the current image.
-      expect(list.delete(cur)).to be(cur)
-      expect(list.cur_image).to be(list[-1])
+    # Try deleting the current image.
+    expect(list.delete(cur)).to be(cur)
+    expect(list.cur_image).to be(list[-1])
 
-      expect { list.delete(2) }.to raise_error(ArgumentError)
-      expect { list.delete([2]) }.to raise_error(ArgumentError)
+    expect { list.delete(2) }.to raise_error(ArgumentError)
+    expect { list.delete([2]) }.to raise_error(ArgumentError)
 
-      # Try deleting something that isn't in the list.
-      # Should return the value of the block.
-      expect do
-        img = Magick::Image.read(FILES[10]).first
-        res = list.delete(img) { 1 }
-        expect(res).to eq(1)
-      end.not_to raise_error
-    end.not_to raise_error
+    # Try deleting something that isn't in the list.
+    # Should return the value of the block.
+    img = Magick::Image.read(FILES[10]).first
+    res = list.delete(img) { 1 }
+    expect(res).to eq(1)
   end
 end

--- a/spec/rmagick/image_list/fill_spec.rb
+++ b/spec/rmagick/image_list/fill_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Magick::ImageList, '#fill' do
 
     list2 = list.copy
     img = list[0].copy
-    expect do
-      expect(list2.fill(img)).to be_instance_of(described_class)
-    end.not_to raise_error
+
+    expect(list2.fill(img)).to be_instance_of(described_class)
+
     list2.each { |el| expect(img).to be(el) }
 
     list2 = list.copy

--- a/spec/rmagick/image_list/find_all_spec.rb
+++ b/spec/rmagick/image_list/find_all_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::ImageList, '#find_all' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      res = list.find_all { |img| File.basename(img.filename) =~ /Button_2/ }
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(1)
-      expect(list[2]).to be(res[0])
-    end.not_to raise_error
+    res = list.find_all { |img| File.basename(img.filename) =~ /Button_2/ }
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(1)
+    expect(list[2]).to be(res[0])
   end
 end

--- a/spec/rmagick/image_list/flatten_images_spec.rb
+++ b/spec/rmagick/image_list/flatten_images_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe Magick::ImageList, '#flatten_images' do
   it "still works" do
     ilist = described_class.new
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    expect do
-      img = ilist.flatten_images
-      expect(img).to be_instance_of(Magick::Image)
-    end.not_to raise_error
+
+    img = ilist.flatten_images
+    expect(img).to be_instance_of(Magick::Image)
   end
 end

--- a/spec/rmagick/image_list/insert_spec.rb
+++ b/spec/rmagick/image_list/insert_spec.rb
@@ -2,14 +2,12 @@ RSpec.describe Magick::ImageList, '#insert' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      list.scene = 7
-      cur = list.cur_image
-      expect(list.insert(1, list[2])).to be_instance_of(described_class)
-      expect(list.cur_image).to be(cur)
-      list.insert(1, list[2], list[3], list[4])
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+    list.scene = 7
+    cur = list.cur_image
+    expect(list.insert(1, list[2])).to be_instance_of(described_class)
+    expect(list.cur_image).to be(cur)
+    list.insert(1, list[2], list[3], list[4])
+    expect(list.cur_image).to be(cur)
 
     expect { list.insert(0, 'x') }.to raise_error(ArgumentError)
     expect { list.insert(0, 'x', 'y') }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/minus_spec.rb
+++ b/spec/rmagick/image_list/minus_spec.rb
@@ -10,23 +10,20 @@ RSpec.describe Magick::ImageList, '#-' do
 
     list.scene = 0
     cur = list.cur_image
-    expect do
-      res = list - list2
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(5)
-      expect(list).not_to be(res)
-      expect(list2).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
+
+    res = list - list2
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(5)
+    expect(list).not_to be(res)
+    expect(list2).not_to be(res)
+    expect(res.cur_image).to be(cur)
 
     # current scene not in result - set result scene to last image in result
     list.scene = 7
-    cur = list.cur_image
-    expect do
-      res = list - list2
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(5)
-      expect(res.scene).to eq(4)
-    end.not_to raise_error
+
+    res = list - list2
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(5)
+    expect(res.scene).to eq(4)
   end
 end

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -10,41 +10,39 @@ RSpec.describe Magick::ImageList, "#montage" do
 
     ilist1.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     ilist2 = ilist1.copy
-    montage = nil
-    expect do
-      montage = ilist2.montage do
-        self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-        self.background_color = 'blue'
-        self.border_color = Magick::Pixel.new(0, 0, 0)
-        self.border_color = 'red'
-        self.border_width = 2
-        self.compose = Magick::OverCompositeOp
-        self.filename = 'test.png'
-        self.fill = 'green'
-        self.font = Magick.fonts.first.name
-        self.frame = '20x20+4+4'
-        self.frame = Magick::Geometry.new(20, 20, 4, 4)
-        self.geometry = '63x60+5+5'
-        self.geometry = Magick::Geometry.new(63, 60, 5, 5)
-        self.gravity = Magick::SouthGravity
-        self.matte_color = '#bdbdbd'
-        self.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-        self.pointsize = 12
-        self.shadow = true
-        self.stroke = 'transparent'
-        self.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-        self.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-        self.tile = '4x9'
-        self.tile = Magick::Geometry.new(4, 9)
-        self.title = 'sample'
-      end
-      expect(montage).to be_instance_of(described_class)
-      expect(ilist2).to eq(ilist1)
 
-      montage_image = montage.first
-      expect(montage_image.background_color).to eq('blue')
-      expect(montage_image.border_color).to eq('red')
-    end.not_to raise_error
+    montage = ilist2.montage do
+      self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      self.background_color = 'blue'
+      self.border_color = Magick::Pixel.new(0, 0, 0)
+      self.border_color = 'red'
+      self.border_width = 2
+      self.compose = Magick::OverCompositeOp
+      self.filename = 'test.png'
+      self.fill = 'green'
+      self.font = Magick.fonts.first.name
+      self.frame = '20x20+4+4'
+      self.frame = Magick::Geometry.new(20, 20, 4, 4)
+      self.geometry = '63x60+5+5'
+      self.geometry = Magick::Geometry.new(63, 60, 5, 5)
+      self.gravity = Magick::SouthGravity
+      self.matte_color = '#bdbdbd'
+      self.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      self.pointsize = 12
+      self.shadow = true
+      self.stroke = 'transparent'
+      self.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      self.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      self.tile = '4x9'
+      self.tile = Magick::Geometry.new(4, 9)
+      self.title = 'sample'
+    end
+    expect(montage).to be_instance_of(described_class)
+    expect(ilist2).to eq(ilist1)
+
+    montage_image = montage.first
+    expect(montage_image.background_color).to eq('blue')
+    expect(montage_image.border_color).to eq('red')
 
     # test illegal option arguments
     # looks like IM doesn't diagnose invalid geometry args

--- a/spec/rmagick/image_list/morph_spec.rb
+++ b/spec/rmagick/image_list/morph_spec.rb
@@ -7,11 +7,10 @@ RSpec.describe Magick::ImageList, "#morph" do
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
     # can't specify a negative argument
     expect { ilist.morph(-1) }.to raise_error(ArgumentError)
-    expect do
-      res = ilist.morph(2)
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(4)
-      expect(res.scene).to eq(0)
-    end.not_to raise_error
+
+    res = ilist.morph(2)
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(4)
+    expect(res.scene).to eq(0)
   end
 end

--- a/spec/rmagick/image_list/mosaic_spec.rb
+++ b/spec/rmagick/image_list/mosaic_spec.rb
@@ -3,10 +3,8 @@ RSpec.describe Magick::ImageList, "#mosaic" do
     ilist = described_class.new
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
 
-    expect do
-      res = ilist.mosaic
-      expect(res).to be_instance_of(Magick::Image)
-    end.not_to raise_error
+    res = ilist.mosaic
+    expect(res).to be_instance_of(Magick::Image)
   end
 
   it "raises an error when images is not set" do

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -2,9 +2,8 @@ RSpec.describe Magick::ImageList, "#new_image" do
   it "works" do
     ilist = described_class.new
 
-    expect do
-      ilist.new_image(20, 20)
-    end.not_to raise_error
+    ilist.new_image(20, 20)
+
     expect(ilist.length).to eq(1)
     expect(ilist.scene).to eq(0)
     ilist.new_image(20, 20, Magick::HatchFill.new('black'))

--- a/spec/rmagick/image_list/optimize_layers_spec.rb
+++ b/spec/rmagick/image_list/optimize_layers_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe Magick::ImageList, "#optimize_layers" do
     Magick::LayerMethod.values do |method|
       next if [Magick::UndefinedLayer, Magick::CompositeLayer, Magick::TrimBoundsLayer].include?(method)
 
-      expect do
-        res = ilist.optimize_layers(method)
-        expect(res).to be_instance_of(described_class)
-        expect(res.length).to be_kind_of(Integer)
-      end.not_to raise_error
+      res = ilist.optimize_layers(method)
+      expect(res).to be_instance_of(described_class)
+      expect(res.length).to be_kind_of(Integer)
     end
 
     expect { ilist.optimize_layers(Magick::CompareClearLayer) }.not_to raise_error

--- a/spec/rmagick/image_list/partition_spec.rb
+++ b/spec/rmagick/image_list/partition_spec.rb
@@ -2,14 +2,13 @@ RSpec.describe Magick::ImageList, '#partition' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    a = nil
     n = -1
-    expect do
-      a = list.partition do
-        n += 1
-        (n & 1).zero?
-      end
-    end.not_to raise_error
+
+    a = list.partition do
+      n += 1
+      (n & 1).zero?
+    end
+
     expect(a).to be_instance_of(Array)
     expect(a.size).to eq(2)
     expect(a[0]).to be_instance_of(described_class)

--- a/spec/rmagick/image_list/pipe_spec.rb
+++ b/spec/rmagick/image_list/pipe_spec.rb
@@ -8,16 +8,14 @@ RSpec.describe Magick::ImageList, '#|' do
     list2 << list[8]
     list2 << list[9]
 
-    expect do
-      list.scene = 7
-      # The or of these two lists should be the same as list
-      # but not be the *same* list
-      res = list | list2
-      expect(res).to be_instance_of(described_class)
-      expect(list).not_to be(res)
-      expect(list2).not_to be(res)
-      expect(list).to eq(res)
-    end.not_to raise_error
+    list.scene = 7
+    # The or of these two lists should be the same as list
+    # but not be the *same* list
+    res = list | list2
+    expect(res).to be_instance_of(described_class)
+    expect(list).not_to be(res)
+    expect(list2).not_to be(res)
+    expect(list).to eq(res)
 
     # Try or'ing disjoint lists
     temp_list = described_class.new(*FILES[10..14])

--- a/spec/rmagick/image_list/plus_spec.rb
+++ b/spec/rmagick/image_list/plus_spec.rb
@@ -10,14 +10,13 @@ RSpec.describe Magick::ImageList, '#+' do
 
     list.scene = 7
     cur = list.cur_image
-    expect do
-      res = list + list2
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(15)
-      expect(list).not_to be(res)
-      expect(list2).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
+
+    res = list + list2
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(15)
+    expect(list).not_to be(res)
+    expect(list2).not_to be(res)
+    expect(res.cur_image).to be(cur)
 
     expect { list + [2] }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image_list/pop_spec.rb
+++ b/spec/rmagick/image_list/pop_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe Magick::ImageList, '#pop' do
     list.scene = 8
     cur = list.cur_image
     last = list[-1]
-    expect do
-      expect(list.pop).to be(last)
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+
+    expect(list.pop).to be(last)
+    expect(list.cur_image).to be(cur)
 
     expect(list.pop).to be(cur)
     expect(list.cur_image).to be(list[-1])

--- a/spec/rmagick/image_list/quantize_spec.rb
+++ b/spec/rmagick/image_list/quantize_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Magick::ImageList, "#quantize" do
     ilist = described_class.new
 
     ilist.read(IMAGES_DIR + '/Button_0.gif', IMAGES_DIR + '/Button_1.gif')
-    expect do
-      res = ilist.quantize
-      expect(res).to be_instance_of(described_class)
-      expect(res.scene).to eq(1)
-    end.not_to raise_error
+
+    res = ilist.quantize
+    expect(res).to be_instance_of(described_class)
+    expect(res.scene).to eq(1)
+
     expect { ilist.quantize(128) }.not_to raise_error
     expect { ilist.quantize('x') }.to raise_error(TypeError)
     expect { ilist.quantize(128, Magick::RGBColorspace) }.not_to raise_error

--- a/spec/rmagick/image_list/reject_bang_spec.rb
+++ b/spec/rmagick/image_list/reject_bang_spec.rb
@@ -4,20 +4,17 @@ RSpec.describe Magick::ImageList, '#reject!' do
 
     list.scene = 7
     cur = list.cur_image
-    expect do
-      list.reject! { |img| File.basename(img.filename) =~ /5/ }
-      expect(list).to be_instance_of(described_class)
-      expect(list.length).to eq(9)
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+
+    list.reject! { |img| File.basename(img.filename) =~ /5/ }
+    expect(list).to be_instance_of(described_class)
+    expect(list.length).to eq(9)
+    expect(list.cur_image).to be(cur)
 
     # Delete the current image
-    expect do
-      list.reject! { |img| File.basename(img.filename) =~ /7/ }
-      expect(list).to be_instance_of(described_class)
-      expect(list.length).to eq(8)
-      expect(list.cur_image).to be(list[-1])
-    end.not_to raise_error
+    list.reject! { |img| File.basename(img.filename) =~ /7/ }
+    expect(list).to be_instance_of(described_class)
+    expect(list.length).to eq(8)
+    expect(list.cur_image).to be(list[-1])
 
     # returns nil if no changes are made
     expect(list.reject! { false }).to be(nil)

--- a/spec/rmagick/image_list/reject_spec.rb
+++ b/spec/rmagick/image_list/reject_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe Magick::ImageList, '#reject' do
     list.scene = 7
     cur = list.cur_image
     list2 = list
-    expect do
-      res = list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
-      expect(res.length).to eq(9)
-      expect(res).to be_instance_of(described_class)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
+
+    res = list.reject { |img| File.basename(img.filename) =~ /Button_9/ }
+    expect(res.length).to eq(9)
+    expect(res).to be_instance_of(described_class)
+    expect(res.cur_image).to be(cur)
+
     expect(list).to be(list2)
     expect(list.cur_image).to be(cur)
 

--- a/spec/rmagick/image_list/replace_spec.rb
+++ b/spec/rmagick/image_list/replace_spec.rb
@@ -14,20 +14,17 @@ RSpec.describe Magick::ImageList, '#replace' do
     list, list2 = make_lists
 
     # Replace with empty list
-    expect do
-      res = list.replace([])
-      expect(list).to be(res)
-      expect(list.length).to eq(0)
-      expect(list.scene).to be(nil)
-    end.not_to raise_error
+    res = list.replace([])
+    expect(list).to be(res)
+    expect(list.length).to eq(0)
+    expect(list.scene).to be(nil)
 
     # Replace empty list with non-empty list
     temp = described_class.new
-    expect do
-      temp.replace(list2)
-      expect(temp.length).to eq(5)
-      expect(temp.scene).to eq(4)
-    end.not_to raise_error
+
+    temp.replace(list2)
+    expect(temp.length).to eq(5)
+    expect(temp.scene).to eq(4)
 
     # Try to replace with illegal values
     expect { list.replace([1, 2, 3]) }.to raise_error(ArgumentError)
@@ -36,29 +33,25 @@ RSpec.describe Magick::ImageList, '#replace' do
   it 'replaces with a shorter list' do
     list, list2 = make_lists
 
-    expect do
-      list.scene = 7
-      cur = list.cur_image
-      res = list.replace(list2)
-      expect(list).to be(res)
-      expect(list.length).to eq(5)
-      expect(list.scene).to eq(2)
-      expect(list.cur_image).to be(cur)
-    end.not_to raise_error
+    list.scene = 7
+    cur = list.cur_image
+    res = list.replace(list2)
+    expect(list).to be(res)
+    expect(list.length).to eq(5)
+    expect(list.scene).to eq(2)
+    expect(list.cur_image).to be(cur)
   end
 
   it 'replaces with a longer list' do
     list, list2 = make_lists
 
     # Replace with longer list
-    expect do
-      list2.scene = 2
-      cur = list2.cur_image
-      res = list2.replace(list)
-      expect(list2).to be(res)
-      expect(list2.length).to eq(10)
-      expect(list2.scene).to eq(7)
-      expect(list2.cur_image).to be(cur)
-    end.not_to raise_error
+    list2.scene = 2
+    cur = list2.cur_image
+    res = list2.replace(list)
+    expect(list2).to be(res)
+    expect(list2.length).to eq(10)
+    expect(list2.scene).to eq(7)
+    expect(list2.cur_image).to be(cur)
   end
 end

--- a/spec/rmagick/image_list/reverse_each_spec.rb
+++ b/spec/rmagick/image_list/reverse_each_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Magick::ImageList, '#reverse_each' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      list.reverse_each { |img| expect(img).to be_instance_of(Magick::Image) }
-    end.not_to raise_error
+    list.reverse_each { |img| expect(img).to be_instance_of(Magick::Image) }
   end
 end

--- a/spec/rmagick/image_list/select_spec.rb
+++ b/spec/rmagick/image_list/select_spec.rb
@@ -2,11 +2,9 @@ RSpec.describe Magick::ImageList, '#select' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      res = list.select { |img| File.basename(img.filename) =~ /Button_2/ }
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(1)
-      expect(list[2]).to be(res[0])
-    end.not_to raise_error
+    res = list.select { |img| File.basename(img.filename) =~ /Button_2/ }
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(1)
+    expect(list[2]).to be(res[0])
   end
 end

--- a/spec/rmagick/image_list/shift_spec.rb
+++ b/spec/rmagick/image_list/shift_spec.rb
@@ -2,13 +2,12 @@ RSpec.describe Magick::ImageList, '#shift' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      list.scene = 0
-      res = list[0]
-      img = list.shift
-      expect(img).to be(res)
-      expect(list.scene).to eq(8)
-    end.not_to raise_error
+    list.scene = 0
+    res = list[0]
+    img = list.shift
+    expect(img).to be(res)
+    expect(list.scene).to eq(8)
+
     res = list[0]
     img = list.shift
     expect(img).to be(res)

--- a/spec/rmagick/image_list/shovel_spec.rb
+++ b/spec/rmagick/image_list/shovel_spec.rb
@@ -8,11 +8,9 @@ RSpec.describe Magick::ImageList, '#<<' do
     list2 << list[8]
     list2 << list[9]
 
-    expect do
-      list2.each { |img| list << img }
-      expect(list.length).to eq(15)
-      expect(list.scene).to eq(14)
-    end.not_to raise_error
+    list2.each { |img| list << img }
+    expect(list.length).to eq(15)
+    expect(list.scene).to eq(14)
 
     expect { list << 2 }.to raise_error(ArgumentError)
     expect { list << [2] }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/slice_bang_spec.rb
+++ b/spec/rmagick/image_list/slice_bang_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe Magick::ImageList, '#slice!' do
     list = described_class.new(*FILES[0..9])
 
     list.scene = 7
-    expect do
-      img0 = list[0]
-      img = list.slice!(0)
-      expect(img).to be(img0)
-      expect(list.length).to eq(9)
-      expect(list.scene).to eq(6)
-    end.not_to raise_error
+
+    img0 = list[0]
+    img = list.slice!(0)
+    expect(img).to be(img0)
+    expect(list.length).to eq(9)
+    expect(list.scene).to eq(6)
+
     cur = list.cur_image
     img = list.slice!(6)
     expect(img).to be(cur)

--- a/spec/rmagick/image_list/star_spec.rb
+++ b/spec/rmagick/image_list/star_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe Magick::ImageList, '#*' do
 
     list.scene = 7
     cur = list.cur_image
-    expect do
-      res = list * 2
-      expect(res).to be_instance_of(described_class)
-      expect(res.length).to eq(20)
-      expect(list).not_to be(res)
-      expect(res.cur_image).to be(cur)
-    end.not_to raise_error
+
+    res = list * 2
+    expect(res).to be_instance_of(described_class)
+    expect(res.length).to eq(20)
+    expect(list).not_to be(res)
+    expect(res.cur_image).to be(cur)
 
     expect { list * 'x' }.to raise_error(ArgumentError)
   end

--- a/spec/rmagick/image_list/uniq_bang_spec.rb
+++ b/spec/rmagick/image_list/uniq_bang_spec.rb
@@ -2,9 +2,8 @@ RSpec.describe Magick::ImageList, '#uniq!' do
   it 'works' do
     list = described_class.new(*FILES[0..9])
 
-    expect do
-      expect(list.uniq!).to be(nil)
-    end.not_to raise_error
+    expect(list.uniq!).to be(nil)
+
     list[1] = list[0]
     list.scene = 7
     cur = list.cur_image

--- a/spec/rmagick/image_list/write_spec.rb
+++ b/spec/rmagick/image_list/write_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe Magick::ImageList, "#write" do
     ilist = described_class.new
 
     ilist.read(IMAGES_DIR + '/Button_0.gif')
-    expect do
-      ilist.write('temp.gif')
-    end.not_to raise_error
+
+    ilist.write('temp.gif')
+
     list = described_class.new('temp.gif')
     expect(list.format).to eq('GIF')
     FileUtils.rm('temp.gif')

--- a/spec/rmagick/image_list_spec.rb
+++ b/spec/rmagick/image_list_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Magick::ImageList do
     list = described_class.new(*FILES[0..9])
 
     expect { list.detect { true } }.not_to raise_error
-    expect do
-      list.each_with_index { |img, _n| expect(img).to be_instance_of(Magick::Image) }
-    end.not_to raise_error
+
+    list.each_with_index { |img, _n| expect(img).to be_instance_of(Magick::Image) }
+
     expect { list.entries }.not_to raise_error
     expect { list.include?(list[0]) }.not_to raise_error
     expect { list.inject(0) { 0 } }.not_to raise_error


### PR DESCRIPTION
This removes most multiline `not_to raise_error` blocks. These are
unnecessary as it will fail the test if an error is raised either way. I
left in some blocks in cases where the test was more focused on whether
or not it raised an error. Eventually it would be nice if those changed
to more precise tests validating the outcome rather than just checking
whether a method call raised an error.