### PR TITLE
Introduced new method that only sets the alpha_trait of a PixelInfo value when the alpha value is not opaque.

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1173,6 +1173,9 @@ extern void   rm_set_user_artifact(Image *, Info *);
 extern void   rm_sync_image_options(Image *, Info *);
 extern void   rm_split(Image *);
 extern void   rm_magick_error(const char *);
+#if defined(IMAGEMAGICK_7)
+extern void   rm_set_pixelinfo_alpha(PixelInfo *, const MagickRealType);
+#endif
 
 //! whether to retain on errors
 typedef enum

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -8967,8 +8967,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eNoMemError, "not enough memory to continue");
     }
 #if defined(IMAGEMAGICK_7)
-    draw_info->fill.alpha = alpha;
-    draw_info->fill.alpha_trait = BlendPixelTrait;
+    rm_set_pixelinfo_alpha(&draw_info->fill, alpha);
 #else
     draw_info->fill.opacity = QuantumRange - alpha;
 #endif
@@ -8980,7 +8979,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.green = (MagickRealType) image->border_color.green;
         target_mpp.blue  = (MagickRealType) image->border_color.blue;
 #if defined(IMAGEMAGICK_7)
-        target_mpp.alpha = (MagickRealType) image->border_color.alpha;
+        rm_set_pixelinfo_alpha(&target_mpp, (MagickRealType) image->border_color.alpha);
 #else
         target_mpp.opacity = (MagickRealType) image->border_color.opacity;
 #endif
@@ -8992,7 +8991,7 @@ Image_matte_flood_fill(int argc, VALUE *argv, VALUE self)
         target_mpp.green = (MagickRealType) target.green;
         target_mpp.blue  = (MagickRealType) target.blue;
 #if defined(IMAGEMAGICK_7)
-        target_mpp.alpha = (MagickRealType) target.alpha;
+        rm_set_pixelinfo_alpha(&target_mpp, (MagickRealType) target.alpha);
 #else
         target_mpp.opacity = (MagickRealType) target.opacity;
 #endif

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -381,12 +381,8 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
         pp->green   = pixel->green;
         pp->blue    = pixel->blue;
 #if defined(IMAGEMAGICK_7)
-        pp->alpha   = pixel->alpha;
-        if (pixel->alpha != OpaqueAlpha)
-        {
-            pp->alpha_trait = BlendPixelTrait;
-        }
         pp->black   = pixel->black;
+        rm_set_pixelinfo_alpha(pp, pixel->alpha);
 #else
         pp->opacity = pixel->opacity;
 #endif

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -285,7 +285,7 @@ Export_ColorInfo(ColorInfo *ci, VALUE st)
         ci->color.green = (MagickRealType) pixel.green;
         ci->color.blue = (MagickRealType) pixel.blue;
 #if defined(IMAGEMAGICK_7)
-        ci->color.alpha = (MagickRealType) OpaqueAlpha;
+        rm_set_pixelinfo_alpha(&ci->color, (MagickRealType) OpaqueAlpha);
 #else
         ci->color.opacity = (MagickRealType) OpaqueOpacity;
 #endif
@@ -760,7 +760,7 @@ Import_SegmentInfo(SegmentInfo *segment)
     RB_GC_GUARD(y1);
     RB_GC_GUARD(x2);
     RB_GC_GUARD(y2);
-    
+
     return rb_funcall(Class_Segment, rm_ID_new, 4, x1, y1, x2, y2);
 }
 

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -858,6 +858,25 @@ rm_magick_error(const char *msg)
     RB_GC_GUARD(mesg);
 }
 
+#if defined(IMAGEMAGICK_7)
+/**
+ * Sets the alpha channel of a pixel color
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param pixel the Pixel
+ * @param value the value
+ */
+void
+rm_set_pixelinfo_alpha(PixelInfo *pixel, const MagickRealType value)
+{
+    pixel->alpha = value;
+    if (value != (MagickRealType) OpaqueAlpha)
+    {
+        pixel->alpha_trait = BlendPixelTrait;
+    }
+}
+#endif
 
 /**
  * Initialize a new ImageMagickError object - store the "loc" string in the


### PR DESCRIPTION
This is a minor refactoring of the previous pull requests and introduces a new method that will set the alpha_trait value when the alpha channel is not fully opaque.