### PR TITLE
Fix assertion failed in Magick::TextureFill.new with with unexpected argument

### DIFF
--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -667,7 +667,10 @@ free_TextureFill(void *fill_obj)
     rm_TextureFill *fill = (rm_TextureFill *)fill_obj;
 
     // Do not trace destruction
-    DestroyImage(fill->texture);
+    if (fill->texture)
+    {
+        DestroyImage(fill->texture);
+    }
     xfree(fill);
 }
 

--- a/spec/rmagick/texture_fill/initialize_spec.rb
+++ b/spec/rmagick/texture_fill/initialize_spec.rb
@@ -9,4 +9,8 @@ RSpec.describe Magick::TextureFill, '#initialize' do
     image_list.new_image(10, 10)
     expect(described_class.new(image_list)).to be_instance_of(described_class)
   end
+
+  it 'raises an exception if an unexpected argument was given' do
+    expect { described_class.new([1]) }.to raise_error(NoMethodError)
+  end
 end


### PR DESCRIPTION
Fix #1215

If exception was raised in TextureFill.new,
rm_TextureFill structure might not be initialized properly.

Then, the assertion failed error will be occurred when destroy Image object
 in uninitialized structure member.