### PR TITLE
RSpec: remove unecessary copy

### DIFF
--- a/spec/rmagick/image_list/mosaic_spec.rb
+++ b/spec/rmagick/image_list/mosaic_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Magick::ImageList, "#mosaic" do
 
   it "raises an error when images is not set" do
     image_list = described_class.new
-    image_list = image_list.copy
 
     image_list.instance_variable_set("@images", nil)
     expect { image_list.mosaic }.to raise_error(Magick::ImageMagickError)


### PR DESCRIPTION
The copy here doesn't appear to serve any purpose.