### PR TITLE
Yardoc: Remove unnecessary attributes annotation

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -29,7 +29,6 @@ static VALUE get_type_metrics(int, VALUE *, VALUE, get_type_metrics_func_t);
 /**
  * Set the affine matrix from an {Magick::AffineMatrix}.
  *
- * @!attribute [w] affine
  * @param matrix [Magick::AffineMatrix] the affine matrix
  * @return [Magick::AffineMatrix] the given matrix
  */
@@ -48,7 +47,6 @@ Draw_affine_eq(VALUE self, VALUE matrix)
 /**
  * Set the text alignment from an {Magick::AlignType}.
  *
- * @!attribute [w] align
  * @param align [Magick::AlignType] the text alignment
  * @return [Magick::AlignType] the given align
  */
@@ -67,7 +65,6 @@ Draw_align_eq(VALUE self, VALUE align)
 /**
  * Set text decorate from an {Magick::DecorationType}.
  *
- * @!attribute [w] decorate
  * @param decorate [Magick::DecorationType] the decorate type
  * @return [Magick::DecorationType] the given decorate
  */
@@ -86,7 +83,6 @@ Draw_decorate_eq(VALUE self, VALUE decorate)
 /**
  * Set density.
  *
- * @!attribute [w] density
  * @param density [String] the density
  * @return [String] the given density
  */
@@ -106,7 +102,6 @@ Draw_density_eq(VALUE self, VALUE density)
 /**
  * Set text encoding.
  *
- * @!attribute [w] encoding
  * @param encoding [String] the encoding name
  * @return [String] the given encoding name
  */
@@ -126,7 +121,6 @@ Draw_encoding_eq(VALUE self, VALUE encoding)
 /**
  * Set fill color.
  *
- * @!attribute [w] fill
  * @param fill [Magick::Pixel, String] the fill color
  * @return [Magick::Pixel, String] the given fill color
  */
@@ -145,7 +139,6 @@ Draw_fill_eq(VALUE self, VALUE fill)
 /**
  * Accept an image as a fill pattern.
  *
- * @!attribute [w] fill_pattern
  * @param pattern [Magick::Image] the pattern image
  * @return [Magick::Image] the given pattern image
  * @see #stroke_pattern=
@@ -183,7 +176,6 @@ Draw_fill_pattern_eq(VALUE self, VALUE pattern)
 /**
  * Set the font name.
  *
- * @!attribute [w] font
  * @param font [String] the font name
  * @return [String] the given font name
  */
@@ -203,7 +195,6 @@ Draw_font_eq(VALUE self, VALUE font)
 /**
  * Set the font family name.
  *
- * @!attribute [w] family
  * @param family [String] the font family name
  * @return [String] the given family name
  */
@@ -223,7 +214,6 @@ Draw_font_family_eq(VALUE self, VALUE family)
 /**
  * Set the stretch as spacing between text characters.
  *
- * @!attribute [w] font_stretch
  * @param stretch [Magick::StretchType] the stretch type
  * @return [Magick::StretchType] the given stretch type
  */
@@ -242,7 +232,6 @@ Draw_font_stretch_eq(VALUE self, VALUE stretch)
 /**
  * Set font style.
  *
- * @!attribute [w] font_style
  *
  * @param style [Magick::StyleType] the font style
  * @return [Magick::StyleType] the given font style
@@ -262,7 +251,6 @@ Draw_font_style_eq(VALUE self, VALUE style)
 /**
  * Font_weight attribute writer.
  *
- * @!attribute [w] font_weight
  *
  * @param weight [Magick::WeightType, Numeric] the font weight
  * @return [Magick::WeightType, Numeric] the given font weight
@@ -332,7 +320,6 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
  * - SouthGravity      - text top-center placed at bottom-center
  * - SouthEastGravity  - text top-right placed at bottom-right
  *
- * @!attribute [w] gravity
  * @param grav [Magick::GravityType] this gravity type
  * @return [Magick::GravityType] the given gravity type
  */
@@ -352,7 +339,6 @@ Draw_gravity_eq(VALUE self, VALUE grav)
 /**
  * Set kerning as spacing between two letters.
  *
- * @!attribute [w] kerning
  * @param kerning [Float] the kerning
  * @return [Float] the given kerning
  */
@@ -371,7 +357,6 @@ Draw_kerning_eq(VALUE self, VALUE kerning)
 /**
  * Set spacing between two lines.
  *
- * @!attribute [w] interline_spacing
  * @param spacing [Float] the spacing
  * @return [Float] the given spacing
  */
@@ -390,7 +375,6 @@ Draw_interline_spacing_eq(VALUE self, VALUE spacing)
 /**
  * Set spacing between two words.
  *
- * @!attribute [w] interword_spacing
  * @param spacing [Float] the spacing
  * @return [Float] the given spacing
  */
@@ -639,7 +623,6 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
 /**
  * Set point size to draw text.
  *
- * @!attribute [w] pointsize
  * @param pointsize [Float] the pointsize
  * @return [Float] the given pointsize
  */
@@ -696,7 +679,6 @@ Draw_rotation_eq(VALUE self, VALUE deg)
 /**
  * Set stroke.
  *
- * @!attribute [w] stroke
  *
  * @param stroke [Magick::Pixel, String] the stroke
  * @return [Magick::Pixel, String] the given stroke
@@ -716,7 +698,6 @@ Draw_stroke_eq(VALUE self, VALUE stroke)
 /**
  * Accept an image as a stroke pattern.
  *
- * @!attribute [w] stroke_pattern
  * @param pattern [Magick::Image] the stroke pattern
  * @return [Magick::Image] the given pattern
  * @see #fill_pattern
@@ -754,7 +735,6 @@ Draw_stroke_pattern_eq(VALUE self, VALUE pattern)
 /**
  * Set stroke width.
  *
- * @!attribute [w] stroke_width
  * @param stroke_width [Float] the stroke width
  * @return [Float] the given stroke width
  */
@@ -773,7 +753,6 @@ Draw_stroke_width_eq(VALUE self, VALUE stroke_width)
 /**
  * Set whether to enable text antialias.
  *
- * @!attribute [w] text_antialias
  * @param text_antialias [Boolean] true if enable text antialias
  * @return [Boolean] the given value
  */
@@ -792,7 +771,6 @@ Draw_text_antialias_eq(VALUE self, VALUE text_antialias)
 /**
  * Accept an image as a fill pattern. This is alias of {Draw#fill_pattern=}.
  *
- * @!attribute [w] tile
  * @param image [Magick::Image] the image to tile
  * @return [Magick::Image] the given image
  */
@@ -806,7 +784,6 @@ Draw_tile_eq(VALUE self, VALUE image)
 /**
  * Set undercolor.
  *
- * @!attribute [w] undercolor
  * @param undercolor [Magick::Pixel, String] the undercolor
  * @return [Magick::Pixel, String] the given undercolor
  */
@@ -1483,7 +1460,6 @@ rm_polaroid_new(void)
 /**
  * Set the shadow color attribute.
  *
- * @!attribute [w] shadow_color
  * @param shadow [Magick::Pixel, String] the shadow color
  * @return [Magick::Pixel, String] the given shadow color
  */
@@ -1501,8 +1477,6 @@ PolaroidOptions_shadow_color_eq(VALUE self, VALUE shadow)
 
 /**
  * Set the border color.
- *
- * @!attribute [w] border_color
  *
  * @param border [Magick::Pixel, String] the border color
  * @return [Magick::Pixel, String] the given border color

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1079,7 +1079,6 @@ Image_auto_orient_bang(VALUE self)
 /**
  * Return the name of the background color as a String.
  *
- * @!attribute [r] background_color
  * @return [String] the background color
  */
 VALUE
@@ -1093,7 +1092,6 @@ Image_background_color(VALUE self)
 /**
  * Set the the background color to the specified color spec.
  *
- * @!attribute [w] background_color
  * @param color [Magick::Pixel, String] the color
  * @return [Magick::Pixel, String] the given color
  */
@@ -1109,7 +1107,6 @@ Image_background_color_eq(VALUE self, VALUE color)
 /**
  * Return the number of rows (before transformations).
  *
- * @!attribute [r] base_columns
  * @return [Numeric]the number of rows
  */
 VALUE
