### PR TITLE
CI: Add mswin environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', 'mswin']
         imagemagick-version:
           - { full: 6.8.9-10, major-minor: '6.8' }
           - { full: 6.9.11-29, major-minor: '6.9' } # seems that binary file mirroring have stopped.


### PR DESCRIPTION
Add mswin to ensure to conform the running on Ruby environment built with the Visual Studio compiler tool chain.