### PR TITLE
Improve Image#resize performance with ImageMagick 7

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11660,9 +11660,12 @@ resize(int bang, int argc, VALUE *argv, VALUE self)
 
     exception = AcquireExceptionInfo();
 #if defined(IMAGEMAGICK_7)
-    Image *preprocess = blurred_image(image, blur);
+    Image *preprocess = (argc == 4) ? blurred_image(image, blur) : image;
     new_image = ResizeImage(preprocess, columns, rows, filter, exception);
-    DestroyImage(preprocess);
+    if (argc == 4)
+    {
+        DestroyImage(preprocess);
+    }
 #else
     new_image = ResizeImage(image, columns, rows, filter, blur, exception);
 #endif


### PR DESCRIPTION
Seems that it takes time in blur process.
So, this PR will apply blur only if necessary.

When it resize the image without blur, it reduce time to 1/2.

## Test code
```ruby
require 'rmagick'
require 'benchmark/ips'

puts Magick::Long_version
Benchmark.ips do |x|
  image = Magick::ImageList.new('./Flower_Hat.jpg').first

  x.report("resize") do
    image.resize(150, 150)
  end
end
```

## Before
### With ImageMagick 6
```
This is RMagick 4.1.2 ($Date: 2009/12/20 02:33:33 $) Copyright (C) 2009 by Timothy P. Hunter
Built with ImageMagick 6.9.11-18 Q16 x86_64 2020-06-24 https://imagemagick.org
Built for ruby 2.7.2
Web page: http://rmagick.rubyforge.org
Email: rmagick@rubyforge.org
Warming up --------------------------------------
              resize    22.000  i/100ms
Calculating -------------------------------------
              resize    231.228  (± 2.6%) i/s -      1.166k in   5.046703s
```

### With ImageMagick 7
```
This is RMagick 4.1.2 ($Date: 2009/12/20 02:33:33 $) Copyright (C) 2009 by Timothy P. Hunter
Built with ImageMagick 7.0.10-31 Q16 x86_64 2020-10-02 https://imagemagick.org
Built for ruby 3.0.0
Web page: http://rmagick.rubyforge.org
Email: rmagick@rubyforge.org
Warming up --------------------------------------
              resize     4.000  i/100ms
Calculating -------------------------------------
              resize     43.789  (± 4.6%) i/s -    220.000  in   5.035119s
```

## After
### With ImageMagick 7
```
This is RMagick 4.1.2 ($Date: 2009/12/20 02:33:33 $) Copyright (C) 2009 by Timothy P. Hunter
Built with ImageMagick 7.0.10-31 Q16 x86_64 2020-10-02 https://imagemagick.org
Built for ruby 3.0.0
Web page: http://rmagick.rubyforge.org
Email: rmagick@rubyforge.org
Warming up --------------------------------------
              resize     7.000  i/100ms
Calculating -------------------------------------
              resize     83.608  (± 4.8%) i/s -    420.000  in   5.033079s
```