### PR TITLE
Use StringValueCStr() instead of RSTRING_PTR()

### DIFF
--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -322,7 +322,7 @@ rm_str2cstr(VALUE str, long *len)
     {
         *len = RSTRING_LEN(str);
     }
-    return RSTRING_PTR(str);
+    return StringValueCStr(str);
 }
 
 


### PR DESCRIPTION
RSTRING_PTR() returns a pointer of buffer in String object.
The buffer might not have null-terminate.

However, the pointer was passed into ImageMagick API without string length in somewhere.
It might cause a SEGV If it is unlucky.

This patch will ensure to return null-terminated Cstring.