### PR TITLE
Example: Fix runtime error of composite_layers.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Style/GuardClause: { MinBodyLength: 3 }
 Style/MethodCalledOnDoEndBlock: { Exclude: [test/**/*.rb, spec/**/*.rb] }
 Style/NumericLiterals: { MinDigits: 6 }
 
+Style/CollectionMethods:
+  Exclude:
+    - 'doc/ex/composite_layers.rb'
+
 ################################################################################
 #
 # Rules we don't want to enable

--- a/doc/ex/composite_layers.rb
+++ b/doc/ex/composite_layers.rb
@@ -4,7 +4,7 @@ module Magick
   class ImageList
     # Create a shadow image for each image in the list
     def shadow(x_offset = 4, y_offset = 4, sigma = 4.0, opacity = 1.0)
-      map { |frame| frame.shadow(x_offset, y_offset, sigma, opacity) }
+      collect { |frame| frame.shadow(x_offset, y_offset, sigma, opacity) }
     end
   end
 end


### PR DESCRIPTION
This patch will solve following runtime error.

```
$ ruby composite_layers.rb
Traceback (most recent call last):
	1: from composite_layers.rb:40:in `<main>'
composite_layers.rb:40:in `composite_layers': @images is not of type Array (Magick::ImageMagickError)
```

Looks like it need to call Magick::ImageList#collect defined in rmagick_internal.rb