@@ -1122,7 +1119,6 @@ Image_base_columns(VALUE self)
 /**
  * Return the image filename (before transformations).
  *
- * @!attribute [r] base_filename
  * @return [String] the base image filename (or the current filename if there is no base)
  */
 VALUE
@@ -1142,7 +1138,6 @@ Image_base_filename(VALUE self)
 /**
  * Return the number of rows (before transformations).
  *
- * @!attribute [r] base_rows
  * @return [Numeric] the number of rows
  */
 VALUE
@@ -1156,7 +1151,6 @@ Image_base_rows(VALUE self)
 /**
  * Get image bias (used when convolving an image).
  *
- * @!attribute [r] bias
  * @return [Float] the image bias
  */
 VALUE
@@ -1190,7 +1184,6 @@ Image_bias(VALUE self)
 /**
  * Set image bias (used when convolving an image).
  *
- * @!attribute [w] bias
  * @param pct [Float, String] Either a number between 0.0 and 1.0 or a string in the form "NN%"
  * @return [Float, String] the given value
  */
@@ -1274,7 +1267,6 @@ Image_bilevel_channel(int argc, VALUE *argv, VALUE self)
 /**
  * Return current black point compensation attribute.
  *
- * @!attribute [r] black_point_compensation
  * @return [Boolean] true or false
  */
 VALUE
@@ -1305,7 +1297,6 @@ Image_black_point_compensation(VALUE self)
 /**
  * Set black point compensation attribute.
  *
- * @!attribute [w] black_point_compensation
  * @param arg [Boolean] true or false
  * @return [Boolean] the given value
  */
@@ -1948,7 +1939,6 @@ Image_border(VALUE self, VALUE width, VALUE height, VALUE color)
 /**
  * Return the name of the border color as a String.
  *
- * @!attribute [r] border_color
  * @return [String] the name of the border color
  */
 VALUE
@@ -1962,7 +1952,6 @@ Image_border_color(VALUE self)
 /**
  * Set the the border color.
  *
- * @!attribute [w] border_color
  * @param [Magick::Pixel, String] color the color
  * @return [Magick::Pixel, String] the given color
  */
@@ -1978,7 +1967,6 @@ Image_border_color_eq(VALUE self, VALUE color)
 /**
  * Returns the bounding box of an image canvas.
  *
- * @!attribute [r] bounding_box
  * @return [Magick::Rectangle] the bounding box
  */
 VALUE
@@ -2456,7 +2444,6 @@ Image_chop(VALUE self, VALUE x, VALUE y, VALUE width, VALUE height)
 /**
  * Return the red, green, blue, and white-point chromaticity values as a {Magick::Chromaticity}.
  *
- * @!attribute [r] chromaticity
  * @return [Magick::Chromaticity] the chromaticity values
  */
 VALUE
@@ -2470,7 +2457,6 @@ Image_chromaticity(VALUE self)
 /**
  * Set the red, green, blue, and white-point chromaticity values from a {Magick::Chromaticity}.
  *
- * @!attribute [w] chromaticity
  * @param [Magick::Chromaticity] chroma the chromaticity
  * @return [Magick::Chromaticity] the given value
  */
@@ -2771,7 +2757,6 @@ set_profile(VALUE self, const char *name, VALUE profile)
  * - This method has no real use but is retained for compatibility with earlier releases of RMagick,
  *   where it had no real use either.
  *
- * @!attribute [r] color_profile
  * @return [String] the ICC color profile
  */
 VALUE
@@ -2798,7 +2783,6 @@ Image_color_profile(VALUE self)
  * - Pass nil to remove any existing profile.
  * - Removes any existing profile before adding the new one.
  *
- * @!attribute [w] color_profile
  * @param profile [String] the profile to set
  * @return [String] the given profile
  */
@@ -3070,7 +3054,6 @@ Image_colormap(int argc, VALUE *argv, VALUE self)
 /**
  * Get the number of colors in the colormap.
  *
- * @!attribute [r] color
  * @return [Numeric] the number of colors
  */
 VALUE
@@ -3084,7 +3067,6 @@ Image_colors(VALUE self)
  * blue. If matte is true, then red, green, blue, and index. If it is CMYK, the pixels are cyan,
  * yellow, magenta, black. Otherwise the colorspace is ignored.
  *
- * @!attribute [r] colorspace
  * @return [Magick::ColorspaceType] the colorspace
  */
 VALUE
@@ -3100,7 +3082,6 @@ Image_colorspace(VALUE self)
 /**
  * Set the image's colorspace.
  *
- * @!attribute [w] colorspace
  * @param colorspace [Magick::ColorspaceType] the colorspace
  * @return [Magick::ColorspaceType] the given colorspace
  */
@@ -3133,7 +3114,6 @@ Image_colorspace_eq(VALUE self, VALUE colorspace)
 /**
  * Get image columns.
  *
- * @!attribute [r] columns
  * @return [Numeric] the columns
  */
 VALUE
@@ -3248,7 +3228,6 @@ Image_compare_channel(int argc, VALUE *argv, VALUE self)
 /**
  * Return the composite operator attribute.
  *
- * @!attribute [r] compose
  * @return [Magick::CompositeOperator] the composite operator
  */
 VALUE
@@ -3262,7 +3241,6 @@ Image_compose(VALUE self)
 /**
  * Set the composite operator attribute.
  *
- * @!attribute [w] compose
  * @param compose_arg [Magick::CompositeOperator] the composite operator
  * @return [Magick::CompositeOperator] the given value
  */
@@ -4004,7 +3982,6 @@ Image_composite_tiled_bang(int argc, VALUE *argv, VALUE self)
 /**
  * Get the compression attribute.
  *
- * @!attribute [r] compression
  * @return [Magick::CompressionType] the compression
  */
 VALUE
@@ -4017,7 +3994,6 @@ Image_compression(VALUE self)
 /**
  * Set the compression attribute.
  *
- * @!attribute [r] compression
  * @param compression [Magick::CompressionType] the compression
  * @return [Magick::CompressionType] the given compression
  */
@@ -4851,7 +4827,6 @@ Image_cycle_colormap(VALUE self, VALUE amount)
  * Get the vertical and horizontal resolution in pixels of the image.
  * The default is "72x72".
  *
- * @!attribute [r] density
  * @return [String] a string of geometry in the form "XresxYres"
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -5037,7 +5012,6 @@ Image_define(VALUE self, VALUE artifact, VALUE value)
  * sequence. The default number of ticks is 0. By default there are 100 ticks per second but this
  * number can be changed via the ticks_per_second attribute.
  *
- * @!attribute [r] delay
  * @return [Numeric] The current delay value.
  */
 VALUE
@@ -5050,7 +5024,6 @@ Image_delay(VALUE self)
  * Set the Number of ticks which must expire before displaying the next image in an animated
  * sequence.
  *
- * @!attribute [w] delay
  * @param val [Numeric] the delay value
  * @return [Numeric] the given value
  */
@@ -5115,7 +5088,6 @@ Image_delete_profile(VALUE self, VALUE name)
  * - If all pixels have lower-order bytes equal to higher-order bytes, the depth will be reported as
  *   8 even if the depth field in the Image structure says 16.
  *
- * @!attribute [r] depth
  * @return [Numeric] the depth
  */
 VALUE
@@ -5299,7 +5271,6 @@ Image_difference(VALUE self, VALUE other)
 /**
  * Get image directory.
  *
- * @!attribute [r] directory
  * @return [String] the directory
  */
 VALUE
@@ -5513,7 +5484,6 @@ Image_display(VALUE self)
 /**
  * Return the dispose attribute as a DisposeType enum.
  *
- * @!attribute [r] dispose
  * @return [Magick::DisposeType] the dispose
  */
 VALUE
@@ -5527,7 +5497,6 @@ Image_dispose(VALUE self)
 /**
  * Set the dispose attribute.
  *
- * @!attribute [w] dispose
  * @param dispose [Magick::DisposeType] the dispose
  * @return [Magick::DisposeType] the given dispose
  */
@@ -6046,7 +6015,6 @@ Image_encipher(VALUE self, VALUE passphrase)
 /**
  * Return endian option for images that support it.
  *
- * @!attribute [r] endian
  * @return [Magick::EndianType] the endian option
  */
 VALUE
@@ -6060,7 +6028,6 @@ Image_endian(VALUE self)
 /**
  * Set endian option for images that support it.
  *
- * @!attribute [w] endian
  * @param type [Magick::EndianType] the endian type
  * @return [Magick::EndianType] the given type
  */
