### PR TITLE
Also set the alpha value of the target pixel (#1296).

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8979,7 +8979,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.red   = (MagickRealType) image->border_color.red;
         target_mpp.green = (MagickRealType) image->border_color.green;
         target_mpp.blue  = (MagickRealType) image->border_color.blue;
-        target_mpp.alpha = (MagickRealType) target.alpha;
+        target_mpp.alpha = (MagickRealType) image->border_color.alpha;
     }
     else
     {

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8968,6 +8968,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
     }
 #if defined(IMAGEMAGICK_7)
     draw_info->fill.alpha = alpha;
+    draw_info->fill.alpha_trait = BlendPixelTrait;
 #else
     draw_info->fill.opacity = QuantumRange - alpha;
 #endif
@@ -8978,6 +8979,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.red   = (MagickRealType) image->border_color.red;
         target_mpp.green = (MagickRealType) image->border_color.green;
         target_mpp.blue  = (MagickRealType) image->border_color.blue;
+        target_mpp.alpha = (MagickRealType) target.alpha;
     }
     else
     {
@@ -8985,6 +8987,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.red   = (MagickRealType) target.red;
         target_mpp.green = (MagickRealType) target.green;
         target_mpp.blue  = (MagickRealType) target.blue;
+        target_mpp.alpha = (MagickRealType) target.alpha;
     }
 
 #if defined(IMAGEMAGICK_7)

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8979,7 +8979,11 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.red   = (MagickRealType) image->border_color.red;
         target_mpp.green = (MagickRealType) image->border_color.green;
         target_mpp.blue  = (MagickRealType) image->border_color.blue;
+#if defined(IMAGEMAGICK_7)
         target_mpp.alpha = (MagickRealType) image->border_color.alpha;
+#else
+        target_mpp.opacity = (MagickRealType) image->border_color.opacity;
+#endif
     }
     else
     {
@@ -8987,7 +8991,11 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.red   = (MagickRealType) target.red;
         target_mpp.green = (MagickRealType) target.green;
         target_mpp.blue  = (MagickRealType) target.blue;
+#if defined(IMAGEMAGICK_7)
         target_mpp.alpha = (MagickRealType) target.alpha;
+#else
+        target_mpp.opacity = (MagickRealType) target.opacity;
+#endif
     }
 
 #if defined(IMAGEMAGICK_7)

--- a/spec/rmagick/image/matte_floodfill_spec.rb
+++ b/spec/rmagick/image/matte_floodfill_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe Magick::Image, '#matte_floodfill' do
     expect { image.matte_flood_fill('blue', image.columns, image.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { image.matte_flood_fill('blue', image.columns, image.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
+  it 'changes the specified color to transparent' do
+    image = described_class.new(1, 1)
+    color = image.pixel_color(0, 0)
+    expect(color.alpha).to eq(Magick::OpaqueAlpha)
+
+    result = image.matte_floodfill(0, 0)
+
+    color = result.pixel_color(0, 0)
+    expect(color.alpha).to eq(Magick::TransparentAlpha)
+  end
 end

--- a/spec/rmagick/image/matte_floodfill_spec.rb
+++ b/spec/rmagick/image/matte_floodfill_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Magick::Image, '#matte_floodfill' do
     expect { image.matte_flood_fill('blue', image.columns, image.rows, Magick::FloodfillMethod, alpha: Magick::TransparentAlpha) }.not_to raise_error
     expect { image.matte_flood_fill('blue', image.columns, image.rows, Magick::FloodfillMethod, wrong: Magick::TransparentAlpha) }.to raise_error(ArgumentError)
   end
+
   it 'changes the specified color to transparent' do
     image = described_class.new(1, 1)
     color = image.pixel_color(0, 0)


### PR DESCRIPTION
The alpha channel of the target pixel should be set to make sure a proper match can be found. This fixes the issue reported in #1296. And the alpha_trait of the fill pixel should also be set to make sure the alpha channel of the resulting image will be enabled. 