### PR TITLE
Fix default value of `fill` argument in Image#initialize

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9962,7 +9962,7 @@ Image_alloc(VALUE class)
 VALUE
 Image_initialize(int argc, VALUE *argv, VALUE self)
 {
-    VALUE fill = 0;
+    VALUE fill = Qnil;
     Info *info;
     VALUE info_obj;
     Image *image;
@@ -10011,7 +10011,7 @@ Image_initialize(int argc, VALUE *argv, VALUE self)
     // If the caller did not supply a fill argument, call SetImageBackgroundColor
     // to fill the image using the background color. The background color can
     // be set by specifying it when creating the Info parm block.
-    if (!fill)
+    if (NIL_P(fill))
     {
 #if defined(IMAGEMAGICK_7)
         exception = AcquireExceptionInfo();

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -12,5 +12,7 @@ RSpec.describe Magick::ImageList, "#new_image" do
     image_list.new_image(20, 20) { self.background_color = 'red' }
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
+
+    expect { image_list.new_image(20, 20, nil) }.not_to raise_error
   end
 end


### PR DESCRIPTION
Because It is determined to be true even if nil was given as an argument.
In Ruby, nil and false should have same behavior in condition