### PR TITLE
Revert "CI: Download ImageMagick tar ball from official site only (#1135)"

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -40,10 +40,21 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  if (( "${version[0]}" >= 7 )); then
+    wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz"
+    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
+    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  elif (( "${version[0]}${version[1]}" >= 69 )); then
+    wget "https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz"
+    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
+    rm "${IMAGEMAGICK_VERSION}.tar.gz"
+    mv "ImageMagick6-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  else
+    wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  fi
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -30,10 +30,21 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  if (( "${version[0]}" >= 7 )); then
+    wget "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz"
+    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
+    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  elif (( "${version[0]}${version[1]}" >= 69 )); then
+    wget "https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz"
+    tar -xf "${IMAGEMAGICK_VERSION}.tar.gz"
+    rm "${IMAGEMAGICK_VERSION}.tar.gz"
+    mv "ImageMagick6-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  else
+    wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+    mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  fi
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then


### PR DESCRIPTION
This reverts commit b91c3d2a8dd30cf0e5e22b92916999593c5b6132.

imagemagick.org only stores the most recent patch version and removes
older patch versions. This means our builds will start failing as soon
as there is a new patch version. We can rely on it for IM 6.7/6.8
because they don't make any releases anymore and they aren't available
on Github. Github has every release, so if we point at that we can
expect stable access to every patch version.