### PR TITLE
Add workaround for FreeBSD that it isn't able to process PDF

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11049,7 +11049,7 @@ file_arg_rescue(VALUE arg, VALUE raised_exc ATTRIBUTE_UNUSED)
  * @see array_from_images
  */
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 void sig_handler(int sig ATTRIBUTE_UNUSED)
 {
 }
@@ -11097,7 +11097,7 @@ rd_image(VALUE class ATTRIBUTE_UNUSED, VALUE file, reader_t reader)
 
     exception = AcquireExceptionInfo();
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
     struct sigaction act, oldact;
     act.sa_handler = sig_handler;
     act.sa_flags = SA_RESTART;
@@ -11109,7 +11109,7 @@ rd_image(VALUE class ATTRIBUTE_UNUSED, VALUE file, reader_t reader)
 
     images = (reader)(info, exception);
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
     if (sigaction(SIGCHLD, &oldact, NULL) < 0)
     {
         rb_sys_fail("sigaction");


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/issues/483

```
$ rake
......

Failures:

  1) Magick::Image#read issue #483 can read PDF file
     Failure/Error: expect { described_class.read(File.join(FIXTURE_PATH, 'sample.pdf')) }.not_to raise_error

       expected no Exception, got #<Magick::ImageMagickError: FailedToExecuteCommand `'gs' -sstdout=%stderr -dQUIET -dSAFER -dBATCH -dN...6N_yZ6expfC7' '-f/tmp/magick-62170WQ3NHSoRCQb'' (-1) @ error/delegate.c/ExternalDelegateCommand/478> with backtrace:
         # ./spec/rmagick/image/read_spec.rb:32:in `read'
         # ./spec/rmagick/image/read_spec.rb:32:in `block (4 levels) in <top (required)>'
         # ./spec/rmagick/image/read_spec.rb:32:in `block (3 levels) in <top (required)>'
     # ./spec/rmagick/image/read_spec.rb:32:in `block (3 levels) in <top (required)>'

Finished in 24.13 seconds (files took 0.6694 seconds to load)
649 examples, 1 failure, 4 pending

$ uname -a
FreeBSD watson-ghostbsd-pc 12.1-STABLE FreeBSD 12.1-STABLE GENERIC  amd64
```