@@ -6588,7 +6555,6 @@ Image_export_pixels_to_str(int argc, VALUE *argv, VALUE self)
 /**
  * The extract_info attribute reader.
  *
- * @!attribute [r] extract_info
  * @return [Magick::Rectangle] the Rectangle object
  */
 VALUE
@@ -6602,7 +6568,6 @@ Image_extract_info(VALUE self)
 /**
  * Set the extract_info attribute.
  *
- * @!attribute [w] extract_info
  * @param rect [Magick::Rectangle] the Rectangle object
  * @return [Magick::Rectangle] the given value
  */
@@ -6618,7 +6583,6 @@ Image_extract_info_eq(VALUE self, VALUE rect)
 /**
  * Get image filename.
  *
- * @!attribute [r] filename
  * @return [String] the filename
  */
 VALUE
@@ -6631,7 +6595,6 @@ Image_filename(VALUE self)
 /**
  * Return the image file size.
  *
- * @!attribute [r] filesize
  * @return [Numeric] the file size
  */
 VALUE Image_filesize(VALUE self)
@@ -6644,7 +6607,6 @@ VALUE Image_filesize(VALUE self)
 /**
  * Get filter type.
  *
- * @!attribute [r] filter
  * @return [Magick::FilterType] the filter
  */
 VALUE
@@ -6658,7 +6620,6 @@ Image_filter(VALUE self)
 /**
  * Set filter type.
  *
- * @!attribute [w] filter
  * @param filter [Magick::FilterType] the filter
  * @return [Magick::FilterType] the given filter
  */
@@ -6844,7 +6805,6 @@ Image_flop_bang(VALUE self)
 /**
  * Return the image encoding format. For example, "GIF" or "PNG".
  *
- * @!attribute [r] format
  * @return [String] the encoding format
  */
 VALUE
@@ -6872,7 +6832,6 @@ Image_format(VALUE self)
 /**
  * Set the image encoding format. For example, "GIF" or "PNG".
  *
- * @!attribute [w] format
  * @param magick [String] the encoding format
  * @return [String] the given value
  */
@@ -7122,7 +7081,6 @@ Image_function_channel(int argc, VALUE *argv, VALUE self)
  * By default the color must be exact.
  * Use this attribute to match colors that are close to the target color in RGB space.
  *
- * @!attribute [r] fuzz
  * @return [Float] the fuzz
  * @see Info#fuzz
  */
@@ -7136,7 +7094,6 @@ Image_fuzz(VALUE self)
 /**
  * Set the number of algorithms search for a target color.
  *
- * @!attribute [w] fuzz
  * @param fuzz [String, Float] The argument may be a floating-point numeric value or a string in the
  *   form "NN%".
  * @return [String, Float] the given value
@@ -7207,7 +7164,6 @@ Image_fx(int argc, VALUE *argv, VALUE self)
 /**
  * Get the gamma level of the image.
  *
- * @!attribute [r] gamma
  * @return [Float] the gamma level
  */
 VALUE
@@ -7219,7 +7175,6 @@ Image_gamma(VALUE self)
 /**
  * Set the gamma level of the image.
  *
- * @!attribute [w] gamma
  * @param val [Float] the gamma level
  * @return [Float] the gamma level
  */
@@ -7450,7 +7405,6 @@ Image_gaussian_blur_channel(int argc, VALUE *argv, VALUE self)
 /**
  * Get the preferred size of the image when encoding.
  *
- * @!attribute [r] geometry
  * @return [String] the geometry
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -7464,7 +7418,6 @@ Image_geometry(VALUE self)
 /**
  * Set the preferred size of the image when encoding.
  *
- * @!attribute [w] geometry
  * @param geometry [String] the geometry
  * @return [String] the given geometry
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -8107,7 +8060,6 @@ Image_inspect(VALUE self)
  * uses plane interlacing. PartitionInterlace is like PlaneInterlace except the different planes are
  * saved to individual files (e.g. image.R, image.G, and image.B).
  *
- * @!attribute [r] interlace
  * @return [Magick::InterlaceType] the interlace
  */
 VALUE
@@ -8121,7 +8073,6 @@ Image_interlace(VALUE self)
 /**
  * Set the type of interlacing scheme.
  *
- * @!attribute [w] interlace
  * @param interlace [Magick::InterlaceType] the interlace
  * @return [Magick::InterlaceType] the given value
  */
@@ -8137,7 +8088,6 @@ Image_interlace_eq(VALUE self, VALUE interlace)
 /**
  * Return the IPTC profile as a String.
  *
- * @!attribute [r] iptc_profile
  * @return [String] the IPTC profile if it exists, otherwise nil
  */
 VALUE
@@ -8162,7 +8112,6 @@ Image_iptc_profile(VALUE self)
 /**
  * Set the IPTC profile. The argument is a string.
  *
- * @!attribute [r] iptc_profile
  * @param profile [String] the IPTC profile
  * @return [String] the given profile
  */
@@ -8997,7 +8946,6 @@ Image_mask(int argc, VALUE *argv, VALUE self)
 /**
  * Return the matte color.
  *
- * @!attribute [r] matte_color
  * @return [String] the matte color
  */
 VALUE
@@ -9010,7 +8958,6 @@ Image_matte_color(VALUE self)
 /**
  * Set the matte color.
  *
- * @!attribute [w] matte_color
  * @param color [Magick::Pixel, String] the matte color
  * @return [Magick::Pixel, String] the given color
  */
@@ -9164,7 +9111,6 @@ Image_median_filter(int argc, VALUE *argv, VALUE self)
 /**
  * Get the mean error per pixel computed when a image is color reduced.
  *
- * @!attribute [r] matte_color
  * @return [Float] the mean error per pixel
  */
 VALUE
@@ -9177,7 +9123,6 @@ Image_mean_error_per_pixel(VALUE self)
 /**
  * Return the officially registered (or de facto) MIME media-type corresponding to the image format.
  *
- * @!attribute [r] mime_type
  * @return [String] the mime type
  */
 VALUE
@@ -9299,7 +9244,6 @@ Image_modulate(int argc, VALUE *argv, VALUE self)
  *   `progress_monitor' as the monitor exit. When `progress_monitor' is called, retrieve the proc
  *   and call it.
  *
- * @!attribute [w] monitor
  * @param monitor [Proc] the progress monitor
  * @return [Proc] the given value
  * @example
@@ -9346,7 +9290,6 @@ Image_monochrome_q(VALUE self)
 /**
  * Tile size and offset within an image montage. Only valid for montage images.
  *
- * @!attribute [r] montage
  * @return [String] the tile size and offset
  */
 VALUE
@@ -9740,7 +9683,6 @@ Image_normalize_channel(int argc, VALUE *argv, VALUE self)
 /**
  * Get the normalized mean error per pixel computed when an image is color reduced.
  *
- * @!attribute [r] normalized_mean_error
  * @return [Float] the normalized mean error
  */
 VALUE
@@ -9752,7 +9694,6 @@ Image_normalized_mean_error(VALUE self)
 /**
  * Get The normalized maximum error per pixel computed when an image is color reduced.
  *
- * @!attribute [r] normalized_maximum_error
  * @return [Float] the normalized maximum error
  */
 VALUE
@@ -9765,7 +9706,6 @@ Image_normalized_maximum_error(VALUE self)
 /**
  * Return the number of unique colors in the image.
  *
- * @!attribute [r] number_colors
  * @return [Numeric] number of unique colors
  */
 VALUE
@@ -9790,7 +9730,6 @@ Image_number_colors(VALUE self)
 /**
  * Get the number of bytes to skip over when reading raw image.
  *
- * @!attribute [r] offset
  * @return [Number] the offset
  */
 VALUE
@@ -9802,7 +9741,6 @@ Image_offset(VALUE self)
 /**
  * Set the number of bytes to skip over when reading raw image.
  *
- * @!attribute [w] offset
  * @param val [Number] the offset
  * @return [Number] the given offset
  */
@@ -10085,7 +10023,6 @@ Image_ordered_dither(int argc, VALUE *argv, VALUE self)
 /**
  * Get the value of the Exif Orientation Tag.
  *
- * @!attribute [r] orientation
  * @return [Magick::OrientationType] the orientation
  */
 VALUE
