### PR TITLE
Yardoc: Describe attributes symbol directly instead of C macro against to yardoc parser

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -448,8 +448,7 @@ EXTERN ID rm_ID_y;                 /**< "y" */
 #define R_dbl_to_C_dbl(attr) NUM2DBL(attr) /**< C double <- Ruby double */
 
 //! define attribute reader
-#define DEF_ATTR_READER(class, attr, type) \
-    VALUE class##_##attr(VALUE self)\
+#define IMPLEMENT_ATTR_READER(class, attr, type) \
     {\
         class *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
@@ -460,8 +459,7 @@ EXTERN ID rm_ID_y;                 /**< "y" */
     }
 
 //! define attribute reader when attribute name is different from the field name
-#define DEF_ATTR_READERF(class, attr, field, type) \
-    VALUE class##_##attr(VALUE self)\
+#define IMPLEMENT_ATTR_READERF(class, attr, field, type) \
     {\
         class *ptr;\
         (void) rm_check_destroyed(self); \
@@ -470,8 +468,7 @@ EXTERN ID rm_ID_y;                 /**< "y" */
     }
 
 //! define attribute writer
-#define DEF_ATTR_WRITER(class, attr, type) \
-    VALUE class##_##attr##_eq(VALUE self, VALUE val)\
+#define IMPLEMENT_ATTR_WRITER(class, attr, type) \
     {\
         class *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
@@ -484,8 +481,7 @@ EXTERN ID rm_ID_y;                 /**< "y" */
     }
 
 //! define attribute writer when attribute name is different from the field name
-#define DEF_ATTR_WRITERF(class, attr, field, type) \
-    VALUE class##_##attr##_eq(VALUE self, VALUE val)\
+#define IMPLEMENT_ATTR_WRITERF(class, attr, field, type) \
     {\
         class *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
@@ -497,15 +493,6 @@ EXTERN ID rm_ID_y;                 /**< "y" */
         return self;\
     }
 
-//! define attribute accessor
-#define DEF_ATTR_ACCESSOR(class, attr, type)\
-    DEF_ATTR_READER(class, attr, type)\
-    DEF_ATTR_WRITER(class, attr, type)
-
-//! define attribute accessor when attribute name is different from the field name
-#define DEF_ATTR_ACCESSORF(class, attr, field, type)\
-    DEF_ATTR_READERF(class, attr, field, type)\
-    DEF_ATTR_WRITERF(class, attr, field, type)
 
 /*
  *  Declare attribute accessors

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3239,7 +3239,11 @@ Image_colormap(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @return the colors
  */
-DEF_ATTR_READER(Image, colors, ulong)
+VALUE
+Image_colors(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, colors, ulong);
+}
 
 /**
  * Return the Image pixel interpretation. If the colorspace is RGB the pixels
@@ -3309,7 +3313,11 @@ Image_colorspace_eq(VALUE self, VALUE colorspace)
  * @param self this object
  * @return the columns
  */
-DEF_ATTR_READER(Image, columns, int)
+VALUE
+Image_columns(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, columns, int);
+}
 
 
 /**
@@ -5048,7 +5056,16 @@ Image_define(VALUE self, VALUE artifact, VALUE value)
 }
 
 
-DEF_ATTR_ACCESSOR(Image, delay, ulong)
+VALUE
+Image_delay(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, delay, ulong);
+}
+VALUE
+Image_delay_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, delay, ulong);
+}
 
 
 /**
@@ -5324,7 +5341,11 @@ Image_difference(VALUE self, VALUE other)
  * @param self this object
  * @return the directory
  */
-DEF_ATTR_READER(Image, directory, str)
+VALUE
+Image_directory(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, directory, str);
+}
 
 
 /**
@@ -6732,7 +6753,11 @@ Image_extract_info_eq(VALUE self, VALUE rect)
  * @param self this object
  * @return the filename
  */
-DEF_ATTR_READER(Image, filename, str)
+VALUE
+Image_filename(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, filename, str);
+}
 
 
 /**
@@ -7289,7 +7314,11 @@ Image_function_channel(int argc, VALUE *argv, VALUE self)
  * @return the fuzz
  * @see Info_fuzz
  */
