### PR TITLE
remove Mutex in trace_proc=

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -84,15 +84,12 @@ module Magick
     #     ...
     #   end
     def trace_proc=(p)
-      m = Mutex.new
-      m.synchronize do
-        if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
-          at_exit { @trace_proc = nil }
-          @exit_block_set_up = true
-        end
-
-        @trace_proc = p
+      if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
+        at_exit { @trace_proc = nil }
+        @exit_block_set_up = true
       end
+
+      @trace_proc = p
     end
   end
 


### PR DESCRIPTION
We had a problem against Ruby 2.2 where setting `trace_proc` on an image
caused a segfault in certain situations. A [mutex was added][1] to
remedy this issue. A reference to this mutex is not preserved, so it
isn't preventing any multi-threading issues where multiple threads set
`trace_proc`. As such, it's not clear to me how this could have fixed
the issue. I think it may have been a transient segfault and the build
just happened to pass in spite of the change.

[1]: #194