### PR TITLE
Flesh out changed_predicate_spec.

### DIFF
--- a/spec/rmagick/image/changed_predicate_spec.rb
+++ b/spec/rmagick/image/changed_predicate_spec.rb
@@ -1,11 +1,30 @@
 RSpec.describe Magick::Image, "#changed?" do
-  it "works" do
-    skip 'image is initially changed'
+  it "returns true when a new image is instantiated" do
+    image = described_class.new(2, 2)
 
-    image = described_class.new(20, 20)
+    expect(image.changed?).to be(true)
+  end
+
+  it "returns false after an image is loaded from disk" do
+    image = described_class.read(FLOWER_HAT).first
 
     expect(image.changed?).to be(false)
-    image.pixel_color(0, 0, 'red')
+  end
+
+  it "returns true when a pixel in the image was changed" do
+    image = described_class.read(FLOWER_HAT).first
+
+    image.import_pixels(0, 0, 1, 1, "RGB", [45, 98, 156])
+
+    expect(image.changed?).to be(true)
+  end
+
+  it "still returns true after it has been persisted" do
+    image = described_class.read(FLOWER_HAT).first
+
+    image.import_pixels(0, 0, 1, 1, "RGB", [45, 98, 156])
+    image.write("./tmp/test_changed_predicate.jpg")
+
     expect(image.changed?).to be(true)
   end
 end


### PR DESCRIPTION
Discovered that there is no way for an image to transition from changed to not changed.
Added a test to document this behavior by saving an image and verifying that `changed?` still returns true.