### PR TITLE
Fix SEGV in Image#marshal_load

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8656,6 +8656,9 @@ Image_marshal_load(VALUE self, VALUE ary)
     filename = rb_ary_shift(ary);
     blob = rb_ary_shift(ary);
 
+    filename = StringValue(filename);
+    blob = StringValue(blob);
+
     exception = AcquireExceptionInfo();
     if (filename != Qnil)
     {

--- a/spec/rmagick/image/marshal_load_spec.rb
+++ b/spec/rmagick/image/marshal_load_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Magick::Image, '#marshal_load' do
+  it 'works' do
+    image1 = described_class.read('granite:').first
+    image2 = described_class.new(10, 10)
+    expect { image2.marshal_load(image1.marshal_dump) }.not_to raise_error
+    expect { image2.marshal_load([1234, 5678]) }.to raise_error(TypeError)
+  end
+end


### PR DESCRIPTION
If non String object was given, RSTRING_PTR() will cause a SEGV.

So, this patch will convert object to String implicitly.