### PR TITLE
Remove deprecation warning about block syntax

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -856,7 +856,6 @@ VALUE Draw_annotate(
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1397,7 +1396,6 @@ DrawOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1469,7 +1467,6 @@ PolaroidOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -448,7 +448,6 @@ ImageList_montage(VALUE self)
         // object's attributes.
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, montage_obj);
         }
         else

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2417,7 +2417,6 @@ Info_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1008,7 +1008,6 @@ rm_get_optional_arguments(VALUE img)
 
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
-            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, opt_args);
         }
         else


### PR DESCRIPTION
Fixes #1270

There are a lot of references to `self.` [still in the RMagick
codebase][still] and documentation, so until we get around to cleaning
all of that up and testing it we can remove the deprecation to avoid
creating a lot of noise in people's logs for things they have no control
over.

[still]: https://github.com/rmagick/rmagick/issues/1270
