### PR TITLE
Rubocop: remove unused `have_enum_` methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -176,18 +176,6 @@ Naming/MethodName:
     - 'lib/rvg/misc.rb'
     - 'lib/rvg/transformable.rb'
 
-# Offense count: 4
-# Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.
-# NamePrefix: is_, has_, have_
-# NamePrefixBlacklist: is_, has_, have_
-# NameWhitelist: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
-  Exclude:
-    - 'spec/**/*'
-    - 'ext/RMagick/extconf.rb'
-    - 'lib/rmagick_internal.rb'
-
 # Offense count: 224
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -100,31 +100,6 @@ module RMagick
       $CFLAGS << (have_macro('__GNUC__') ? ' -std=gnu99' : ' -std=c99')
     end
 
-    # Test for a specific value in an enum type
-    def have_enum_value(enum, value, headers = nil, &b)
-      checking_for "#{enum}.#{value}" do
-        source = <<~"SRC"
-          #{COMMON_HEADERS}
-          #{cpp_include(headers)}
-          int main() { #{enum} t = #{value}; t = t; return 0; }
-        SRC
-
-        if try_compile(source, &b)
-          $defs.push(format('-DHAVE_ENUM_%s', value.upcase))
-          true
-        else
-          false
-        end
-      end
-    end
-
-    # Test for multiple values of the same enum type
-    def have_enum_values(enum, values, headers = nil, &b)
-      values.each do |value|
-        have_enum_value(enum, value, headers, &b)
-      end
-    end
-
     def exit_failure(msg)
       msg = "ERROR: #{msg}"
 


### PR DESCRIPTION
The `Naming/PredicateName` rubocop rule doesn't like methods named with
`have_`. Conveniently, the last usage of these methods was removed in
6c997e5 (PR #434), so we can remove these methods as well.

https://rubocop.readthedocs.io/en/stable/cops_naming/#namingpredicatename