### PR TITLE
CI: Remove rmagick.h from forced recompile checking

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -358,7 +358,7 @@ module RMagick
       $defs = []
 
       # Force re-compilation if the generated Makefile changed.
-      $config_h = 'Makefile rmagick.h'
+      $config_h = 'Makefile'
 
       create_makefile('RMagick2')
       print_summary


### PR DESCRIPTION
Because if there is `rmagick.h` in the list of files to be force recompile,
the build will fail before running tests with `rake test` in mswin environment.

This PR will fix error in https://github.com/rmagick/rmagick/runs/1636694056
(See https://github.com/rmagick/rmagick/pull/1254)