@@ -10099,7 +10036,6 @@ Image_orientation(VALUE self)
 /**
  * Set the orientation attribute.
  *
- * @!attribute [w] orientation
  * @param orientation [Magick::OrientationType] the orientation
  * @return [Magick::OrientationType] the given value
  */
@@ -10115,7 +10051,6 @@ Image_orientation_eq(VALUE self, VALUE orientation)
 /**
  * The page attribute getter.
  *
- * @!attribute [r] page
  * @return [Magick::Rectang] the page rectangle
  */
 VALUE
@@ -10129,7 +10064,6 @@ Image_page(VALUE self)
 /**
  * The page attribute setter.
  *
- * @!attribute [w] page
  * @param rect [Magick::Rectang] the page rectangle
  * @return [Magick::Rectang] the given value
  */
@@ -10447,7 +10381,6 @@ Image_pixel_color(int argc, VALUE *argv, VALUE self)
 /**
  * Get the "interpolate" field.
  *
- * @!attribute [r] pixel_interpolation_method
  * @return [Magick::PixelInterpolateMethod] the interpolate field
  * @see Image#pixel_interpolation_method=
  */
@@ -10462,7 +10395,6 @@ Image_pixel_interpolation_method(VALUE self)
 /**
  * Set the "interpolate" field.
  *
- * @!attribute [w] pixel_interpolation_method
  * @param method [Magick::PixelInterpolateMethod] the interpolate field
  * @return [Magick::PixelInterpolateMethod] the given method
  * @see Image#pixel_interpolation_method
@@ -10658,7 +10590,6 @@ Image_profile_bang(VALUE self, VALUE name, VALUE profile)
 /**
  * Get image quality.
  *
- * @!attribute [r] quality
  * @return [Numeric] the quality
  */
 VALUE
@@ -10671,7 +10602,6 @@ Image_quality(VALUE self)
 /**
  * Return the image depth to the nearest Quantum (8, 16, or 32).
  *
- * @!attribute [r] quantum_depth
  * @return [Numeric] image depth
  */
 VALUE
@@ -11524,7 +11454,6 @@ Image_remap(int argc, VALUE *argv, VALUE self)
 /**
  * Get the type of rendering intent.
  *
- * @!attribute [r] rendering_intent
  * @return [Magick::RenderingIntent] the rendering intent
  */
 VALUE
@@ -11538,7 +11467,6 @@ Image_rendering_intent(VALUE self)
 /**
  * Set the type of rendering intent..
  *
- * @!attribute [w] rendering_intent
  * @param ri [Magick::RenderingIntent] the rendering intent
  * @return [Magick::RenderingIntent] the given value
  */
@@ -12028,7 +11956,6 @@ Image_rotate_bang(int argc, VALUE *argv, VALUE self)
 /**
  * Return image rows.
  *
- * @!attribute [r] rows
  * @return [Numeric] the image rows
  */
 VALUE
@@ -12217,7 +12144,6 @@ scale(int bang, int argc, VALUE *argv, VALUE self, scaler_t scaler)
  * Return the scene number assigned to the image the last time the image was written to a
  * multi-image image file.
  *
- * @!attribute [r] scene
  * @return [Numeric] the image scene
  */
 VALUE
@@ -13326,7 +13252,6 @@ Image_spread(int argc, VALUE *argv, VALUE self)
 /**
  * Get the Boolean value that indicates the first image in an animation.
  *
- * @!attribute [r] start_loop
  * @return [Boolean] true or false
  */
 VALUE
@@ -13338,7 +13263,6 @@ Image_start_loop(VALUE self)
 /**
  * Set the Boolean value that indicates the first image in an animation.
  *
- * @!attribute [w] start_loop
  * @param val [Boolean] true or false
  * @return [Boolean] the given value
  */
@@ -13429,7 +13353,6 @@ Image_stereo(VALUE self, VALUE offset_image_arg)
  * pixels contain valid RGB or CMYK colors.  If PseudoClass then the image has a colormap referenced
  * by the pixel's index member.
  *
- * @!attribute [r] class_type
  * @return [Magick::ClassType] the storage class
  */
 VALUE
@@ -13443,7 +13366,6 @@ Image_class_type(VALUE self)
 /**
  * Change the image's storage class.
  *
- * @!attribute [w] class_type
  * @param new_class_type [Magick::ClassType] the storage class
  * @return [Magick::ClassType] the given value
  */
@@ -14013,7 +13935,6 @@ Image_thumbnail_bang(int argc, VALUE *argv, VALUE self)
  * This attribute is used in conjunction with the delay attribute to establish the amount of time
  * that must elapse between frames in an animation.The default is 100.
  *
- * @!attribute [r] ticks_per_second
  * @return [Numeric] ticks per second
  */
 VALUE
@@ -14029,7 +13950,6 @@ Image_ticks_per_second(VALUE self)
  * This attribute is used in conjunction with the delay attribute to establish the amount of time
  * that must elapse between frames in an animation.The default is 100.
  *
- * @!attribute [w] ticks_per_second
  * @param tps [Numeric] ticks per second
  * @return [Numeric] the given value
  */
@@ -14255,7 +14175,6 @@ Image_to_color(VALUE self, VALUE pixel_arg)
 /**
  * Alias for {Image#number_colors}.
  *
- * @!attribute [r] total_colors
  * @return [Numeric] number of unique colors
  * @see Image#number_colors
  */
@@ -14269,7 +14188,6 @@ Image_total_colors(VALUE self)
 /**
  * Return the total ink density for a CMYK image.
  *
- * @!attribute [r] total_ink_density
  * @return [Float] the total ink density
  */
 VALUE
@@ -14437,7 +14355,6 @@ Image_transparent_chroma(int argc, VALUE *argv, VALUE self)
 /**
  * Return the name of the transparent color as a String.
  *
- * @!attribute [r] transparent_color
  * @return [String] the name of the transparent color
  */
 VALUE
@@ -14451,7 +14368,6 @@ Image_transparent_color(VALUE self)
 /**
  * Set the the transparent color to the specified color spec.
  *
- * @!attribute [w] transparent_color
  * @param color [Magick::Pixel, String] the transparent color
  * @return [Magick::Pixel, String] the given color
  */
@@ -14628,7 +14544,6 @@ Image_trim_bang(int argc, VALUE *argv, VALUE self)
 /**
  * Get the direction that the image gravitates within the composite.
  *
- * @!attribute [r] gravity
  * @return [Magick::GravityType] the image gravity
  */
 VALUE Image_gravity(VALUE self)
@@ -14641,7 +14556,6 @@ VALUE Image_gravity(VALUE self)
 /**
  * Set the direction that the image gravitates within the composite.
  *
- * @!attribute [w] gravity
  * @param gravity [Magick::GravityType] the image gravity
  * @return [Magick::GravityType] the given value
  */
@@ -14658,7 +14572,6 @@ VALUE Image_gravity_eq(VALUE self, VALUE gravity)
  * For example, GrayscaleType.
  * Don't confuse this attribute with the format, that is "GIF" or "JPG".
  *
- * @!attribute [r] image_type
  * @return [Magick::ImageType] the image type
  */
 VALUE Image_image_type(VALUE self)
@@ -14687,7 +14600,6 @@ VALUE Image_image_type(VALUE self)
 /**
  * Set the image type classification.
  *
- * @!attribute [w] image_type
  * @param image_type [Magick::ImageType] the image type
  * @return [Magick::ImageType] the given type
  */
@@ -14762,7 +14674,6 @@ Image_unique_colors(VALUE self)
 /**
  * Get the units of image resolution.
  *
- * @!attribute [r] units
  * @return [Magick::ResolutionType] the resolution type
  */
 VALUE
@@ -14776,7 +14687,6 @@ Image_units(VALUE self)
 /**
  * Set the units of image resolution.
  *
- * @!attribute [r] units
  * @param restype [Magick::ResolutionType] the resolution type
  * @return [Magick::ResolutionType] the given value
  */
@@ -15050,7 +14960,6 @@ Image_vignette(int argc, VALUE *argv, VALUE self)
  * Get the "virtual pixels" behave.
  * Virtual pixels are pixels that are outside the boundaries of the image.
  *
- * @!attribute [r] virtual_pixel_method
  * @return [Magick::VirtualPixelMethod] the VirtualPixelMethod
  */
 VALUE
