### PR TITLE
Use rm_strcasecmp() for constant string instead

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1148,7 +1148,6 @@ extern void   rm_init_magickpixel(const Image *, MagickPixel *);
 extern void   rm_set_magickpixel(MagickPixel *, const char *);
 extern VALUE  rm_no_freeze(VALUE) ATTRIBUTE_NORETURN;
 extern int    rm_strcasecmp(const char *, const char *);
-extern int    rm_strncasecmp(const char *, const char *, size_t);
 extern size_t rm_strnlen_s(const char *, size_t);
 extern void   rm_check_ary_len(VALUE, long);
 extern VALUE  rm_check_ary_type(VALUE ary);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -158,36 +158,6 @@ rm_strcasecmp(const char *s1, const char *s2)
 
 
 /**
- * Compare s1 and s2 ignoring case.
- *
- * No Ruby usage (internal function)
- *
- * @param s1 the first string
- * @param s2 the second string
- * @param n number of characters to compare
- * @return same as strcmp(3)
- */
-int
-rm_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    if (n == 0)
-    {
-        return 0;
-    }
-    while (toupper(*s1) == toupper(*s2))
-    {
-        if (--n == 0 || *s1 == '\0')
-        {
-            return 0;
-        }
-        s1 += 1;
-        s2 += 1;
-    }
-    return (int)(*s1 - *s2);
-}
-
-
-/**
  * Get string length.
  *
  * No Ruby usage (internal function)
@@ -1276,7 +1246,7 @@ rm_exif_by_entry(Image *image)
     {
         // ignore properties that don't start with "exif:"
         property_l = rm_strnlen_s(property, MaxTextExtent);
-        if (property_l > 5 && rm_strncasecmp(property, "exif:", 5) == 0)
+        if (property_l > 5 && rm_strcasecmp(property, "exif:") == 0)
         {
             if (len > 0)
             {
@@ -1316,7 +1286,7 @@ rm_exif_by_entry(Image *image)
     while (property)
     {
         property_l = rm_strnlen_s(property, MaxTextExtent);
-        if (property_l > 5 && rm_strncasecmp(property, "exif:", 5) == 0)
+        if (property_l > 5 && rm_strcasecmp(property, "exif:") == 0)
         {
             if (len > 0)
             {


### PR DESCRIPTION
When comparing with a string constant with value of string length,
there is no need to check the string length because the length is fixed and there is no buffer overrun.