### PR TITLE
Replaced block that does not receive arguments

### DIFF
--- a/doc/ex/bounding_box.rb
+++ b/doc/ex/bounding_box.rb
@@ -1,6 +1,6 @@
 require 'rmagick'
 
-img = Magick::Image.new(200, 200) { self.background_color = '#ffffcc' }
+img = Magick::Image.new(200, 200) { |e| e.background_color = '#ffffcc' }
 
 # Draw a blue circle.
 gc = Magick::Draw.new

--- a/doc/ex/bounding_box.rb
+++ b/doc/ex/bounding_box.rb
@@ -1,6 +1,6 @@
 require 'rmagick'
 
-img = Magick::Image.new(200, 200) { |e| e.background_color = '#ffffcc' }
+img = Magick::Image.new(200, 200) { |info| info.background_color = '#ffffcc' }
 
 # Draw a blue circle.
 gc = Magick::Draw.new

--- a/doc/ex/channel.rb
+++ b/doc/ex/channel.rb
@@ -11,13 +11,13 @@ imgs.cur_image['Label'] = 'GreenChannel'
 imgs << img.channel(Magick::BlueChannel)
 imgs.cur_image['Label'] = 'BlueChannel'
 
-result = imgs.montage do |e|
-  e.tile = '2x2'
-  e.background_color = 'black'
-  e.stroke = 'transparent'
-  e.fill = 'white'
-  e.pointsize = 9
-  e.geometry = Magick::Geometry.new(img.columns / 2, img.rows / 2, 5, 5)
+result = imgs.montage do |options|
+  options.tile = '2x2'
+  options.background_color = 'black'
+  options.stroke = 'transparent'
+  options.fill = 'white'
+  options.pointsize = 9
+  options.geometry = Magick::Geometry.new(img.columns / 2, img.rows / 2, 5, 5)
 end
 
 result.write('channel.jpg')

--- a/doc/ex/channel.rb
+++ b/doc/ex/channel.rb
@@ -11,13 +11,13 @@ imgs.cur_image['Label'] = 'GreenChannel'
 imgs << img.channel(Magick::BlueChannel)
 imgs.cur_image['Label'] = 'BlueChannel'
 
-result = imgs.montage do
-  self.tile = '2x2'
-  self.background_color = 'black'
-  self.stroke = 'transparent'
-  self.fill = 'white'
-  self.pointsize = 9
-  self.geometry = Magick::Geometry.new(img.columns / 2, img.rows / 2, 5, 5)
+result = imgs.montage do |e|
+  e.tile = '2x2'
+  e.background_color = 'black'
+  e.stroke = 'transparent'
+  e.fill = 'white'
+  e.pointsize = 9
+  e.geometry = Magick::Geometry.new(img.columns / 2, img.rows / 2, 5, 5)
 end
 
 result.write('channel.jpg')

--- a/doc/ex/coalesce.rb
+++ b/doc/ex/coalesce.rb
@@ -15,8 +15,8 @@ end
 
 # Create a image that will hold the alphabet images in 5 rows and 5 columns.
 cells = Magick::ImageList.new
-cells.new_image buttons.columns * 5, buttons.rows * 5 do
-  self.background_color = '#000000ff' # transparent
+cells.new_image buttons.columns * 5, buttons.rows * 5 do |e|
+  e.background_color = '#000000ff' # transparent
 end
 cells.alpha(Magick::ActivateAlphaChannel)
 

--- a/doc/ex/coalesce.rb
+++ b/doc/ex/coalesce.rb
@@ -15,8 +15,8 @@ end
 
 # Create a image that will hold the alphabet images in 5 rows and 5 columns.
 cells = Magick::ImageList.new
-cells.new_image buttons.columns * 5, buttons.rows * 5 do |e|
-  e.background_color = '#000000ff' # transparent
+cells.new_image buttons.columns * 5, buttons.rows * 5 do |options|
+  options.background_color = '#000000ff' # transparent
 end
 cells.alpha(Magick::ActivateAlphaChannel)
 

--- a/doc/ex/color_fill_to_border.rb
+++ b/doc/ex/color_fill_to_border.rb
@@ -2,9 +2,9 @@ require 'rmagick'
 
 # Demonstrate the Image#color_fill_to_border method
 
-before = Magick::Image.new(200, 200) do
-  self.background_color = 'white'
-  self.border_color = 'black'
+before = Magick::Image.new(200, 200) do |e|
+  e.background_color = 'white'
+  e.border_color = 'black'
 end
 before.border!(1, 1, 'black')
 

--- a/doc/ex/color_fill_to_border.rb
+++ b/doc/ex/color_fill_to_border.rb
@@ -2,9 +2,9 @@ require 'rmagick'
 
 # Demonstrate the Image#color_fill_to_border method
 
-before = Magick::Image.new(200, 200) do |e|
-  e.background_color = 'white'
-  e.border_color = 'black'
+before = Magick::Image.new(200, 200) do |options|
+  options.background_color = 'white'
+  options.border_color = 'black'
 end
 before.border!(1, 1, 'black')
 

--- a/doc/ex/color_floodfill.rb
+++ b/doc/ex/color_floodfill.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Image#color_floodfill method
 
-before = Magick::Image.new(200, 200) { |e| e.background_color = 'white' }
+before = Magick::Image.new(200, 200) { |info| info.background_color = 'white' }
 before.border!(1, 1, 'black')
 
 circle = Magick::Draw.new

--- a/doc/ex/color_floodfill.rb
+++ b/doc/ex/color_floodfill.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Image#color_floodfill method
 
-before = Magick::Image.new(200, 200) { self.background_color = 'white' }
+before = Magick::Image.new(200, 200) { |e| e.background_color = 'white' }
 before.border!(1, 1, 'black')
 
 circle = Magick::Draw.new

--- a/doc/ex/color_histogram.rb
+++ b/doc/ex/color_histogram.rb
@@ -31,10 +31,10 @@ canvas = Magick::Image.new(NUM_COLORS, HIST_HEIGHT, hatch)
 gc.draw(canvas)
 
 text = Magick::Draw.new
-text.annotate(canvas, 0, 0, 0, 20, "Color Frequency\nHistogram") do
-  self.pointsize = 10
-  self.gravity = Magick::NorthGravity
-  self.stroke = 'transparent'
+text.annotate(canvas, 0, 0, 0, 20, "Color Frequency\nHistogram") do |e|
+  e.pointsize = 10
+  e.gravity = Magick::NorthGravity
+  e.stroke = 'transparent'
 end
 
 canvas.border!(1, 1, 'white')

--- a/doc/ex/color_histogram.rb
+++ b/doc/ex/color_histogram.rb
@@ -31,10 +31,10 @@ canvas = Magick::Image.new(NUM_COLORS, HIST_HEIGHT, hatch)
 gc.draw(canvas)
 
 text = Magick::Draw.new
-text.annotate(canvas, 0, 0, 0, 20, "Color Frequency\nHistogram") do |e|
-  e.pointsize = 10
-  e.gravity = Magick::NorthGravity
-  e.stroke = 'transparent'
+text.annotate(canvas, 0, 0, 0, 20, "Color Frequency\nHistogram") do |options|
+  options.pointsize = 10
+  options.gravity = Magick::NorthGravity
+  options.stroke = 'transparent'
 end
 
 canvas.border!(1, 1, 'white')

--- a/doc/ex/color_reset.rb
+++ b/doc/ex/color_reset.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Image#color_reset! method
 
-f = Magick::Image.new(100, 100) { |e| e.background_color = 'white' }
+f = Magick::Image.new(100, 100) { |info| info.background_color = 'white' }
 red = Magick::Pixel.from_color('red')
 f.color_reset!(red)
 # f.display

--- a/doc/ex/color_reset.rb
+++ b/doc/ex/color_reset.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Image#color_reset! method
 
-f = Magick::Image.new(100, 100) { self.background_color = 'white' }
+f = Magick::Image.new(100, 100) { |e| e.background_color = 'white' }
 red = Magick::Pixel.from_color('red')
 f.color_reset!(red)
 # f.display

--- a/doc/ex/colors.rb
+++ b/doc/ex/colors.rb
@@ -15,9 +15,9 @@ puts("\tCreating color swatches...")
 # Label with the name, RGB values, and compliance type.
 colors do |c|
   if c.name !~ /grey/ # omit SVG 'grays'
-    colors.new_image(200, 25) do |e|
-      e.background_color = c.color
-      e.border_color = 'gray50'
+    colors.new_image(200, 25) do |options|
+      options.background_color = c.color
+      options.border_color = 'gray50'
     end
     rgb  = sprintf('#%02x%02x%02x', c.color.red & 0xff, c.color.green & 0xff, c.color.blue & 0xff)
     rgb += sprintf('%02x', c.color.alpha & 0xff) if c.color.alpha != Magick::QuantumRange
@@ -30,25 +30,25 @@ puts("\tCreating montage...")
 
 # Montage. Each image will have 40 tiles.
 # There will be 16 images.
-montage = colors.montage do |e|
-  e.geometry = '200x25+10+5'
-  e.gravity = CenterGravity
-  e.tile = '4x10'
-  e.background_color = 'black'
-  e.border_width = 1
-  e.fill = 'white'
-  e.stroke = 'transparent'
+montage = colors.montage do |options|
+  options.geometry = '200x25+10+5'
+  options.gravity = CenterGravity
+  options.tile = '4x10'
+  options.background_color = 'black'
+  options.border_width = 1
+  options.fill = 'white'
+  options.stroke = 'transparent'
 end
 
 # Add the title at the top, over the 'null:'
 # tiles we added at the very beginning.
 title = Draw.new
-title.annotate(montage, 0, 0, 0, 20, 'Named Colors') do |e|
-  e.fill = 'white'
-  e.stroke = 'transparent'
-  e.pointsize = 32
-  e.font_weight = BoldWeight
-  e.gravity = NorthGravity
+title.annotate(montage, 0, 0, 0, 20, 'Named Colors') do |options|
+  options.fill = 'white'
+  options.stroke = 'transparent'
+  options.pointsize = 32
+  options.font_weight = BoldWeight
+  options.gravity = NorthGravity
 end
 
 puts("\tWriting ./colors.miff")

--- a/doc/ex/colors.rb
+++ b/doc/ex/colors.rb
@@ -15,9 +15,9 @@ puts("\tCreating color swatches...")
 # Label with the name, RGB values, and compliance type.
 colors do |c|
   if c.name !~ /grey/ # omit SVG 'grays'
-    colors.new_image(200, 25) do
-      self.background_color = c.color
-      self.border_color = 'gray50'
+    colors.new_image(200, 25) do |e|
+      e.background_color = c.color
+      e.border_color = 'gray50'
     end
     rgb  = sprintf('#%02x%02x%02x', c.color.red & 0xff, c.color.green & 0xff, c.color.blue & 0xff)
     rgb += sprintf('%02x', c.color.alpha & 0xff) if c.color.alpha != Magick::QuantumRange
@@ -30,25 +30,25 @@ puts("\tCreating montage...")
 
 # Montage. Each image will have 40 tiles.
 # There will be 16 images.
-montage = colors.montage do
-  self.geometry = '200x25+10+5'
-  self.gravity = CenterGravity
-  self.tile = '4x10'
-  self.background_color = 'black'
-  self.border_width = 1
-  self.fill = 'white'
-  self.stroke = 'transparent'
+montage = colors.montage do |e|
+  e.geometry = '200x25+10+5'
+  e.gravity = CenterGravity
+  e.tile = '4x10'
+  e.background_color = 'black'
+  e.border_width = 1
+  e.fill = 'white'
+  e.stroke = 'transparent'
 end
 
 # Add the title at the top, over the 'null:'
 # tiles we added at the very beginning.
 title = Draw.new
-title.annotate(montage, 0, 0, 0, 20, 'Named Colors') do
-  self.fill = 'white'
-  self.stroke = 'transparent'
-  self.pointsize = 32
-  self.font_weight = BoldWeight
-  self.gravity = NorthGravity
+title.annotate(montage, 0, 0, 0, 20, 'Named Colors') do |e|
+  e.fill = 'white'
+  e.stroke = 'transparent'
+  e.pointsize = 32
+  e.font_weight = BoldWeight
+  e.gravity = NorthGravity
 end
 
 puts("\tWriting ./colors.miff")

--- a/doc/ex/compose_mask.rb
+++ b/doc/ex/compose_mask.rb
@@ -1,18 +1,18 @@
 require 'rmagick'
 
 background = Magick::Image.read('images/Flower_Hat.jpg').first
-source = Magick::Image.read('pattern:checkerboard') { |e| e.size = "#{background.columns}x#{background.rows}" }.first
+source = Magick::Image.read('pattern:checkerboard') { |options| options.size = "#{background.columns}x#{background.rows}" }.first
 mask = Magick::Image.new(background.columns, background.rows) { |info| info.background_color = 'black' }
 
 # Make a mask
 gc = Magick::Draw.new
-gc.annotate(mask, 0, 0, 0, 0, 'Ruby') do |e|
-  e.gravity = Magick::CenterGravity
-  e.pointsize = 100
-  e.rotation = 90
-  e.font_weight = Magick::BoldWeight
-  e.fill = 'white'
-  e.stroke = 'none'
+gc.annotate(mask, 0, 0, 0, 0, 'Ruby') do |options|
+  options.gravity = Magick::CenterGravity
+  options.pointsize = 100
+  options.rotation = 90
+  options.font_weight = Magick::BoldWeight
+  options.fill = 'white'
+  options.stroke = 'none'
 end
 
 background.add_compose_mask(mask)

--- a/doc/ex/compose_mask.rb
+++ b/doc/ex/compose_mask.rb
@@ -1,12 +1,12 @@
 require 'rmagick'
 
 background = Magick::Image.read('images/Flower_Hat.jpg').first
-source = Magick::Image.read('pattern:checkerboard') { self.size = "#{background.columns}x#{background.rows}" }.first
-mask = Magick::Image.new(background.columns, background.rows) { self.background_color = 'black' }
+source = Magick::Image.read('pattern:checkerboard') { |e| e.size = "#{background.columns}x#{background.rows}" }.first
+mask = Magick::Image.new(background.columns, background.rows) { |e| e.background_color = 'black' }
 
 # Make a mask
 gc = Magick::Draw.new
-gc.annotate(mask, 0, 0, 0, 0, 'Ruby') do
+gc.annotate(mask, 0, 0, 0, 0, 'Ruby') do |e|
   gc.gravity = Magick::CenterGravity
   gc.pointsize = 100
   gc.rotation = 90

--- a/doc/ex/compose_mask.rb
+++ b/doc/ex/compose_mask.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 background = Magick::Image.read('images/Flower_Hat.jpg').first
 source = Magick::Image.read('pattern:checkerboard') { |e| e.size = "#{background.columns}x#{background.rows}" }.first
-mask = Magick::Image.new(background.columns, background.rows) { |e| e.background_color = 'black' }
+mask = Magick::Image.new(background.columns, background.rows) { |info| info.background_color = 'black' }
 
 # Make a mask
 gc = Magick::Draw.new