@@ -15069,7 +14978,6 @@ Image_virtual_pixel_method(VALUE self)
  * Specify how "virtual pixels" behave.
  * Virtual pixels are pixels that are outside the boundaries of the image.
  *
- * @!attribute [r] virtual_pixel_method
  * @param method [Magick::VirtualPixelMethod] the VirtualPixelMethod
  * @return [Magick::VirtualPixelMethod] the given method
  */
@@ -15602,7 +15510,6 @@ Image_write(VALUE self, VALUE file)
 /**
  * Get the horizontal resolution of the image.
  *
- * @!attribute [r] x_resolution
  * @return [Float] the resolution
  */
 VALUE
@@ -15614,7 +15521,6 @@ Image_x_resolution(VALUE self)
 /**
  * Set the horizontal resolution of the image.
  *
- * @!attribute [w] x_resolution
  * @param val [Float] the resolution
  * @return [Float] the given resolution
  */
@@ -15627,7 +15533,6 @@ Image_x_resolution_eq(VALUE self, VALUE val)
 /**
  * Get the vertical resolution of the image.
  *
- * @!attribute [r] y_resolution
  * @return [Float] the resolution
  */
 VALUE
@@ -15639,7 +15544,6 @@ Image_y_resolution(VALUE self)
 /**
  * Set the vertical resolution of the image.
  *
- * @!attribute [w] y_resolution
  * @param val [Float] the resolution
  * @return [Float] the given resolution
  */
@@ -15652,7 +15556,6 @@ Image_y_resolution_eq(VALUE self, VALUE val)
 /**
  * Get the horizontal resolution of the image.
  *
- * @!attribute [r] x_resolution
  * @return [Float] the resolution
  */
 VALUE
@@ -15664,7 +15567,6 @@ Image_x_resolution(VALUE self)
 /**
  * Set the horizontal resolution of the image.
  *
- * @!attribute [w] x_resolution
  * @param val [Float] the resolution
  * @return [Float] the given resolution
  */
@@ -15677,7 +15579,6 @@ Image_x_resolution_eq(VALUE self, VALUE val)
 /**
  * Get the vertical resolution of the image.
  *
- * @!attribute [r] y_resolution
  * @return [Float] the resolution
  */
 VALUE
@@ -15689,7 +15590,6 @@ Image_y_resolution(VALUE self)
 /**
  * Set the vertical resolution of the image.
  *
- * @!attribute [w] y_resolution
  * @param val [Float] the resolution
  * @return [Float] the given resolution
  */

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -223,7 +223,6 @@ static char *pixel_packet_to_hexname(PixelPacket *pp, char *name)
 /**
  * Get antialias value
  *
- * @!attribute [r] antialias
  * @return [Boolean] true if antialias is enabled
  */
 VALUE
@@ -235,7 +234,6 @@ Info_antialias(VALUE self)
 /**
  * Set antialias value
  *
- * @!attribute [w] antialias
  * @param val [Boolean] true or false
  * @return [Boolean] the given value
  */
@@ -393,7 +391,6 @@ Info_aset(int argc, VALUE *argv, VALUE self)
 /**
  * Get the attenuate value.
  *
- * @!attribute [r] attenuate
  * @return [Float] the attenuate
  */
 VALUE
@@ -406,7 +403,6 @@ Info_attenuate(VALUE self)
 /**
  * Set the attenuate value.
  *
- * @!attribute [w] attenuate
  * @param value [Float] the attenuate
  * @return [Float] the attenuate
  */
@@ -420,7 +416,6 @@ Info_attenuate_eq(VALUE self, VALUE value)
 /**
  * Get the authenticate value.
  *
- * @!attribute [r] authenticate
  * @return [String] the authenticate
  */
 VALUE
@@ -440,7 +435,6 @@ Info_authenticate(VALUE self)
 /**
  * Set the authenticate value.
  *
- * @!attribute [w] authenticate
  * @param passwd_arg [String] the authenticating password
  * @return [String] the given value
  */
@@ -485,7 +479,6 @@ Info_authenticate_eq(VALUE self, VALUE passwd_arg)
 /**
  * Return the name of the background color as a String
  *
- * @!attribute [r] background_color
  * @return [String] the name of the background color
  * @see Image#background_color
  */
@@ -502,7 +495,6 @@ Info_background_color(VALUE self)
 /**
  * Set the background color.
  *
- * @!attribute [w] background_color
  * @param bc_arg [Magick::Pixel, String] the background color
  * @return [Magick::Pixel, String] the given color
  */
@@ -521,7 +513,6 @@ Info_background_color_eq(VALUE self, VALUE bc_arg)
 /**
  * Return the name of the border color as a String.
  *
- * @!attribute [r] border_color
  * @return [String] the border color name
  * @see Image#border_color
  */
@@ -537,7 +528,6 @@ Info_border_color(VALUE self)
 /**
  * set the border color
  *
- * @!attribute [w] border_color
  * @param bc_arg [Magick::Pixel, String] the border color
  * @return [Magick::Pixel, String] the given color
  */
@@ -558,7 +548,6 @@ Info_border_color_eq(VALUE self, VALUE bc_arg)
 /**
  * Get a caption of image
  *
- * @!attribute [r] caption
  * @return [String] the caption
  */
 VALUE
@@ -572,7 +561,6 @@ Info_caption(VALUE self)
 /**
  * Assigns a caption to an image.
  *
- * @!attribute [w] caption
  * @param caption [String] the caption
  * @return [String] the given value
  */
@@ -618,7 +606,6 @@ Info_channel(int argc, VALUE *argv, VALUE self)
 /**
  * Get the colorspace type.
  *
- * @!attribute [r] colorspace
  * @return [Magick::ColorspaceType] the colorspace type
  */
 VALUE
@@ -633,7 +620,6 @@ Info_colorspace(VALUE self)
 /**
  * Set the colorspace type
  *
- * @!attribute [w] colorspace
  * @param colorspace [Magick::ColorspaceType] the colorspace type
  * @return [Magick::ColorspaceType] the given colorspace
  */
@@ -650,7 +636,6 @@ Info_colorspace_eq(VALUE self, VALUE colorspace)
 /**
  * Get the comment.
  *
- * @!attribute [r] comment
  * @return [String] the comment
  */
 VALUE Info_comment(VALUE self)
@@ -661,7 +646,6 @@ VALUE Info_comment(VALUE self)
 /**
  * Set the comment
  *
- * @!attribute [w] comment
  * @param string [String] the comment
  * @return [String] the given comment
  */
@@ -673,7 +657,6 @@ VALUE Info_comment_eq(VALUE self, VALUE string)
 /**
  * Get the compression type.
  *
- * @!attribute [r] compression
  * @return [Magick::CompressionType] the compression type
  */
 VALUE
@@ -688,7 +671,6 @@ Info_compression(VALUE self)
 /**
  * Set the compression type
  *
- * @!attribute [r] compression
  * @param type [Magick::CompressionType] the compression type
  * @return [Magick::CompressionType] the given type
  */
@@ -761,7 +743,6 @@ Info_define(int argc, VALUE *argv, VALUE self)
 /**
  * Get the delay value.
  *
- * @!attribute [r] delay
  * @return [Numeric] the delay
  */
 VALUE
@@ -805,7 +786,6 @@ arg_is_integer(VALUE arg)
 /**
  * Set the delay value.
  *
- * @!attribute [w] delay
  * @param string [String] the delay
  * @return [String] the given value
  */
@@ -842,7 +822,6 @@ Info_delay_eq(VALUE self, VALUE string)
 /**
  * Get the density value
  *
- * @!attribute [r] density
  * @return [String] the density
  */
 VALUE
@@ -854,7 +833,6 @@ Info_density(VALUE self)
 /**
  * Set the text rendering density geometry
  *
- * @!attribute [w] density
  * @param density_arg [String] the density
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -892,7 +870,6 @@ Info_density_eq(VALUE self, VALUE density_arg)
 /**
  * Get the depth value
  *
- * @!attribute [r] depth
  * @return [Numeric] the depth
  */
 VALUE
@@ -904,7 +881,6 @@ Info_depth(VALUE self)
 /**
  * Set the depth (8, 16, 32, 64).
  *
- * @!attribute [w] depth
  * @param depth [Numeric] the depth
  * @return [Numeric] the given depth
  */
