### PR TITLE
Flesh out specs for Image#chromaticity, chromaticity=

### DIFF
--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -605,7 +605,7 @@ VALUE
 Import_PrimaryInfo(PrimaryInfo *p)
 {
     return rb_funcall(Class_Primary, rm_ID_new, 3,
-                      INT2FIX(p->x), INT2FIX(p->y), INT2FIX(p->z));
+                      rb_float_new(p->x), rb_float_new(p->y), rb_float_new(p->z));
 }
 
 

--- a/spec/rmagick/image/chromaticity_spec.rb
+++ b/spec/rmagick/image/chromaticity_spec.rb
@@ -1,23 +1,31 @@
 RSpec.describe Magick::Image, '#chromaticity' do
-  it 'works' do
-    image = described_class.new(100, 100)
+  it "returns an assigned chromaticity" do
+    image = build_image
 
-    chrom = image.chromaticity
-    expect { image.chromaticity }.not_to raise_error
-    expect(chrom).to be_instance_of(Magick::Chromaticity)
-    expect(chrom.red_primary.x).to eq(0)
-    expect(chrom.red_primary.y).to eq(0)
-    expect(chrom.red_primary.z).to eq(0)
-    expect(chrom.green_primary.x).to eq(0)
-    expect(chrom.green_primary.y).to eq(0)
-    expect(chrom.green_primary.z).to eq(0)
-    expect(chrom.blue_primary.x).to eq(0)
-    expect(chrom.blue_primary.y).to eq(0)
-    expect(chrom.blue_primary.z).to eq(0)
-    expect(chrom.white_point.x).to eq(0)
-    expect(chrom.white_point.y).to eq(0)
-    expect(chrom.white_point.z).to eq(0)
-    expect { image.chromaticity = chrom }.not_to raise_error
-    expect { image.chromaticity = 2 }.to raise_error(TypeError)
+    red_primary = Magick::Primary.new(70, 200, 0)
+    green_primary = Magick::Primary.new(200, 44, 0)
+    blue_primary = Magick::Primary.new(60, 22, 0)
+    white_point = Magick::Primary.new(77, 43, 0)
+    chromaticity = Magick::Chromaticity.new(red_primary, green_primary, blue_primary, white_point)
+    image.chromaticity = chromaticity
+
+    expect(image.chromaticity.red_primary).to eq(red_primary)
+    expect(image.chromaticity.green_primary).to eq(green_primary)
+    expect(image.chromaticity.blue_primary).to eq(blue_primary)
+    expect(image.chromaticity.white_point).to eq(white_point)
+  end
+
+  it "returns default chromaticity values" do
+    image = build_image
+
+    red_primary = Magick::Primary.new(0.6399999856948853, 0.33000001311302185, 0.029999999329447746)
+    green_primary = Magick::Primary.new(0.30000001192092896, 0.6000000238418579, 0.10000000149011612)
+    blue_primary = Magick::Primary.new(0.15000000596046448, 0.05999999865889549, 0.7900000214576721)
+    white_point = Magick::Primary.new(0.3127000033855438, 0.32899999618530273, 0.35830000042915344)
+
+    expect(image.chromaticity.red_primary).to eq(red_primary)
+    expect(image.chromaticity.green_primary).to eq(green_primary)
+    expect(image.chromaticity.blue_primary).to eq(blue_primary)
+    expect(image.chromaticity.white_point).to eq(white_point)
   end
 end

--- a/spec/rmagick/image/chromaticity_writer_spec.rb
+++ b/spec/rmagick/image/chromaticity_writer_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Magick::Image, '#chromaticity=' do
+  it "allows setting the chromaticity" do
+    image = build_image
+
+    red_primary = Magick::Primary.new(70, 200, 0)
+    green_primary = Magick::Primary.new(200, 44, 0)
+    blue_primary = Magick::Primary.new(60, 22, 0)
+    white_point = Magick::Primary.new(77, 43, 0)
+    chromaticity = Magick::Chromaticity.new(red_primary, green_primary, blue_primary, white_point)
+    image.chromaticity = chromaticity
+
+    expect(image.chromaticity.red_primary).to eq(red_primary)
+    expect(image.chromaticity.green_primary).to eq(green_primary)
+    expect(image.chromaticity.blue_primary).to eq(blue_primary)
+    expect(image.chromaticity.white_point).to eq(white_point)
+  end
+
+  it "sets the z values to 0" do
+    image = build_image
+
+    chromaticity = Magick::Chromaticity.new(
+      Magick::Primary.new(70, 200, 50),
+      Magick::Primary.new(200, 44, 33),
+      Magick::Primary.new(60, 22, 1),
+      Magick::Primary.new(77, 43, 122)
+    )
+    image.chromaticity = chromaticity
+
+    expected_red_primary = Magick::Primary.new(70, 200, 0)
+    expected_green_primary = Magick::Primary.new(200, 44, 0)
+    expected_blue_primary = Magick::Primary.new(60, 22, 0)
+    expected_white_point = Magick::Primary.new(77, 43, 0)
+    expect(image.chromaticity.red_primary).to eq(expected_red_primary)
+    expect(image.chromaticity.green_primary).to eq(expected_green_primary)
+    expect(image.chromaticity.blue_primary).to eq(expected_blue_primary)
+    expect(image.chromaticity.white_point).to eq(expected_white_point)
+  end
+end


### PR DESCRIPTION
We discovered weird behavior with chromaticity where it loses the floating point values. This seemed wrong so we changed the function `Import_PrimaryInfo` in
`rmstruct.c` from an integer conversion to a floating point conversion. This function is only used when instantiating a new chromaticity.

We have questions:

* Should this be floating point?
* Why are the numbers different in the test (`0.64` comes out as `0.63999998...`)
* Why are the z values of the `Primary` objects being set to 0 in `Export_ChromaticityInfo`?