### PR TITLE
CI: Use ghostscript 9.50 on Windows to avoid command exection failure in ImageMagick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
         $imagemagick_version_without_patch = $imagemagick_version.split("-")[0]
         $installer_name = "ImageMagick-$($imagemagick_version)-Q16-x64-dll.exe"
         $url = "https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/$($installer_name)"
-        choco install wget ghostscript
+        choco install wget
+        choco install ghostscript -Version 9.50
         wget $url --progress=dot
         cmd.exe /D /S /C "$($installer_name) /DIR=D:\ImageMagick /VERYSILENT /TASKS=install_Devel"
     - name: Build and test with Rake


### PR DESCRIPTION
Related to https://github.com/rmagick/rmagick/runs/1106626777

```
  1) Magick::Image#read issue #483 can read PDF file
     Failure/Error: expect { described_class.read(File.join(FIXTURE_PATH, 'sample.pdf')) }.not_to raise_error
     
       expected no Exception, got #<Magick::ImageMagickError: FailedToExecuteCommand `"gswin64c.exe" -q -dQUIET -dSAFER -dBATCH -dNOPAU...TuB"' (The system cannot find the file specified.

       ) @ error/delegate.c/ExternalDelegateCommand/475> with backtrace:
         # ./spec/rmagick/image/read_spec.rb:13:in `read'
         # ./spec/rmagick/image/read_spec.rb:13:in `block (4 levels) in <top (required)>'
         # ./spec/rmagick/image/read_spec.rb:13:in `block (3 levels) in <top (required)>'
     # ./spec/rmagick/image/read_spec.rb:13:in `block (3 levels) in <top (required)>'
```