### PR TITLE
Ci: Update ImageMagick version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         imagemagick-version:
           - { full: 6.7.7-10, major-minor: '6.7' }
           - { full: 6.8.9-10, major-minor: '6.8' }
-          - { full: 6.9.11-23, major-minor: '6.9' }
-          - { full: 7.0.10-23, major-minor: '7.0' }
+          - { full: 6.9.11-34, major-minor: '6.9' }
+          - { full: 7.0.10-34, major-minor: '7.0' }
 
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
@@ -58,8 +58,8 @@ jobs:
       matrix:
         ruby-version: [2.6, 2.7]
         imagemagick-version:
-          - { full: 6.9.11-23, major-minor: '6.9' }
-          - { full: 7.0.10-23, major-minor: '7.0' }
+          - { full: 6.9.11-34, major-minor: '6.9' }
+          - { full: 7.0.10-34, major-minor: '7.0' }
 
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
@@ -84,8 +84,8 @@ jobs:
         ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
         imagemagick-version:
           - { full: 6.8.9-10, major-minor: '6.8' }
-          - { full: 6.9.11-23, major-minor: '6.9' }
-          - { full: 7.0.10-23, major-minor: '7.0' }
+          - { full: 6.9.11-29, major-minor: '6.9' } # seems that binary file mirroring have stopped.
+          - { full: 7.0.10-29, major-minor: '7.0' } # seems that binary file mirroring have stopped.
     name: MSWin, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Seems that the mirroring of the Windows installer file has stopped at https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/ .
I have stopped updating the latest version of Windows.
