### PR TITLE
Add messages to `unsupported_before` and `supported_before` helpers

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,12 +22,14 @@ FreezeError = RUBY_VERSION > '2.5' ? FrozenError : RuntimeError
 
 def unsupported_before(version, condition = {})
   cond = condition.key?(:if) ? condition[:if] : true
-  :skip if cond && Gem::Version.new(Magick::IMAGEMAGICK_VERSION) < Gem::Version.new(version)
+  message = "Unsupported before #{version}; running #{Magick::IMAGEMAGICK_VERSION}"
+  { skip: message } if cond && Gem::Version.new(Magick::IMAGEMAGICK_VERSION) < Gem::Version.new(version)
 end
 
 def supported_before(version, condition = {})
   cond = condition.key?(:if) ? condition[:if] : true
-  :skip if cond && Gem::Version.new(Magick::IMAGEMAGICK_VERSION) >= Gem::Version.new(version)
+  message = "Supported before #{version}; running #{Magick::IMAGEMAGICK_VERSION}"
+  { skip: message } if cond && Gem::Version.new(Magick::IMAGEMAGICK_VERSION) >= Gem::Version.new(version)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
The existing message doesn't give any context as to why it's skipped, so this adds some explanation.

**Before:**

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Magick::Image#channel_entropy raises an error on earlier versions
     # No reason given
     # ./spec/rmagick/image/channel_entropy_spec.rb:36
```

**After:**

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Magick::Image#channel_entropy raises an error on earlier versions
     # Supported before 6.9.0; running 7.0.10
     # ./spec/rmagick/image/channel_entropy_spec.rb:36
```