-DEF_ATTR_READER(Image, fuzz, dbl)
+VALUE
+Image_fuzz(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, fuzz, dbl);
+}
 
 
 /**
@@ -7370,7 +7399,16 @@ Image_fx(int argc, VALUE *argv, VALUE self)
 }
 
 
-DEF_ATTR_ACCESSOR(Image, gamma, dbl)
+VALUE
+Image_gamma(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, gamma, dbl);
+}
+VALUE
+Image_gamma_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, gamma, dbl);
+}
 
 
 /**
@@ -7624,7 +7662,11 @@ Image_gaussian_blur_channel(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @return the geometry
  */
-DEF_ATTR_READER(Image, geometry, str)
+VALUE
+Image_geometry(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, geometry, str);
+}
 
 
 /**
@@ -8395,7 +8437,16 @@ Image_iptc_profile_eq(VALUE self, VALUE profile)
  *  called only by Image#iterations=.
  *  The reader is only used by the unit tests!
  */
-DEF_ATTR_ACCESSOR(Image, iterations, int)
+VALUE
+Image_iterations(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, iterations, int);
+}
+VALUE
+Image_iterations_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, iterations, int);
+}
 
 /**
  * Adjust the levels of an image given these points: black, mid, and white.
@@ -9448,7 +9499,11 @@ Image_median_filter(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @return the mean error per pixel
  */
-DEF_ATTR_READERF(Image, mean_error_per_pixel, error.mean_error_per_pixel, dbl)
+VALUE
+Image_mean_error_per_pixel(VALUE self)
+{
+    IMPLEMENT_ATTR_READERF(Image, mean_error_per_pixel, error.mean_error_per_pixel, dbl);
+}
 
 
 /**
@@ -9656,7 +9711,11 @@ Image_monochrome_q(VALUE self)
  * @param self this object
  * @return the tile size and offset
  */
-DEF_ATTR_READER(Image, montage, str)
+VALUE
+Image_montage(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, montage, str);
+}
 
 
 /**
@@ -10096,7 +10155,11 @@ Image_normalize_channel(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @return the normalized mean error
  */
-DEF_ATTR_READERF(Image, normalized_mean_error, error.normalized_mean_error, dbl)
+VALUE
+Image_normalized_mean_error(VALUE self)
+{
+    IMPLEMENT_ATTR_READERF(Image, normalized_mean_error, error.normalized_mean_error, dbl);
+}
 
 /**
  * Get image normalized maximum error
@@ -10107,7 +10170,11 @@ DEF_ATTR_READERF(Image, normalized_mean_error, error.normalized_mean_error, dbl)
  * @param self this object
  * @return the normalized maximum error
  */
-DEF_ATTR_READERF(Image, normalized_maximum_error, error.normalized_maximum_error, dbl)
+VALUE
+Image_normalized_maximum_error(VALUE self)
+{
+    IMPLEMENT_ATTR_READERF(Image, normalized_maximum_error, error.normalized_maximum_error, dbl);
+}
 
 
 /**
@@ -10138,7 +10205,16 @@ Image_number_colors(VALUE self)
 }
 
 
-DEF_ATTR_ACCESSOR(Image, offset, long)
+VALUE
+Image_offset(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, offset, long);
+}
+VALUE
+Image_offset_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, offset, long);
+}
 
 
 /**
@@ -11065,7 +11141,11 @@ Image_profile_bang(VALUE self, VALUE name, VALUE profile)
  * @param self this object
  * @return the quality
  */
-DEF_ATTR_READER(Image, quality, ulong)
+VALUE
+Image_quality(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, quality, ulong);
+}
 
 
 /**
@@ -12526,7 +12606,11 @@ Image_rotate_bang(int argc, VALUE *argv, VALUE self)
  * @param self this object
  * @return the image rows
  */
