### PR TITLE
CI: Remove caching Ruby dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,13 +136,6 @@ jobs:
         choco install wget ghostscript
         wget $url --progress=dot
         cmd.exe /D /S /C "$($installer_name) /DIR=D:\ImageMagick /VERYSILENT /TASKS=install_Devel"
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v1
-      with:
-        path: ./vendor/bundle
-        key: v1-windows-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
-        restore-keys: |
-          v1-windows-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
     - name: Build and test with Rake
       run: |
         cmd.exe /D /S /C "SET MAKE=make & SET PATH=D:\ImageMagick;%PATH% & bundle install --path=vendor/bundle --retry 3 & bundle exec rake"


### PR DESCRIPTION
Error about cached directory. I don't know what caused it….

https://github.com/rmagick/rmagick/pull/1194/checks?check_run_id=561661438