### PR TITLE
Fix error in running spec with Ruby 3.2 under development

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
-  s.add_development_dependency 'pry', '~> 0.12.2'
+  s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'


### PR DESCRIPTION
To fix following error when run the spec with Ruby 3.2.0-dev, this patch will update pry gem version.

```
$ ruby -v
ruby 3.2.0dev (2022-03-19T05:33:04Z master fafa40997e) [x86_64-linux]

$ bundle exec rake
/usr/bin/gmake install target_prefix=
/usr/bin/install -c -m 0755 RMagick2.so /home/watson/prj/rmagick/lib
cp tmp/x86_64-linux/RMagick2/3.2.0/RMagick2.so tmp/x86_64-linux/stage/lib/RMagick2.so
/home/watson/.rbenv/versions/3.2.0-dev/bin/ruby -I/home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-core-3.11.0/lib:/home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-support-3.11.0/lib /home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

An error occurred while loading spec_helper.
Failure/Error: require 'pry'

NameError:
  undefined method `=~' for class `Pry::Code'
# ./spec/spec_helper.rb:5:in `require'
# ./spec/spec_helper.rb:5:in `<top (required)>'
No examples found.


Finished in 0.00002 seconds (files took 0.06842 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

/home/watson/.rbenv/versions/3.2.0-dev/bin/ruby -I/home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-core-3.11.0/lib:/home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-support-3.11.0/lib /home/watson/.rbenv/versions/3.2.0-dev/lib/ruby/gems/3.2.0+0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```