### PR TITLE
channel_mean_spec: fix floating point comparison

### DIFF
--- a/spec/rmagick/image/channel_mean_spec.rb
+++ b/spec/rmagick/image/channel_mean_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Magick::Image, "#channel_mean" do
       "7.1": 115.6730305646048
     )
 
-    expect(mean_and_stddev).to eq([125.25, expected_stddev])
+    expect(mean_and_stddev[0]).to be_within(0.0000001).of(125.25)
+    expect(mean_and_stddev[1]).to be_within(0.0000001).of(expected_stddev)
   end
 
   it "returns the mean and std. dev for the GreenChannel" do
@@ -26,7 +27,8 @@ RSpec.describe Magick::Image, "#channel_mean" do
       "7.1": 76.46567857542362
     )
 
-    expect(mean_and_stddev).to eq([142.5, expected_stddev])
+    expect(mean_and_stddev[0]).to be_within(0.0000001).of(142.5)
+    expect(mean_and_stddev[1]).to be_within(0.0000001).of(expected_stddev)
   end
 
   it "returns the mean and std. dev for the RedChannel and GreenChannel" do
@@ -41,7 +43,8 @@ RSpec.describe Magick::Image, "#channel_mean" do
       "7.1": 96.06935457001421
     )
 
-    expect(mean_and_stddev).to eq([133.875, expected_stddev])
+    expect(mean_and_stddev[0]).to be_within(0.0000001).of(133.875)
+    expect(mean_and_stddev[1]).to be_within(0.0000001).of(expected_stddev)
   end
 
   it "returns the mean and std. dev for all channels when no arguments are passed" do
@@ -56,7 +59,8 @@ RSpec.describe Magick::Image, "#channel_mean" do
       "7.1": 103.58337316538109
     )
 
-    expect(mean_and_stddev).to eq([123.91666666666667, expected_stddev])
+    expect(mean_and_stddev[0]).to be_within(0.0000001).of(123.91666666666667)
+    expect(mean_and_stddev[1]).to be_within(0.0000001).of(expected_stddev)
   end
 
   it "raises an error when the wrong type of argument is passed" do


### PR DESCRIPTION
One should not never compare floating point numbers for equality,
because that is not is not garanteed to work on some architectures. For
example on a Intel 32-bit userspace (i386) I get the following failure:

  1) Magick::Image#channel_mean returns the mean and std. dev for the RedChannel
     Failure/Error: expect(mean_and_stddev).to eq([125.25, expected_stddev])

       expected: [125.25, 115.6730305646048]
            got: [125.25, 115.67303056460482]

       (compared using ==)
     # ./spec/rmagick/image/channel_mean_spec.rb:14:in `block (2 levels) in <top (required)>'