### PR TITLE
Flesh out tests for Image#charcoal

### DIFF
--- a/spec/rmagick/image/charcoal_spec.rb
+++ b/spec/rmagick/image/charcoal_spec.rb
@@ -1,12 +1,39 @@
 RSpec.describe Magick::Image, "#charcoal" do
-  it "works" do
-    image = described_class.new(20, 20)
+  def build_image
+    image = Magick::Image.new(2, 2)
+    pixels = [[45, 98, 156], [209, 171, 11], [239, 236, 2], [8, 65, 247]]
+    image.import_pixels(0, 0, 2, 2, "RGB", pixels.flatten)
+  end
 
-    result = image.charcoal
-    expect(result).to be_instance_of(described_class)
+  def gray(pixel_value)
+    [pixel_value, pixel_value, pixel_value]
+  end
 
-    expect { image.charcoal(1.0) }.not_to raise_error
-    expect { image.charcoal(1.0, 2.0) }.not_to raise_error
-    expect { image.charcoal(1.0, 2.0, 3.0) }.to raise_error(ArgumentError)
+  it "applies a charcoal effect", unsupported_before('6.8') do
+    image = build_image
+    expected_pixels = [gray(53736), gray(48703), gray(9953), gray(51857)]
+
+    expect(image.charcoal).to match_pixels(expected_pixels, delta: 1)
+  end
+
+  it "applies a charcoal effect with radius", unsupported_before('6.8') do
+    image = build_image
+    expected_pixels = [gray(55422), gray(49372), gray(9121), gray(53918)]
+
+    expect(image.charcoal(1.0)).to match_pixels(expected_pixels, delta: 50)
+  end
+
+  it "applies a charcoal effect with radius and sigma", unsupported_before('6.8') do
+    image = build_image
+    expected_pixels = [gray(51460), gray(48203), gray(11918), gray(50352)]
+
+    expect(image.charcoal(1.0, 2.0)).to match_pixels(expected_pixels, delta: 100)
+  end
+
+  it "raises an error with an incorrect number of arguments" do
+    image = build_image
+
+    expect { image.charcoal(1.0, 2.0, 3.0) }
+      .to raise_error(ArgumentError, "wrong number of arguments (3 for 0 to 2)")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require_relative 'support/simplecov' if ENV['COVERAGE'] == 'true'
+require_relative 'support/matchers'
 
 require 'pry'
 require_relative '../lib/rmagick'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,5 @@
+require_relative 'matchers/match_pixels_matcher'
+
+def match_pixels(expected, delta: 0)
+  Matchers::MatchPixels.new(expected, delta: delta)
+end

--- a/spec/support/matchers/match_pixels_matcher.rb
+++ b/spec/support/matchers/match_pixels_matcher.rb
@@ -1,0 +1,24 @@
+module Matchers
+  class MatchPixels
+    attr_accessor :actual, :expected, :delta
+
+    def initialize(expected, delta:)
+      self.expected = expected.flatten
+      self.delta = delta
+    end
+
+    def matches?(actual)
+      self.actual = actual
+
+      actual.export_pixels.each_with_index.all? do |value, index|
+        expected_value = expected[index]
+        value.between?(expected_value - delta, expected_value + delta)
+      end
+    end
+
+    def failure_message
+      "expected all pixel values to differ by max #{delta}\n" \
+        "\nexpected: #{expected}\n     got: #{actual.export_pixels}\n\n\n"
+    end
+  end
+end


### PR DESCRIPTION
This introduces a new `match_pixels` test matcher that accepts a delta argument.
These tests produce varying results on different operating systems and versions of ImageMagick, so we set the delta to 1..
We're filtering out ImageMagick 6.7 because it produces a black and white image.