### PR TITLE
CI: Disable cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,6 @@ jobs:
       uses: ruby/setup-ruby@master
       with:
         ruby-version: 2.3
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v1
-      with:
-        path: ./vendor/bundle
-        key: v1-linux-2.3-${{ hashFiles('rmagick.gemspec') }}
-        restore-keys: |
-          v1-linux-2.3-${{ hashFiles('rmagick.gemspec') }}
     - name: Build and test with Rake
       run: |
         bundle install --path=vendor/bundle --jobs 4 --retry 3
@@ -45,13 +38,6 @@ jobs:
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v2
-    - name: Cache ImageMagick
-      uses: actions/cache@v1
-      with:
-        path: ./build-ImageMagick
-        key: v1-linux-imagemagick-${{ matrix.imagemagick-version.full }}
-        restore-keys: |
-          v1-linux-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@master
       with:
@@ -60,13 +46,6 @@ jobs:
       run: |
         export IMAGEMAGICK_VERSION=${{ matrix.imagemagick-version.full }}
         ./before_install_linux.sh
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v1
-      with:
-        path: ./vendor/bundle
-        key: v1-linux-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
-        restore-keys: |
-          v1-linux-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
     - name: Build and test with Rake
       run: |
         bundle install --path=vendor/bundle --jobs 4 --retry 3
@@ -84,13 +63,6 @@ jobs:
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v2
-    - name: Cache ImageMagick
-      uses: actions/cache@v1
-      with:
-        path: ./build-ImageMagick
-        key: v1-macos-imagemagick-${{ matrix.imagemagick-version.full }}
-        restore-keys: |
-          v1-macos-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@master
       with:
@@ -98,13 +70,6 @@ jobs:
     - name: Update/Install packages
       run: |
         IMAGEMAGICK_VERSION=${{ matrix.imagemagick-version.full }} ./before_install_osx.sh
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v1
-      with:
-        path: ./vendor/bundle
-        key: v1-macos-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
-        restore-keys: |
-          v1-macos-${{ matrix.ruby-version }}-${{ hashFiles('rmagick.gemspec') }}
     - name: Build and test with Rake
       run: |
         bundle install --path=vendor/bundle --jobs 4 --retry 3


### PR DESCRIPTION
Sometimes the cache breaks and the test fails.

https://github.com/rmagick/rmagick/runs/601806135

The test will continue to fail unless  we update the cache key or get rid of the broken cache..

So, This PR disable the cache action because it looks unstable.
(If it becomes stable, we can revert this PR)