### PR TITLE
Yardoc: Fix unexpected syntax in @return tag

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -718,7 +718,7 @@ Draw_stroke_eq(VALUE self, VALUE stroke)
  *
  * @!attribute [w] stroke_pattern
  * @param pattern [Magick::Image] the stroke pattern
- * @return pattern [Magick::Image] the given pattern
+ * @return [Magick::Image] the given pattern
  * @see #fill_pattern
  */
 VALUE


### PR DESCRIPTION
https://github.com/rmagick/rmagick/issues/628