### PR TITLE
spec_helper: drop require_relative to lib directory

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,8 @@ require_relative 'support/matchers'
 require_relative 'support/helpers'
 
 require 'pry'
-require_relative '../lib/rmagick'
-require_relative '../lib/rvg/rvg'
+require 'rmagick'
+require 'rvg/rvg'
 
 root_dir = File.expand_path('..', __dir__)
 IMAGES_DIR = File.join(root_dir, 'doc/ex/images')


### PR DESCRIPTION
This makes it possible to run the test suite against the installed
package, while still ensure it just works in development because rspec
automatically adds lib/ to the RUby $LOAD_PATH.