-DEF_ATTR_READER(Image, rows, int)
+VALUE
+Image_rows(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, rows, int);
+}
 
 
 /**
@@ -12705,7 +12789,11 @@ scale(int bang, int argc, VALUE *argv, VALUE self, scaler_t scaler)
  * @param self this object
  * @return the image scene
  */
-DEF_ATTR_READER(Image, scene, ulong)
+VALUE
+Image_scene(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, scene, ulong);
+}
 
 
 /**
@@ -13902,7 +13990,16 @@ Image_spread(int argc, VALUE *argv, VALUE self)
 }
 
 
-DEF_ATTR_ACCESSOR(Image, start_loop, boolean)
+VALUE
+Image_start_loop(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, start_loop, boolean);
+}
+VALUE
+Image_start_loop_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, start_loop, boolean);
+}
 
 
 /**
@@ -16324,13 +16421,49 @@ Image_write(VALUE self, VALUE file)
 }
 
 #if defined(IMAGEMAGICK_7)
-DEF_ATTR_ACCESSORF(Image, x_resolution, resolution.x, dbl)
+VALUE
+Image_x_resolution(VALUE self)
+{
+    IMPLEMENT_ATTR_READERF(Image, x_resolution, resolution.x, dbl);
+}
+VALUE
+Image_x_resolution_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITERF(Image, x_resolution, resolution.x, dbl);
+}
 
-DEF_ATTR_ACCESSORF(Image, y_resolution, resolution.y, dbl)
+VALUE
+Image_y_resolution(VALUE self)
+{
+    IMPLEMENT_ATTR_READERF(Image, y_resolution, resolution.y, dbl);
+}
+VALUE
+Image_y_resolution_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITERF(Image, y_resolution, resolution.y, dbl);
+}
 #else
-DEF_ATTR_ACCESSOR(Image, x_resolution, dbl)
+VALUE
+Image_x_resolution(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, x_resolution, dbl);
+}
+VALUE
+Image_x_resolution_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, x_resolution, dbl);
+}
 
-DEF_ATTR_ACCESSOR(Image, y_resolution, dbl)
+VALUE
+Image_y_resolution(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Image, y_resolution, dbl);
+}
+VALUE
+Image_y_resolution_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Image, y_resolution, dbl);
+}
 #endif
 
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -244,7 +244,16 @@ static char *pixel_packet_to_hexname(PixelPacket *pp, char *name)
 #endif
 
 
-DEF_ATTR_ACCESSOR(Info, antialias, boolean)
+VALUE
+Info_antialias(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, antialias, boolean);
+}
+VALUE
+Info_antialias_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, antialias, boolean);
+}
 
 /** Maximum length of a format (@see Info_aref) */
 #define MAX_FORMAT_LEN 60
@@ -909,7 +918,11 @@ Info_delay_eq(VALUE self, VALUE string)
  * @param self this object
  * @return the density
  */
-DEF_ATTR_READER(Info, density, str)
+VALUE
+Info_density(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, density, str);
+}
 
 /**
  * Set the text rendering density
@@ -964,7 +977,11 @@ Info_density_eq(VALUE self, VALUE density_arg)
  * @param self this object
  * @return the depth
  */
-DEF_ATTR_READER(Info, depth, int)
+VALUE
+Info_depth(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, depth, int);
+}
 
 /**
  * Set the depth (8, 16, 32).
@@ -1134,7 +1151,16 @@ Info_dispose_eq(VALUE self, VALUE disp)
     return disp;
 }
 
-DEF_ATTR_ACCESSOR(Info, dither, boolean)
+VALUE
+Info_dither(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, dither, boolean);
+}
+VALUE
+Info_dither_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, dither, boolean);
+}
 
 
 /**
@@ -1195,7 +1221,11 @@ Info_endian_eq(VALUE self, VALUE endian)
  * @param self this object
  * @return the extract string
  */
-DEF_ATTR_READER(Info, extract, str)
+VALUE
+Info_extract(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, extract, str);
+}
 
 /**
  * Set the extract string, e.g. "200x200+100+100"
@@ -1344,7 +1374,11 @@ Info_fill_eq(VALUE self, VALUE color)
  * @param self this object
  * @return the font
  */
