### PR TITLE
RSpec: Enable spec of Magick::Image#liquid_rescale

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -24,7 +24,7 @@ sudo apt-get autoremove -y imagemagick* libmagick* --purge
 # install build tools, ImageMagick delegates
 sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
   liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
-  libtiff5-dev libwebp-dev vim gsfonts ghostscript ccache
+  libtiff5-dev libwebp-dev liblqr-1-0-dev vim gsfonts ghostscript ccache
 
 if [ ! -d /usr/include/freetype ]; then
   # If `/usr/include/freetype` is not existed, ImageMagick 6.7 configuration fails about Freetype.

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -16,7 +16,7 @@ if [ ! -v IMAGEMAGICK_VERSION ]; then
 fi
 
 export HOMEBREW_NO_AUTO_UPDATE=true
-brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff libtool libxml2 zlib webp
+brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool libxml2 zlib webp
 
 export LDFLAGS="-L/usr/local/opt/libxml2/lib -L/usr/local/opt/zlib/li"
 export CPPFLAGS="-I/usr/local/opt/libxml2/include/libxml2 -I/usr/local/opt/zlib/include"

--- a/spec/rmagick/image/liquid_rescale_spec.rb
+++ b/spec/rmagick/image/liquid_rescale_spec.rb
@@ -1,6 +1,5 @@
 describe Magick::Image, '#liquid_rescale' do
   it 'works' do
-    skip "delegate library support not built-in ''"
     image = described_class.new(20, 20)
 
     begin


### PR DESCRIPTION
Magick::Image#liquid_rescale requires ImageMagick feature which need to install liblqr (http://liblqr.wikidot.com).

seems that Windows version of ImageMagick binary have liblqr as built-in.