### PR TITLE
Avoid crash with monitor feature on Ruby 3.0 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0']
         imagemagick-version:
           - { full: 6.7.7-10, major-minor: '6.7' }
           - { full: 6.8.9-10, major-minor: '6.8' }
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0]
+        ruby-version: [2.6, 2.7, '3.0']
         imagemagick-version:
           - { full: 6.9.11-34, major-minor: '6.9' }
           - { full: 7.0.10-34, major-minor: '7.0' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0']
         imagemagick-version:
           - { full: 6.8.9-10, major-minor: '6.8' }
           - { full: 6.9.11-29, major-minor: '6.9' } # seems that binary file mirroring have stopped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby 2.3
       uses: ruby/setup-ruby@master
       with:
-        ruby-version: 2.3
+        ruby-version: '2.3'
     - name: Build and test with Rake
       run: |
         bundle install --path=vendor/bundle --jobs 4 --retry 3
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
         imagemagick-version:
           - { full: 6.7.7-10, major-minor: '6.7' }
           - { full: 6.8.9-10, major-minor: '6.8' }
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, '3.0']
+        ruby-version: ['2.6', '2.7', '3.0']
         imagemagick-version:
           - { full: 6.9.11-34, major-minor: '6.9' }
           - { full: 7.0.10-34, major-minor: '7.0' }
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
         imagemagick-version:
           - { full: 6.8.9-10, major-minor: '6.8' }
           - { full: 6.9.11-29, major-minor: '6.9' } # seems that binary file mirroring have stopped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
         imagemagick-version:
           - { full: 6.7.7-10, major-minor: '6.7' }
           - { full: 6.8.9-10, major-minor: '6.8' }
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7]
+        ruby-version: [2.6, 2.7, 3.0]
         imagemagick-version:
           - { full: 6.9.11-34, major-minor: '6.9' }
           - { full: 7.0.10-34, major-minor: '7.0' }

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -411,6 +411,8 @@ EXTERN ID rm_ID_push;              /**< "push" */
 EXTERN ID rm_ID_values;            /**< "values" */
 EXTERN ID rm_ID_width;             /**< "width" */
 
+EXTERN unsigned long long rm_main_thread_id;
+
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */
 #endif
@@ -1197,6 +1199,7 @@ extern void   rm_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_warning_handler(const ExceptionType, const char *, const char *);
 extern MagickBooleanType rm_should_raise_exception(ExceptionInfo *, const ExceptionRetention);
 extern void   rm_raise_exception(ExceptionInfo *);
+extern unsigned long long rm_current_thread_id();
 #if defined(IMAGEMAGICK_6)
 extern void   rm_check_image_exception(Image *, ErrorRetention);
 #endif

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -242,6 +242,8 @@ Init_RMagick2(void)
 
     test_Magick_version();
 
+    rm_main_thread_id = rm_current_thread_id();
+
     /*-----------------------------------------------------------------------*/
     /* Create IDs for frequently used methods, etc.                          */
     /*-----------------------------------------------------------------------*/


### PR DESCRIPTION
Seems that ImageMagick might call back in a different thread than Ruby is running in.
If it is a different thread, it would not have a Ruby GVL and it could not retrieve properly Ruby stack.

Unfortunately, there is no API available to check if the current thread has a GVL, so the thread id was checked in here.

There is a private API to check whether the current thread has a GVL :(
https://github.com/ruby/ruby/blob/06b44f819eb7b5ede1ff69cecb25682b56a1d60c/thread.c#L1908-L1919



Related to https://github.com/rmagick/rmagick/issues/464