### PR TITLE
Update shadow example

### DIFF
--- a/doc/ex/shadow.rb
+++ b/doc/ex/shadow.rb
@@ -10,21 +10,13 @@ gc.stroke_width(10)
 gc.bezier(20, 60, 20, -90, 320, 210, 320, 60)
 gc.draw(img)
 
-# Composite it onto a white background, draw a border around the result,
-# write it to the "before" file.
-before = img.copy
-bg = Magick::Image.new(before.columns, before.rows) { |info| info.background_color = 'white' }
-before = bg.composite(before, Magick::CenterGravity, Magick::OverCompositeOp)
-before.border!(1, 1, 'gray80')
-before.write('shadow_before.gif')
+img.write('shadow_before.png')
 
 # Create the shadow.
-shadow = img.shadow
-# Composite the original image over the shadow, composite the result
-# onto a white background, add a border, write it to the "after" file.
-shadow = shadow.composite(img, Magick::NorthWestGravity, Magick::OverCompositeOp)
-bg = Magick::Image.new(shadow.columns, shadow.rows) { |info| info.background_color = 'white' }
-after = bg.composite(shadow, Magick::CenterGravity, Magick::OverCompositeOp)
-after.border!(1, 1, 'gray80')
+shadow = img.shadow(-5, -5)
 
-after.write('shadow_after.gif')
+image_list = Magick::ImageList.new
+image_list.new_image(img.columns, img.rows, Magick::SolidFill.new('white'))
+image_list << shadow
+image_list << img
+image_list.flatten_images.write('shadow_after.png')


### PR DESCRIPTION
Fix #1294

https://github.com/ImageMagick/ImageMagick/blob/75be18b28a037f37aa0c58dd81a044ac113c98e4/MagickCore/visual-effects.c#L2128-L2131

Seems that `ShadowImage()` holds the offset position as layer information, it is not absolute pixel position.
And it needs to be creative when merging images.

It may be easier to use `ImageList#flatten_images` for this case.