--- a/doc/ex/compose_mask.rb
+++ b/doc/ex/compose_mask.rb
@@ -7,12 +7,12 @@ mask = Magick::Image.new(background.columns, background.rows) { |e| e.background
 # Make a mask
 gc = Magick::Draw.new
 gc.annotate(mask, 0, 0, 0, 0, 'Ruby') do |e|
-  gc.gravity = Magick::CenterGravity
-  gc.pointsize = 100
-  gc.rotation = 90
-  gc.font_weight = Magick::BoldWeight
-  gc.fill = 'white'
-  gc.stroke = 'none'
+  e.gravity = Magick::CenterGravity
+  e.pointsize = 100
+  e.rotation = 90
+  e.font_weight = Magick::BoldWeight
+  e.fill = 'white'
+  e.stroke = 'none'
 end
 
 background.add_compose_mask(mask)

--- a/doc/ex/composite.rb
+++ b/doc/ex/composite.rb
@@ -28,7 +28,7 @@ image__b = img.transparent('white', alpha: TransparentAlpha)
 image__b['Label'] = 'B'
 
 list = ImageList.new
-null = Image.read('xc:white') { self.size = Geometry.new(COLS, ROWS) }
+null = Image.read('xc:white') { |e| e.size = Geometry.new(COLS, ROWS) }
 null = null.first.transparent('white', alpha: TransparentAlpha)
 null.border_color = 'transparent'
 granite = Image.read('granite:')
@@ -118,13 +118,13 @@ list.cur_image['Label'] = 'B modulate A'
 list << image__b.composite(image_a, CenterGravity, OverlayCompositeOp)
 list.cur_image['Label'] = 'A overlay B'
 
-montage = list.montage do
-  self.geometry = Geometry.new(COLS, ROWS, 3, 3)
+montage = list.montage do |e|
+  e.geometry = Geometry.new(COLS, ROWS, 3, 3)
   rows = (list.size + 3) / 4
-  self.tile = Geometry.new(4, rows)
-  self.texture = granite[0]
-  self.fill = 'white'
-  self.stroke = 'transparent'
+  e.tile = Geometry.new(4, rows)
+  e.texture = granite[0]
+  e.fill = 'white'
+  e.stroke = 'transparent'
 end
 
 montage.write('composite.gif')

--- a/doc/ex/composite.rb
+++ b/doc/ex/composite.rb
@@ -28,7 +28,7 @@ image__b = img.transparent('white', alpha: TransparentAlpha)
 image__b['Label'] = 'B'
 
 list = ImageList.new
-null = Image.read('xc:white') { |e| e.size = Geometry.new(COLS, ROWS) }
+null = Image.read('xc:white') { |options| options.size = Geometry.new(COLS, ROWS) }
 null = null.first.transparent('white', alpha: TransparentAlpha)
 null.border_color = 'transparent'
 granite = Image.read('granite:')
@@ -118,13 +118,13 @@ list.cur_image['Label'] = 'B modulate A'
 list << image__b.composite(image_a, CenterGravity, OverlayCompositeOp)
 list.cur_image['Label'] = 'A overlay B'
 
-montage = list.montage do |e|
-  e.geometry = Geometry.new(COLS, ROWS, 3, 3)
+montage = list.montage do |options|
+  options.geometry = Geometry.new(COLS, ROWS, 3, 3)
   rows = (list.size + 3) / 4
-  e.tile = Geometry.new(4, rows)
-  e.texture = granite[0]
-  e.fill = 'white'
-  e.stroke = 'transparent'
+  options.tile = Geometry.new(4, rows)
+  options.texture = granite[0]
+  options.fill = 'white'
+  options.stroke = 'transparent'
 end
 
 montage.write('composite.gif')

--- a/doc/ex/composite_layers.rb
+++ b/doc/ex/composite_layers.rb
@@ -21,7 +21,7 @@ gc.stroke = 'black'
 gc.stroke_width = 1
 
 23.times do
-  ruby << Magick::Image.new(100, 100) { |e| e.background_color = 'none' }
+  ruby << Magick::Image.new(100, 100) { |info| info.background_color = 'none' }
   gc.annotate(ruby, 0, 0, 0, 0, 'Ruby')
   gc.rotation = 15
 end

--- a/doc/ex/composite_layers.rb
+++ b/doc/ex/composite_layers.rb
@@ -21,7 +21,7 @@ gc.stroke = 'black'
 gc.stroke_width = 1
 
 23.times do
-  ruby << Magick::Image.new(100, 100) { self.background_color = 'none' }
+  ruby << Magick::Image.new(100, 100) { |e| e.background_color = 'none' }
   gc.annotate(ruby, 0, 0, 0, 0, 'Ruby')
   gc.rotation = 15
 end

--- a/doc/ex/composite_tiled.rb
+++ b/doc/ex/composite_tiled.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 # Create a transparent image to tile over the background image.
-wm = Magick::Image.read('xc:none') { |e| e.size = '100x50' }.first
+wm = Magick::Image.read('xc:none') { |options| options.size = '100x50' }.first
 
 # Draw "RMagick" in semi-transparent text on the transparent image.
 gc = Magick::Draw.new

--- a/doc/ex/composite_tiled.rb
+++ b/doc/ex/composite_tiled.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 # Create a transparent image to tile over the background image.
-wm = Magick::Image.read('xc:none') { self.size = '100x50' }.first
+wm = Magick::Image.read('xc:none') { |e| e.size = '100x50' }.first
 
 # Draw "RMagick" in semi-transparent text on the transparent image.
 gc = Magick::Draw.new

--- a/doc/ex/contrast.rb
+++ b/doc/ex/contrast.rb
@@ -25,9 +25,9 @@ end
 legend.annotate(img, 0, 0, 7, 10, f.to_s)
 
 # Montage into a single image
-imgs = img.montage do |e|
-  e.geometry = Magick::Geometry.new(img.columns, img.rows)
-  e.tile = '2x2'
+imgs = img.montage do |options|
+  options.geometry = Magick::Geometry.new(img.columns, img.rows)
+  options.tile = '2x2'
 end
 
 imgs.write('contrast.jpg')

--- a/doc/ex/contrast.rb
+++ b/doc/ex/contrast.rb
@@ -25,9 +25,9 @@ end
 legend.annotate(img, 0, 0, 7, 10, f.to_s)
 
 # Montage into a single image
-imgs = img.montage do
-  self.geometry = Magick::Geometry.new(img.columns, img.rows)
-  self.tile = '2x2'
+imgs = img.montage do |e|
+  e.geometry = Magick::Geometry.new(img.columns, img.rows)
+  e.tile = '2x2'
 end
 
 imgs.write('contrast.jpg')

--- a/doc/ex/crop.rb
+++ b/doc/ex/crop.rb
@@ -20,7 +20,7 @@ img.write('crop_before.png')
 
 # Create a image to use as a background for
 # the "after" image.
-bg = Magick::Image.new(img.columns, img.rows) { self.background_color = 'none' }
+bg = Magick::Image.new(img.columns, img.rows) { |e| e.background_color = 'none' }
 
 # Composite the the "after" (chopped) image on the background
 bg = bg.composite(chopped, 23, 81, Magick::OverCompositeOp)

--- a/doc/ex/crop.rb
+++ b/doc/ex/crop.rb
@@ -20,7 +20,7 @@ img.write('crop_before.png')
 
 # Create a image to use as a background for
 # the "after" image.
-bg = Magick::Image.new(img.columns, img.rows) { |e| e.background_color = 'none' }
+bg = Magick::Image.new(img.columns, img.rows) { |info| info.background_color = 'none' }
 
 # Composite the the "after" (chopped) image on the background
 bg = bg.composite(chopped, 23, 81, Magick::OverCompositeOp)

--- a/doc/ex/crop_with_gravity.rb
+++ b/doc/ex/crop_with_gravity.rb
@@ -34,10 +34,10 @@ pairs = ImageList.new
 end
 
 # Montage into a single image
-montage = pairs.montage do |e|
-  e.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
-  e.tile = '6x3'
-  e.border_width = 1
+montage = pairs.montage do |options|
+  options.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
+  options.tile = '6x3'
+  options.border_width = 1
 end
 montage.write('crop_with_gravity.png')
 # montage.display

--- a/doc/ex/crop_with_gravity.rb
+++ b/doc/ex/crop_with_gravity.rb
@@ -13,11 +13,11 @@ shorts = Image.read('images/Shorts.jpg').first
 regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
-mask = Image.new(regwidth, regheight) { |e| e.background_color = 'white' }
+mask = Image.new(regwidth, regheight) { |info| info.background_color = 'white' }
 mask.alpha(Magick::ActivateAlphaChannel)
 mask.quantum_operator(SetQuantumOperator, 0.50 * QuantumRange, AlphaChannel)
 
-black = Image.new(shorts.columns, shorts.rows) { |e| e.background_color = 'black' }
+black = Image.new(shorts.columns, shorts.rows) { |info| info.background_color = 'black' }
 pairs = ImageList.new
 
 [

--- a/doc/ex/crop_with_gravity.rb
+++ b/doc/ex/crop_with_gravity.rb
@@ -13,11 +13,11 @@ shorts = Image.read('images/Shorts.jpg').first
 regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
-mask = Image.new(regwidth, regheight) { self.background_color = 'white' }
+mask = Image.new(regwidth, regheight) { |e| e.background_color = 'white' }
 mask.alpha(Magick::ActivateAlphaChannel)
 mask.quantum_operator(SetQuantumOperator, 0.50 * QuantumRange, AlphaChannel)
 
-black = Image.new(shorts.columns, shorts.rows) { self.background_color = 'black' }
+black = Image.new(shorts.columns, shorts.rows) { |e| e.background_color = 'black' }
 pairs = ImageList.new
 
 [
@@ -34,10 +34,10 @@ pairs = ImageList.new
 end
 
 # Montage into a single image
-montage = pairs.montage do
-  self.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
-  self.tile = '6x3'
-  self.border_width = 1
+montage = pairs.montage do |e|
+  e.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
+  e.tile = '6x3'
+  e.border_width = 1
 end
 montage.write('crop_with_gravity.png')
 # montage.display

--- a/doc/ex/drop_shadow.rb
+++ b/doc/ex/drop_shadow.rb
@@ -25,8 +25,8 @@ text.stroke = 'transparent'
 
 # Draw the shadow text first. The color is a very light gray.
 # Position the text to the right and down.
-text.annotate(ex, 0, 0, 2, 2, Text) do |e|
-  e.fill = 'gray60'
+text.annotate(ex, 0, 0, 2, 2, Text) do |options|
+  options.fill = 'gray60'
 end
 
 # Save the first frame of the animation.
@@ -38,8 +38,8 @@ anim << ex.copy
 
 # Add the foreground text in solid black. Position it
 # to the left and up from the shadow text.
-text.annotate(ex, 0, 0, -1, -1, Text) do |e|
-  e.fill = 'maroon'
+text.annotate(ex, 0, 0, -1, -1, Text) do |options|
+  options.fill = 'maroon'
 end
 
 # Save yet another copy of the image as the 3rd frame.

--- a/doc/ex/drop_shadow.rb
+++ b/doc/ex/drop_shadow.rb
@@ -25,8 +25,8 @@ text.stroke = 'transparent'
 
 # Draw the shadow text first. The color is a very light gray.
 # Position the text to the right and down.
-text.annotate(ex, 0, 0, 2, 2, Text) do
-  self.fill = 'gray60'
+text.annotate(ex, 0, 0, 2, 2, Text) do |e|
+  e.fill = 'gray60'
 end
 
 # Save the first frame of the animation.
@@ -38,8 +38,8 @@ anim << ex.copy
 
 # Add the foreground text in solid black. Position it
 # to the left and up from the shadow text.
-text.annotate(ex, 0, 0, -1, -1, Text) do
-  self.fill = 'maroon'
+text.annotate(ex, 0, 0, -1, -1, Text) do |e|
+  e.fill = 'maroon'
 end
 
 # Save yet another copy of the image as the 3rd frame.

--- a/doc/ex/fill_pattern.rb
+++ b/doc/ex/fill_pattern.rb
@@ -3,20 +3,20 @@ require 'rmagick'
 # Demonstrate the Magick::Draw#fill_pattern and #stroke_pattern attributes.
 
 temp = Magick::ImageList.new
-temp << Magick::Image.new(5, 10) { self.background_color = 'black' }
-temp << Magick::Image.new(5, 10) { self.background_color = 'gold' }
+temp << Magick::Image.new(5, 10) { |e| e.background_color = 'black' }
+temp << Magick::Image.new(5, 10) { |e| e.background_color = 'gold' }
 stroke_pattern = temp.append(false)
 
-img = Magick::Image.new(280, 250) { self.background_color = 'none' }
+img = Magick::Image.new(280, 250) { |e| e.background_color = 'none' }
 
 gc = Magick::Draw.new
-gc.annotate(img, 0, 0, 0, 0, "PATT\nERNS") do
-  self.gravity = Magick::CenterGravity
-  self.font_weight = Magick::BoldWeight
-  self.pointsize = 100
-  self.fill_pattern = Magick::Image.read('images/Flower_Hat.jpg').first
-  self.stroke_width = 5
-  self.stroke_pattern = stroke_pattern
+gc.annotate(img, 0, 0, 0, 0, "PATT\nERNS") do |e|
+  e.gravity = Magick::CenterGravity
+  e.font_weight = Magick::BoldWeight
+  e.pointsize = 100
+  e.fill_pattern = Magick::Image.read('images/Flower_Hat.jpg').first
+  e.stroke_width = 5
+  e.stroke_pattern = stroke_pattern
 end
 
 img.write('fill_pattern.gif')

--- a/doc/ex/fill_pattern.rb
+++ b/doc/ex/fill_pattern.rb
@@ -3,11 +3,11 @@ require 'rmagick'
 # Demonstrate the Magick::Draw#fill_pattern and #stroke_pattern attributes.
 
 temp = Magick::ImageList.new
-temp << Magick::Image.new(5, 10) { |e| e.background_color = 'black' }
-temp << Magick::Image.new(5, 10) { |e| e.background_color = 'gold' }
+temp << Magick::Image.new(5, 10) { |info| info.background_color = 'black' }
+temp << Magick::Image.new(5, 10) { |info| info.background_color = 'gold' }
 stroke_pattern = temp.append(false)
 
-img = Magick::Image.new(280, 250) { |e| e.background_color = 'none' }
+img = Magick::Image.new(280, 250) { |info| info.background_color = 'none' }
 
 gc = Magick::Draw.new
 gc.annotate(img, 0, 0, 0, 0, "PATT\nERNS") do |e|

--- a/doc/ex/fill_pattern.rb
+++ b/doc/ex/fill_pattern.rb
@@ -10,13 +10,13 @@ stroke_pattern = temp.append(false)
 img = Magick::Image.new(280, 250) { |info| info.background_color = 'none' }
 
 gc = Magick::Draw.new
-gc.annotate(img, 0, 0, 0, 0, "PATT\nERNS") do |e|
-  e.gravity = Magick::CenterGravity
-  e.font_weight = Magick::BoldWeight
-  e.pointsize = 100
-  e.fill_pattern = Magick::Image.read('images/Flower_Hat.jpg').first
-  e.stroke_width = 5
-  e.stroke_pattern = stroke_pattern
+gc.annotate(img, 0, 0, 0, 0, "PATT\nERNS") do |options|
+  options.gravity = Magick::CenterGravity
+  options.font_weight = Magick::BoldWeight
+  options.pointsize = 100
+  options.fill_pattern = Magick::Image.read('images/Flower_Hat.jpg').first
+  options.stroke_width = 5
+  options.stroke_pattern = stroke_pattern
 end
 
 img.write('fill_pattern.gif')

--- a/doc/ex/flatten_images.rb
+++ b/doc/ex/flatten_images.rb
@@ -12,20 +12,20 @@ i.new_image(200, 100, Magick::GradientFill.new(100, 50, 100, 50, 'khaki1', 'turq
 # Create a transparent image for the text shadow
 i.new_image(200, 100) { |info| info.background_color = 'transparent' }
 primitives = Magick::Draw.new
-primitives.annotate i, 0, 0, 2, 2, RMagick do |e|
-  e.pointsize = 32
-  e.fill = 'gray50'
-  e.gravity = Magick::CenterGravity
+primitives.annotate i, 0, 0, 2, 2, RMagick do |options|
+  options.pointsize = 32
+  options.fill = 'gray50'
+  options.gravity = Magick::CenterGravity
 end
 
 # Create another transparent image for the text itself
 i.new_image(200, 100) { |info| info.background_color = 'transparent' }
 primitives = Magick::Draw.new
-primitives.annotate i, 0, 0, -2, -2, RMagick do |e|
-  e.pointsize = 32
-  e.fill = 'red'
-  e.stroke = 'black'
-  e.gravity = Magick::CenterGravity
+primitives.annotate i, 0, 0, -2, -2, RMagick do |options|
+  options.pointsize = 32
+  options.fill = 'red'
+  options.stroke = 'black'
+  options.gravity = Magick::CenterGravity
 end
 
 # Flatten all 3 into a single image.

--- a/doc/ex/flatten_images.rb
+++ b/doc/ex/flatten_images.rb
@@ -10,7 +10,7 @@ i = Magick::ImageList.new
 i.new_image(200, 100, Magick::GradientFill.new(100, 50, 100, 50, 'khaki1', 'turquoise'))
 
 # Create a transparent image for the text shadow
-i.new_image(200, 100) { |e| e.background_color = 'transparent' }
+i.new_image(200, 100) { |info| info.background_color = 'transparent' }
 primitives = Magick::Draw.new
 primitives.annotate i, 0, 0, 2, 2, RMagick do |e|
   e.pointsize = 32
@@ -19,7 +19,7 @@ primitives.annotate i, 0, 0, 2, 2, RMagick do |e|
 end
 
 # Create another transparent image for the text itself
-i.new_image(200, 100) { |e| e.background_color = 'transparent' }
+i.new_image(200, 100) { |info| info.background_color = 'transparent' }
 primitives = Magick::Draw.new
 primitives.annotate i, 0, 0, -2, -2, RMagick do |e|
   e.pointsize = 32

--- a/doc/ex/flatten_images.rb
+++ b/doc/ex/flatten_images.rb
@@ -10,22 +10,22 @@ i = Magick::ImageList.new
 i.new_image(200, 100, Magick::GradientFill.new(100, 50, 100, 50, 'khaki1', 'turquoise'))
 
 # Create a transparent image for the text shadow
-i.new_image(200, 100) { self.background_color = 'transparent' }
+i.new_image(200, 100) { |e| e.background_color = 'transparent' }
 primitives = Magick::Draw.new
-primitives.annotate i, 0, 0, 2, 2, RMagick do
-  self.pointsize = 32
-  self.fill = 'gray50'
-  self.gravity = Magick::CenterGravity
+primitives.annotate i, 0, 0, 2, 2, RMagick do |e|
+  e.pointsize = 32
+  e.fill = 'gray50'
+  e.gravity = Magick::CenterGravity
 end
 
 # Create another transparent image for the text itself
-i.new_image(200, 100) { self.background_color = 'transparent' }
+i.new_image(200, 100) { |e| e.background_color = 'transparent' }
 primitives = Magick::Draw.new
-primitives.annotate i, 0, 0, -2, -2, RMagick do
-  self.pointsize = 32
-  self.fill = 'red'
-  self.stroke = 'black'
-  self.gravity = Magick::CenterGravity
+primitives.annotate i, 0, 0, -2, -2, RMagick do |e|
+  e.pointsize = 32
+  e.fill = 'red'
+  e.stroke = 'black'
+  e.gravity = Magick::CenterGravity
 end
 
 # Flatten all 3 into a single image.

--- a/doc/ex/get_multiline_type_metrics.rb
+++ b/doc/ex/get_multiline_type_metrics.rb
@@ -6,7 +6,7 @@ background = Magick::Image.new(200, 200)
 gc = Magick::Draw.new
 
 # Draw the text centered on the background
-gc.annotate(background, 0, 0, 0, 0, TEXT) do
+gc.annotate(background, 0, 0, 0, 0, TEXT) do |e|
   gc.font_family = 'Verdana'
   gc.pointsize = 36
   gc.gravity = Magick::CenterGravity

--- a/doc/ex/get_multiline_type_metrics.rb
+++ b/doc/ex/get_multiline_type_metrics.rb
@@ -7,10 +7,10 @@ gc = Magick::Draw.new
 
 # Draw the text centered on the background
 gc.annotate(background, 0, 0, 0, 0, TEXT) do |e|
-  gc.font_family = 'Verdana'
-  gc.pointsize = 36
-  gc.gravity = Magick::CenterGravity
-  gc.stroke = 'none'
+  e.font_family = 'Verdana'
+  e.pointsize = 36
+  e.gravity = Magick::CenterGravity
+  e.stroke = 'none'
 end
 
 # Get the metrics

--- a/doc/ex/get_multiline_type_metrics.rb
+++ b/doc/ex/get_multiline_type_metrics.rb
@@ -6,11 +6,11 @@ background = Magick::Image.new(200, 200)
 gc = Magick::Draw.new
 
 # Draw the text centered on the background
-gc.annotate(background, 0, 0, 0, 0, TEXT) do |e|
-  e.font_family = 'Verdana'
-  e.pointsize = 36
-  e.gravity = Magick::CenterGravity
-  e.stroke = 'none'
+gc.annotate(background, 0, 0, 0, 0, TEXT) do |options|
+  options.font_family = 'Verdana'
+  options.pointsize = 36
+  options.gravity = Magick::CenterGravity
+  options.stroke = 'none'
 end
 
 # Get the metrics

--- a/doc/ex/get_type_metrics.rb
+++ b/doc/ex/get_type_metrics.rb
@@ -32,12 +32,12 @@ canvas = Magick::Image.new(410, 320, Magick::HatchFill.new('white', 'lightcyan2'
 # Draw a big lowercase 'g' on the canvas. Leave room on all sides for
 # the labels. Use 'undercolor' to set off the glyph.
 glyph = Magick::Draw.new
-glyph.annotate(canvas, 0, 0, Origin_x, Origin_y, Glyph) do |e|
-  e.pointsize = 124
-  e.stroke = 'none'
-  e.fill = 'black'
-  e.font_family = Face
-  e.undercolor = '#ffff00c0'
+glyph.annotate(canvas, 0, 0, Origin_x, Origin_y, Glyph) do |options|
+  options.pointsize = 124
+  options.stroke = 'none'
+  options.fill = 'black'
+  options.font_family = Face
+  options.undercolor = '#ffff00c0'
 end
 
 # Call get_type_metrics. This is what this example's all about.

--- a/doc/ex/get_type_metrics.rb
+++ b/doc/ex/get_type_metrics.rb
@@ -32,7 +32,7 @@ canvas = Magick::Image.new(410, 320, Magick::HatchFill.new('white', 'lightcyan2'
 # Draw a big lowercase 'g' on the canvas. Leave room on all sides for
 # the labels. Use 'undercolor' to set off the glyph.
 glyph = Magick::Draw.new
-glyph.annotate(canvas, 0, 0, Origin_x, Origin_y, Glyph) do
+glyph.annotate(canvas, 0, 0, Origin_x, Origin_y, Glyph) do |e|
   glyph.pointsize = 124
   glyph.stroke = 'none'
   glyph.fill = 'black'

--- a/doc/ex/get_type_metrics.rb
+++ b/doc/ex/get_type_metrics.rb
@@ -33,11 +33,11 @@ canvas = Magick::Image.new(410, 320, Magick::HatchFill.new('white', 'lightcyan2'
 # the labels. Use 'undercolor' to set off the glyph.
 glyph = Magick::Draw.new
 glyph.annotate(canvas, 0, 0, Origin_x, Origin_y, Glyph) do |e|
-  glyph.pointsize = 124
-  glyph.stroke = 'none'
-  glyph.fill = 'black'
-  glyph.font_family = Face
-  glyph.undercolor = '#ffff00c0'
+  e.pointsize = 124
+  e.stroke = 'none'
+  e.fill = 'black'
+  e.font_family = Face
+  e.undercolor = '#ffff00c0'
 end
 
 # Call get_type_metrics. This is what this example's all about.

--- a/doc/ex/gradientfill.rb
+++ b/doc/ex/gradientfill.rb
@@ -14,11 +14,11 @@ img = Magick::Image.new(Cols, Rows, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, "GradientFill.new(0, 0, 0, #{Rows}, '#{Start}', '#{End}')") do |e|
-  e.gravity = Magick::CenterGravity
-  e.fill = 'white'
-  e.stroke = 'transparent'
-  e.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, "GradientFill.new(0, 0, 0, #{Rows}, '#{Start}', '#{End}')") do |options|
+  options.gravity = Magick::CenterGravity
+  options.fill = 'white'
+  options.stroke = 'transparent'
+  options.pointsize = 14
 end
 
 # img.display

--- a/doc/ex/gradientfill.rb
+++ b/doc/ex/gradientfill.rb
@@ -14,11 +14,11 @@ img = Magick::Image.new(Cols, Rows, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, "GradientFill.new(0, 0, 0, #{Rows}, '#{Start}', '#{End}')") do
-  self.gravity = Magick::CenterGravity
-  self.fill = 'white'
-  self.stroke = 'transparent'
-  self.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, "GradientFill.new(0, 0, 0, #{Rows}, '#{Start}', '#{End}')") do |e|
+  e.gravity = Magick::CenterGravity
+  e.fill = 'white'
+  e.stroke = 'transparent'
+  e.pointsize = 14
 end
 
 # img.display

--- a/doc/ex/gravity.rb
+++ b/doc/ex/gravity.rb
@@ -24,45 +24,45 @@ begin
 
   0.step(330, 30) do |angle|
     puts "angle #{angle}"
-    pic.new_image(600, 600) { self.background_color = 'white' }
+    pic.new_image(600, 600) { |e| e.background_color = 'white' }
 
     lines.draw pic
 
-    draw.annotate(pic, 0, 0, x, y, 'NorthWest') do
-      self.gravity = Magick::NorthWestGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'NorthWest') do |e|
+      e.gravity = Magick::NorthWestGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, y, 'North') do
-      self.gravity = Magick::NorthGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, 0, y, 'North') do |e|
+      e.gravity = Magick::NorthGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'NorthEast') do
-      self.gravity = Magick::NorthEastGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'NorthEast') do |e|
+      e.gravity = Magick::NorthEastGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, 0, 'East') do
-      self.gravity = Magick::EastGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, 0, 'East') do |e|
+      e.gravity = Magick::EastGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, 0, 'Center') do
-      self.gravity = Magick::CenterGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, 0, 0, 'Center') do |e|
+      e.gravity = Magick::CenterGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'SouthEast') do
-      self.gravity = Magick::SouthEastGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'SouthEast') do |e|
+      e.gravity = Magick::SouthEastGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, y, 'South') do
-      self.gravity = Magick::SouthGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, 0, y, 'South') do |e|
+      e.gravity = Magick::SouthGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'SouthWest') do
-      self.gravity = Magick::SouthWestGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'SouthWest') do |e|
+      e.gravity = Magick::SouthWestGravity
+      e.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, 0, 'West') do
-      self.gravity = Magick::WestGravity
-      self.rotation = angle
+    draw.annotate(pic, 0, 0, x, 0, 'West') do |e|
+      e.gravity = Magick::WestGravity
+      e.rotation = angle
     end
   end
 

--- a/doc/ex/gravity.rb
+++ b/doc/ex/gravity.rb
@@ -28,41 +28,41 @@ begin
 
     lines.draw pic
 
-    draw.annotate(pic, 0, 0, x, y, 'NorthWest') do |e|
-      e.gravity = Magick::NorthWestGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'NorthWest') do |options|
+      options.gravity = Magick::NorthWestGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, y, 'North') do |e|
-      e.gravity = Magick::NorthGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, 0, y, 'North') do |options|
+      options.gravity = Magick::NorthGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'NorthEast') do |e|
-      e.gravity = Magick::NorthEastGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'NorthEast') do |options|
+      options.gravity = Magick::NorthEastGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, 0, 'East') do |e|
-      e.gravity = Magick::EastGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, 0, 'East') do |options|
+      options.gravity = Magick::EastGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, 0, 'Center') do |e|
-      e.gravity = Magick::CenterGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, 0, 0, 'Center') do |options|
+      options.gravity = Magick::CenterGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'SouthEast') do |e|
-      e.gravity = Magick::SouthEastGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'SouthEast') do |options|
+      options.gravity = Magick::SouthEastGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, 0, y, 'South') do |e|
-      e.gravity = Magick::SouthGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, 0, y, 'South') do |options|
+      options.gravity = Magick::SouthGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, y, 'SouthWest') do |e|
-      e.gravity = Magick::SouthWestGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, y, 'SouthWest') do |options|
+      options.gravity = Magick::SouthWestGravity
+      options.rotation = angle
     end
-    draw.annotate(pic, 0, 0, x, 0, 'West') do |e|
-      e.gravity = Magick::WestGravity
-      e.rotation = angle
+    draw.annotate(pic, 0, 0, x, 0, 'West') do |options|
+      options.gravity = Magick::WestGravity
+      options.rotation = angle
     end
   end
 

--- a/doc/ex/gravity.rb
+++ b/doc/ex/gravity.rb
@@ -24,7 +24,7 @@ begin
 
   0.step(330, 30) do |angle|
     puts "angle #{angle}"
-    pic.new_image(600, 600) { |e| e.background_color = 'white' }
+    pic.new_image(600, 600) { |info| info.background_color = 'white' }
 
     lines.draw pic
 

--- a/doc/ex/hatchfill.rb
+++ b/doc/ex/hatchfill.rb
@@ -15,11 +15,11 @@ img.new_image(Cols, Rows, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, "HatchFill.new('#{Background}', '#{Foreground}')") do |e|
-  e.gravity = Magick::CenterGravity
-  e.fill = 'black'
-  e.stroke = 'transparent'
-  e.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, "HatchFill.new('#{Background}', '#{Foreground}')") do |options|
+  options.gravity = Magick::CenterGravity
+  options.fill = 'black'
+  options.stroke = 'transparent'
+  options.pointsize = 14
 end
 # img.display
 img.write('hatchfill.gif')

--- a/doc/ex/hatchfill.rb
+++ b/doc/ex/hatchfill.rb
@@ -15,11 +15,11 @@ img.new_image(Cols, Rows, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, "HatchFill.new('#{Background}', '#{Foreground}')") do
-  self.gravity = Magick::CenterGravity
-  self.fill = 'black'
-  self.stroke = 'transparent'
-  self.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, "HatchFill.new('#{Background}', '#{Foreground}')") do |e|
+  e.gravity = Magick::CenterGravity
+  e.fill = 'black'
+  e.stroke = 'transparent'
+  e.pointsize = 14
 end
 # img.display
 img.write('hatchfill.gif')

--- a/doc/ex/mask.rb
+++ b/doc/ex/mask.rb
@@ -14,10 +14,10 @@ img = Magick::Image.read('images/Flower_Hat.jpg').first
 q = Magick::Image.new(img.columns, img.rows)
 
 gc = Magick::Draw.new
-gc.annotate(q, 0, 0, 0, 0, 'Flower Hat') do |e|
-  e.gravity = Magick::SouthGravity
-  e.pointsize = 36
-  e.font_weight = Magick::BoldWeight
+gc.annotate(q, 0, 0, 0, 0, 'Flower Hat') do |options|
+  options.gravity = Magick::SouthGravity
+  options.pointsize = 36
+  options.font_weight = Magick::BoldWeight
 end
 
 # Set the matte attribute to false, indicating the absence of an alpha channel

--- a/doc/ex/mask.rb
+++ b/doc/ex/mask.rb
@@ -14,7 +14,7 @@ img = Magick::Image.read('images/Flower_Hat.jpg').first
 q = Magick::Image.new(img.columns, img.rows)
 
 gc = Magick::Draw.new
-gc.annotate(q, 0, 0, 0, 0, 'Flower Hat') do
+gc.annotate(q, 0, 0, 0, 0, 'Flower Hat') do |e|
   gc.gravity = Magick::SouthGravity
   gc.pointsize = 36
   gc.font_weight = Magick::BoldWeight

--- a/doc/ex/mask.rb
+++ b/doc/ex/mask.rb
@@ -15,9 +15,9 @@ q = Magick::Image.new(img.columns, img.rows)
 
 gc = Magick::Draw.new
 gc.annotate(q, 0, 0, 0, 0, 'Flower Hat') do |e|
-  gc.gravity = Magick::SouthGravity
-  gc.pointsize = 36
-  gc.font_weight = Magick::BoldWeight
+  e.gravity = Magick::SouthGravity
+  e.pointsize = 36
+  e.font_weight = Magick::BoldWeight
 end
 
 # Set the matte attribute to false, indicating the absence of an alpha channel

--- a/doc/ex/matte_fill_to_border.rb
+++ b/doc/ex/matte_fill_to_border.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |options| options.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/matte_fill_to_border.rb
+++ b/doc/ex/matte_fill_to_border.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/matte_floodfill.rb
+++ b/doc/ex/matte_floodfill.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |options| options.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/matte_floodfill.rb
+++ b/doc/ex/matte_floodfill.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/matte_replace.rb
+++ b/doc/ex/matte_replace.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |options| options.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/matte_replace.rb
+++ b/doc/ex/matte_replace.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.new(200, 200)
 img.compression = Magick::LZWCompression
 
-bg = Magick::Image.read('plasma:fractal') { self.size = '200x200' }
+bg = Magick::Image.read('plasma:fractal') { |e| e.size = '200x200' }
 bg[0].alpha(Magick::DeactivateAlphaChannel)
 
 gc = Magick::Draw.new

--- a/doc/ex/polaroid.rb
+++ b/doc/ex/polaroid.rb
@@ -7,11 +7,11 @@ img = Magick::Image.read('images/Flower_Hat.jpg').first
 img[:Caption] = "\nLosha\n" + Date.today.to_s
 
 begin
-  picture = img.polaroid do
-    self.font_weight = Magick::NormalWeight
-    self.font_style = Magick::NormalStyle
-    self.gravity = Magick::CenterGravity
-    self.border_color = '#f0f0f8'
+  picture = img.polaroid do |e|
+    e.font_weight = Magick::NormalWeight
+    e.font_style = Magick::NormalStyle
+    e.gravity = Magick::CenterGravity
+    e.border_color = '#f0f0f8'
   end
 
   # Composite it on a white background so the result is opaque.

--- a/doc/ex/polaroid.rb
+++ b/doc/ex/polaroid.rb
@@ -7,11 +7,11 @@ img = Magick::Image.read('images/Flower_Hat.jpg').first
 img[:Caption] = "\nLosha\n" + Date.today.to_s
 
 begin
-  picture = img.polaroid do |e|
-    e.font_weight = Magick::NormalWeight
-    e.font_style = Magick::NormalStyle
-    e.gravity = Magick::CenterGravity
-    e.border_color = '#f0f0f8'
+  picture = img.polaroid do |options|
+    options.font_weight = Magick::NormalWeight
+    options.font_style = Magick::NormalStyle
+    options.gravity = Magick::CenterGravity
+    options.border_color = '#f0f0f8'
   end
 
   # Composite it on a white background so the result is opaque.

--- a/doc/ex/remap_images.rb
+++ b/doc/ex/remap_images.rb
@@ -10,7 +10,7 @@ result << rose
 
 begin
   result += images.copy.affinity(rose)
-  montage = result.montage { |e| e.tile = '4x2' }
+  montage = result.montage { |options| options.tile = '4x2' }
   montage.alpha Magick::DeactivateAlphaChannel
 rescue NotImplementedError
   montage = Magick::Image.read('images/notimplemented.gif').first

--- a/doc/ex/remap_images.rb
+++ b/doc/ex/remap_images.rb
@@ -10,7 +10,7 @@ result << rose
 
 begin
   result += images.copy.affinity(rose)
-  montage = result.montage { self.tile = '4x2' }
+  montage = result.montage { |e| e.tile = '4x2' }
   montage.alpha Magick::DeactivateAlphaChannel
 rescue NotImplementedError
   montage = Magick::Image.read('images/notimplemented.gif').first

--- a/doc/ex/rubyname.rb
+++ b/doc/ex/rubyname.rb
@@ -12,16 +12,16 @@ text = Magick::Draw.new
 text.pointsize = 52
 text.gravity = Magick::CenterGravity
 
-text.annotate(canvas, 0, 0, 2, 2, Text) do
-  self.fill = 'gray83'
+text.annotate(canvas, 0, 0, 2, 2, Text) do |e|
+  e.fill = 'gray83'
 end
 
-text.annotate(canvas, 0, 0, -1.5, -1.5, Text) do
-  self.fill = 'gray40'
+text.annotate(canvas, 0, 0, -1.5, -1.5, Text) do |e|
+  e.fill = 'gray40'
 end
 
-text.annotate(canvas, 0, 0, 0, 0, Text) do
-  self.fill = 'darkred'
+text.annotate(canvas, 0, 0, 0, 0, Text) do |e|
+  e.fill = 'darkred'
 end
 
 # canvas.display

--- a/doc/ex/rubyname.rb
+++ b/doc/ex/rubyname.rb
@@ -12,16 +12,16 @@ text = Magick::Draw.new
 text.pointsize = 52
 text.gravity = Magick::CenterGravity
 
-text.annotate(canvas, 0, 0, 2, 2, Text) do |e|
-  e.fill = 'gray83'
+text.annotate(canvas, 0, 0, 2, 2, Text) do |options|
+  options.fill = 'gray83'
 end
 
-text.annotate(canvas, 0, 0, -1.5, -1.5, Text) do |e|
-  e.fill = 'gray40'
+text.annotate(canvas, 0, 0, -1.5, -1.5, Text) do |options|
+  options.fill = 'gray40'
 end
 
-text.annotate(canvas, 0, 0, 0, 0, Text) do |e|
-  e.fill = 'darkred'
+text.annotate(canvas, 0, 0, 0, 0, Text) do |options|
+  options.fill = 'darkred'
 end
 
 # canvas.display

--- a/doc/ex/shadow.rb
+++ b/doc/ex/shadow.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 # Draw a big red Bezier curve on a transparent background.
-img = Magick::Image.new(340, 120) { self.background_color = 'none' }
+img = Magick::Image.new(340, 120) { |e| e.background_color = 'none' }
 gc = Magick::Draw.new
 gc.fill('none')
 gc.stroke('red')
@@ -13,7 +13,7 @@ gc.draw(img)
 # Composite it onto a white background, draw a border around the result,
 # write it to the "before" file.
 before = img.copy
-bg = Magick::Image.new(before.columns, before.rows) { self.background_color = 'white' }
+bg = Magick::Image.new(before.columns, before.rows) { |e| e.background_color = 'white' }
 before = bg.composite(before, Magick::CenterGravity, Magick::OverCompositeOp)
 before.border!(1, 1, 'gray80')
 before.write('shadow_before.gif')
@@ -23,7 +23,7 @@ shadow = img.shadow
 # Composite the original image over the shadow, composite the result
 # onto a white background, add a border, write it to the "after" file.
 shadow = shadow.composite(img, Magick::NorthWestGravity, Magick::OverCompositeOp)
-bg = Magick::Image.new(shadow.columns, shadow.rows) { self.background_color = 'white' }
+bg = Magick::Image.new(shadow.columns, shadow.rows) { |e| e.background_color = 'white' }
 after = bg.composite(shadow, Magick::CenterGravity, Magick::OverCompositeOp)
 after.border!(1, 1, 'gray80')
 

--- a/doc/ex/shadow.rb
+++ b/doc/ex/shadow.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 # Draw a big red Bezier curve on a transparent background.
-img = Magick::Image.new(340, 120) { |e| e.background_color = 'none' }
+img = Magick::Image.new(340, 120) { |info| info.background_color = 'none' }
 gc = Magick::Draw.new
 gc.fill('none')
 gc.stroke('red')
@@ -13,7 +13,7 @@ gc.draw(img)
 # Composite it onto a white background, draw a border around the result,
 # write it to the "before" file.
 before = img.copy
-bg = Magick::Image.new(before.columns, before.rows) { |e| e.background_color = 'white' }
+bg = Magick::Image.new(before.columns, before.rows) { |info| info.background_color = 'white' }
 before = bg.composite(before, Magick::CenterGravity, Magick::OverCompositeOp)
 before.border!(1, 1, 'gray80')
 before.write('shadow_before.gif')
@@ -23,7 +23,7 @@ shadow = img.shadow
 # Composite the original image over the shadow, composite the result
 # onto a white background, add a border, write it to the "after" file.
 shadow = shadow.composite(img, Magick::NorthWestGravity, Magick::OverCompositeOp)
-bg = Magick::Image.new(shadow.columns, shadow.rows) { |e| e.background_color = 'white' }
+bg = Magick::Image.new(shadow.columns, shadow.rows) { |info| info.background_color = 'white' }
 after = bg.composite(shadow, Magick::CenterGravity, Magick::OverCompositeOp)
 after.border!(1, 1, 'gray80')
 

--- a/doc/ex/sparse_color.rb
+++ b/doc/ex/sparse_color.rb
@@ -51,10 +51,10 @@ begin
   img2['Label'] = 'Barycentric'
   imgl << draw_centers(img2, false)
 
-  montage = imgl.montage do
-    self.background_color = 'none'
-    self.geometry = '100x100+10+10'
-    self.tile = '2x2'
+  montage = imgl.montage do |e|
+    e.background_color = 'none'
+    e.geometry = '100x100+10+10'
+    e.tile = '2x2'
   end
 
   montage.write('sparse_color.png')

--- a/doc/ex/sparse_color.rb
+++ b/doc/ex/sparse_color.rb
@@ -51,10 +51,10 @@ begin
   img2['Label'] = 'Barycentric'
   imgl << draw_centers(img2, false)
 
-  montage = imgl.montage do |e|
-    e.background_color = 'none'
-    e.geometry = '100x100+10+10'
-    e.tile = '2x2'
+  montage = imgl.montage do |options|
+    options.background_color = 'none'
+    options.geometry = '100x100+10+10'
+    options.tile = '2x2'
   end
 
   montage.write('sparse_color.png')

--- a/doc/ex/stegano.rb
+++ b/doc/ex/stegano.rb
@@ -35,9 +35,9 @@ begin
     true
   end
 
-  stegano = Magick::Image.read('stegano:img.miff') do |e|
-    e.size = Magick::Geometry.new(wmcols, wmrows, 91)
-    e.monitor = monitor
+  stegano = Magick::Image.read('stegano:img.miff') do |options|
+    options.size = Magick::Geometry.new(wmcols, wmrows, 91)
+    options.monitor = monitor
   end
 
   stegano[0].monitor = nil

--- a/doc/ex/stegano.rb
+++ b/doc/ex/stegano.rb
@@ -35,9 +35,9 @@ begin
     true
   end
 
-  stegano = Magick::Image.read('stegano:img.miff') do
-    self.size = Magick::Geometry.new(wmcols, wmrows, 91)
-    self.monitor = monitor
+  stegano = Magick::Image.read('stegano:img.miff') do |e|
+    e.size = Magick::Geometry.new(wmcols, wmrows, 91)
+    e.monitor = monitor
   end
 
   stegano[0].monitor = nil

--- a/doc/ex/stroke_linejoin.rb
+++ b/doc/ex/stroke_linejoin.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 imgl = Magick::ImageList.new
-imgl.new_image(400, 150) { self.background_color = 'white' }
+imgl.new_image(400, 150) { |e| e.background_color = 'white' }
 
 gc = Magick::Draw.new
 

--- a/doc/ex/stroke_linejoin.rb
+++ b/doc/ex/stroke_linejoin.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 imgl = Magick::ImageList.new
-imgl.new_image(400, 150) { |e| e.background_color = 'white' }
+imgl.new_image(400, 150) { |info| info.background_color = 'white' }
 
 gc = Magick::Draw.new
 

--- a/doc/ex/text_antialias.rb
+++ b/doc/ex/text_antialias.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 imgl = Magick::ImageList.new
-imgl.new_image(275, 170) { self.background_color = 'white' }
+imgl.new_image(275, 170) { |e| e.background_color = 'white' }
 
 gc = Magick::Draw.new
 gc.fill('black')

--- a/doc/ex/text_antialias.rb
+++ b/doc/ex/text_antialias.rb
@@ -1,7 +1,7 @@
 require 'rmagick'
 
 imgl = Magick::ImageList.new
-imgl.new_image(275, 170) { |e| e.background_color = 'white' }
+imgl.new_image(275, 170) { |info| info.background_color = 'white' }
 
 gc = Magick::Draw.new
 gc.fill('black')

--- a/doc/ex/text_undercolor.rb
+++ b/doc/ex/text_undercolor.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Draw#text_undercolor method
 
-canvas = Magick::Image.new(250, 100) { |e| e.background_color = 'white' }
+canvas = Magick::Image.new(250, 100) { |info| info.background_color = 'white' }
 
 gc = Magick::Draw.new
 

--- a/doc/ex/text_undercolor.rb
+++ b/doc/ex/text_undercolor.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 # Demonstrate the Draw#text_undercolor method
 
-canvas = Magick::Image.new(250, 100) { self.background_color = 'white' }
+canvas = Magick::Image.new(250, 100) { |e| e.background_color = 'white' }
 
 gc = Magick::Draw.new
 

--- a/doc/ex/texture_fill_to_border.rb
+++ b/doc/ex/texture_fill_to_border.rb
@@ -3,9 +3,9 @@ require 'rmagick'
 # Demonstrate the Image#texture_fill_to_border method
 # This example is nearly identical to the color_fill_to_border example.
 
-before = Magick::Image.new(200, 200) do |e|
-  e.background_color = 'white'
-  e.border_color = 'black'
+before = Magick::Image.new(200, 200) do |options|
+  options.background_color = 'white'
+  options.border_color = 'black'
 end
 before.border!(1, 1, 'black')
 

--- a/doc/ex/texture_fill_to_border.rb
+++ b/doc/ex/texture_fill_to_border.rb
@@ -3,9 +3,9 @@ require 'rmagick'
 # Demonstrate the Image#texture_fill_to_border method
 # This example is nearly identical to the color_fill_to_border example.
 
-before = Magick::Image.new(200, 200) do
-  self.background_color = 'white'
-  self.border_color = 'black'
+before = Magick::Image.new(200, 200) do |e|
+  e.background_color = 'white'
+  e.border_color = 'black'
 end
 before.border!(1, 1, 'black')
 

--- a/doc/ex/texture_floodfill.rb
+++ b/doc/ex/texture_floodfill.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 # Demonstrate the Image#texture_floodfill method
 # This example is nearly identical to the color_floodfill example.
 
-before = Magick::Image.new(200, 200) { self.background_color = 'white' }
+before = Magick::Image.new(200, 200) { |e| e.background_color = 'white' }
 before.border!(1, 1, 'black')
 
 circle = Magick::Draw.new

--- a/doc/ex/texture_floodfill.rb
+++ b/doc/ex/texture_floodfill.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 # Demonstrate the Image#texture_floodfill method
 # This example is nearly identical to the color_floodfill example.
 
-before = Magick::Image.new(200, 200) { |e| e.background_color = 'white' }
+before = Magick::Image.new(200, 200) { |info| info.background_color = 'white' }
 before.border!(1, 1, 'black')
 
 circle = Magick::Draw.new

--- a/doc/ex/texturefill.rb
+++ b/doc/ex/texturefill.rb
@@ -10,12 +10,12 @@ img.new_image(300, 100, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, 'TextureFill.new(granite)') do |e|
-  e.gravity = Magick::CenterGravity
-  e.fill = 'white'
-  e.font_weight = Magick::BoldWeight
-  e.stroke = 'transparent'
-  e.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, 'TextureFill.new(granite)') do |options|
+  options.gravity = Magick::CenterGravity
+  options.fill = 'white'
+  options.font_weight = Magick::BoldWeight
+  options.stroke = 'transparent'
+  options.pointsize = 14
 end
 
 # img.display

--- a/doc/ex/texturefill.rb
+++ b/doc/ex/texturefill.rb
@@ -10,12 +10,12 @@ img.new_image(300, 100, fill)
 # Annotate the filled image with the code that created the fill.
 
 ann = Magick::Draw.new
-ann.annotate(img, 0, 0, 0, 0, 'TextureFill.new(granite)') do
-  self.gravity = Magick::CenterGravity
-  self.fill = 'white'
-  self.font_weight = Magick::BoldWeight
-  self.stroke = 'transparent'
-  self.pointsize = 14
+ann.annotate(img, 0, 0, 0, 0, 'TextureFill.new(granite)') do |e|
+  e.gravity = Magick::CenterGravity
+  e.fill = 'white'
+  e.font_weight = Magick::BoldWeight
+  e.stroke = 'transparent'
+  e.pointsize = 14
 end
 
 # img.display

--- a/doc/ex/transparent.rb
+++ b/doc/ex/transparent.rb
@@ -3,8 +3,8 @@ require 'rmagick'
 # Demonstrate the Image#transparent method.
 # Change all black pixels in the image to transparent.
 
-before = Magick::Image.new(200, 200) do
-  self.background_color = 'black'
+before = Magick::Image.new(200, 200) do |e|
+  e.background_color = 'black'
 end
 
 circle = Magick::Draw.new
@@ -30,7 +30,7 @@ after = before.transparent('black', alpha: Magick::TransparentAlpha)
 # Use the plasma image as a background so we can see that
 # the black pixels have been made transparent.
 bg = Magick::ImageList.new
-bg.read('plasma:purple-gold') { self.size = '200x200' }
+bg.read('plasma:purple-gold') { |e| e.size = '200x200' }
 
 after = bg.composite(after, Magick::CenterGravity, Magick::OverCompositeOp)
 after.write('transparent_after.gif')

--- a/doc/ex/transparent.rb
+++ b/doc/ex/transparent.rb
@@ -3,8 +3,8 @@ require 'rmagick'
 # Demonstrate the Image#transparent method.
 # Change all black pixels in the image to transparent.
 
-before = Magick::Image.new(200, 200) do |e|
-  e.background_color = 'black'
+before = Magick::Image.new(200, 200) do |options|
+  options.background_color = 'black'
 end
 
 circle = Magick::Draw.new
@@ -30,7 +30,7 @@ after = before.transparent('black', alpha: Magick::TransparentAlpha)
 # Use the plasma image as a background so we can see that
 # the black pixels have been made transparent.
 bg = Magick::ImageList.new
-bg.read('plasma:purple-gold') { |e| e.size = '200x200' }
+bg.read('plasma:purple-gold') { |options| options.size = '200x200' }
 
 after = bg.composite(after, Magick::CenterGravity, Magick::OverCompositeOp)
 after.write('transparent_after.gif')

--- a/doc/ex/viewex.rb
+++ b/doc/ex/viewex.rb
@@ -1,6 +1,6 @@
 require 'rmagick'
 
-img = Magick::Image.new(40, 40) { |e| e.background_color = 'lightcyan2' }
+img = Magick::Image.new(40, 40) { |info| info.background_color = 'lightcyan2' }
 
 # The view is 400 pixels square, starting
 # column 10, row 5 from the top of the image.

--- a/doc/ex/viewex.rb
+++ b/doc/ex/viewex.rb
@@ -1,6 +1,6 @@
 require 'rmagick'
 
-img = Magick::Image.new(40, 40) { self.background_color = 'lightcyan2' }
+img = Magick::Image.new(40, 40) { |e| e.background_color = 'lightcyan2' }
 
 # The view is 400 pixels square, starting
 # column 10, row 5 from the top of the image.

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -3,10 +3,10 @@ require 'rmagick'
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 
 # Make a watermark from the word "RMagick"
-mark = Magick::Image.new(140, 40) { self.background_color = 'none' }
+mark = Magick::Image.new(140, 40) { |e| e.background_color = 'none' }
 gc = Magick::Draw.new
 
-gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do
+gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |e|
   gc.gravity = Magick::CenterGravity
   gc.pointsize = 32
   gc.font_family = if RUBY_PLATFORM =~ /mswin32/

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -6,16 +6,16 @@ img = Magick::Image.read('images/Flower_Hat.jpg').first
 mark = Magick::Image.new(140, 40) { |info| info.background_color = 'none' }
 gc = Magick::Draw.new
 
-gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |e|
-  e.gravity = Magick::CenterGravity
-  e.pointsize = 32
-  e.font_family = if RUBY_PLATFORM =~ /mswin32/
-                    'Georgia'
-                  else
-                    'Times'
-                  end
-  e.fill = 'white'
-  e.stroke = 'none'
+gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |options|
+  options.gravity = Magick::CenterGravity
+  options.pointsize = 32
+  options.font_family = if RUBY_PLATFORM =~ /mswin32/
+                          'Georgia'
+                        else
+                          'Times'
+                        end
+  options.fill = 'white'
+  options.stroke = 'none'
 end
 
 mark = mark.wave(2.5, 70).rotate(-90)

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -3,7 +3,7 @@ require 'rmagick'
 img = Magick::Image.read('images/Flower_Hat.jpg').first
 
 # Make a watermark from the word "RMagick"
-mark = Magick::Image.new(140, 40) { |e| e.background_color = 'none' }
+mark = Magick::Image.new(140, 40) { |info| info.background_color = 'none' }
 gc = Magick::Draw.new
 
 gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |e|

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -7,15 +7,15 @@ mark = Magick::Image.new(140, 40) { |e| e.background_color = 'none' }
 gc = Magick::Draw.new
 
 gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |e|
-  gc.gravity = Magick::CenterGravity
-  gc.pointsize = 32
-  gc.font_family = if RUBY_PLATFORM =~ /mswin32/
-                     'Georgia'
-                   else
-                     'Times'
-                   end
-  gc.fill = 'white'
-  gc.stroke = 'none'
+  e.gravity = Magick::CenterGravity
+  e.pointsize = 32
+  e.font_family = if RUBY_PLATFORM =~ /mswin32/
+                    'Georgia'
+                  else
+                    'Times'
+                  end
+  e.fill = 'white'
+  e.stroke = 'none'
 end
 
 mark = mark.wave(2.5, 70).rotate(-90)

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -6,17 +6,17 @@ img = Magick::Image.new(270, 60) { |e| e.background_color = 'black' }
 
 gc = Magick::Draw.new
 gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |e|
-  gc.fill = '#a00'
-  gc.stroke = '#f00'
-  gc.stroke_width = 2
-  gc.font_weight = Magick::BoldWeight
-  gc.gravity = Magick::SouthGravity
+  e.fill = '#a00'
+  e.stroke = '#f00'
+  e.stroke_width = 2
+  e.font_weight = Magick::BoldWeight
+  e.gravity = Magick::SouthGravity
   if RUBY_PLATFORM =~ /mswin32/
-    gc.font_family = 'Georgia'
-    gc.pointsize = 76
+    e.font_family = 'Georgia'
+    e.pointsize = 76
   else
-    gc.font_family = 'times'
-    gc.pointsize = 80
+    e.font_family = 'times'
+    e.pointsize = 80
   end
 end
 

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -2,10 +2,10 @@ require 'rmagick'
 
 results = Magick::ImageList.new
 
-img = Magick::Image.new(270, 60) { self.background_color = 'black' }
+img = Magick::Image.new(270, 60) { |e| e.background_color = 'black' }
 
 gc = Magick::Draw.new
-gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do
+gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |e|
   gc.fill = '#a00'
   gc.stroke = '#f00'
   gc.stroke_width = 2
@@ -48,9 +48,9 @@ results << ilist.append(true)
 
 # Montage into a single demo image. Use a white background so
 # there won't be any problems with transparency in the browser.
-result = results.montage do
-  self.geometry = '270x120'
-  self.tile = '1x4'
-  self.background_color = 'black'
+result = results.montage do |e|
+  e.geometry = '270x120'
+  e.tile = '1x4'
+  e.background_color = 'black'
 end
 result.write('wet_floor.gif')

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -2,7 +2,7 @@ require 'rmagick'
 
 results = Magick::ImageList.new
 
-img = Magick::Image.new(270, 60) { |e| e.background_color = 'black' }
+img = Magick::Image.new(270, 60) { |info| info.background_color = 'black' }
 
 gc = Magick::Draw.new
 gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |e|

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -5,18 +5,18 @@ results = Magick::ImageList.new
 img = Magick::Image.new(270, 60) { |info| info.background_color = 'black' }
 
 gc = Magick::Draw.new
-gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |e|
-  e.fill = '#a00'
-  e.stroke = '#f00'
-  e.stroke_width = 2
-  e.font_weight = Magick::BoldWeight
-  e.gravity = Magick::SouthGravity
+gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |options|
+  options.fill = '#a00'
+  options.stroke = '#f00'
+  options.stroke_width = 2
+  options.font_weight = Magick::BoldWeight
+  options.gravity = Magick::SouthGravity
   if RUBY_PLATFORM =~ /mswin32/
-    e.font_family = 'Georgia'
-    e.pointsize = 76
+    options.font_family = 'Georgia'
+    options.pointsize = 76
   else
-    e.font_family = 'times'
-    e.pointsize = 80
+    options.font_family = 'times'
+    options.pointsize = 80
   end
 end
 
@@ -48,9 +48,9 @@ results << ilist.append(true)
 
 # Montage into a single demo image. Use a white background so
 # there won't be any problems with transparency in the browser.
-result = results.montage do |e|
-  e.geometry = '270x120'
-  e.tile = '1x4'
-  e.background_color = 'black'
+result = results.montage do |options|
+  options.geometry = '270x120'
+  options.tile = '1x4'
+  options.background_color = 'black'
 end
 result.write('wet_floor.gif')

--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -13,11 +13,11 @@ shorts = Image.read('../doc/ex/images/Shorts.jpg').first
 regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
-mask = Image.new(regwidth, regheight) { |info| info.background_color = 'white' }
+mask = Image.new(regwidth, regheight) { |options| options.background_color = 'white' }
 mask.alpha(Magick::ActivateAlphaChannel)
 mask.quantum_operator(SetQuantumOperator, 0.50 * QuantumRange, AlphaChannel)
 
-black = Image.new(shorts.columns, shorts.rows) { |info| info.background_color = 'black' }
+black = Image.new(shorts.columns, shorts.rows) { |options| options.background_color = 'black' }
 pairs = ImageList.new
 
 [
@@ -34,10 +34,10 @@ pairs = ImageList.new
 end
 
 # Montage into a single image
-montage = pairs.montage do |e|
-  e.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
-  e.tile = '6x3'
-  e.border_width = 1
+montage = pairs.montage do |options|
+  options.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
+  options.tile = '6x3'
+  options.border_width = 1
 end
 montage.write('crop_with_gravity.png')
 # montage.display

--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -13,11 +13,11 @@ shorts = Image.read('../doc/ex/images/Shorts.jpg').first
 regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
-mask = Image.new(regwidth, regheight) { self.background_color = 'white' }
+mask = Image.new(regwidth, regheight) { |e| e.background_color = 'white' }
 mask.alpha(Magick::ActivateAlphaChannel)
 mask.quantum_operator(SetQuantumOperator, 0.50 * QuantumRange, AlphaChannel)
 
-black = Image.new(shorts.columns, shorts.rows) { self.background_color = 'black' }
+black = Image.new(shorts.columns, shorts.rows) { |e| e.background_color = 'black' }
 pairs = ImageList.new
 
 [
@@ -34,10 +34,10 @@ pairs = ImageList.new
 end
 
 # Montage into a single image
-montage = pairs.montage do
-  self.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
-  self.tile = '6x3'
-  self.border_width = 1
+montage = pairs.montage do |e|
+  e.geometry = "#{pairs.columns}x#{pairs.rows}+0+0"
+  e.tile = '6x3'
+  e.border_width = 1
 end
 montage.write('crop_with_gravity.png')
 # montage.display

--- a/examples/crop_with_gravity.rb
+++ b/examples/crop_with_gravity.rb
@@ -13,11 +13,11 @@ shorts = Image.read('../doc/ex/images/Shorts.jpg').first
 regwidth = shorts.columns / 2
 regheight = shorts.rows / 2
 
-mask = Image.new(regwidth, regheight) { |e| e.background_color = 'white' }
+mask = Image.new(regwidth, regheight) { |info| info.background_color = 'white' }
 mask.alpha(Magick::ActivateAlphaChannel)
 mask.quantum_operator(SetQuantumOperator, 0.50 * QuantumRange, AlphaChannel)
 
-black = Image.new(shorts.columns, shorts.rows) { |e| e.background_color = 'black' }
+black = Image.new(shorts.columns, shorts.rows) { |info| info.background_color = 'black' }
 pairs = ImageList.new
 
 [

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -36,7 +36,7 @@ begin
   # optional "size" attribute in the parm block associated with
   # the read method. There are two more examples of this, below.
   example = ImageList.new
-  5.times { example.read('NULL:black') { |e| e.size = '70x70' } }
+  5.times { example.read('NULL:black') { |options| options.size = '70x70' } }
 
   puts '   add noise...'
   example << model.add_noise(LaplacianNoise)
@@ -46,12 +46,12 @@ begin
   example << model.cur_image.copy
   example.cur_image[:Label] = 'Annotate'
   draw = Draw.new
-  draw.annotate(example, 0, 0, 0, 20, 'RMagick') do |e|
-    e.pointsize = 18
-    e.font = Font
-    e.stroke = 'gold'
-    e.fill = 'gold'
-    e.gravity = NorthGravity
+  draw.annotate(example, 0, 0, 0, 20, 'RMagick') do |options|
+    options.pointsize = 18
+    options.font = Font
+    options.stroke = 'gold'
+    options.fill = 'gold'
+    options.gravity = NorthGravity
   end
 
   puts '   blur...'
@@ -147,8 +147,8 @@ begin
   # with the read method. Here we create a gradient image that is
   # the same size as the model image.
   puts '   gradient...'
-  example.read('gradient:#20a0ff-#ffff00') do |e|
-    e.size = Geometry.new(model.columns, model.rows)
+  example.read('gradient:#20a0ff-#ffff00') do |options|
+    options.size = Geometry.new(model.columns, model.rows)
   end
   example.cur_image[:Label] = 'Gradient'
 
@@ -186,8 +186,8 @@ begin
 
   # The plasma format is very similar to the gradient format, above.
   puts '   plasma...'
-  example.read('plasma:fractal') do |e|
-    e.size = Geometry.new(model.columns, model.rows)
+  example.read('plasma:fractal') do |options|
+    options.size = Geometry.new(model.columns, model.rows)
   end
   example.cur_image[:Label] = 'Plasma'
 
@@ -270,25 +270,25 @@ begin
 
   puts 'Montage images...'
 
-  montage = example.montage do |e|
-    e.geometry = '130x194+10+5>'
-    e.gravity = CenterGravity
-    e.border_width = 1
+  montage = example.montage do |options|
+    options.geometry = '130x194+10+5>'
+    options.gravity = CenterGravity
+    options.border_width = 1
     rows = (example.size + 4) / 5
-    e.tile = Geometry.new(5, rows)
-    e.compose = OverCompositeOp
+    options.tile = Geometry.new(5, rows)
+    options.compose = OverCompositeOp
 
     # Use the ImageMagick built-in "granite" format
     # as the background texture.
 
-    #       e.texture = Image.read("granite:").first
-    e.background_color = 'white'
-    e.font = Font
-    e.pointsize = 18
-    e.fill = '#600'
-    e.filename = 'RMagick Demo'
-    #       e.shadow = true
-    #       e.frame = "20x20+4+4"
+    #       options.texture = Image.read("granite:").first
+    options.background_color = 'white'
+    options.font = Font
+    options.pointsize = 18
+    options.fill = '#600'
+    options.filename = 'RMagick Demo'
+    #       options.shadow = true
+    #       options.frame = "20x20+4+4"
   end
 
   # Add the ImageMagick logo to the top of the montage. The "logo:"

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -36,7 +36,7 @@ begin
   # optional "size" attribute in the parm block associated with
   # the read method. There are two more examples of this, below.
   example = ImageList.new
-  5.times { example.read('NULL:black') { self.size = '70x70' } }
+  5.times { example.read('NULL:black') { |e| e.size = '70x70' } }
 
   puts '   add noise...'
   example << model.add_noise(LaplacianNoise)
@@ -46,12 +46,12 @@ begin
   example << model.cur_image.copy
   example.cur_image[:Label] = 'Annotate'
   draw = Draw.new
-  draw.annotate(example, 0, 0, 0, 20, 'RMagick') do
-    self.pointsize = 18
-    self.font = Font
-    self.stroke = 'gold'
-    self.fill = 'gold'
-    self.gravity = NorthGravity
+  draw.annotate(example, 0, 0, 0, 20, 'RMagick') do |e|
+    e.pointsize = 18
+    e.font = Font
+    e.stroke = 'gold'
+    e.fill = 'gold'
+    e.gravity = NorthGravity
   end
 
   puts '   blur...'
@@ -147,8 +147,8 @@ begin
   # with the read method. Here we create a gradient image that is
   # the same size as the model image.
   puts '   gradient...'
-  example.read('gradient:#20a0ff-#ffff00') do
-    self.size = Geometry.new(model.columns, model.rows)
+  example.read('gradient:#20a0ff-#ffff00') do |e|
+    e.size = Geometry.new(model.columns, model.rows)
   end
   example.cur_image[:Label] = 'Gradient'
 
@@ -186,8 +186,8 @@ begin
 
   # The plasma format is very similar to the gradient format, above.
   puts '   plasma...'
-  example.read('plasma:fractal') do
-    self.size = Geometry.new(model.columns, model.rows)
+  example.read('plasma:fractal') do |e|
+    e.size = Geometry.new(model.columns, model.rows)
   end
   example.cur_image[:Label] = 'Plasma'
 
@@ -270,25 +270,25 @@ begin
 
   puts 'Montage images...'
 
-  montage = example.montage do
-    self.geometry = '130x194+10+5>'
-    self.gravity = CenterGravity
-    self.border_width = 1
+  montage = example.montage do |e|
+    e.geometry = '130x194+10+5>'
+    e.gravity = CenterGravity
+    e.border_width = 1
     rows = (example.size + 4) / 5
-    self.tile = Geometry.new(5, rows)
-    self.compose = OverCompositeOp
+    e.tile = Geometry.new(5, rows)
+    e.compose = OverCompositeOp
 
     # Use the ImageMagick built-in "granite" format
     # as the background texture.
 
-    #       self.texture = Image.read("granite:").first
-    self.background_color = 'white'
-    self.font = Font
-    self.pointsize = 18
-    self.fill = '#600'
-    self.filename = 'RMagick Demo'
-    #       self.shadow = true
-    #       self.frame = "20x20+4+4"
+    #       e.texture = Image.read("granite:").first
+    e.background_color = 'white'
+    e.font = Font
+    e.pointsize = 18
+    e.fill = '#600'
+    e.filename = 'RMagick Demo'
+    #       e.shadow = true
+    #       e.frame = "20x20+4+4"
   end
 
   # Add the ImageMagick logo to the top of the montage. The "logo:"

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -160,9 +160,9 @@ module Magick
         Colors: #{number_colors}
       END_TEXT
 
-      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
-        info.background_color = bg
-        info.border_color = fg
+      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |inner_info|
+        inner_info.background_color = bg
+        inner_info.border_color = fg
       end
 
       gc = Draw.new

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -35,9 +35,9 @@ module Magick
 
     # The alpha frequencies are shown as white dots.
     def alpha_hist(freqs, scale, fg, bg)
-      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
-        e.background_color = bg
-        e.border_color = fg
+      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
+        info.background_color = bg
+        info.border_color = fg
       end
 
       gc = Draw.new
@@ -55,9 +55,9 @@ module Magick
     end
 
     def channel_histograms(red, green, blue, int, scale, fg, bg)
-      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
-        e.background_color = bg
-        e.border_color = fg
+      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
+        info.background_color = bg
+        info.border_color = fg
       end
       rgb_histogram['Label'] = 'RGB'
       red_histogram = rgb_histogram.copy
@@ -128,9 +128,9 @@ module Magick
         pixels = hist.keys.sort_by { |pixel| hist[pixel] }
         scale = HISTOGRAM_ROWS / (hist.values.max * AIR_FACTOR)
 
-        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
-          e.background_color = bg
-          e.border_color = fg
+        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
+          info.background_color = bg
+          info.border_color = fg
         end
 
         x = 0
@@ -160,9 +160,9 @@ module Magick
         Colors: #{number_colors}
       END_TEXT
 
-      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
-        e.background_color = bg
-        e.border_color = fg
+      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
+        info.background_color = bg
+        info.border_color = fg
       end
 
       gc = Draw.new

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -35,9 +35,9 @@ module Magick
 
     # The alpha frequencies are shown as white dots.
     def alpha_hist(freqs, scale, fg, bg)
-      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do
-        self.background_color = bg
-        self.border_color = fg
+      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
+        e.background_color = bg
+        e.border_color = fg
       end
 
       gc = Draw.new
@@ -55,9 +55,9 @@ module Magick
     end
 
     def channel_histograms(red, green, blue, int, scale, fg, bg)
-      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do
-        self.background_color = bg
-        self.border_color = fg
+      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
+        e.background_color = bg
+        e.border_color = fg
       end
       rgb_histogram['Label'] = 'RGB'
       red_histogram = rgb_histogram.copy
@@ -128,9 +128,9 @@ module Magick
         pixels = hist.keys.sort_by { |pixel| hist[pixel] }
         scale = HISTOGRAM_ROWS / (hist.values.max * AIR_FACTOR)
 
-        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do
-          self.background_color = bg
-          self.border_color = fg
+        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
+          e.background_color = bg
+          e.border_color = fg
         end
 
         x = 0
@@ -160,17 +160,17 @@ module Magick
         Colors: #{number_colors}
       END_TEXT
 
-      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do
-        self.background_color = bg
-        self.border_color = fg
+      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |e|
+        e.background_color = bg
+        e.border_color = fg
       end
 
       gc = Draw.new
 
-      gc.annotate(info, 0, 0, 0, 0, text) do
-        self.stroke = 'transparent'
-        self.fill = fg
-        self.gravity = CenterGravity
+      gc.annotate(info, 0, 0, 0, 0, text) do |e|
+        e.stroke = 'transparent'
+        e.fill = fg
+        e.gravity = CenterGravity
       end
       info['Label'] = 'Info'
 
@@ -178,7 +178,7 @@ module Magick
     end
 
     def intensity_hist(int_histogram)
-      gradient = (Image.read('gradient:#ffff80-#ff9000') { self.size = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}" }).first
+      gradient = (Image.read('gradient:#ffff80-#ff9000') { |e| e.size = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}" }).first
       int_histogram = gradient.composite(int_histogram, CenterGravity, OverCompositeOp)
 
       int_histogram['Label'] = 'Intensity'
@@ -254,13 +254,13 @@ module Magick
       charts << color_hist(fg, bg)
 
       # Make a montage.
-      histogram = charts.montage do
-        self.background_color = bg
-        self.stroke = 'transparent'
-        self.fill = fg
-        self.border_width = 1
-        self.tile         = '4x2'
-        self.geometry     = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}+10+10"
+      histogram = charts.montage do |e|
+        e.background_color = bg
+        e.stroke = 'transparent'
+        e.fill = fg
+        e.border_width = 1
+        e.tile = '4x2'
+        e.geometry = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}+10+10"
       end
 
       histogram

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -35,9 +35,9 @@ module Magick
 
     # The alpha frequencies are shown as white dots.
     def alpha_hist(freqs, scale, fg, bg)
-      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
-        info.background_color = bg
-        info.border_color = fg
+      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
+        options.background_color = bg
+        options.border_color = fg
       end
 
       gc = Draw.new
@@ -55,9 +55,9 @@ module Magick
     end
 
     def channel_histograms(red, green, blue, int, scale, fg, bg)
-      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
-        info.background_color = bg
-        info.border_color = fg
+      rgb_histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
+        options.background_color = bg
+        options.border_color = fg
       end
       rgb_histogram['Label'] = 'RGB'
       red_histogram = rgb_histogram.copy
@@ -128,9 +128,9 @@ module Magick
         pixels = hist.keys.sort_by { |pixel| hist[pixel] }
         scale = HISTOGRAM_ROWS / (hist.values.max * AIR_FACTOR)
 
-        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |info|
-          info.background_color = bg
-          info.border_color = fg
+        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
+          options.background_color = bg
+          options.border_color = fg
         end
 
         x = 0
@@ -160,17 +160,17 @@ module Magick
         Colors: #{number_colors}
       END_TEXT
 
-      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |inner_info|
-        inner_info.background_color = bg
-        inner_info.border_color = fg
+      info = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
+        options.background_color = bg
+        options.border_color = fg
       end
 
       gc = Draw.new
 
-      gc.annotate(info, 0, 0, 0, 0, text) do |e|
-        e.stroke = 'transparent'
-        e.fill = fg
-        e.gravity = CenterGravity
+      gc.annotate(info, 0, 0, 0, 0, text) do |options|
+        options.stroke = 'transparent'
+        options.fill = fg
+        options.gravity = CenterGravity
       end
       info['Label'] = 'Info'
 
@@ -178,7 +178,7 @@ module Magick
     end
 
     def intensity_hist(int_histogram)
-      gradient = (Image.read('gradient:#ffff80-#ff9000') { |e| e.size = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}" }).first
+      gradient = (Image.read('gradient:#ffff80-#ff9000') { |options| options.size = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}" }).first
       int_histogram = gradient.composite(int_histogram, CenterGravity, OverCompositeOp)
 
       int_histogram['Label'] = 'Intensity'
@@ -254,13 +254,13 @@ module Magick
       charts << color_hist(fg, bg)
 
       # Make a montage.
-      histogram = charts.montage do |e|
-        e.background_color = bg
-        e.stroke = 'transparent'
-        e.fill = fg
-        e.border_width = 1
-        e.tile = '4x2'
-        e.geometry = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}+10+10"
+      histogram = charts.montage do |options|
+        options.background_color = bg
+        options.stroke = 'transparent'
+        options.fill = fg
+        options.border_width = 1
+        options.tile = '4x2'
+        options.geometry = "#{HISTOGRAM_COLS}x#{HISTOGRAM_ROWS}+10+10"
       end
 
       histogram

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -11,7 +11,7 @@ puts <<~END_INFO
 END_INFO
 
 balloons = Image.read('../doc/ex/images/Hot_Air_Balloons_H.jpg').first
-legend = Image.new(160, 50) { |e| e.background_color = '#ffffffc0' }
+legend = Image.new(160, 50) { |info| info.background_color = '#ffffffc0' }
 
 gc = Draw.new
 gc.annotate(legend, 0, 0, 0, 0, 'Balloon Day!\\nFri May 2 2003') do |e|

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -11,14 +11,14 @@ puts <<~END_INFO
 END_INFO
 
 balloons = Image.read('../doc/ex/images/Hot_Air_Balloons_H.jpg').first
-legend = Image.new(160, 50) { self.background_color = '#ffffffc0' }
+legend = Image.new(160, 50) { |e| e.background_color = '#ffffffc0' }
 
 gc = Draw.new
-gc.annotate(legend, 0, 0, 0, 0, 'Balloon Day!\\nFri May 2 2003') do
-  self.gravity = CenterGravity
-  self.stroke = 'transparent'
-  self.fill = 'white'
-  self.pointsize = 18
+gc.annotate(legend, 0, 0, 0, 0, 'Balloon Day!\\nFri May 2 2003') do |e|
+  e.gravity = CenterGravity
+  e.stroke = 'transparent'
+  e.fill = 'white'
+  e.pointsize = 18
 end
 
 result = balloons.composite(legend, SouthGravity, OverCompositeOp)

--- a/examples/image_opacity.rb
+++ b/examples/image_opacity.rb
@@ -11,14 +11,14 @@ puts <<~END_INFO
 END_INFO
 
 balloons = Image.read('../doc/ex/images/Hot_Air_Balloons_H.jpg').first
-legend = Image.new(160, 50) { |info| info.background_color = '#ffffffc0' }
+legend = Image.new(160, 50) { |options| options.background_color = '#ffffffc0' }
 
 gc = Draw.new
-gc.annotate(legend, 0, 0, 0, 0, 'Balloon Day!\\nFri May 2 2003') do |e|
-  e.gravity = CenterGravity
-  e.stroke = 'transparent'
-  e.fill = 'white'
-  e.pointsize = 18
+gc.annotate(legend, 0, 0, 0, 0, 'Balloon Day!\\nFri May 2 2003') do |options|
+  options.gravity = CenterGravity
+  options.stroke = 'transparent'
+  options.fill = 'white'
+  options.pointsize = 18
 end
 
 result = balloons.composite(legend, SouthGravity, OverCompositeOp)

--- a/examples/rotating_text.rb
+++ b/examples/rotating_text.rb
@@ -23,7 +23,7 @@ fill = GradientFill.new(100, 100, 100, 100, 'yellow', 'red')
 bg = Image.new(200, 200, fill)
 
 # The "none" color is transparent.
-fg = Image.new(bg.columns, bg.rows) { |e| e.background_color = 'none' }
+fg = Image.new(bg.columns, bg.rows) { |info| info.background_color = 'none' }
 
 # Here's where we'll collect the individual frames.
 animation = ImageList.new

--- a/examples/rotating_text.rb
+++ b/examples/rotating_text.rb
@@ -23,15 +23,15 @@ fill = GradientFill.new(100, 100, 100, 100, 'yellow', 'red')
 bg = Image.new(200, 200, fill)
 
 # The "none" color is transparent.
-fg = Image.new(bg.columns, bg.rows) { self.background_color = 'none' }
+fg = Image.new(bg.columns, bg.rows) { |e| e.background_color = 'none' }
 
 # Here's where we'll collect the individual frames.
 animation = ImageList.new
 
 0.step(345, 15) do |degrees|
   frame = fg.copy
-  text.annotate(frame, 0, 0, 0, 0, 'Rotating Text') do
-    self.rotation = degrees
+  text.annotate(frame, 0, 0, 0, 0, 'Rotating Text') do |e|
+    e.rotation = degrees
   end
   # Composite the text over the gradient filled background frame.
   animation << bg.composite(frame, CenterGravity, DisplaceCompositeOp)

--- a/examples/rotating_text.rb
+++ b/examples/rotating_text.rb
@@ -23,15 +23,15 @@ fill = GradientFill.new(100, 100, 100, 100, 'yellow', 'red')
 bg = Image.new(200, 200, fill)
 
 # The "none" color is transparent.
-fg = Image.new(bg.columns, bg.rows) { |info| info.background_color = 'none' }
+fg = Image.new(bg.columns, bg.rows) { |options| options.background_color = 'none' }
 
 # Here's where we'll collect the individual frames.
 animation = ImageList.new
 
 0.step(345, 15) do |degrees|
   frame = fg.copy
-  text.annotate(frame, 0, 0, 0, 0, 'Rotating Text') do |e|
-    e.rotation = degrees
+  text.annotate(frame, 0, 0, 0, 0, 'Rotating Text') do |options|
+    options.rotation = degrees
   end
   # Composite the text over the gradient filled background frame.
   animation << bg.composite(frame, CenterGravity, DisplaceCompositeOp)

--- a/examples/spinner.rb
+++ b/examples/spinner.rb
@@ -15,7 +15,7 @@ DIM = 32                        # width & height of image in pixels
 DELAY = 100.0 / (NFRAMES / 2) # 2 rotations per second
 
 # 'frame' is a single frame in the animation.
-frame = Magick::Image.new(DIM, DIM) { |info| info.background_color = 'transparent' }
+frame = Magick::Image.new(DIM, DIM) { |options| options.background_color = 'transparent' }
 
 # 'spinner' will contain the frames that make up the animated GIF
 spinner = Magick::ImageList.new

--- a/examples/spinner.rb
+++ b/examples/spinner.rb
@@ -15,7 +15,7 @@ DIM = 32                        # width & height of image in pixels
 DELAY = 100.0 / (NFRAMES / 2) # 2 rotations per second
 
 # 'frame' is a single frame in the animation.
-frame = Magick::Image.new(DIM, DIM) { self.background_color = 'transparent' }
+frame = Magick::Image.new(DIM, DIM) { |e| e.background_color = 'transparent' }
 
 # 'spinner' will contain the frames that make up the animated GIF
 spinner = Magick::ImageList.new

--- a/examples/spinner.rb
+++ b/examples/spinner.rb
@@ -15,7 +15,7 @@ DIM = 32                        # width & height of image in pixels
 DELAY = 100.0 / (NFRAMES / 2) # 2 rotations per second
 
 # 'frame' is a single frame in the animation.
-frame = Magick::Image.new(DIM, DIM) { |e| e.background_color = 'transparent' }
+frame = Magick::Image.new(DIM, DIM) { |info| info.background_color = 'transparent' }
 
 # 'spinner' will contain the frames that make up the animated GIF
 spinner = Magick::ImageList.new

--- a/examples/thumbnail.rb
+++ b/examples/thumbnail.rb
@@ -48,13 +48,13 @@ img.change_geometry!(geom) { |cols, rows| img.thumbnail! cols, rows }
 # for the raised border. A 3-pixel raised edge means that the
 # background needs to be 6 pixels larger in each dimension.
 
-bg = Image.new(size + 6, size + 6) { self.background_color = 'gray75' }
+bg = Image.new(size + 6, size + 6) { |e| e.background_color = 'gray75' }
 bg = bg.raise(3, 3)
 
 # Just for the purposes of this example, display the thumbnail background on
 # a larger white background.
 
-white_bg = Image.new(size + 50, size + 50) { self.background_color = 'white' }
+white_bg = Image.new(size + 50, size + 50) { |e| e.background_color = 'white' }
 white_bg = white_bg.composite(bg, CenterGravity, OverCompositeOp)
 
 # Finally, center the thumbnail on the gray background.

--- a/examples/thumbnail.rb
+++ b/examples/thumbnail.rb
@@ -48,13 +48,13 @@ img.change_geometry!(geom) { |cols, rows| img.thumbnail! cols, rows }
 # for the raised border. A 3-pixel raised edge means that the
 # background needs to be 6 pixels larger in each dimension.
 
-bg = Image.new(size + 6, size + 6) { |info| info.background_color = 'gray75' }
+bg = Image.new(size + 6, size + 6) { |options| options.background_color = 'gray75' }
 bg = bg.raise(3, 3)
 
 # Just for the purposes of this example, display the thumbnail background on
 # a larger white background.
 
-white_bg = Image.new(size + 50, size + 50) { |info| info.background_color = 'white' }
+white_bg = Image.new(size + 50, size + 50) { |options| options.background_color = 'white' }
 white_bg = white_bg.composite(bg, CenterGravity, OverCompositeOp)
 
 # Finally, center the thumbnail on the gray background.

--- a/examples/thumbnail.rb
+++ b/examples/thumbnail.rb
@@ -48,13 +48,13 @@ img.change_geometry!(geom) { |cols, rows| img.thumbnail! cols, rows }
 # for the raised border. A 3-pixel raised edge means that the
 # background needs to be 6 pixels larger in each dimension.
 
-bg = Image.new(size + 6, size + 6) { |e| e.background_color = 'gray75' }
+bg = Image.new(size + 6, size + 6) { |info| info.background_color = 'gray75' }
 bg = bg.raise(3, 3)
 
 # Just for the purposes of this example, display the thumbnail background on
 # a larger white background.
 
-white_bg = Image.new(size + 50, size + 50) { |e| e.background_color = 'white' }
+white_bg = Image.new(size + 50, size + 50) { |info| info.background_color = 'white' }
 white_bg = white_bg.composite(bg, CenterGravity, OverCompositeOp)
 
 # Finally, center the thumbnail on the gray background.

--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -28,7 +28,7 @@ ballerina = Image.read('../doc/ex/images/Ballerina3.jpg')[0]
 # The size of the oval is arbitrary - in this case it's 90% of the
 # size of the image.
 
-oval = Image.new(ballerina.columns, ballerina.rows) { self.background_color = 'black' }
+oval = Image.new(ballerina.columns, ballerina.rows) { |e| e.background_color = 'black' }
 gc = Draw.new
 gc.stroke('white')
 gc.fill('white')
@@ -74,7 +74,7 @@ end
 # supports 1`level of transparency. Therefore, composite the vignette over a
 # standard "checkerboard" background. The resulting image will be 100% opaque.
 
-checkerboard = Image.read('pattern:checkerboard') { self.size = "#{ballerina.columns}x#{ballerina.rows}" }
+checkerboard = Image.read('pattern:checkerboard') { |e| e.size = "#{ballerina.columns}x#{ballerina.rows}" }
 vignette = checkerboard[0].composite(ballerina, CenterGravity, OverCompositeOp)
 vignette.write('vignette1.png')
 exit

--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -28,7 +28,7 @@ ballerina = Image.read('../doc/ex/images/Ballerina3.jpg')[0]
 # The size of the oval is arbitrary - in this case it's 90% of the
 # size of the image.
 
-oval = Image.new(ballerina.columns, ballerina.rows) { |info| info.background_color = 'black' }
+oval = Image.new(ballerina.columns, ballerina.rows) { |options| options.background_color = 'black' }
 gc = Draw.new
 gc.stroke('white')
 gc.fill('white')
@@ -74,7 +74,7 @@ end
 # supports 1`level of transparency. Therefore, composite the vignette over a
 # standard "checkerboard" background. The resulting image will be 100% opaque.
 
-checkerboard = Image.read('pattern:checkerboard') { |e| e.size = "#{ballerina.columns}x#{ballerina.rows}" }
+checkerboard = Image.read('pattern:checkerboard') { |options| options.size = "#{ballerina.columns}x#{ballerina.rows}" }
 vignette = checkerboard[0].composite(ballerina, CenterGravity, OverCompositeOp)
 vignette.write('vignette1.png')
 exit

--- a/examples/vignette.rb
+++ b/examples/vignette.rb
@@ -28,7 +28,7 @@ ballerina = Image.read('../doc/ex/images/Ballerina3.jpg')[0]
 # The size of the oval is arbitrary - in this case it's 90% of the
 # size of the image.
 
-oval = Image.new(ballerina.columns, ballerina.rows) { |e| e.background_color = 'black' }
+oval = Image.new(ballerina.columns, ballerina.rows) { |info| info.background_color = 'black' }
 gc = Draw.new
 gc.stroke('white')
 gc.fill('white')

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -856,6 +856,7 @@ VALUE Draw_annotate(
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1396,6 +1397,7 @@ DrawOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else
@@ -1467,6 +1469,7 @@ PolaroidOptions_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -428,7 +428,7 @@ ImageList_flatten_images(VALUE self)
  * @overload montage
  *   Creates {Magick::ImageList::Montage} object, yields to block
  *   if present in {Magick::ImageList::Montage} object's scope.
- *   @yield []
+ *   @yield [Magick::ImageList::Montage]
  * 
  * @return [Magick::ImageList] a new image list
  */
@@ -1009,7 +1009,7 @@ ImageList_remap(int argc, VALUE *argv, VALUE self)
  *
  * @overload to_blob
  *   Runs an info parm block if present - the user can specify the image format and depth
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *
  * @return [String] the blob
  */

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -448,6 +448,7 @@ ImageList_montage(VALUE self)
         // object's attributes.
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, montage_obj);
         }
         else

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1990,7 +1990,7 @@ Image_bounding_box(VALUE self)
  *     importantly, you can capture menus or other popups that are independent windows but appear
  *     over the specified window.
  *   @param borders [Boolean] If true, include the border in the image.
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *
  * @return [Magick::Image] a new image
  * @example
@@ -3114,7 +3114,7 @@ Image_columns(VALUE self)
  *     imagelist, uses the current image.
  *   @param metric [Magick::MetricType] The desired distortion metric.
  *   @param channel [Magick::ChannelType] a ChannelType arguments.
- *   @yield []
+ *   @yield [Magick::OptionalMethodArguments]
  *
  * @overload compare_channel(image, metric, *channels)
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
@@ -3135,7 +3135,7 @@ Image_columns(VALUE self)
  *   @param metric [Magick::MetricType] The desired distortion metric.
  *   @param channel [Magick::ChannelType] a ChannelType arguments.
  *   @param *channels [Magick::ChannelType] one or more ChannelType arguments.
- *   @yield []
+ *   @yield [Magick::OptionalMethodArguments]
  *
  * @return [Array] The first element is a difference image, the second is a the value of the
  *   computed distortion represented as a Float.
@@ -5569,7 +5569,7 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *     image is adjusted to ensure the whole source image will just fit within the final destination
  *     image, which will be sized and offset accordingly.  Also in many cases the virtual offset of
  *     the source image will be taken into account in the mapping.
- *   @yield []
+ *   @yield [Magick::OptionalMethodArguments]
  *
  * @return [Magick::Image] a new image
  * @example
@@ -6881,7 +6881,7 @@ Image_frame(int argc, VALUE *argv, VALUE self)
  * @overload from_blob(blob)
  *   This yields {Magick::Image::Info} to block with its object's scope.
  *   @param blob [String] the blob data
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *
  * @return [Array<Magick::Image>] an array of new images
  * @see Image#to_blob
@@ -10352,7 +10352,7 @@ Image_pixel_interpolation_method_eq(VALUE self, VALUE method)
  *   To specify a different border color (that is, the color of the image border) use info.border_color.
  *   Both of these methods accept either a color name or a Pixel argument.
  *   @param angle [Float] The resulting image is rotated by this amount, measured in degrees.
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *
  * @return [Magick::Image] a new image
  */
@@ -12324,7 +12324,7 @@ Image_segment(int argc, VALUE *argv, VALUE self)
  *   @return [Hash] the properties
  *
  * @overload properties
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *   @return [Magick::Image] self
  */
 VALUE

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1994,8 +1994,8 @@ Image_bounding_box(VALUE self)
  *
  * @return [Magick::Image] a new image
  * @example
- *   img = Image.capture {
- *     e.filename = "root"
+ *   img = Image.capture { |info|
+ *     info.filename = "root"
  *   }
  */
 VALUE
@@ -5573,9 +5573,9 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *
  * @return [Magick::Image] a new image
  * @example
- *   img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do
- *     self.define "distort:viewport", "44x44+15+0"
- *     self.define "distort:scale", 2
+ *   img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do |opts|
+ *     opts.define "distort:viewport", "44x44+15+0"
+ *     opts.define "distort:scale", 2
  *   end
  */
 VALUE

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1994,8 +1994,8 @@ Image_bounding_box(VALUE self)
  *
  * @return [Magick::Image] a new image
  * @example
- *   img = Image.capture { |info|
- *     info.filename = "root"
+ *   img = Image.capture { |options|
+ *     options.filename = "root"
  *   }
  */
 VALUE
@@ -3106,9 +3106,9 @@ Image_columns(VALUE self)
  * @overload compare_channel(image, metric, channel = Magick::AllChannels)
  *   When a block is given, compare_channel yields with a block argument you can optionally use to
  *   set attributes.
- *   - info.highlight_color = color
+ *   - options.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - info.lowlight_color = color
+ *   - options.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
@@ -3126,9 +3126,9 @@ Image_columns(VALUE self)
  * @overload compare_channel(image, metric, *channels)
  *   When a block is given, compare_channel yields with a block argument you can optionally use to
  *   set attributes.
- *   - info.highlight_color = color
+ *   - options.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - info.lowlight_color = color
+ *   - options.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
@@ -5552,15 +5552,15 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *
  * @overload distort(type, points, bestfit = false)
  *   When a block is given, distort yields with a block argument you can optionally use to set attributes.
- *   - opts.define("distort:viewport", "WxH+X+Y")
+ *   - options.define("distort:viewport", "WxH+X+Y")
  *     - Specify the size and offset of the generated viewport image of the distorted image space. W and
  *       H are the width and height, and X and Y are the offset.
- *   - opts.define("distort:scale", N)
+ *   - options.define("distort:scale", N)
  *     - N is an integer factor. Scale the output image (viewport or otherwise) by that factor without
  *       changing the viewed contents of the distorted image. This can be used either for
  *       'super-sampling' the image for a higher quality result, or for panning and zooming around
  *       the image (with appropriate viewport changes, or post-distort cropping and resizing).
- *   - opts.verbose(true)
+ *   - options.verbose(true)
  *     - Attempt to output the internal coefficients, and the -fx equivalent to the distortion, for
          expert study, and debugging purposes. This many not be available for all distorts.
  *   @param type [Magick::DistortMethod] a DistortMethod value
@@ -5573,9 +5573,9 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *
  * @return [Magick::Image] a new image
  * @example
- *   img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do |opts|
- *     opts.define "distort:viewport", "44x44+15+0"
- *     opts.define "distort:scale", 2
+ *   img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do |options|
+ *     options.define "distort:viewport", "44x44+15+0"
+ *     options.define "distort:scale", 2
  *   end
  */
 VALUE
@@ -10348,8 +10348,8 @@ Image_pixel_interpolation_method_eq(VALUE self, VALUE method)
  *   If present a block, optional arguments may be specified in a block associated with the method.
  *   These arguments control the shadow color and how the label is rendered.
  *   By default the shadow color is gray75. To specify a different shadow color,
- *   use info.shadow_color.
- *   To specify a different border color (that is, the color of the image border) use info.border_color.
+ *   use options.shadow_color.
+ *   To specify a different border color (that is, the color of the image border) use options.border_color.
  *   Both of these methods accept either a color name or a Pixel argument.
  *   @param angle [Float] The resulting image is rotated by this amount, measured in degrees.
  *   @yield [Magick::Image::Info]

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -1995,7 +1995,7 @@ Image_bounding_box(VALUE self)
  * @return [Magick::Image] a new image
  * @example
  *   img = Image.capture {
- *     self.filename = "root"
+ *     e.filename = "root"
  *   }
  */
 VALUE
@@ -3106,9 +3106,9 @@ Image_columns(VALUE self)
  * @overload compare_channel(image, metric, channel = Magick::AllChannels)
  *   If present a block, compare_channel yields to a block in which you can set optional arguments
  *   by setting attributes on self.
- *   - self.highlight_color = color
+ *   - e.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - self.lowlight_color = color
+ *   - e.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
@@ -3126,9 +3126,9 @@ Image_columns(VALUE self)
  * @overload compare_channel(image, metric, *channels)
  *   If present a block, compare_channel yields to a block in which you can set optional arguments
  *   by setting attributes on self.
- *   - self.highlight_color = color
+ *   - e.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - self.lowlight_color = color
+ *   - e.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -3104,11 +3104,11 @@ Image_columns(VALUE self)
  *   @param channel [Magick::ChannelType] a ChannelType arguments.
  *
  * @overload compare_channel(image, metric, channel = Magick::AllChannels)
- *   If present a block, compare_channel yields to a block in which you can set optional arguments
- *   by setting attributes on self.
- *   - e.highlight_color = color
+ *   When a block is given, compare_channel yields with a block argument you can optionally use to
+ *   set attributes.
+ *   - info.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - e.lowlight_color = color
+ *   - info.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
@@ -3124,11 +3124,11 @@ Image_columns(VALUE self)
  *   @param *channels [Magick::ChannelType] one or more ChannelType arguments.
  *
  * @overload compare_channel(image, metric, *channels)
- *   If present a block, compare_channel yields to a block in which you can set optional arguments
- *   by setting attributes on self.
- *   - e.highlight_color = color
+ *   When a block is given, compare_channel yields with a block argument you can optionally use to
+ *   set attributes.
+ *   - info.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
- *   - e.lowlight_color = color
+ *   - info.lowlight_color = color
  *     - Demphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
@@ -5551,17 +5551,16 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *     the source image will be taken into account in the mapping.
  *
  * @overload distort(type, points, bestfit = false)
- *   If present a block, distort yields to a block in which you can set optional arguments by
- *   setting attributes on self.
- *   - self.define("distort:viewport", "WxH+X+Y")
+ *   When a block is given, distort yields with a block argument you can optionally use to set attributes.
+ *   - opts.define("distort:viewport", "WxH+X+Y")
  *     - Specify the size and offset of the generated viewport image of the distorted image space. W and
  *       H are the width and height, and X and Y are the offset.
- *   - self.define("distort:scale", N)
+ *   - opts.define("distort:scale", N)
  *     - N is an integer factor. Scale the output image (viewport or otherwise) by that factor without
  *       changing the viewed contents of the distorted image. This can be used either for
  *       'super-sampling' the image for a higher quality result, or for panning and zooming around
  *       the image (with appropriate viewport changes, or post-distort cropping and resizing).
- *   - self.verbose(true)
+ *   - opts.verbose(true)
  *     - Attempt to output the internal coefficients, and the -fx equivalent to the distortion, for
          expert study, and debugging purposes. This many not be available for all distorts.
  *   @param type [Magick::DistortMethod] a DistortMethod value
@@ -10349,8 +10348,8 @@ Image_pixel_interpolation_method_eq(VALUE self, VALUE method)
  *   If present a block, optional arguments may be specified in a block associated with the method.
  *   These arguments control the shadow color and how the label is rendered.
  *   By default the shadow color is gray75. To specify a different shadow color,
- *   use self.shadow_color.
- *   To specify a different border color (that is, the color of the image border) use self.border_color.
+ *   use info.shadow_color.
+ *   To specify a different border color (that is, the color of the image border) use info.border_color.
  *   Both of these methods accept either a color name or a Pixel argument.
  *   @param angle [Float] The resulting image is rotated by this amount, measured in degrees.
  *   @yield []

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2405,7 +2405,7 @@ rm_info_new(void)
  * @overload initialize
  *
  * @overload initialize
- *   @yield []
+ *   @yield [Magick::Image::Info]
  *
  * @return self
  */

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2417,6 +2417,7 @@ Info_initialize(VALUE self)
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
             // Run the block in self's context
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, self);
         }
         else

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1008,6 +1008,7 @@ rm_get_optional_arguments(VALUE img)
 
         if (rb_proc_arity(rb_block_proc()) == 0)
         {
+            rb_warn("passing a block without an image argument is deprecated");
             rb_obj_instance_eval(0, NULL, opt_args);
         }
         else

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -85,7 +85,7 @@ module Magick
                      @background_image.change_geometry(Magick::Geometry.new(width, height)) do |new_cols, new_rows|
                        bg_image = @background_image.resize(new_cols, new_rows)
                        if bg_image.columns != width || bg_image.rows != height
-                         bg = Magick::Image.new(width, height) { self.background_color = bgcolor }
+                         bg = Magick::Image.new(width, height) { |e| e.background_color = bgcolor }
                          bg_image = bg.composite!(bg_image, Magick::CenterGravity, Magick::OverCompositeOp)
                        end
                        bg_image
@@ -96,7 +96,7 @@ module Magick
                  end
       else
         bgcolor = bgfill
-        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { self.background_color = bgcolor }
+        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { |e| e.background_color = bgcolor }
       end
       canvas[:desc] = @desc if @desc
       canvas[:title] = @title if @title

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -85,7 +85,7 @@ module Magick
                      @background_image.change_geometry(Magick::Geometry.new(width, height)) do |new_cols, new_rows|
                        bg_image = @background_image.resize(new_cols, new_rows)
                        if bg_image.columns != width || bg_image.rows != height
-                         bg = Magick::Image.new(width, height) { |info| info.background_color = bgcolor }
+                         bg = Magick::Image.new(width, height) { |options| options.background_color = bgcolor }
                          bg_image = bg.composite!(bg_image, Magick::CenterGravity, Magick::OverCompositeOp)
                        end
                        bg_image
@@ -96,7 +96,7 @@ module Magick
                  end
       else
         bgcolor = bgfill
-        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { |info| info.background_color = bgcolor }
+        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { |options| options.background_color = bgcolor }
       end
       canvas[:desc] = @desc if @desc
       canvas[:title] = @title if @title

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -85,7 +85,7 @@ module Magick
                      @background_image.change_geometry(Magick::Geometry.new(width, height)) do |new_cols, new_rows|
                        bg_image = @background_image.resize(new_cols, new_rows)
                        if bg_image.columns != width || bg_image.rows != height
-                         bg = Magick::Image.new(width, height) { |e| e.background_color = bgcolor }
+                         bg = Magick::Image.new(width, height) { |info| info.background_color = bgcolor }
                          bg_image = bg.composite!(bg_image, Magick::CenterGravity, Magick::OverCompositeOp)
                        end
                        bg_image
@@ -96,7 +96,7 @@ module Magick
                  end
       else
         bgcolor = bgfill
-        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { |e| e.background_color = bgcolor }
+        canvas = Magick::Image.new(Integer(@width), Integer(@height)) { |info| info.background_color = bgcolor }
       end
       canvas[:desc] = @desc if @desc
       canvas[:title] = @title if @title

--- a/spec/rmagick/class_methods/_tmpnam__spec.rb
+++ b/spec/rmagick/class_methods/_tmpnam__spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick, '._tmpnam_' do
   it 'works' do
     tmpfiles = Dir[ENV['HOME'] + '/tmp/magick*'].length
 
-    texture = Magick::Image.read('granite:') { self.size = '20x20' }.first
+    texture = Magick::Image.read('granite:') { |e| e.size = '20x20' }.first
     info = Magick::Image::Info.new
 
     # does not exist at first

--- a/spec/rmagick/class_methods/_tmpnam__spec.rb
+++ b/spec/rmagick/class_methods/_tmpnam__spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick, '._tmpnam_' do
   it 'works' do
     tmpfiles = Dir[ENV['HOME'] + '/tmp/magick*'].length
 
-    texture = Magick::Image.read('granite:') { |e| e.size = '20x20' }.first
+    texture = Magick::Image.read('granite:') { |options| options.size = '20x20' }.first
     info = Magick::Image::Info.new
 
     # does not exist at first

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     draw = described_class.new
 
     granite = Magick::Image.read('granite:').first
-    s = granite.to_blob { self.format = 'miff' }
+    s = granite.to_blob { |e| e.format = 'miff' }
     granite = Magick::Image.from_blob(s).first
-    blue_stroke = Magick::Image.new(20, 20) { self.background_color = 'blue' }
-    s = blue_stroke.to_blob { self.format = 'miff' }
+    blue_stroke = Magick::Image.new(20, 20) { |e| e.background_color = 'blue' }
+    s = blue_stroke.to_blob { |e| e.format = 'miff' }
     blue_stroke = Magick::Image.from_blob(s).first
 
     draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
@@ -45,7 +45,7 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     draw2.encoding = 'AdobeCustom'
     draw2.gravity = Magick::CenterGravity
     draw2.fill = Magick::Pixel.from_color('red')
-    draw2.fill_pattern = Magick::Image.new(10, 10) { self.format = 'miff' }
+    draw2.fill_pattern = Magick::Image.new(10, 10) { |e| e.format = 'miff' }
     draw2.stroke = Magick::Pixel.from_color('blue')
     draw2.stroke_width = 5
     draw2.text_antialias = true

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     granite = Magick::Image.read('granite:').first
     s = granite.to_blob { |e| e.format = 'miff' }
     granite = Magick::Image.from_blob(s).first
-    blue_stroke = Magick::Image.new(20, 20) { |e| e.background_color = 'blue' }
+    blue_stroke = Magick::Image.new(20, 20) { |info| info.background_color = 'blue' }
     s = blue_stroke.to_blob { |e| e.format = 'miff' }
     blue_stroke = Magick::Image.from_blob(s).first
 
@@ -45,7 +45,7 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     draw2.encoding = 'AdobeCustom'
     draw2.gravity = Magick::CenterGravity
     draw2.fill = Magick::Pixel.from_color('red')
-    draw2.fill_pattern = Magick::Image.new(10, 10) { |e| e.format = 'miff' }
+    draw2.fill_pattern = Magick::Image.new(10, 10) { |info| info.format = 'miff' }
     draw2.stroke = Magick::Pixel.from_color('blue')
     draw2.stroke_width = 5
     draw2.text_antialias = true

--- a/spec/rmagick/draw/marshal_dump_spec.rb
+++ b/spec/rmagick/draw/marshal_dump_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     draw = described_class.new
 
     granite = Magick::Image.read('granite:').first
-    s = granite.to_blob { |e| e.format = 'miff' }
+    s = granite.to_blob { |options| options.format = 'miff' }
     granite = Magick::Image.from_blob(s).first
-    blue_stroke = Magick::Image.new(20, 20) { |info| info.background_color = 'blue' }
-    s = blue_stroke.to_blob { |e| e.format = 'miff' }
+    blue_stroke = Magick::Image.new(20, 20) { |options| options.background_color = 'blue' }
+    s = blue_stroke.to_blob { |options| options.format = 'miff' }
     blue_stroke = Magick::Image.from_blob(s).first
 
     draw.affine = Magick::AffineMatrix.new(1, 2, 3, 4, 5, 6)
@@ -45,7 +45,7 @@ RSpec.describe Magick::Draw, '#marshal_dump' do
     draw2.encoding = 'AdobeCustom'
     draw2.gravity = Magick::CenterGravity
     draw2.fill = Magick::Pixel.from_color('red')
-    draw2.fill_pattern = Magick::Image.new(10, 10) { |info| info.format = 'miff' }
+    draw2.fill_pattern = Magick::Image.new(10, 10) { |options| options.format = 'miff' }
     draw2.stroke = Magick::Pixel.from_color('blue')
     draw2.stroke_width = 5
     draw2.text_antialias = true

--- a/spec/rmagick/image/blend_spec.rb
+++ b/spec/rmagick/image/blend_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, "#blend" do
   it "works" do
     image = described_class.new(20, 20)
-    image2 = described_class.new(20, 20) { self.background_color = 'black' }
+    image2 = described_class.new(20, 20) { |e| e.background_color = 'black' }
 
     expect { image.blend(image2, 0.25) }.not_to raise_error
     result = image.blend(image2, 0.25)

--- a/spec/rmagick/image/blend_spec.rb
+++ b/spec/rmagick/image/blend_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, "#blend" do
   it "works" do
     image = described_class.new(20, 20)
-    image2 = described_class.new(20, 20) { |e| e.background_color = 'black' }
+    image2 = described_class.new(20, 20) { |options| options.background_color = 'black' }
 
     expect { image.blend(image2, 0.25) }.not_to raise_error
     result = image.blend(image2, 0.25)

--- a/spec/rmagick/image/clut_channel_spec.rb
+++ b/spec/rmagick/image/clut_channel_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, "#clut_channel" do
   it "works" do
-    image = described_class.new(20, 20) { self.colorspace = Magick::GRAYColorspace }
-    clut = described_class.new(20, 1) { self.background_color = 'red' }
+    image = described_class.new(20, 20) { |e| e.colorspace = Magick::GRAYColorspace }
+    clut = described_class.new(20, 1) { |e| e.background_color = 'red' }
 
     result = image.clut_channel(clut)
     expect(result).to be(image)

--- a/spec/rmagick/image/clut_channel_spec.rb
+++ b/spec/rmagick/image/clut_channel_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, "#clut_channel" do
   it "works" do
-    image = described_class.new(20, 20) { |e| e.colorspace = Magick::GRAYColorspace }
-    clut = described_class.new(20, 1) { |e| e.background_color = 'red' }
+    image = described_class.new(20, 20) { |options| options.colorspace = Magick::GRAYColorspace }
+    clut = described_class.new(20, 1) { |options| options.background_color = 'red' }
 
     result = image.clut_channel(clut)
     expect(result).to be(image)

--- a/spec/rmagick/image/composite_mathematics_spec.rb
+++ b/spec/rmagick/image/composite_mathematics_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#composite_mathematics' do
   it 'works' do
     bg = described_class.new(50, 50)
-    fg = described_class.new(50, 50) { |e| e.background_color = 'black' }
+    fg = described_class.new(50, 50) { |options| options.background_color = 'black' }
 
     result = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/composite_mathematics_spec.rb
+++ b/spec/rmagick/image/composite_mathematics_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#composite_mathematics' do
   it 'works' do
     bg = described_class.new(50, 50)
-    fg = described_class.new(50, 50) { self.background_color = 'black' }
+    fg = described_class.new(50, 50) { |e| e.background_color = 'black' }
 
     result = bg.composite_mathematics(fg, 1, 0, 0, 0, Magick::CenterGravity)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/composite_tiled_spec.rb
+++ b/spec/rmagick/image/composite_tiled_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#composite_tiled' do
   it 'works' do
     bg = described_class.new(200, 200)
-    fg = described_class.new(50, 100) { self.background_color = 'black' }
+    fg = described_class.new(50, 100) { |e| e.background_color = 'black' }
 
     result = bg.composite_tiled(fg)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/composite_tiled_spec.rb
+++ b/spec/rmagick/image/composite_tiled_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#composite_tiled' do
   it 'works' do
     bg = described_class.new(200, 200)
-    fg = described_class.new(50, 100) { |e| e.background_color = 'black' }
+    fg = described_class.new(50, 100) { |options| options.background_color = 'black' }
 
     result = bg.composite_tiled(fg)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/displace_spec.rb
+++ b/spec/rmagick/image/displace_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#displace' do
   it 'works' do
     image = described_class.new(20, 20)
-    image2 = described_class.new(20, 20) { |e| e.background_color = 'black' }
+    image2 = described_class.new(20, 20) { |options| options.background_color = 'black' }
 
     expect { image.displace(image2, 25) }.not_to raise_error
     result = image.displace(image2, 25)

--- a/spec/rmagick/image/displace_spec.rb
+++ b/spec/rmagick/image/displace_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#displace' do
   it 'works' do
     image = described_class.new(20, 20)
-    image2 = described_class.new(20, 20) { self.background_color = 'black' }
+    image2 = described_class.new(20, 20) { |e| e.background_color = 'black' }
 
     expect { image.displace(image2, 25) }.not_to raise_error
     result = image.displace(image2, 25)

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#dissolve' do
   it 'raises an error given invalid arguments' do
-    image1 = described_class.new(100, 100) { self.background_color = 'transparent' }
-    image2 = described_class.new(100, 100) { self.background_color = 'green' }
+    image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
+    image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
 
     expect { image1.dissolve }.to raise_error(ArgumentError)
     expect { image1.dissolve(image2, 'x') }.to raise_error(ArgumentError)
@@ -12,8 +12,8 @@ RSpec.describe Magick::Image, '#dissolve' do
 
   context 'when given 2 arguments' do
     it 'works when alpha is float 0.0 to 1.0' do
-      image1 = described_class.new(100, 100) { self.background_color = 'transparent' }
-      image2 = described_class.new(100, 100) { self.background_color = 'green' }
+      image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
+      image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
 
       dissolved = image1.dissolve(image2, 0.50)
       expect(dissolved).to be_instance_of(described_class)
@@ -23,8 +23,8 @@ RSpec.describe Magick::Image, '#dissolve' do
     end
 
     it 'works when alpha is string percentage' do
-      image1 = described_class.new(100, 100) { self.background_color = 'transparent' }
-      image2 = described_class.new(100, 100) { self.background_color = 'green' }
+      image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
+      image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
 
       dissolved = image1.dissolve(image2, '50%')
       expect(dissolved).to be_instance_of(described_class)
@@ -45,14 +45,14 @@ RSpec.describe Magick::Image, '#dissolve' do
 
   context 'when given gravity' do
     # generate an image to use with gravity
-    wk = described_class.new(40, 40) { self.background_color = 'transparent' }
+    wk = described_class.new(40, 40) { |e| e.background_color = 'transparent' }
     d = Magick::Draw.new
     d.stroke('none').fill('blue')
     d.circle(wk.columns / 2, wk.rows / 2, 4, wk.rows / 2)
     d.draw(wk)
 
     it 'works on colored background' do
-      image = described_class.new(100, 100) { self.background_color = 'green' }
+      image = described_class.new(100, 100) { |e| e.background_color = 'green' }
 
       # generate an image to use with gravity
       dissolved = image.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
@@ -74,8 +74,8 @@ RSpec.describe Magick::Image, '#dissolve' do
   # still need to test with destination percentage, offsets
 
   it 'raises an error when the image has been destroyed' do
-    image1 = described_class.new(100, 100) { self.background_color = 'transparent' }
-    image2 = described_class.new(100, 100) { self.background_color = 'green' }
+    image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
+    image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
 
     image1.destroy!
     expect { image1.dissolve(image2, 0.50) }.to raise_error(Magick::DestroyedImageError)

--- a/spec/rmagick/image/dissolve_spec.rb
+++ b/spec/rmagick/image/dissolve_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#dissolve' do
   it 'raises an error given invalid arguments' do
-    image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
-    image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
+    image1 = described_class.new(100, 100) { |options| options.background_color = 'transparent' }
+    image2 = described_class.new(100, 100) { |options| options.background_color = 'green' }
 
     expect { image1.dissolve }.to raise_error(ArgumentError)
     expect { image1.dissolve(image2, 'x') }.to raise_error(ArgumentError)
@@ -12,8 +12,8 @@ RSpec.describe Magick::Image, '#dissolve' do
 
   context 'when given 2 arguments' do
     it 'works when alpha is float 0.0 to 1.0' do
-      image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
-      image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
+      image1 = described_class.new(100, 100) { |options| options.background_color = 'transparent' }
+      image2 = described_class.new(100, 100) { |options| options.background_color = 'green' }
 
       dissolved = image1.dissolve(image2, 0.50)
       expect(dissolved).to be_instance_of(described_class)
@@ -23,8 +23,8 @@ RSpec.describe Magick::Image, '#dissolve' do
     end
 
     it 'works when alpha is string percentage' do
-      image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
-      image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
+      image1 = described_class.new(100, 100) { |options| options.background_color = 'transparent' }
+      image2 = described_class.new(100, 100) { |options| options.background_color = 'green' }
 
       dissolved = image1.dissolve(image2, '50%')
       expect(dissolved).to be_instance_of(described_class)
@@ -45,14 +45,14 @@ RSpec.describe Magick::Image, '#dissolve' do
 
   context 'when given gravity' do
     # generate an image to use with gravity
-    wk = described_class.new(40, 40) { |e| e.background_color = 'transparent' }
+    wk = described_class.new(40, 40) { |options| options.background_color = 'transparent' }
     d = Magick::Draw.new
     d.stroke('none').fill('blue')
     d.circle(wk.columns / 2, wk.rows / 2, 4, wk.rows / 2)
     d.draw(wk)
 
     it 'works on colored background' do
-      image = described_class.new(100, 100) { |e| e.background_color = 'green' }
+      image = described_class.new(100, 100) { |options| options.background_color = 'green' }
 
       # generate an image to use with gravity
       dissolved = image.dissolve(wk, 0.50, 1.0, Magick::CenterGravity)
@@ -74,8 +74,8 @@ RSpec.describe Magick::Image, '#dissolve' do
   # still need to test with destination percentage, offsets
 
   it 'raises an error when the image has been destroyed' do
-    image1 = described_class.new(100, 100) { |e| e.background_color = 'transparent' }
-    image2 = described_class.new(100, 100) { |e| e.background_color = 'green' }
+    image1 = described_class.new(100, 100) { |options| options.background_color = 'transparent' }
+    image2 = described_class.new(100, 100) { |options| options.background_color = 'green' }
 
     image1.destroy!
     expect { image1.dissolve(image2, 0.50) }.to raise_error(Magick::DestroyedImageError)

--- a/spec/rmagick/image/function_channel_spec.rb
+++ b/spec/rmagick/image/function_channel_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Magick::Image, '#function_channel' do
   it 'works' do
-    image = described_class.read('gradient:') { |e| e.size = '20x600' }
+    image = described_class.read('gradient:') { |options| options.size = '20x600' }
     image = image.first
     image.rotate!(90)
     expect { image.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error

--- a/spec/rmagick/image/function_channel_spec.rb
+++ b/spec/rmagick/image/function_channel_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Magick::Image, '#function_channel' do
   it 'works' do
-    image = described_class.read('gradient:') { self.size = '20x600' }
+    image = described_class.read('gradient:') { |e| e.size = '20x600' }
     image = image.first
     image.rotate!(90)
     expect { image.function_channel Magick::PolynomialFunction, 0.33 }.not_to raise_error

--- a/spec/rmagick/image/gray_predicate_spec.rb
+++ b/spec/rmagick/image/gray_predicate_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Magick::Image, '#gray?' do
   it 'works' do
-    gray = described_class.new(20, 20) { self.background_color = 'gray50' }
+    gray = described_class.new(20, 20) { |e| e.background_color = 'gray50' }
     expect(gray.gray?).to be(true)
-    red = described_class.new(20, 20) { self.background_color = 'red' }
+    red = described_class.new(20, 20) { |e| e.background_color = 'red' }
     expect(red.gray?).to be(false)
   end
 end

--- a/spec/rmagick/image/gray_predicate_spec.rb
+++ b/spec/rmagick/image/gray_predicate_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Magick::Image, '#gray?' do
   it 'works' do
-    gray = described_class.new(20, 20) { |e| e.background_color = 'gray50' }
+    gray = described_class.new(20, 20) { |options| options.background_color = 'gray50' }
     expect(gray.gray?).to be(true)
-    red = described_class.new(20, 20) { |e| e.background_color = 'red' }
+    red = described_class.new(20, 20) { |options| options.background_color = 'red' }
     expect(red.gray?).to be(false)
   end
 end

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.background_color = red }.not_to raise_error
     expect(info.background_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |info| info.background_color = 'red' }
+    image = Magick::Image.new(20, 20) { |inner_info| inner_info.background_color = 'red' }
     expect(image.background_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.background_color = red }.not_to raise_error
     expect(info.background_color).to eq('red')
-    image = Magick::Image.new(20, 20) { self.background_color = 'red' }
+    image = Magick::Image.new(20, 20) { |e| e.background_color = 'red' }
     expect(image.background_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.background_color = red }.not_to raise_error
     expect(info.background_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |e| e.background_color = 'red' }
+    image = Magick::Image.new(20, 20) { |info| info.background_color = 'red' }
     expect(image.background_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.background_color = red }.not_to raise_error
     expect(info.background_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |inner_info| inner_info.background_color = 'red' }
+    image = Magick::Image.new(20, 20) { |options| options.background_color = 'red' }
     expect(image.background_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.border_color = red }.not_to raise_error
     expect(info.border_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |info| info.border_color = 'red' }
+    image = Magick::Image.new(20, 20) { |inner_info| inner_info.border_color = 'red' }
     expect(image.border_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.border_color = red }.not_to raise_error
     expect(info.border_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |e| e.border_color = 'red' }
+    image = Magick::Image.new(20, 20) { |info| info.border_color = 'red' }
     expect(image.border_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.border_color = red }.not_to raise_error
     expect(info.border_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |inner_info| inner_info.border_color = 'red' }
+    image = Magick::Image.new(20, 20) { |options| options.border_color = 'red' }
     expect(image.border_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.border_color = red }.not_to raise_error
     expect(info.border_color).to eq('red')
-    image = Magick::Image.new(20, 20) { self.border_color = 'red' }
+    image = Magick::Image.new(20, 20) { |e| e.border_color = 'red' }
     expect(image.border_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/info/caption_spec.rb
+++ b/spec/rmagick/image/info/caption_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Magick::Image::Info, '#caption' do
     expect(info.caption).to eq('string')
     expect { info.caption = nil }.not_to raise_error
     expect(info.caption).to be(nil)
-    expect { Magick::Image.new(20, 20) { |info| info.caption = 'string' } }.not_to raise_error
+    expect { Magick::Image.new(20, 20) { |inner_info| inner_info.caption = 'string' } }.not_to raise_error
   end
 end

--- a/spec/rmagick/image/info/caption_spec.rb
+++ b/spec/rmagick/image/info/caption_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Magick::Image::Info, '#caption' do
     expect(info.caption).to eq('string')
     expect { info.caption = nil }.not_to raise_error
     expect(info.caption).to be(nil)
-    expect { Magick::Image.new(20, 20) { |e| e.caption = 'string' } }.not_to raise_error
+    expect { Magick::Image.new(20, 20) { |info| info.caption = 'string' } }.not_to raise_error
   end
 end

--- a/spec/rmagick/image/info/caption_spec.rb
+++ b/spec/rmagick/image/info/caption_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Magick::Image::Info, '#caption' do
     expect(info.caption).to eq('string')
     expect { info.caption = nil }.not_to raise_error
     expect(info.caption).to be(nil)
-    expect { Magick::Image.new(20, 20) { |inner_info| inner_info.caption = 'string' } }.not_to raise_error
+    expect { Magick::Image.new(20, 20) { |options| options.caption = 'string' } }.not_to raise_error
   end
 end

--- a/spec/rmagick/image/info/caption_spec.rb
+++ b/spec/rmagick/image/info/caption_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Magick::Image::Info, '#caption' do
     expect(info.caption).to eq('string')
     expect { info.caption = nil }.not_to raise_error
     expect(info.caption).to be(nil)
-    expect { Magick::Image.new(20, 20) { self.caption = 'string' } }.not_to raise_error
+    expect { Magick::Image.new(20, 20) { |e| e.caption = 'string' } }.not_to raise_error
   end
 end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.matte_color = red }.not_to raise_error
     expect(info.matte_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |info| info.matte_color = 'red' }
+    image = Magick::Image.new(20, 20) { |inner_info| inner_info.matte_color = 'red' }
     expect(image.matte_color).to eq('red')
     expect { info.matte_color = nil }.to raise_error(TypeError)
   end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.matte_color = red }.not_to raise_error
     expect(info.matte_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |e| e.matte_color = 'red' }
+    image = Magick::Image.new(20, 20) { |info| info.matte_color = 'red' }
     expect(image.matte_color).to eq('red')
     expect { info.matte_color = nil }.to raise_error(TypeError)
   end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.matte_color = red }.not_to raise_error
     expect(info.matte_color).to eq('red')
-    image = Magick::Image.new(20, 20) { |inner_info| inner_info.matte_color = 'red' }
+    image = Magick::Image.new(20, 20) { |options| options.matte_color = 'red' }
     expect(image.matte_color).to eq('red')
     expect { info.matte_color = nil }.to raise_error(TypeError)
   end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.matte_color = red }.not_to raise_error
     expect(info.matte_color).to eq('red')
-    image = Magick::Image.new(20, 20) { self.matte_color = 'red' }
+    image = Magick::Image.new(20, 20) { |e| e.matte_color = 'red' }
     expect(image.matte_color).to eq('red')
     expect { info.matte_color = nil }.to raise_error(TypeError)
   end

--- a/spec/rmagick/image/info/monitor_spec.rb
+++ b/spec/rmagick/image/info/monitor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Magick::Image::Info, '#monitor' do
       GC.start
       true
     end
-    image = Magick::Image.new(2000, 2000) { |info| info.monitor = monitor }
+    image = Magick::Image.new(2000, 2000) { |inner_info| inner_info.monitor = monitor }
     image.resize!(20, 20)
     image.monitor = nil
 

--- a/spec/rmagick/image/info/monitor_spec.rb
+++ b/spec/rmagick/image/info/monitor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Magick::Image::Info, '#monitor' do
       GC.start
       true
     end
-    image = Magick::Image.new(2000, 2000) { |inner_info| inner_info.monitor = monitor }
+    image = Magick::Image.new(2000, 2000) { |options| options.monitor = monitor }
     image.resize!(20, 20)
     image.monitor = nil
 

--- a/spec/rmagick/image/info/monitor_spec.rb
+++ b/spec/rmagick/image/info/monitor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Magick::Image::Info, '#monitor' do
       GC.start
       true
     end
-    image = Magick::Image.new(2000, 2000) { |e| e.monitor = monitor }
+    image = Magick::Image.new(2000, 2000) { |info| info.monitor = monitor }
     image.resize!(20, 20)
     image.monitor = nil
 

--- a/spec/rmagick/image/info/monitor_spec.rb
+++ b/spec/rmagick/image/info/monitor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Magick::Image::Info, '#monitor' do
       GC.start
       true
     end
-    image = Magick::Image.new(2000, 2000) { self.monitor = monitor }
+    image = Magick::Image.new(2000, 2000) { |e| e.monitor = monitor }
     image.resize!(20, 20)
     image.monitor = nil
 

--- a/spec/rmagick/image/info/texture_spec.rb
+++ b/spec/rmagick/image/info/texture_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image::Info, '#texture' do
   it 'works' do
     info = described_class.new
-    image = Magick::Image.read('granite:') { self.size = '20x20' }
+    image = Magick::Image.read('granite:') { |e| e.size = '20x20' }
 
     expect { info.texture = image.first }.not_to raise_error
     expect { info.texture = nil }.not_to raise_error

--- a/spec/rmagick/image/info/texture_spec.rb
+++ b/spec/rmagick/image/info/texture_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image::Info, '#texture' do
   it 'works' do
     info = described_class.new
-    image = Magick::Image.read('granite:') { |e| e.size = '20x20' }
+    image = Magick::Image.read('granite:') { |options| options.size = '20x20' }
 
     expect { info.texture = image.first }.not_to raise_error
     expect { info.texture = nil }.not_to raise_error

--- a/spec/rmagick/image/new_spec.rb
+++ b/spec/rmagick/image/new_spec.rb
@@ -3,24 +3,12 @@ RSpec.describe Magick::Image, '#new' do
     self_obj = nil
     yield_obj = nil
 
-    # call instance_eval
-    described_class.new(20, 20) do
-      self_obj = self
-    end
-    expect(self_obj).to be_instance_of(Magick::Image::Info)
-
-    # call yield
     described_class.new(20, 20) do |e|
       yield_obj = e
       self_obj = self
     end
+
     expect(yield_obj).to be_instance_of(Magick::Image::Info)
     expect(self_obj).to eq(self)
-
-    # Able to write in the following manner by calling in yield
-    #
-    # @background_color = 'red'
-    # image = described_class.new(20, 20) { |e| e.background_color = @background_color }
-    # expect(image.background_color).to eq('red')
   end
 end

--- a/spec/rmagick/image/new_spec.rb
+++ b/spec/rmagick/image/new_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Magick::Image, '#new' do
     self_obj = nil
     yield_obj = nil
 
-    described_class.new(20, 20) do |e|
-      yield_obj = e
+    described_class.new(20, 20) do |options|
+      yield_obj = options
       self_obj = self
     end
 

--- a/spec/rmagick/image/pixel_color_spec.rb
+++ b/spec/rmagick/image/pixel_color_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Magick::Image, '#pixel_color' do
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     expect { image.pixel_color(0, 0, blue) }.not_to raise_error
     # If args are out-of-bounds return the background color
-    image = described_class.new(10, 10) { self.background_color = 'blue' }
+    image = described_class.new(10, 10) { |e| e.background_color = 'blue' }
     expect(image.pixel_color(50, 50).to_color).to eq('blue')
 
     image.class_type = Magick::PseudoClass
@@ -24,7 +24,7 @@ RSpec.describe Magick::Image, '#pixel_color' do
   end
 
   it 'get/set CYMK color', unsupported_before('6.8.0') do
-    image = described_class.new(20, 30) { self.quality = 100 }
+    image = described_class.new(20, 30) { |e| e.quality = 100 }
     image.colorspace = Magick::CMYKColorspace
 
     pixel = Magick::Pixel.new

--- a/spec/rmagick/image/pixel_color_spec.rb
+++ b/spec/rmagick/image/pixel_color_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Magick::Image, '#pixel_color' do
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     expect { image.pixel_color(0, 0, blue) }.not_to raise_error
     # If args are out-of-bounds return the background color
-    image = described_class.new(10, 10) { |e| e.background_color = 'blue' }
+    image = described_class.new(10, 10) { |options| options.background_color = 'blue' }
     expect(image.pixel_color(50, 50).to_color).to eq('blue')
 
     image.class_type = Magick::PseudoClass
@@ -24,7 +24,7 @@ RSpec.describe Magick::Image, '#pixel_color' do
   end
 
   it 'get/set CYMK color', unsupported_before('6.8.0') do
-    image = described_class.new(20, 30) { |e| e.quality = 100 }
+    image = described_class.new(20, 30) { |options| options.quality = 100 }
     image.colorspace = Magick::CMYKColorspace
 
     pixel = Magick::Pixel.new

--- a/spec/rmagick/image/remap_spec.rb
+++ b/spec/rmagick/image/remap_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#remap' do
   it 'works' do
     image = described_class.new(20, 20)
-    remap_image = described_class.new(20, 20) { |e| e.background_color = 'green' }
+    remap_image = described_class.new(20, 20) { |options| options.background_color = 'green' }
 
     expect { image.remap(remap_image) }.not_to raise_error
     expect { image.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error

--- a/spec/rmagick/image/remap_spec.rb
+++ b/spec/rmagick/image/remap_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#remap' do
   it 'works' do
     image = described_class.new(20, 20)
-    remap_image = described_class.new(20, 20) { self.background_color = 'green' }
+    remap_image = described_class.new(20, 20) { |e| e.background_color = 'green' }
 
     expect { image.remap(remap_image) }.not_to raise_error
     expect { image.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error

--- a/spec/rmagick/image/stegano_spec.rb
+++ b/spec/rmagick/image/stegano_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#stegano' do
   it 'works' do
-    image = described_class.new(100, 100) { self.background_color = 'black' }
-    watermark = described_class.new(10, 10) { self.background_color = 'white' }
+    image = described_class.new(100, 100) { |e| e.background_color = 'black' }
+    watermark = described_class.new(10, 10) { |e| e.background_color = 'white' }
 
     result = image.stegano(watermark, 0)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/stegano_spec.rb
+++ b/spec/rmagick/image/stegano_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Magick::Image, '#stegano' do
   it 'works' do
-    image = described_class.new(100, 100) { |e| e.background_color = 'black' }
-    watermark = described_class.new(10, 10) { |e| e.background_color = 'white' }
+    image = described_class.new(100, 100) { |options| options.background_color = 'black' }
+    watermark = described_class.new(10, 10) { |options| options.background_color = 'white' }
 
     result = image.stegano(watermark, 0)
     expect(result).to be_instance_of(described_class)

--- a/spec/rmagick/image/to_blob_spec.rb
+++ b/spec/rmagick/image/to_blob_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Magick::Image, '#to_blob' do
   it 'works' do
     image = described_class.new(20, 20)
 
-    result = image.to_blob { |e| e.format = 'miff' }
+    result = image.to_blob { |options| options.format = 'miff' }
     expect(result).to be_instance_of(String)
     restored = described_class.from_blob(result)
     expect(restored[0]).to eq(image)

--- a/spec/rmagick/image/to_blob_spec.rb
+++ b/spec/rmagick/image/to_blob_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Magick::Image, '#to_blob' do
   it 'works' do
     image = described_class.new(20, 20)
 
-    result = image.to_blob { self.format = 'miff' }
+    result = image.to_blob { |e| e.format = 'miff' }
     expect(result).to be_instance_of(String)
     restored = described_class.from_blob(result)
     expect(restored[0]).to eq(image)

--- a/spec/rmagick/image/write_spec.rb
+++ b/spec/rmagick/image/write_spec.rb
@@ -12,33 +12,33 @@ RSpec.describe Magick::Image, '#write' do
     expect(image2.first.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
-    image1.write('temp.0') { |e| e.format = 'JPEG' }
+    image1.write('temp.0') { |options| options.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
     # JPEG has two names.
-    image1.write('jpeg:temp.0') { |e| e.format = 'JPEG' }
+    image1.write('jpeg:temp.0') { |options| options.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpg:temp.0') { |e| e.format = 'JPG' }
+    image1.write('jpg:temp.0') { |options| options.format = 'JPG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpg:temp.0') { |e| e.format = 'JPEG' }
+    image1.write('jpg:temp.0') { |options| options.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpeg:temp.0') { |e| e.format = 'JPG' }
+    image1.write('jpeg:temp.0') { |options| options.format = 'JPG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
     expect do
-      image1.write('gif:temp.0') { |e| e.format = 'JPEG' }
+      image1.write('gif:temp.0') { |options| options.format = 'JPEG' }
     end.to raise_error(RuntimeError)
 
     f = File.new('test.0', 'w')
-    image1.write(f) { |e| e.format = 'JPEG' }
+    image1.write(f) { |options| options.format = 'JPEG' }
     f.close
     image2 = described_class.read('test.0')
     expect(image2.first.format).to eq('JPEG')
@@ -54,9 +54,9 @@ RSpec.describe Magick::Image, '#write' do
     end # Avoid failure on AppVeyor
 
     f = File.new('test.0', 'w')
-    described_class.new(100, 100).write(f) do |e|
-      e.format = 'JPEG'
-      e.colorspace = Magick::CMYKColorspace
+    described_class.new(100, 100).write(f) do |options|
+      options.format = 'JPEG'
+      options.colorspace = Magick::CMYKColorspace
     end
     f.close
     image2 = described_class.read('test.0')

--- a/spec/rmagick/image/write_spec.rb
+++ b/spec/rmagick/image/write_spec.rb
@@ -12,33 +12,33 @@ RSpec.describe Magick::Image, '#write' do
     expect(image2.first.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
-    image1.write('temp.0') { self.format = 'JPEG' }
+    image1.write('temp.0') { |e| e.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
     # JPEG has two names.
-    image1.write('jpeg:temp.0') { self.format = 'JPEG' }
+    image1.write('jpeg:temp.0') { |e| e.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpg:temp.0') { self.format = 'JPG' }
+    image1.write('jpg:temp.0') { |e| e.format = 'JPG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpg:temp.0') { self.format = 'JPEG' }
+    image1.write('jpg:temp.0') { |e| e.format = 'JPEG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
-    image1.write('jpeg:temp.0') { self.format = 'JPG' }
+    image1.write('jpeg:temp.0') { |e| e.format = 'JPG' }
     image2 = described_class.read('temp.0')
     expect(image2.first.format).to eq('JPEG')
 
     expect do
-      image1.write('gif:temp.0') { self.format = 'JPEG' }
+      image1.write('gif:temp.0') { |e| e.format = 'JPEG' }
     end.to raise_error(RuntimeError)
 
     f = File.new('test.0', 'w')
-    image1.write(f) { self.format = 'JPEG' }
+    image1.write(f) { |e| e.format = 'JPEG' }
     f.close
     image2 = described_class.read('test.0')
     expect(image2.first.format).to eq('JPEG')
@@ -54,9 +54,9 @@ RSpec.describe Magick::Image, '#write' do
     end # Avoid failure on AppVeyor
 
     f = File.new('test.0', 'w')
-    described_class.new(100, 100).write(f) do
-      self.format = 'JPEG'
-      self.colorspace = Magick::CMYKColorspace
+    described_class.new(100, 100).write(f) do |e|
+      e.format = 'JPEG'
+      e.colorspace = Magick::CMYKColorspace
     end
     f.close
     image2 = described_class.read('test.0')

--- a/spec/rmagick/image_list/combine_spec.rb
+++ b/spec/rmagick/image_list/combine_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Magick::ImageList, '#combine' do
   it 'works' do
-    red   = Magick::Image.new(20, 20) { |info| info.background_color = 'red' }
-    green = Magick::Image.new(20, 20) { |info| info.background_color = 'green' }
-    blue  = Magick::Image.new(20, 20) { |info| info.background_color = 'blue' }
-    black = Magick::Image.new(20, 20) { |info| info.background_color = 'black' }
-    alpha = Magick::Image.new(20, 20) { |info| info.background_color = 'transparent' }
+    red   = Magick::Image.new(20, 20) { |options| options.background_color = 'red' }
+    green = Magick::Image.new(20, 20) { |options| options.background_color = 'green' }
+    blue  = Magick::Image.new(20, 20) { |options| options.background_color = 'blue' }
+    black = Magick::Image.new(20, 20) { |options| options.background_color = 'black' }
+    alpha = Magick::Image.new(20, 20) { |options| options.background_color = 'transparent' }
 
     image_list = described_class.new
     expect { image_list.combine }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/combine_spec.rb
+++ b/spec/rmagick/image_list/combine_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Magick::ImageList, '#combine' do
   it 'works' do
-    red   = Magick::Image.new(20, 20) { self.background_color = 'red' }
-    green = Magick::Image.new(20, 20) { self.background_color = 'green' }
-    blue  = Magick::Image.new(20, 20) { self.background_color = 'blue' }
-    black = Magick::Image.new(20, 20) { self.background_color = 'black' }
-    alpha = Magick::Image.new(20, 20) { self.background_color = 'transparent' }
+    red   = Magick::Image.new(20, 20) { |e| e.background_color = 'red' }
+    green = Magick::Image.new(20, 20) { |e| e.background_color = 'green' }
+    blue  = Magick::Image.new(20, 20) { |e| e.background_color = 'blue' }
+    black = Magick::Image.new(20, 20) { |e| e.background_color = 'black' }
+    alpha = Magick::Image.new(20, 20) { |e| e.background_color = 'transparent' }
 
     image_list = described_class.new
     expect { image_list.combine }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/combine_spec.rb
+++ b/spec/rmagick/image_list/combine_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Magick::ImageList, '#combine' do
   it 'works' do
-    red   = Magick::Image.new(20, 20) { |e| e.background_color = 'red' }
-    green = Magick::Image.new(20, 20) { |e| e.background_color = 'green' }
-    blue  = Magick::Image.new(20, 20) { |e| e.background_color = 'blue' }
-    black = Magick::Image.new(20, 20) { |e| e.background_color = 'black' }
-    alpha = Magick::Image.new(20, 20) { |e| e.background_color = 'transparent' }
+    red   = Magick::Image.new(20, 20) { |info| info.background_color = 'red' }
+    green = Magick::Image.new(20, 20) { |info| info.background_color = 'green' }
+    blue  = Magick::Image.new(20, 20) { |info| info.background_color = 'blue' }
+    black = Magick::Image.new(20, 20) { |info| info.background_color = 'black' }
+    alpha = Magick::Image.new(20, 20) { |info| info.background_color = 'transparent' }
 
     image_list = described_class.new
     expect { image_list.combine }.to raise_error(ArgumentError)

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -11,31 +11,31 @@ RSpec.describe Magick::ImageList, "#montage" do
     image_list1.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     image_list2 = image_list1.copy
 
-    montage = image_list2.montage do |e|
-      e.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-      e.background_color = 'blue'
-      e.border_color = Magick::Pixel.new(0, 0, 0)
-      e.border_color = 'red'
-      e.border_width = 2
-      e.compose = Magick::OverCompositeOp
-      e.filename = 'test.png'
-      e.fill = 'green'
-      e.font = Magick.fonts.first.name
-      e.frame = '20x20+4+4'
-      e.frame = Magick::Geometry.new(20, 20, 4, 4)
-      e.geometry = '63x60+5+5'
-      e.geometry = Magick::Geometry.new(63, 60, 5, 5)
-      e.gravity = Magick::SouthGravity
-      e.matte_color = '#bdbdbd'
-      e.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-      e.pointsize = 12
-      e.shadow = true
-      e.stroke = 'transparent'
-      e.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-      e.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-      e.tile = '4x9'
-      e.tile = Magick::Geometry.new(4, 9)
-      e.title = 'sample'
+    montage = image_list2.montage do |options|
+      options.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      options.background_color = 'blue'
+      options.border_color = Magick::Pixel.new(0, 0, 0)
+      options.border_color = 'red'
+      options.border_width = 2
+      options.compose = Magick::OverCompositeOp
+      options.filename = 'test.png'
+      options.fill = 'green'
+      options.font = Magick.fonts.first.name
+      options.frame = '20x20+4+4'
+      options.frame = Magick::Geometry.new(20, 20, 4, 4)
+      options.geometry = '63x60+5+5'
+      options.geometry = Magick::Geometry.new(63, 60, 5, 5)
+      options.gravity = Magick::SouthGravity
+      options.matte_color = '#bdbdbd'
+      options.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      options.pointsize = 12
+      options.shadow = true
+      options.stroke = 'transparent'
+      options.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      options.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      options.tile = '4x9'
+      options.tile = Magick::Geometry.new(4, 9)
+      options.title = 'sample'
     end
     expect(montage).to be_instance_of(described_class)
     expect(image_list2).to eq(image_list1)
@@ -48,51 +48,51 @@ RSpec.describe Magick::ImageList, "#montage" do
     # looks like IM doesn't diagnose invalid geometry args
     # to tile= and geometry=
     expect do
-      montage = image_list2.montage { |e| e.background_color = 2 }
+      montage = image_list2.montage { |options| options.background_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.border_color = 2 }
+      montage = image_list2.montage { |options| options.border_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.border_width = [2] }
+      montage = image_list2.montage { |options| options.border_width = [2] }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.compose = 2 }
+      montage = image_list2.montage { |options| options.compose = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.filename = 2 }
+      montage = image_list2.montage { |options| options.filename = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.fill = 2 }
+      montage = image_list2.montage { |options| options.fill = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.font = 2 }
+      montage = image_list2.montage { |options| options.font = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.gravity = 2 }
+      montage = image_list2.montage { |options| options.gravity = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.matte_color = 2 }
+      montage = image_list2.montage { |options| options.matte_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.pointsize = 'x' }
+      montage = image_list2.montage { |options| options.pointsize = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { |e| e.stroke = 'x' }
+      montage = image_list2.montage { |options| options.stroke = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(ArgumentError)
     expect do
-      montage = image_list2.montage { |e| e.texture = 'x' }
+      montage = image_list2.montage { |options| options.texture = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(NoMethodError)
   end
@@ -100,13 +100,13 @@ RSpec.describe Magick::ImageList, "#montage" do
   it 'montages the image' do
     imagelist = described_class.new(IMAGES_DIR + '/Flower_Hat.jpg')
 
-    new_imagelist = imagelist.montage do |e|
-      e.border_width = 100
-      e.border_color = 'red'
-      e.background_color = 'blue'
-      e.matte_color = 'yellow'
-      e.frame = '10x10'
-      e.gravity = Magick::CenterGravity
+    new_imagelist = imagelist.montage do |options|
+      options.border_width = 100
+      options.border_color = 'red'
+      options.background_color = 'blue'
+      options.matte_color = 'yellow'
+      options.frame = '10x10'
+      options.gravity = Magick::CenterGravity
     end
 
     # montage ../../doc/ex/images/Flower_Hat.jpg -border 100x -bordercolor red -mattecolor yellow -background blue -frame 10x10 -gravity Center expected/montage_border_color.jpg

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -11,31 +11,31 @@ RSpec.describe Magick::ImageList, "#montage" do
     image_list1.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     image_list2 = image_list1.copy
 
-    montage = image_list2.montage do
-      self.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-      self.background_color = 'blue'
-      self.border_color = Magick::Pixel.new(0, 0, 0)
-      self.border_color = 'red'
-      self.border_width = 2
-      self.compose = Magick::OverCompositeOp
-      self.filename = 'test.png'
-      self.fill = 'green'
-      self.font = Magick.fonts.first.name
-      self.frame = '20x20+4+4'
-      self.frame = Magick::Geometry.new(20, 20, 4, 4)
-      self.geometry = '63x60+5+5'
-      self.geometry = Magick::Geometry.new(63, 60, 5, 5)
-      self.gravity = Magick::SouthGravity
-      self.matte_color = '#bdbdbd'
-      self.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
-      self.pointsize = 12
-      self.shadow = true
-      self.stroke = 'transparent'
-      self.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
-      self.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
-      self.tile = '4x9'
-      self.tile = Magick::Geometry.new(4, 9)
-      self.title = 'sample'
+    montage = image_list2.montage do |e|
+      e.background_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      e.background_color = 'blue'
+      e.border_color = Magick::Pixel.new(0, 0, 0)
+      e.border_color = 'red'
+      e.border_width = 2
+      e.compose = Magick::OverCompositeOp
+      e.filename = 'test.png'
+      e.fill = 'green'
+      e.font = Magick.fonts.first.name
+      e.frame = '20x20+4+4'
+      e.frame = Magick::Geometry.new(20, 20, 4, 4)
+      e.geometry = '63x60+5+5'
+      e.geometry = Magick::Geometry.new(63, 60, 5, 5)
+      e.gravity = Magick::SouthGravity
+      e.matte_color = '#bdbdbd'
+      e.matte_color = Magick::Pixel.new(Magick::QuantumRange, 0, 0)
+      e.pointsize = 12
+      e.shadow = true
+      e.stroke = 'transparent'
+      e.texture = Magick::Image.read(IMAGES_DIR + '/Button_0.gif').first
+      e.texture = Magick::Image.read(IMAGES_DIR + '/Button_1.gif').first
+      e.tile = '4x9'
+      e.tile = Magick::Geometry.new(4, 9)
+      e.title = 'sample'
     end
     expect(montage).to be_instance_of(described_class)
     expect(image_list2).to eq(image_list1)
@@ -48,51 +48,51 @@ RSpec.describe Magick::ImageList, "#montage" do
     # looks like IM doesn't diagnose invalid geometry args
     # to tile= and geometry=
     expect do
-      montage = image_list2.montage { self.background_color = 2 }
+      montage = image_list2.montage { |e| e.background_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.border_color = 2 }
+      montage = image_list2.montage { |e| e.border_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.border_width = [2] }
+      montage = image_list2.montage { |e| e.border_width = [2] }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.compose = 2 }
+      montage = image_list2.montage { |e| e.compose = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.filename = 2 }
+      montage = image_list2.montage { |e| e.filename = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.fill = 2 }
+      montage = image_list2.montage { |e| e.fill = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.font = 2 }
+      montage = image_list2.montage { |e| e.font = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.gravity = 2 }
+      montage = image_list2.montage { |e| e.gravity = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.matte_color = 2 }
+      montage = image_list2.montage { |e| e.matte_color = 2 }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.pointsize = 'x' }
+      montage = image_list2.montage { |e| e.pointsize = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(TypeError)
     expect do
-      montage = image_list2.montage { self.stroke = 'x' }
+      montage = image_list2.montage { |e| e.stroke = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(ArgumentError)
     expect do
-      montage = image_list2.montage { self.texture = 'x' }
+      montage = image_list2.montage { |e| e.texture = 'x' }
       expect(image_list2).to eq(image_list1)
     end.to raise_error(NoMethodError)
   end
@@ -100,13 +100,13 @@ RSpec.describe Magick::ImageList, "#montage" do
   it 'montages the image' do
     imagelist = described_class.new(IMAGES_DIR + '/Flower_Hat.jpg')
 
-    new_imagelist = imagelist.montage do
-      self.border_width = 100
-      self.border_color = 'red'
-      self.background_color = 'blue'
-      self.matte_color = 'yellow'
-      self.frame = '10x10'
-      self.gravity = Magick::CenterGravity
+    new_imagelist = imagelist.montage do |e|
+      e.border_width = 100
+      e.border_color = 'red'
+      e.background_color = 'blue'
+      e.matte_color = 'yellow'
+      e.frame = '10x10'
+      e.gravity = Magick::CenterGravity
     end
 
     # montage ../../doc/ex/images/Flower_Hat.jpg -border 100x -bordercolor red -mattecolor yellow -background blue -frame 10x10 -gravity Center expected/montage_border_color.jpg

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Magick::ImageList, "#new_image" do
     image_list.new_image(20, 20, Magick::HatchFill.new('black'))
     expect(image_list.length).to eq(2)
     expect(image_list.scene).to eq(1)
-    image_list.new_image(20, 20) { self.background_color = 'red' }
+    image_list.new_image(20, 20) { |e| e.background_color = 'red' }
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
 

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Magick::ImageList, "#new_image" do
     image_list.new_image(20, 20, Magick::HatchFill.new('black'))
     expect(image_list.length).to eq(2)
     expect(image_list.scene).to eq(1)
-    image_list.new_image(20, 20) { |e| e.background_color = 'red' }
+    image_list.new_image(20, 20) { |info| info.background_color = 'red' }
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
 

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Magick::ImageList, "#new_image" do
     image_list.new_image(20, 20, Magick::HatchFill.new('black'))
     expect(image_list.length).to eq(2)
     expect(image_list.scene).to eq(1)
-    image_list.new_image(20, 20) { |info| info.background_color = 'red' }
+    image_list.new_image(20, 20) { |options| options.background_color = 'red' }
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
 

--- a/spec/rmagick/image_list/ping_spec.rb
+++ b/spec/rmagick/image_list/ping_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick::ImageList, "#ping" do
     expect { image_list.ping(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
-    expect { image_list.ping(FLOWER_HAT) { |e| e.background_color = 'red ' } }.not_to raise_error
+    expect { image_list.ping(FLOWER_HAT) { |options| options.background_color = 'red ' } }.not_to raise_error
     expect(image_list.length).to eq(4)
     expect(image_list.scene).to eq(3)
   end

--- a/spec/rmagick/image_list/ping_spec.rb
+++ b/spec/rmagick/image_list/ping_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick::ImageList, "#ping" do
     expect { image_list.ping(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
-    expect { image_list.ping(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
+    expect { image_list.ping(FLOWER_HAT) { |e| e.background_color = 'red ' } }.not_to raise_error
     expect(image_list.length).to eq(4)
     expect(image_list.scene).to eq(3)
   end

--- a/spec/rmagick/image_list/read_spec.rb
+++ b/spec/rmagick/image_list/read_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick::ImageList, "#read" do
     expect { image_list.read(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
-    expect { image_list.read(FLOWER_HAT) { |e| e.background_color = 'red ' } }.not_to raise_error
+    expect { image_list.read(FLOWER_HAT) { |options| options.background_color = 'red ' } }.not_to raise_error
     expect(image_list.length).to eq(4)
     expect(image_list.scene).to eq(3)
   end

--- a/spec/rmagick/image_list/read_spec.rb
+++ b/spec/rmagick/image_list/read_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magick::ImageList, "#read" do
     expect { image_list.read(FLOWER_HAT, FLOWER_HAT) }.not_to raise_error
     expect(image_list.length).to eq(3)
     expect(image_list.scene).to eq(2)
-    expect { image_list.read(FLOWER_HAT) { self.background_color = 'red ' } }.not_to raise_error
+    expect { image_list.read(FLOWER_HAT) { |e| e.background_color = 'red ' } }.not_to raise_error
     expect(image_list.length).to eq(4)
     expect(image_list.scene).to eq(3)
   end

--- a/spec/rmagick/image_list/remap_spec.rb
+++ b/spec/rmagick/image_list/remap_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Magick::ImageList, "#remap" do
 
     image_list.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     expect { image_list.remap }.not_to raise_error
-    remap_image = Magick::Image.new(20, 20) { |info| info.background_color = 'green' }
+    remap_image = Magick::Image.new(20, 20) { |options| options.background_color = 'green' }
     expect { image_list.remap(remap_image) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error

--- a/spec/rmagick/image_list/remap_spec.rb
+++ b/spec/rmagick/image_list/remap_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Magick::ImageList, "#remap" do
 
     image_list.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     expect { image_list.remap }.not_to raise_error
-    remap_image = Magick::Image.new(20, 20) { self.background_color = 'green' }
+    remap_image = Magick::Image.new(20, 20) { |e| e.background_color = 'green' }
     expect { image_list.remap(remap_image) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error

--- a/spec/rmagick/image_list/remap_spec.rb
+++ b/spec/rmagick/image_list/remap_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Magick::ImageList, "#remap" do
 
     image_list.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     expect { image_list.remap }.not_to raise_error
-    remap_image = Magick::Image.new(20, 20) { |e| e.background_color = 'green' }
+    remap_image = Magick::Image.new(20, 20) { |info| info.background_color = 'green' }
     expect { image_list.remap(remap_image) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::NoDitherMethod) }.not_to raise_error
     expect { image_list.remap(remap_image, Magick::RiemersmaDitherMethod) }.not_to raise_error

--- a/spec/rmagick/image_list/write_spec.rb
+++ b/spec/rmagick/image_list/write_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Magick::ImageList, "#write" do
     expect(image_list.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
-    image_list.write('temp.0') { self.format = 'JPEG' }
+    image_list.write('temp.0') { |e| e.format = 'JPEG' }
     image_list = described_class.new('temp.0')
     expect(image_list.format).to eq('JPEG')
     FileUtils.rm('temp.0')
 
     f = File.new('test.0', 'w')
-    image_list.write(f) { self.format = 'JPEG' }
+    image_list.write(f) { |e| e.format = 'JPEG' }
     f.close
     image_list = described_class.new('test.0')
     expect(image_list.format).to eq('JPEG')

--- a/spec/rmagick/image_list/write_spec.rb
+++ b/spec/rmagick/image_list/write_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Magick::ImageList, "#write" do
     expect(image_list.format).to eq('JPEG')
     FileUtils.rm('temp.foo')
 
-    image_list.write('temp.0') { |e| e.format = 'JPEG' }
+    image_list.write('temp.0') { |options| options.format = 'JPEG' }
     image_list = described_class.new('temp.0')
     expect(image_list.format).to eq('JPEG')
     FileUtils.rm('temp.0')
 
     f = File.new('test.0', 'w')
-    image_list.write(f) { |e| e.format = 'JPEG' }
+    image_list.write(f) { |options| options.format = 'JPEG' }
     f.close
     image_list = described_class.new('test.0')
     expect(image_list.format).to eq('JPEG')


### PR DESCRIPTION
# Substitution procedure

    "{\s+self\." → '{ |e| e.'
    "self\.(\w+)\s*=\s*" → 'e.#{$1} = '
    "(\.annotate|\.montage|\.read|\.new_image|\.write|\.polaroid|Image\.new)\b(.*)do\n" → '#{$1}#{$2}do |e|\n'
    "Image.new(.*){ \|e\| e\." → 'Image.new#{$1}{ |info| info.'
    "(\.new_image)(.*){ \|e\| e\." → '#{$1}#{$2}{ |info| info.'
    "(\.new_image)(.*) do \|e\| e\." → '#{$1}#{$2} do |info| info.'
    "|e|" → "|options|"
    "|info|" → "|options|"

# Exchange too much undo

    "e\.(background_color|scene)\b" → 'self.#{$1}' lib/rmagick_internal.rb
    "e\.(red|green|blue|alpha)" → 'self.#{$1}' examples/histogram.rb

    git checkout -- lib/rvg/text.rb
    git checkout -- spec/support/matchers/match_pixels_matcher.rb
    git checkout -- doc/*.html

# Operation check procedure

    rake
    (cd doc/ex && find -name '*.rb' -exec ruby -I../../lib {} \;)
    (cd examples && find -name '*.rb' -exec ruby -I../lib {} \;)

I confirmed that there was no warning.

Block arguments were generally used to use `e`.
