### PR TITLE
Updated error messages if runtime ImageMagick version was not matched with when installed rmagick

### DIFF
--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1870,7 +1870,8 @@ test_Magick_version(void)
         }
 
         rb_raise(rb_eRuntimeError,
-                 "This installation of RMagick was configured with %s %s but %.*s is in use.\n" ,
+                 "This installation of RMagick was configured with %s %s but %.*s is in use.\n"
+                 "Please re-install RMagick to correct the issue.\n",
                  MagickPackageName, MagickLibVersionText, x, version_str);
     }
 


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/issues/1210

This patch will show the error message, like
```
$ ruby rmagick-sample.rb
Traceback (most recent call last):
	2: from rmagick.rb:1:in `<main>'
	1: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- rmagick (LoadError)
	9: from rmagick.rb:1:in `<main>'
	8: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:156:in `require'
	7: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `rescue in require'
	6: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `require'
	5: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rmagick-4.1.2/lib/rmagick.rb:1:in `<top (required)>'
	4: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	3: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	2: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rmagick-4.1.2/lib/rmagick_internal.rb:23:in `<top (required)>'
	1: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/Users/watson/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': This installation of RMagick was configured with ImageMagick 7.0.9 but ImageMagick 7.0.10-1 is in use. (RuntimeError)
Please re-install RMagick to get rid of this exception.
```

(Added last line "Please re-install RMagick to get rid of this exception." with this patch)