### PR TITLE
CI: add dependency on linux build for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
   test-windows:
     runs-on: windows-latest
     timeout-minutes: 10
+    needs: [test-linux]
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6]


### PR DESCRIPTION
I posted in the Github Actions forums and [it was suggested][1] that the
reason our build was flaky was because we're queueing too many jobs at
once. I'm not sure why that would be a problem, but thought I'd give it
a try to see if it resolves our issues.

[1]: https://github.community/t5/GitHub-Actions/Checks-hang-with-no-output/m-p/46689#M6582