### PR TITLE
Replace blocks that do not receive arguments in document

### DIFF
--- a/doc/comtasks.html
+++ b/doc/comtasks.html
@@ -255,7 +255,7 @@ thumb = img.resize_to_fit(75, 75)
   <p>For more information, see the ImageMagick documentation for
   the <code>-quality</code> option to the utility commands.</p>
   <pre class="example">
-img.write("myimage.jpg") { self.quality = 50 }
+img.write("myimage.jpg") { |options| options.quality = 50 }
 </pre>
 
   <h2 id="shadow">Making a drop shadow</h2>

--- a/doc/draw.html
+++ b/doc/draw.html
@@ -370,13 +370,13 @@ gc = Draw.new
     "Click to see the example script">colors.rb</a>. Many other
     examples also use <code>annotate</code>.</p>
     <pre>
-title.annotate(montage, 0,0,0,40, 'Named Colors') {
-    self.font_family = 'Helvetica'
-    self.fill = 'white'
-    self.stroke = 'transparent'
-    self.pointsize = 32
-    self.font_weight = BoldWeight
-    self.gravity = NorthGravity
+title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
+    options.font_family = 'Helvetica'
+    options.fill = 'white'
+    options.stroke = 'transparent'
+    options.pointsize = 32
+    options.font_weight = BoldWeight
+    options.gravity = NorthGravity
 }
 </pre>
 

--- a/doc/ilist.html
+++ b/doc/ilist.html
@@ -468,7 +468,7 @@ example &lt;&lt; model.add_noise Magick::LaplacisanNoise
     <h4>Example</h4>
     <pre>
 ilist.animate
-ilist.animate { self.server_name = "other:0.0" }
+ilist.animate { |options| options.server_name = "other:0.0" }
 </pre>
 
     <h4>See also</h4>
@@ -1000,7 +1000,7 @@ ilist.display
     <pre>
 # Produce a navy blue image from a black image
 imgl = Magick::ImageList.new
-imgl &lt;&lt; Magick::Image.new(64, 64) {self.background_color = 'black'}
+imgl &lt;&lt; Magick::Image.new(64, 64) { |options| options.background_color = 'black'}
 
 res = imgl.fx('1/2', Magick::BlueChannel)
 </pre>
@@ -1429,7 +1429,7 @@ img[2]['Label'] = "Mom's Birthday"
     <p>Create a square red image.</p>
     <pre>
 ilist = Magick::ImageList.new
-ilist.new_image(100, 100) { self.background_color = "red" }
+ilist.new_image(100, 100) { |options| options.background_color = "red" }
 </pre>
   </div>
 

--- a/doc/ilist.html
+++ b/doc/ilist.html
@@ -1181,10 +1181,10 @@ scene=1
         surround each tile with a frame 20 pixels wide by 20 pixels
         high and a 4-pixel inner and outer bevel, use:
         <pre>
-self.frame = "20x20+4+4"
+options.frame = "20x20+4+4"
 </pre>or
         <pre>
-self.frame = Magick::Geometry.new(20,20,4,4)
+options.frame = Magick::Geometry.new(20,20,4,4)
 </pre>
       </dd>
 
@@ -1210,10 +1210,10 @@ self.frame = Magick::Geometry.new(20,20,4,4)
         194 pixels tall, with 10 pixels between each column of
         tiles and 5 between each row, use:
         <pre>
-self.geometry = "130x194+10+5"
+options.geometry = "130x194+10+5"
 </pre>or
         <pre>
-self.geometry = Magick::Geometry.new(130, 194, 10, 5)
+options.geometry = Magick::Geometry.new(130, 194, 10, 5)
 </pre>Both the geometry string and the <code>Geometry</code> object
 support flags that specify additional constraints. The default
 geometry is "120x120+4+3&gt;".
@@ -1252,7 +1252,7 @@ geometry is "120x120+4+3&gt;".
         color. For example, to use ImageMagick's built-in "granite"
         texture as the background, use:
         <pre>
-self.texture = Magick::Image.read("granite:").first
+options.texture = Magick::Image.read("granite:").first
 </pre>
 
         <p>The default is no texture.</p>
@@ -1272,10 +1272,10 @@ self.texture = Magick::Image.read("granite:").first
         generates all the rows, leaving empty cells if necessary.
         To arrange the tiles 4 across and 10 down, use:
         <pre>
-self.tile = "4x10"
+options.tile = "4x10"
 </pre>or
         <pre>
-self.tile = Magick::Geometry.new(4,10)
+options.tile = Magick::Geometry.new(4,10)
 </pre>
 
         <p>The default is "6x4". If there are too many tiles to fit

--- a/doc/image1.html
+++ b/doc/image1.html
@@ -309,9 +309,9 @@
     a cross. Click the cursor on the window to be captured.</p>
 
     <p>Within the optional arguments block, specify
-    <code>self.filename = "root"</code> to capture the entire
+    <code>options.filename = "root"</code> to capture the entire
     desktop. To programatically specify the window to be captured,
-    use <code>self.filename = window_id</code>, where window_id is
+    use <code>options.filename = window_id</code>, where window_id is
     the id displayed by xwininfo(1).</p>
 
     <h4>Arguments</h4>
@@ -366,9 +366,9 @@
 
     <h4>Example</h4>
     <pre>
-img = Image.capture {
- self.filename = "root"
- }
+img = Image.capture { |options|
+  options.filename = "root"
+}
 </pre>
   </div>
 
@@ -564,9 +564,9 @@ image = Image.constitute(width, height, "RGB", pixels)
 
     <h4>Example</h4>
     <pre>
-img = Image.new(256, 64) {
- self.background_color = 'red'
- }
+img = Image.new(256, 64) { |options|
+  options.background_color = 'red'
+}
 </pre>
 
     <h4>See also</h4>
@@ -2972,12 +2972,12 @@ f.color_reset!(red)
         "struct.html#Pixel">pixel</a>.
 
         <dl>
-          <dt>self.highlight_color = color</dt>
+          <dt>options.highlight_color = color</dt>
 
           <dd>Emphasize pixel differences with this color. The
           default is partially transparent red.</dd>
 
-          <dt>self.lowlight_color = color</dt>
+          <dt>options.lowlight_color = color</dt>
 
           <dd>Demphasize pixel differences with this color. The
           default is partially transparent white.</dd>
@@ -4547,13 +4547,13 @@ pixels = f.dispatch(0, 0, f.columns, f.rows, "RGB")
         <em>self</em>.
 
         <dl>
-          <dt>self.define("distort:viewport", "WxH+X+Y")</dt>
+          <dt>options.define("distort:viewport", "WxH+X+Y")</dt>
 
           <dd>Specify the size and offset of the generated viewport
           image of the distorted image space. W and H are the width
           and height, and X and Y are the offset.</dd>
 
-          <dt>self.define("distort:scale", N)</dt>
+          <dt>options.define("distort:scale", N)</dt>
 
           <dd>N is an integer factor. <span class="imquote">Scale
           the output image (viewport or otherwise) by that factor
@@ -4564,7 +4564,7 @@ pixels = f.dispatch(0, 0, f.columns, f.rows, "RGB")
           changes, or post-distort cropping and
           resizing).</span></dd>
 
-          <dt>self.verbose(true)</dt>
+          <dt>options.verbose(true)</dt>
 
           <dd class="imquote">Attempt to output the internal
           coefficients, and the -fx equivalent to the distortion,
@@ -4580,10 +4580,10 @@ pixels = f.dispatch(0, 0, f.columns, f.rows, "RGB")
 
     <h4>Example</h4>
     <pre>
-result = img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do
-                     self.define "distort:viewport", "44x44+15+0"
-                     self.define "distort:scale", 2
-                  end
+result = img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do |options|
+  options.define "distort:viewport", "44x44+15+0"
+  options.define "distort:scale", 2
+end
 </pre>
 
     <h4>Note</h4>

--- a/doc/image3.html
+++ b/doc/image3.html
@@ -4009,7 +4009,7 @@ img.to_color(pixel)
     "ex/viewex.gif" title="Click to see the example script" alt=
     "view example" /></a></p>
     <pre>
-img = Image.new(40, 40) {self.background_color = 'lightcyan2'}
+img = Image.new(40, 40) { |options| options.background_color = 'lightcyan2'}
 
 # The view is 400 pixels square, starting at
 # column 10, row 5 from the top of the image.

--- a/doc/image3.html
+++ b/doc/image3.html
@@ -407,9 +407,9 @@ old = image.pixel_color(20,40,"white")
     with the method. These arguments control the shadow color and
     how the label is rendered. By default the shadow color is
     gray75. To specify a different shadow color, use
-    <code>self.shadow_color</code>. To specify a different border
+    <code>options.shadow_color</code>. To specify a different border
     color (that is, the color of the image border) use
-    <code>self.border_color</code>. Both of these methods accept
+    <code>options.border_color</code>. Both of these methods accept
     either a <a href="imusage.html#color_names">color name</a> or a
     <a href="struct.html#Pixel">Pixel</a> argument.</p>
 
@@ -432,9 +432,9 @@ old = image.pixel_color(20,40,"white")
     "draw.html#text_antialias_eq">text_antialias</a>, <a href=
     "draw.html#undercolor_eq">undercolor</a>.</p>
     <pre>
-img.polaroid do
-   self.shadow_color = "gray40"
-   self.pointsize = 12
+img.polaroid do |options|
+  options.shadow_color = "gray40"
+  options.pointsize = 12
 end
 </pre>
 

--- a/doc/imusage.html
+++ b/doc/imusage.html
@@ -402,7 +402,7 @@
   example, to create a image in the gradient format that is 100
   pixels wide and 200 pixels high, use:</p>
   <pre class="example">
-i = Image.read("gradient:red-blue") { self.size = "100x200" }
+i = Image.read("gradient:red-blue") { |options| options.size = "100x200" }
 </pre>
 
   <p>See <a href="javascript:popup('demo.rb.html')">demo.rb</a> for

--- a/doc/info.html
+++ b/doc/info.html
@@ -399,7 +399,7 @@ self["tiff", "bits-per-sample"] &raquo; 2
 
     <h4>Example</h4>
     <pre>
-self.define("tiff", "bits-per-sample", 2)
+options.define("tiff", "bits-per-sample", 2)
 </pre>
 
     <h4>Magick API</h4>
@@ -441,8 +441,7 @@ self.define("tiff", "bits-per-sample", 2)
 
     <h4>Example</h4>
     <pre>
-self.undefine("tiff", "bits-per-sample")
-
+options.undefine("tiff", "bits-per-sample")
 </pre>
   </div>
 
@@ -545,9 +544,9 @@ self.undefine("tiff", "bits-per-sample")
     assigns a caption to an image. The caption is an image
     property:</p>
     <pre>
-img = Magick::Image.read("xc:white") do
-  self.caption = "a new caption"
-  self.size = "20x20"
+img = Magick::Image.read("xc:white") do |options|
+  options.caption = "a new caption"
+  options.size = "20x20"
 end
 p img.first.properties &raquo; {"caption"=&gt;"a new caption"}
 p img.first['caption'] &raquo; "a new caption"
@@ -917,7 +916,7 @@ p img.first['caption'] &raquo; "a new caption"
 
     <p>Either a geometry string or a <a href=
     "struct.html#Geometry">Geometry</a> object. For example:
-    <code>self.extract = "200x200+100+100"</code>.</p>
+    <code>options.extract = "200x200+100+100"</code>.</p>
   </div>
 
   <div class="sig">
@@ -1141,7 +1140,7 @@ p img.first['caption'] &raquo; "a new caption"
     information about the proc. This attribute is set-only.</p>
 
     <p>If you assign a monitor to an image with
-    <code>self.monitor=</code> when the image is created, the image
+    <code>options.monitor=</code> when the image is created, the image
     object inherits the monitor. Any methods applied to the new
     image will be monitored as well.</p>
 

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -296,7 +296,7 @@
 require "rmagick"
 include Magick
 # Create a 100x100 red image.
-f = Image.new(100,100) { self.background_color = "red" }
+f = Image.new(100,100) { |options| options.background_color = "red" }
 f.display
 exit
 </pre>

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -1509,16 +1509,16 @@ exit
 14.   text.pointsize = 52
 15.   text.gravity = Magick::CenterGravity
 16.
-17.   text.annotate(canvas, 0,0,2,2, Text) {
-18.      self.fill = 'gray83'
+17.   text.annotate(canvas, 0,0,2,2, Text) { |options|
+18.      options.fill = 'gray83'
 19.   }
 20.
-21.   text.annotate(canvas, 0,0,-1.5,-1.5, Text) {
-22.      self.fill = 'gray40'
+21.   text.annotate(canvas, 0,0,-1.5,-1.5, Text) { |options|
+22.      options.fill = 'gray40'
 23.   }
 24.
-25.   text.annotate(canvas, 0,0,0,0, Text) {
-26.      self.fill = 'darkred'
+25.   text.annotate(canvas, 0,0,0,0, Text) { |options|
+26.      options.fill = 'darkred'
 27.   }
 28.
 29.   canvas.write('rubyname.gif')
@@ -1553,7 +1553,7 @@ exit
 
   <p>The first call to <code>annotate</code>, on lines 17-19, draws
   the text 2 pixels to the right and down from the center. The
-  <code>self.fill = 'gray83'</code> statement sets the text color
+  <code>options.fill = 'gray83'</code> statement sets the text color
   to light gray. The second call to <code>annotate</code>, on lines
   21-22, draws dark gray text 1.5 pixels to the left and up from
   the center. The last call, on lines 25-27, draws the text a third


### PR DESCRIPTION
Continued #1279 

    "self\.(\w+)" → 'options.#{$1}'
    "{\s*self\.(\w+)" → '{ |options| options.#{$1}'
