### PR TITLE
Yardoc: Mix Observable module into Pixel class on Ruby land

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -742,11 +742,6 @@ Init_RMagick2(void)
 
     Class_Pixel = rb_define_class_under(Module_Magick, "Pixel", rb_cObject);
 
-    // include Observable in Pixel for Image::View class
-    (void) rb_require("observer");
-    observable = rb_const_get(rb_cObject, rb_intern("Observable"));
-    rb_include_module(Class_Pixel, observable);
-
     // include Comparable
     rb_include_module(Class_Pixel, rb_mComparable);
 

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -19,6 +19,7 @@ if RUBY_PLATFORM =~ /mingw/i
 end
 
 require 'English'
+require 'observer'
 require 'RMagick2.so'
 
 module Magick
@@ -1805,6 +1806,11 @@ module Magick
     alias indexes values_at
     alias indices values_at
   end # Magick::ImageList
+
+  class Pixel
+    # include Observable for Image::View class
+    include Observable
+  end
 
   #  Collects non-specific optional method arguments
   class OptionalMethodArguments


### PR DESCRIPTION
Because yard doesn't recognize it correctly.

https://github.com/rmagick/rmagick/issues/628