### PR TITLE
CI: add workflow_dispatch CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
This doesn't seem like a huge deal, but I came across this
[`workflow_dispatch` trigger][trigger] for Github Actions that allows
you to trigger a build manually through the interface.

I also changed the `pull_request` setting to trigger for all branches,
not just PRs to `main`. Also not a big deal, since I don't think we've
made a PR to another branch in a while.

[trigger]: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/