### PR TITLE
Use rb_String() instead which converts object using #to_s method

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -409,7 +409,6 @@ EXTERN ID rm_ID_notify_observers;  /**< "notify_observers" */
 EXTERN ID rm_ID_new;               /**< "new" */
 EXTERN ID rm_ID_push;              /**< "push" */
 EXTERN ID rm_ID_to_i;              /**< "to_i" */
-EXTERN ID rm_ID_to_s;              /**< "to_s" */
 EXTERN ID rm_ID_values;            /**< "values" */
 EXTERN ID rm_ID_width;             /**< "width" */
 
@@ -1156,7 +1155,6 @@ extern void   rm_check_ary_len(VALUE, long);
 extern VALUE  rm_check_ary_type(VALUE ary);
 extern Image *rm_check_destroyed(VALUE);
 extern Image *rm_check_frozen(VALUE);
-extern VALUE  rm_to_s(VALUE);
 extern char  *rm_str2cstr(VALUE, long *);
 extern int    rm_check_num2dbl(VALUE);
 extern double rm_fuzz_to_dbl(VALUE);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2087,7 +2087,7 @@ Image_change_geometry(VALUE self, VALUE geom_arg)
     VALUE ary;
 
     image = rm_check_destroyed(self);
-    geom_str = rm_to_s(geom_arg);
+    geom_str = rb_String(geom_arg);
     geometry = StringValueCStr(geom_str);
 
     memset(&rect, 0, sizeof(rect));
@@ -7380,7 +7380,7 @@ Image_geometry_eq(VALUE self, VALUE geometry)
     }
 
 
-    geom_str = rm_to_s(geometry);
+    geom_str = rb_String(geometry);
     geom = StringValueCStr(geom_str);
     if (!IsGeometry(geom))
     {
@@ -10915,7 +10915,7 @@ Image_random_threshold_channel(int argc, VALUE *argv, VALUE self)
     }
 
     // Accept any argument that has a to_s method.
-    geom_str = rm_to_s(argv[0]);
+    geom_str = rb_String(argv[0]);
     thresholds = StringValueCStr(geom_str);
 
     new_image = rm_clone_image(image);

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -349,7 +349,7 @@ Info_aset(int argc, VALUE *argv, VALUE self)
         unsigned int okay;
 
         /* Allow any argument that supports to_s */
-        value = rm_to_s(value);
+        value = rb_String(value);
         value_p = StringValueCStr(value);
 
         okay = SetImageOption(info, ckey, value_p);
@@ -829,7 +829,7 @@ Info_density_eq(VALUE self, VALUE density_arg)
         return self;
     }
 
-    density = rm_to_s(density_arg);
+    density = rb_String(density_arg);
     dens = StringValueCStr(density);
     if (!IsGeometry(dens))
     {
@@ -1106,7 +1106,7 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
         return self;
     }
 
-    extract = rm_to_s(extract_arg);
+    extract = rb_String(extract_arg);
     extr = StringValueCStr(extract);
     if (!IsGeometry(extr))
     {
@@ -1703,7 +1703,7 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
         return self;
     }
 
-    origin_str = rm_to_s(origin_arg);
+    origin_str = rb_String(origin_arg);
     origin = GetPageGeometry(StringValueCStr(origin_str));
 
     if (IsGeometry(origin) == MagickFalse)
@@ -1758,7 +1758,7 @@ Info_page_eq(VALUE self, VALUE page_arg)
         info->page = NULL;
         return self;
     }
-    geom_str = rm_to_s(page_arg);
+    geom_str = rb_String(page_arg);
     geometry = GetPageGeometry(StringValueCStr(geom_str));
     if (*geometry == '\0')
     {
@@ -1985,7 +1985,7 @@ Info_size_eq(VALUE self, VALUE size_arg)
         return self;
     }
 
-    size = rm_to_s(size_arg);
+    size = rb_String(size_arg);
     sz = StringValueCStr(size);
     if (!IsGeometry(sz))
     {
@@ -2127,7 +2127,7 @@ Info_tile_offset_eq(VALUE self, VALUE offset)
     VALUE offset_str;
     char *tile_offset;
 
-    offset_str = rm_to_s(offset);
+    offset_str = rb_String(offset);
     tile_offset = StringValueCStr(offset_str);
     if (!IsGeometry(tile_offset))
     {

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -259,7 +259,6 @@ Init_RMagick2(void)
     rm_ID_new              = rb_intern("new");
     rm_ID_push             = rb_intern("push");
     rm_ID_to_i             = rb_intern("to_i");
-    rm_ID_to_s             = rb_intern("to_s");
     rm_ID_values           = rb_intern("values");
     rm_ID_width            = rb_intern("width");
 

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -223,7 +223,7 @@ Montage_frame_eq(VALUE self, VALUE frame_arg)
     VALUE frame;
 
     Data_Get_Struct(self, Montage, montage);
-    frame = rm_to_s(frame_arg);
+    frame = rb_String(frame_arg);
     magick_clone_string(&montage->info->frame, StringValueCStr(frame));
 
     RB_GC_GUARD(frame);
@@ -250,7 +250,7 @@ Montage_geometry_eq(VALUE self, VALUE geometry_arg)
     VALUE geometry;
 
     Data_Get_Struct(self, Montage, montage);
-    geometry = rm_to_s(geometry_arg);
+    geometry = rb_String(geometry_arg);
     magick_clone_string(&montage->info->geometry, StringValueCStr(geometry));
 
     RB_GC_GUARD(geometry);
@@ -411,7 +411,7 @@ Montage_tile_eq(VALUE self, VALUE tile_arg)
     VALUE tile;
 
     Data_Get_Struct(self, Montage, montage);
-    tile = rm_to_s(tile_arg);
+    tile = rb_String(tile_arg);
     magick_clone_string(&montage->info->tile, StringValueCStr(tile));
 
     RB_GC_GUARD(tile);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -306,26 +306,6 @@ rm_no_freeze(VALUE obj)
 
 
 /**
- * Return obj.to_s, or obj if obj is already a string.
- *
- * No Ruby usage (internal function)
- *
- * @param obj a Ruby object
- * @return a String representation of obj
- */
-VALUE
-rm_to_s(VALUE obj)
-{
-
-    if (TYPE(obj) != T_STRING)
-    {
-        return rb_funcall(obj, rm_ID_to_s, 0);
-    }
-    return obj;
-}
-
-
-/**
  * Supply our own version of the "obsolete" rb_str2cstr.
  *
  * No Ruby usage (internal function)


### PR DESCRIPTION
Because the same behavior function is implemented in Ruby core