### PR TITLE
changed_predicate_spec: ensure target directory exists

### DIFF
--- a/spec/rmagick/image/changed_predicate_spec.rb
+++ b/spec/rmagick/image/changed_predicate_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe Magick::Image, "#changed?" do
   it "still returns true after it has been persisted" do
     image = described_class.read(FLOWER_HAT).first
 
-    image.import_pixels(0, 0, 1, 1, "RGB", [45, 98, 156])
-    image.write("./tmp/test_changed_predicate.jpg")
-
-    expect(image.changed?).to be(true)
+    Dir.mktmpdir do |tmp|
+      image.import_pixels(0, 0, 1, 1, "RGB", [45, 98, 156])
+      image.write("#{tmp}/test_changed_predicate.jpg")
+      expect(image.changed?).to be(true)
+    end
   end
 end


### PR DESCRIPTION
When the tests on the Debian package, this test failed because ./tmp/
./tmp/ didn't exist. Instead of just assuming ./tmp/ exists, write to a
dynamically generated a dynamically generated temporary directory
instead.