### PR TITLE
Fix compilation with optimization on glibc

### DIFF
--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -12,6 +12,11 @@
 
 #include "rmagick.h"
 #include <errno.h>
+#if defined(_WIN32)
+#include <Windows.h>
+#else
+#include <pthread.h>
+#endif
 
 static VALUE rescue_not_str(VALUE, VALUE ATTRIBUTE_UNUSED) ATTRIBUTE_NORETURN;
 static void handle_exception(ExceptionInfo *, Image *, ErrorRetention);
@@ -1889,10 +1894,8 @@ unsigned long long
 rm_current_thread_id()
 {
 #if defined(_WIN32)
-#include <Windows.h>
     return (unsigned long long)GetCurrentThreadId();
 #else
-#include <pthread.h>
     return (unsigned long long)pthread_self();
 #endif
 }


### PR DESCRIPTION
At least with glibc 2.32, compiling with -O2 causes the following error:
```
In file included from /usr/include/features.h:465,
                 from /usr/include/assert.h:35,
                 from rmagick.h:19,
                 from rmutil.c:13:
/usr/include/pthread.h: In function 'rm_current_thread_id':
/usr/include/pthread.h:1180:1: error: nested function 'pthread_equal' declared 'extern'
 1180 | __NTH (pthread_equal (pthread_t __thread1, pthread_t __thread2))
      | ^~~~~
/usr/include/pthread.h:1180:1: error: static declaration of 'pthread_equal' follows non-static declaration
In file included from rmutil.c:1895:
/usr/include/pthread.h:255:12: note: previous declaration of 'pthread_equal' was here
  255 | extern int pthread_equal (pthread_t __thread1, pthread_t __thread2)
      |            ^~~~~~~~~~~~~
make: *** [Makefile:245: rmutil.o] Error 1
```

This is because with optimization, glibc headers defines some inline functions, and
including such header in the body of function causes defined inline functions looking
like nested function being defined, which causes the above error.

The fix is to move the inclusion of system headers to the top of source file.

closes #1262