### PR TITLE
Rubocop: enable Lint/Void

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -84,13 +84,6 @@ Lint/UselessComparison:
   Exclude:
     - 'spec/rmagick/enum/case_equality_spec.rb'
 
-# Offense count: 6
-# Configuration parameters: CheckForMethodsWithNoSideEffects.
-Lint/Void:
-  Exclude:
-    - 'lib/rmagick_internal.rb'
-    - 'lib/rvg/embellishable.rb'
-
 # Offense count: 44
 Metrics/AbcSize:
   Max: 537

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1130,7 +1130,6 @@ module Magick
           each { |x| @view[x] = rv.dup }
           changed
           notify_observers(self)
-          nil
         end
 
         # A pixel has been modified. Tell the view.
@@ -1302,7 +1301,6 @@ module Magick
       n = Integer(n)
       Kernel.raise IndexError, 'scene number out of bounds' if n < 0 || n > length - 1
       @scene = n
-      @scene
     end
 
     # All the binary operators work the same way.
@@ -1386,7 +1384,6 @@ module Magick
       else
         set_current nil
       end
-      obj
     end
 
     %i[
@@ -1556,10 +1553,8 @@ module Magick
       filenames.each do |f|
         Magick::Image.read(f, &block).each { |n| @images << n }
       end
-      if length > 0
-        @scene = length - 1 # last image in array
-      end
-      self
+
+      @scene = length - 1 if length > 0 # last image in array
     end
 
     def insert(index, *args)
@@ -1582,7 +1577,6 @@ module Magick
       n = Integer(n)
       Kernel.raise ArgumentError, 'iterations must be between 0 and 65535' if n < 0 || n > 65_535
       @images.each { |f| f.iterations = n }
-      self
     end
 
     def last(*args)

--- a/lib/rvg/embellishable.rb
+++ b/lib/rvg/embellishable.rb
@@ -30,7 +30,6 @@ module Magick
 
         @primitive = :circle
         @args = [cx, cy, cx + r, cy]
-        self
       end
     end # class Circle
 


### PR DESCRIPTION
This rule disallows implicit returns in methods that ignore return
values. In particular, `initialize` returns `self` implicitly and
ignores any return value, and setter methods implicitly return the
passed in value.

https://rubocop.readthedocs.io/en/stable/cops_lint/#lintvoid