### PR TITLE
Rubocop: enable RSpec/EmptyLineAfterExample

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -182,13 +182,6 @@ Naming/MethodName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowConsecutiveOneLiners.
-RSpec/EmptyLineAfterExample:
-  Exclude:
-    - 'spec/rmagick/image/dissolve_spec.rb'
-
 # Offense count: 439
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Magick::Image, '#dissolve' do
       dissolved = image1.dissolve(image2, 0.20)
       expect(Float(dissolved.pixel_color(2, 2).alpha) / Magick::QuantumRange).to be_between(0.15, 0.25)
     end
+
     it 'works when alpha is string percentage' do
       image1 = described_class.new(100, 100) { self.background_color = 'transparent' }
       image2 = described_class.new(100, 100) { self.background_color = 'green' }


### PR DESCRIPTION
https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecemptylineafterexample