### PR TITLE
Fix SEGV in rm_check_ary_len() with unexpected argument value

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4599,8 +4599,7 @@ Image_convolve_channel(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "order must be non-zero and positive");
     }
 
-    ary = argv[1];
-
+    ary = rb_Array(argv[1]);
     rm_check_ary_len(ary, (long)(order*order));
 
 #if defined(IMAGEMAGICK_7)
@@ -13356,6 +13355,7 @@ Image_store_pixels(VALUE self, VALUE x_arg, VALUE y_arg, VALUE cols_arg,
     }
 
     size = (long)(cols * rows);
+    new_pixels = rb_Array(new_pixels);
     rm_check_ary_len(new_pixels, size);
 
 #if defined(IMAGEMAGICK_7)

--- a/spec/rmagick/image/convolve_channel_spec.rb
+++ b/spec/rmagick/image/convolve_channel_spec.rb
@@ -15,5 +15,6 @@ RSpec.describe Magick::Image, '#convolve_channel' do
 
     expect { image.convolve_channel(order, kernel, Magick::RedChannel, Magick:: BlueChannel) }.not_to raise_error
     expect { image.convolve_channel(order, kernel, Magick::RedChannel, 2) }.to raise_error(TypeError)
+    expect { image.convolve_channel(order, 1234) }.to raise_error(IndexError)
   end
 end

--- a/spec/rmagick/image/store_pixels_spec.rb
+++ b/spec/rmagick/image/store_pixels_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Magick::Image, '#store_pixels' do
     expect { image.store_pixels(0, 0, 1 + image.columns, 1, pixels) }.to raise_error(RangeError)
     expect { image.store_pixels(-1, 0, 1, 1 + image.rows, pixels) }.to raise_error(RangeError)
     expect { image.store_pixels(0, 0, image.columns, 1, ['x']) }.to raise_error(IndexError)
+    expect { image.store_pixels(0, 0, image.columns, 1, 1234) }.to raise_error(IndexError)
   end
 
   it 'supports CMYK color' do


### PR DESCRIPTION
If non array object was given, rm_check_ary_len() will cause a SEGV.
So, this patch will convert object to Array implicitly.