@@ -989,7 +965,6 @@ DisposeType rm_dispose_to_enum(const char *name)
  * Retrieve the dispose option string and convert it to a DisposeType
  * enumerator.
  *
- * @!attribute [r] dispose
  * @return [Magick::DisposeType] a DisposeType enumerator
  */
 VALUE
@@ -1023,7 +998,6 @@ Info_dispose(VALUE self)
 /**
  * Convert a DisposeType enumerator into the equivalent dispose option string.
  *
- * @!attribute [w] dispose
  * @param disp [Magic::DisposeType] the DisposeType enumerator
  * @return [Magic::DisposeType] the given value
  */
@@ -1062,7 +1036,6 @@ Info_dispose_eq(VALUE self, VALUE disp)
 /**
  * Get dither value
  *
- * @!attribute [r] dither
  * @return [Boolean] true if dither is enabled
  */
 VALUE
@@ -1074,7 +1047,6 @@ Info_dither(VALUE self)
 /**
  * Set dither value
  *
- * @!attribute [w] dither
  * @param val [Boolean] true if dither will be enabled
  * @return [Boolean] true if dither is enabled
  */
@@ -1088,7 +1060,6 @@ Info_dither_eq(VALUE self, VALUE val)
 /**
  * Get the endian value.
  *
- * @!attribute [r] endian
  * @return [Magick::EndianType] the endian
  */
 VALUE
@@ -1104,7 +1075,6 @@ Info_endian(VALUE self)
 /**
  * Set the endian value.
  *
- * @!attribute [w] endian
  * @param endian [Magick::EndianType] the endian
  * @return [Magick::EndianType] the given endian
  */
@@ -1128,7 +1098,6 @@ Info_endian_eq(VALUE self, VALUE endian)
 /**
  * Get the extract geometry, e.g. "200x200+100+100"
  *
- * @!attribute [r] extract
  * @return [String] the extract string
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -1141,7 +1110,6 @@ Info_extract(VALUE self)
 /**
  * Set the extract geometry.
  *
- * @!attribute [w] extract
  * @param extract_arg [String] the extract string
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -1180,7 +1148,6 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
 /**
  * Get the "filename" value.
  *
- * @!attribute [r] filename
  * @return [String] the file name ("" if filename not set)
  * @note Only used for Image#capture
  * @see Image#capture
@@ -1197,7 +1164,6 @@ Info_filename(VALUE self)
 /**
  * Set the "filename" value.
  *
- * @!attribute [w] filename
  * @param filename [String] the file name
  * @return [String] the given file name
  * @note Only used for Image#capture
@@ -1230,7 +1196,6 @@ Info_filename_eq(VALUE self, VALUE filename)
 /**
  * Return the fill color as a String.
  *
- * @!attribute [r] fill
  * @return [String] the fill color
  */
 VALUE
@@ -1242,7 +1207,6 @@ Info_fill(VALUE self)
 /**
  * Set the fill color
  *
- * @!attribute [w] fill
  * @param color [String] the fill color
  * @return [String] the given value
  */
@@ -1256,7 +1220,6 @@ Info_fill_eq(VALUE self, VALUE color)
 /**
  * Get the text font.
  *
- * @!attribute [r] font
  * @return [String] the font
  */
 VALUE
@@ -1268,7 +1231,6 @@ Info_font(VALUE self)
 /**
  * Set the text font.
  *
- * @!attribute [w] font
  * @param font_arg [String] the font
  * @return [String] the given font
  */
@@ -1296,7 +1258,6 @@ Info_font_eq(VALUE self, VALUE font_arg)
 /**
  * Return the image encoding format.
  *
- * @!attribute [r] format
  * @return [String] the encoding format
  */
 VALUE Info_format(VALUE self)
@@ -1322,7 +1283,6 @@ VALUE Info_format(VALUE self)
 /**
  * Set the image encoding format.
  *
- * @!attribute [w] format
  * @param magick [String] the encoding format
  * @return [String] the given format
  */
@@ -1355,7 +1315,6 @@ Info_format_eq(VALUE self, VALUE magick)
 /**
  * Get the fuzz.
  *
- * @!attribute [r] fuzz
  * @return [Float] the fuzz
  * @see Image#fuzz
  */
@@ -1368,7 +1327,6 @@ Info_fuzz(VALUE self)
 /**
  * Set the fuzz.
  *
- * @!attribute [w] fuzz
  * @param fuzz [Float, String] the fuzz with Float or
  *   percent format "xx%" with String
  * @return [Float, String] the given value
@@ -1438,7 +1396,6 @@ GravityType rm_gravity_to_enum(const char *name)
 /**
  * Return the value of the gravity option as a GravityType enumerator.
  *
- * @!attribute [r] gravity
  * @return [Magick::GravityType] the gravity enumerator
  */
 VALUE Info_gravity(VALUE self)
@@ -1472,7 +1429,6 @@ VALUE Info_gravity(VALUE self)
  * Convert a GravityType enum to a gravity option name and store in the Info
  * structure.
  *
- * @!attribute [w] gravity
  * @param grav [Magick::GravityType] the gravity enumerator
  * @return [Magick::GravityType] the given gravity
  */
@@ -1512,7 +1468,6 @@ Info_gravity_eq(VALUE self, VALUE grav)
 /**
  * Get the classification type.
  *
- * @!attribute [r] image_type
  * @return [Magick::ImageType] the classification type
  */
 VALUE
@@ -1527,7 +1482,6 @@ Info_image_type(VALUE self)
 /**
  * Set the classification type.
  *
- * @!attribute [w] image_type
  * @param type [Magick::ImageType] the classification type
  * @return [Magick::ImageType] the given type
  */
@@ -1544,7 +1498,6 @@ Info_image_type_eq(VALUE self, VALUE type)
 /**
  * Get the interlace type.
  *
- * @!attribute [r] interlace
  * @return [Magick::InterlaceType] the interlace type
  */
 VALUE
@@ -1559,7 +1512,6 @@ Info_interlace(VALUE self)
 /**
  * Set the interlace type
  *
- * @!attribute [w] interlace
  * @param inter [Magick::InterlaceType] the interlace type
  * @return [Magick::InterlaceType] the given interlace
  */
@@ -1576,7 +1528,6 @@ Info_interlace_eq(VALUE self, VALUE inter)
 /**
  * Get the label.
  *
- * @!attribute [r] label
  * @return [String] the label
  */
 VALUE Info_label(VALUE self)
@@ -1587,7 +1538,6 @@ VALUE Info_label(VALUE self)
 /**
  * Set the label.
  *
- * @!attribute [w] label
  * @param string [String] the label
  * @return [String] the given label
  */
@@ -1599,7 +1549,6 @@ VALUE Info_label_eq(VALUE self, VALUE string)
 /**
  * Return the name of the matte color as a String.
  *
- * @!attribute [r] matte_color
  * @return [String] the name of the matte color
  * @see Image#matte_color
  */
@@ -1615,7 +1564,6 @@ Info_matte_color(VALUE self)
 /**
  * Set the matte color.
  *
- * @!attribute [w] matte_color
  * @param matte_arg [Magick::Pixel, String] the name of the matte as a String
  * @return [Magick::Pixel, String] the given value
  */
@@ -1634,7 +1582,6 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
 /**
  * Establish a progress monitor.
  *
- * @!attribute [w] monitor
  * @param monitor [Proc] the monitor
  * @return [Proc] monitor
  * @see Image#monitor=
@@ -1661,7 +1608,6 @@ Info_monitor_eq(VALUE self, VALUE monitor)
 /**
  * Get the monochrome value.
  *
- * @!attribute [r] monochrome
  * @return [Boolean] true or false
  */
 VALUE
@@ -1673,7 +1619,6 @@ Info_monochrome(VALUE self)
 /**
  * Set the monochrome value.
  *
- * @!attribute [w] monochrome
  * @param val [Boolean] true or false
  * @return [Boolean] the given value
  */
@@ -1686,7 +1631,6 @@ Info_monochrome_eq(VALUE self, VALUE val)
 /**
  * Get the scene number of an image or the first image in a sequence.
  *
- * @!attribute [r] number_scenes
  * @return [Numeric] the scene number
  */
 VALUE
@@ -1698,7 +1642,6 @@ Info_number_scenes(VALUE self)
 /**
  * Set the scene number of an image or the first image in a sequence.
  *
- * @!attribute [w] number_scenes
  * @param val [Numeric] the scene number
  * @return [Numeric] the given value
  */
