### PR TITLE
CI: Download ImageMagick tar ball from official site only

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -40,21 +40,10 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  if (( "${version[0]}" >= 7 )); then
-    wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz"
-    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
-    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  elif (( "${version[0]}${version[1]}" >= 69 )); then
-    wget "https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz"
-    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
-    rm "${IMAGEMAGICK_VERSION}.tar.gz"
-    mv "ImageMagick6-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  else
-    wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  fi
+  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -30,21 +30,10 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  if (( "${version[0]}" >= 7 )); then
-    wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz"
-    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
-    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  elif (( "${version[0]}${version[1]}" >= 69 )); then
-    wget "https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz"
-    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
-    rm "${IMAGEMAGICK_VERSION}.tar.gz"
-    mv "ImageMagick6-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  else
-    wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
-  fi
+  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then


### PR DESCRIPTION
- All tar ball files of recently release are on ImageMagick site
- ImageMagick team forget tagging and then we fail to get from Github