### PR TITLE
Use StringValueCStr() to get null-terminated C-lang string

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -140,7 +140,10 @@
  */
 #define OBJ_TO_MAGICK_STRING(f, obj) \
     if ((obj) != Qnil)\
-        magick_clone_string(&f, StringValueCStr(obj));\
+    {\
+        VALUE str = rb_String(obj);\
+        magick_clone_string(&f, StringValueCStr(str));\
+    }\
     else\
         f = NULL;
 

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -140,7 +140,7 @@
  */
 #define OBJ_TO_MAGICK_STRING(f, obj) \
     if ((obj) != Qnil)\
-        magick_clone_string(&f, RSTRING_PTR(obj));\
+        magick_clone_string(&f, StringValueCStr(obj));\
     else\
         f = NULL;
 


### PR DESCRIPTION
Because RSTRING_PTR() just return raw pointer in String object which might not have null-terminate in string.
It might cause a crash in magick_clone_string()