@@ -1711,7 +1654,6 @@ Info_number_scenes_eq(VALUE self, VALUE val)
 /**
  * Return the orientation attribute as an OrientationType enum value.
  *
- * @!attribute [r] orientation
  * @return [Magick::OrientationType] the orientation
  */
 VALUE
@@ -1727,7 +1669,6 @@ Info_orientation(VALUE self)
 /**
  * Set the Orientation type.
  *
- * @!attribute [w] orientation
  * @param inter [Magick::OrientationType] the orientation type as an OrientationType enum value
  * @return [Magick::OrientationType] the given value
  */
@@ -1745,7 +1686,6 @@ Info_orientation_eq(VALUE self, VALUE inter)
 /**
  * Return origin geometry.
  *
- * @!attribute [r] origin
  * @return [String] the origin geometry
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -1769,7 +1709,6 @@ Info_origin(VALUE self)
  * The geometry format is
  *     +-x+-y
  *
- * @!attribute [w] origin
  * @param origin_arg [String] the origin geometry
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -1810,7 +1749,6 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
 /**
  * Get the Postscript page geometry.
  *
- * @!attribute [r] page
  * @return [String] the page geometry
  */
 VALUE
@@ -1827,7 +1765,6 @@ Info_page(VALUE self)
  * Store the Postscript page geometry. Argument may be a Geometry object as well
  * as a geometry string.
  *
- * @!attribute [w] page
  * @param page_arg [String] the geometry
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -1864,7 +1801,6 @@ Info_page_eq(VALUE self, VALUE page_arg)
 /**
  * Get the point size.
  *
- * @!attribute [r] pointsize
  * @return [Float] the point size
  */
 VALUE
@@ -1876,7 +1812,6 @@ Info_pointsize(VALUE self)
 /**
  * Set the point size.
  *
- * @!attribute [w] pointsize
  * @param val [Float] the point size
  * @return [Float] the given value
  */
@@ -1889,7 +1824,6 @@ Info_pointsize_eq(VALUE self, VALUE val)
 /**
  * Get the compression level for JPEG, etc.
  *
- * @!attribute [r] quality
  * @return [Numeric] the compression level
  */
 VALUE
@@ -1901,7 +1835,6 @@ Info_quality(VALUE self)
 /**
  * Get the compression level for JPEG, etc.
  *
- * @!attribute [w] quality
  * @param val [Numeric] the compression level
  * @return [Numeric] the given value
  */
@@ -1914,7 +1847,6 @@ Info_quality_eq(VALUE self, VALUE val)
 /**
  * Get sampling factors used by JPEG or MPEG-2 encoder and YUV decoder/encoder.
  *
- * @!attribute [r] sampling_factor
  * @return [String] the sampling factors
  */
 VALUE
@@ -1936,7 +1868,6 @@ Info_sampling_factor(VALUE self)
 /**
  * Set sampling factors used by JPEG or MPEG-2 encoder and YUV decoder/encoder.
  *
- * @!attribute [w] sampling_factor
  * @param sampling_factor [String] the sampling factors
  * @return [String] the given value
  */
@@ -1971,7 +1902,6 @@ Info_sampling_factor_eq(VALUE self, VALUE sampling_factor)
 /**
  * Get the scene number.
  *
- * @!attribute [r] scene
  * @return [Numeric] the scene number
  */
 VALUE
@@ -1987,7 +1917,6 @@ Info_scene(VALUE self)
 /**
  * Set the scene number.
  *
- * @!attribute [w] scene
  * @param scene [Numeric] the scene number
  * @return [Numeric] the given value
  */
@@ -2010,7 +1939,6 @@ Info_scene_eq(VALUE self, VALUE scene)
 /**
  * Get the server name.
  *
- * @!attribute [r] server_name
  * @return [String] the server name
  */
 VALUE
@@ -2023,7 +1951,6 @@ Info_server_name(VALUE self)
 /**
  * Set the server name.
  *
- * @!attribute [w] server_name
  * @param server_arg [String] the server name
  * @return [String] the given value
  */
@@ -2051,7 +1978,6 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
 /**
  * Get ths size
  *
- * @!attribute [r] size
  * @return [String] the size as a Geometry object
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -2064,7 +1990,6 @@ Info_size(VALUE self)
 /**
  * Set the size (either as a Geometry object or a Geometry string
  *
- * @!attribute [w] size
  * @param size_arg [String] the size
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -2103,7 +2028,6 @@ Info_size_eq(VALUE self, VALUE size_arg)
 /**
  * Return the stroke color as a String.
  *
- * @!attribute [r] stroke
  * @return [String] the stroke color
  */
 VALUE
@@ -2115,7 +2039,6 @@ Info_stroke(VALUE self)
 /**
  * Set the stroke color
  *
- * @!attribute [w] stroke
  * @param color [String] the stroke color
  * @return [String] the given value
  */
@@ -2129,7 +2052,6 @@ Info_stroke_eq(VALUE self, VALUE color)
 /**
  * Get stroke width.
  *
- * @!attribute [r] stroke_width
  * @return [Float] the stroke width
  */
 VALUE
@@ -2142,7 +2064,6 @@ Info_stroke_width(VALUE self)
 /**
  * Set stroke width.
  *
- * @!attribute [w] stroke_width
  * @param stroke_width [Float] the stroke width
  * @return [Float] the given value
  */
@@ -2156,7 +2077,6 @@ Info_stroke_width_eq(VALUE self, VALUE stroke_width)
 /**
  * Set name of texture to tile onto the image background.
  *
- * @!attribute [w] texture
  * @param texture [Magick::Image] the texture image
  * @return [Magick::Image] the given image
  */
@@ -2196,7 +2116,6 @@ Info_texture_eq(VALUE self, VALUE texture)
 /**
  * Return tile_offset geometry.
  *
- * @!attribute [r] tile_offset
  * @return [String] the tile offset
  * @see https://www.imagemagick.org/Magick++/Geometry.html
  */
@@ -2222,7 +2141,6 @@ Info_tile_offset(VALUE self)
 /**
  * Set tile offset geometry.
  *
- * @!attribute [w] tile_offset
  * @param offset [String] the offset geometry
  * @return [String] the given value
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -2255,7 +2173,6 @@ Info_tile_offset_eq(VALUE self, VALUE offset)
 /**
  * Return the name of the transparent color.
  *
- * @!attribute [r] transparent_color
  * @return [String] the name of the transparent color
  * @see Image#transparent_color
  */
@@ -2272,7 +2189,6 @@ Info_transparent_color(VALUE self)
 /**
  * Set the transparent color.
  *
- * @!attribute [w] transparent_color
  * @param tc_arg [String] the transparent color
  * @return [Magick::Pixel, String] the given value
  */
@@ -2324,7 +2240,6 @@ Info_undefine(VALUE self, VALUE format, VALUE key)
 /**
  * Return the undercolor color.
  *
- * @!attribute [r] undercolor
  * @return [String] the undercolor
  */
 VALUE
@@ -2336,7 +2251,6 @@ Info_undercolor(VALUE self)
 /**
  * Set the undercolor color.
  *
- * @!attribute [w] undercolor
  * @param color [String] the undercolor color
  * @return [String] the given value
  */
@@ -2349,7 +2263,6 @@ Info_undercolor_eq(VALUE self, VALUE color)
 /**
  * Get the resolution type.
  *
- * @!attribute [r] units
  * @return [Magick::ResolutionType] the resolution type
  */
 VALUE
@@ -2364,7 +2277,6 @@ Info_units(VALUE self)
 /**
  * Set the resolution type
  *
- * @!attribute [w] units
  * @param units [Magick::ResolutionType] the resolution type
  * @return [Magick::ResolutionType] the given value
  */
@@ -2381,7 +2293,6 @@ Info_units_eq(VALUE self, VALUE units)
 /**
  * Get FlashPix viewing parameters.
  *
- * @!attribute [r] view
  * @return [String] the viewing parameters
  */
 VALUE
@@ -2400,7 +2311,6 @@ Info_view(VALUE self)
 /**
  * Set FlashPix viewing parameters.
  *
- * @!attribute [w] view
  * @param view_arg [String] the viewing parameters
  * @return [String] the given value
  */

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -90,7 +90,6 @@ Montage_alloc(VALUE class)
 /**
  * Set background_color value.
  *
- * @!attribute [w] background_color
  * @param color [Magick::Pixel, String] the color name
  * @return [Magick::Pixel, String] the given color name
  */