-DEF_ATTR_READER(Info, font, str)
+VALUE
+Info_font(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, font, str);
+}
 
 /**
  * Set the text font.
@@ -1452,7 +1486,11 @@ Info_format_eq(VALUE self, VALUE magick)
  * @return the fuzz
  * @see Image_fuzz
  */
-DEF_ATTR_READER(Info, fuzz, dbl)
+VALUE
+Info_fuzz(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, fuzz, dbl);
+}
 
 /**
  * Set the fuzz.
@@ -1761,9 +1799,27 @@ Info_monitor_eq(VALUE self, VALUE monitor)
 
 
 
-DEF_ATTR_ACCESSOR(Info, monochrome, boolean)
+VALUE
+Info_monochrome(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, monochrome, boolean);
+}
+VALUE
+Info_monochrome_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, monochrome, boolean);
+}
 
-DEF_ATTR_ACCESSOR(Info, number_scenes, ulong)
+VALUE
+Info_number_scenes(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, number_scenes, ulong);
+}
+VALUE
+Info_number_scenes_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, number_scenes, ulong);
+}
 
 /**
  * Return the orientation attribute as an OrientationType enum value.
@@ -1931,8 +1987,26 @@ Info_page_eq(VALUE self, VALUE page_arg)
     return page_arg;
 }
 
-DEF_ATTR_ACCESSOR(Info, pointsize, dbl)
-DEF_ATTR_ACCESSOR(Info, quality, ulong)
+VALUE
+Info_pointsize(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, pointsize, dbl);
+}
+VALUE
+Info_pointsize_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, pointsize, dbl);
+}
+VALUE
+Info_quality(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, quality, ulong);
+}
+VALUE
+Info_quality_eq(VALUE self, VALUE val)
+{
+    IMPLEMENT_ATTR_WRITER(Info, quality, ulong);
+}
 
 /**
  * Get sampling factors used by JPEG or MPEG-2 encoder and YUV decoder/encoder.
@@ -2051,7 +2125,11 @@ Info_scene_eq(VALUE self, VALUE scene)
  * @param self this object
  * @return the server name
  */
-DEF_ATTR_READER(Info, server_name, str)
+VALUE
+Info_server_name(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, server_name, str);
+}
 
 
 /**
@@ -2094,7 +2172,11 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
  * @param self this object
  * @return the size as a Geometry object
  */
-DEF_ATTR_READER(Info, size, str)
+VALUE
+Info_size(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Info, size, str);
+}
 
 /**
  * Set the size (either as a Geometry object or a Geometry string, i.e.

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -90,7 +90,11 @@ destroy_Pixel(Pixel *pixel)
  * @param self this object
  * @return the red value
  */
-DEF_ATTR_READER(Pixel, red, int)
+VALUE
+Pixel_red(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Pixel, red, int);
+}
 
 /**
  * Get Pixel green attribute.
@@ -101,7 +105,11 @@ DEF_ATTR_READER(Pixel, red, int)
  * @param self this object
  * @return the green value
  */
-DEF_ATTR_READER(Pixel, green, int)
+VALUE
+Pixel_green(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Pixel, green, int);
+}
 
 /**
  * Get Pixel blue attribute.
@@ -112,7 +120,11 @@ DEF_ATTR_READER(Pixel, green, int)
  * @param self this object
  * @return the blue value
  */
-DEF_ATTR_READER(Pixel, blue, int)
+VALUE
+Pixel_blue(VALUE self)
+{
+    IMPLEMENT_ATTR_READER(Pixel, blue, int);
+}
 
 /**
  * Get Pixel alpha attribute.


### PR DESCRIPTION
yardoc parser written by ruby and it cannot recognize/expand C macro.

To describe Yardoc document, it need to expose symbol without C macro.

Similar with https://github.com/rmagick/rmagick/pull/1092
https://github.com/rmagick/rmagick/issues/628

Close https://github.com/rmagick/rmagick/issues/784