### PR TITLE
Set alpha_trait to BlendPixelTrait when the alpha value of the pixel is not opaque.

### DIFF
--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -172,7 +172,7 @@ VALUE
 Pixel_alpha_eq(VALUE self, VALUE v)
 {
     Pixel *pixel;
- 
+
     rb_check_frozen(self);
     Data_Get_Struct(self, Pixel, pixel);
 #if defined(IMAGEMAGICK_7)
@@ -382,6 +382,10 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
         pp->blue    = pixel->blue;
 #if defined(IMAGEMAGICK_7)
         pp->alpha   = pixel->alpha;
+        if (pixel->alpha != OpaqueAlpha)
+        {
+            pp->alpha_trait = BlendPixelTrait;
+        }
         pp->black   = pixel->black;
 #else
         pp->opacity = pixel->opacity;


### PR DESCRIPTION
This patch sets the `alpha_trait` to `BlendPixelTrait`. This makes sure that setting the `background_fill_opacity` in issue #1292 now works with IM7.