@@ -108,7 +107,6 @@ Montage_background_color_eq(VALUE self, VALUE color)
 /**
  * Set border_color value.
  *
- * @!attribute [w] border_color
  * @param color [Magick::Pixel, String] the color name
  * @return [Magick::Pixel, String] the given color name
  */
@@ -126,7 +124,6 @@ Montage_border_color_eq(VALUE self, VALUE color)
 /**
  * Set border_width value.
  *
- * @!attribute [w] border_width
  * @param width [Numeric] the width
  * @return [Numeric] the given width
  */
@@ -144,7 +141,6 @@ Montage_border_width_eq(VALUE self, VALUE width)
 /**
  * Set a composition operator.
  *
- * @!attribute [w] compose
  * @param compose [Magick::CompositeOperator] the composition operator
  * @return [Magick::CompositeOperator] the given compose operator
  */
@@ -162,7 +158,6 @@ Montage_compose_eq(VALUE self, VALUE compose)
 /**
  * Set filename value.
  *
- * @!attribute [w] filename
  * @param filename [String] the filename
  * @return [String] filename
  */
@@ -180,7 +175,6 @@ Montage_filename_eq(VALUE self, VALUE filename)
 /**
  * Set fill value.
  *
- * @!attribute [w] fill
  * @param color [Magick::Pixel, String] the color name
  * @return [Magick::Pixel, String] the given color name
  */
@@ -198,7 +192,6 @@ Montage_fill_eq(VALUE self, VALUE color)
 /**
  * Set font value.
  *
- * @!attribute [w] font
  * @param font [String] the font name
  * @return [String] the given font name
  */
@@ -221,7 +214,6 @@ Montage_font_eq(VALUE self, VALUE font)
  *      <width>x<height>+<outer-bevel-width>+<inner-bevel-width>
  *   or a Geometry object
  *
- * @!attribute [w] frame
  * @param frame_arg [String] the frame geometry
  * @return [String] the given frame geometry
  */
@@ -248,7 +240,6 @@ Montage_frame_eq(VALUE self, VALUE frame_arg)
  *      <width>x<height>+<outer-bevel-width>+<inner-bevel-width>
  *   or a Geometry object
  *
- * @!attribute [w] geometry
  * @param geometry_arg [String] the geometry
  * @return [String] the given geometry
  */
@@ -271,7 +262,6 @@ Montage_geometry_eq(VALUE self, VALUE geometry_arg)
 /**
  * Set gravity value.
  *
- * @!attribute [w] gravity
  * @param gravity [Magick::GravityType] the gravity type
  * @return [Magick::GravityType] the given gravity
  */
@@ -302,7 +292,6 @@ Montage_initialize(VALUE self)
 /**
  * Set matte_color value.
  *
- * @!attribute [w] matte_color
  * @param color [Magick::Pixel, String] the color name
  * @return [Magick::Pixel, String] the given color name
  */
@@ -320,7 +309,6 @@ Montage_matte_color_eq(VALUE self, VALUE color)
 /**
  * Set pointsize value.
  *
- * @!attribute [w] pointsize
  * @param size [Numeric] the point size
  * @return [Numeric] the given point size
  */
@@ -338,7 +326,6 @@ Montage_pointsize_eq(VALUE self, VALUE size)
 /**
  * Set shadow value.
  *
- * @!attribute [w] shadow
  * @param shadow [Bool] true if the shadow will be enabled
  * @return [Bool] the given value
  */
@@ -356,7 +343,6 @@ Montage_shadow_eq(VALUE self, VALUE shadow)
 /**
  * Set stroke value.
  *
- * @!attribute [w] stroke
  * @param color [Magick::Pixel, String] the color name
  * @return [Magick::Pixel, String] the given color name
  */
@@ -374,7 +360,6 @@ Montage_stroke_eq(VALUE self, VALUE color)
 /**
  * Set texture value.
  *
- * @!attribute [w] texture
  * @param texture [Magick::Image] the texture image
  * @return [Magick::Image] the given texture image
  */
@@ -414,7 +399,6 @@ Montage_texture_eq(VALUE self, VALUE texture)
  *      <width>x<height>+<outer-bevel-width>+<inner-bevel-width>
  *   or a Geometry object
  *
- * @!attribute [w] tile
  * @param tile_arg [String] the tile geometry
  * @return [String] the given tile geometry
  */
@@ -437,7 +421,6 @@ Montage_tile_eq(VALUE self, VALUE tile_arg)
 /**
  * Set title value.
  *
- * @!attribute [w] title
  * @param title [String] the title
  * @return [String] the given title
  */

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -38,7 +38,6 @@ destroy_Pixel(Pixel *pixel)
 /**
  * Get Pixel red value.
  *
- * @!attribute [r] red
  * @return [Numeric] the red value
  */
 VALUE
@@ -50,7 +49,6 @@ Pixel_red(VALUE self)
 /**
  * Get Pixel green value.
  *
- * @!attribute [r] green
  * @return [Numeric] the green value
  */
 VALUE
@@ -62,7 +60,6 @@ Pixel_green(VALUE self)
 /**
  * Get Pixel blue value.
  *
- * @!attribute [r] blue
  * @return [Numeric] the blue value
  */
 VALUE
@@ -74,7 +71,6 @@ Pixel_blue(VALUE self)
 /**
  * Get Pixel alpha value.
  *
- * @!attribute [r] alpha
  * @return [Numeric] the alpha value
  */
 VALUE
@@ -96,7 +92,6 @@ Pixel_alpha(VALUE self)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] red
  * @param v [Numeric] the red value
  * @return [Numeric] the given red value
  */
@@ -120,7 +115,6 @@ Pixel_red_eq(VALUE self, VALUE v)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] green
  * @param v [Numeric] the green value
  * @return [Numeric] the given green value
  */
@@ -144,7 +138,6 @@ Pixel_green_eq(VALUE self, VALUE v)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] blue
  * @param v [Numeric] the blue value
  * @return [Numeric] the given blue value
  */
@@ -168,7 +161,6 @@ Pixel_blue_eq(VALUE self, VALUE v)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] alpha
  * @param v [Numeric] the alpha value
  * @return [Numeric] the given alpha value
  */
@@ -195,7 +187,6 @@ Pixel_alpha_eq(VALUE self, VALUE v)
 /**
  * Get Pixel cyan value.
  *
- * @!attribute [r] cyan
  * @return [Numeric] the cyan value
  */
 VALUE
@@ -214,7 +205,6 @@ Pixel_cyan(VALUE self)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] cyan
  * @param v [Numeric] the cyan value
  * @return [Numeric] the given cyan value
  */
@@ -234,7 +224,6 @@ Pixel_cyan_eq(VALUE self, VALUE v)
 /**
  * Get Pixel magenta value.
  *
- * @!attribute [r] magenta
  * @return [Numeric] the magenta value
  */
 VALUE
@@ -253,7 +242,6 @@ Pixel_magenta(VALUE self)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] magenta
  * @param v [Numeric] the magenta value
  * @return [Numeric] the given magenta value
  */
@@ -273,7 +261,6 @@ Pixel_magenta_eq(VALUE self, VALUE v)
 /**
  * Get Pixel yellow value.
  *
- * @!attribute [r] yellow
  * @return [Numeric] the yellow value
  */
 VALUE
@@ -292,7 +279,6 @@ Pixel_yellow(VALUE self)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] yellow
  * @param v [Numeric] the yellow value
  * @return [Numeric] the given yellow value
  */
@@ -312,7 +298,6 @@ Pixel_yellow_eq(VALUE self, VALUE v)
 /**
  * Get Pixel black value.
  *
- * @!attribute [r] black
  * @return [Numeric] the black value
  */
 VALUE
@@ -331,7 +316,6 @@ Pixel_black(VALUE self)
  * - Setters return their argument values for backward compatibility to when
  *   Pixel was a Struct class.
  *
- * @!attribute [w] black
  * @param v [Numeric] the black value
  * @return [Numeric] the given black value
  */


### PR DESCRIPTION
Because yard show the warning message with @!attribute in C lang.

https://github.com/rmagick/rmagick/issues/628