### PR TITLE
RSpec: Remove MPEG format because it was renamed at 6.9.11-31 and 7.0.10-31

### DIFF
--- a/spec/rmagick/image/format_spec.rb
+++ b/spec/rmagick/image/format_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Magick::Image, '#format' do
     expect { image.format = 'JPG' }.not_to raise_error
     expect { image.format = 'TIFF' }.not_to raise_error
     expect { image.format = 'MIFF' }.not_to raise_error
-    expect { image.format = 'MPEG' }.not_to raise_error
     v = $VERBOSE
     $VERBOSE = nil
     expect { image.format = 'shit' }.to raise_error(ArgumentError)


### PR DESCRIPTION
The test code checks whether if #format= works properly.
 The format name is not so important in there.

So, this RP removed the code.

See: https://github.com/rmagick/rmagick/pull/1231#issuecomment-702759185