### PR TITLE
CI: Use setup-ruby instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         restore-keys: |
           v1-macos-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: eregon/use-ruby-action@master
+      uses: ruby/setup-ruby@master
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Update/Install packages


### PR DESCRIPTION
Because `eregon/use-ruby-action` fails

https://github.com/rmagick/rmagick/pull/1182/checks?check_run_id=533577828