### PR TITLE
Suppress compilation warning messages

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -434,9 +434,9 @@ EXTERN unsigned long long rm_main_thread_id;
 #define R_boolean_to_C_boolean(attr) RTEST(attr) /**<  C boolean <- Ruby boolean */
 #define C_int_to_R_int(attr) INT2FIX(attr) /**< C int -> Ruby int */
 #define R_int_to_C_int(attr) NUM2INT(attr) /**< C int <- Ruby int */
-#define C_long_to_R_long(attr) INT2NUM(attr) /**< C long -> Ruby long */
+#define C_long_to_R_long(attr) LONG2NUM(attr) /**< C long -> Ruby long */
 #define R_long_to_C_long(attr) NUM2LONG(attr) /**< C long <- Ruby long */
-#define C_ulong_to_R_ulong(attr) UINT2NUM(attr) /**< C unsigned long -> Ruby unsigned long */
+#define C_ulong_to_R_ulong(attr) ULONG2NUM(attr) /**< C unsigned long -> Ruby unsigned long */
 #define R_ulong_to_C_ulong(attr) NUM2ULONG(attr) /**< C unsigned long <- Ruby unsigned long */
 #define C_str_to_R_str(attr) attr ? rb_str_new2(attr) : Qnil /**< C string -> Ruby string */
 #define C_dbl_to_R_dbl(attr) rb_float_new(attr) /**< C double -> Ruby double */

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -672,10 +672,10 @@ Import_RectangleInfo(RectangleInfo *rect)
     VALUE height;
     VALUE x, y;
 
-    width  = UINT2NUM(rect->width);
-    height = UINT2NUM(rect->height);
-    x      = INT2NUM(rect->x);
-    y      = INT2NUM(rect->y);
+    width  = ULONG2NUM(rect->width);
+    height = ULONG2NUM(rect->height);
+    x      = LONG2NUM(rect->x);
+    y      = LONG2NUM(rect->y);
 
     RB_GC_GUARD(width);
     RB_GC_GUARD(height);


### PR DESCRIPTION
This patch will suppress following compilation warning messages with clang compiler.

```
rmimage.c:3032:34: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
    IMPLEMENT_ATTR_READER(Image, colors, ulong);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
./rmagick.h:453:44: note: expanded from macro 'IMPLEMENT_ATTR_READER'
        return C_##type##_to_R_##type(ptr->attr);\
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
./rmagick.h:439:43: note: expanded from macro 'C_ulong_to_R_ulong'
#define C_ulong_to_R_ulong(attr) UINT2NUM(attr) /**< C unsigned long -> Ruby unsigned long */
                                 ~~~~~~~~ ^~~~
```