### PR TITLE
Fix Image#profile! that can't delete exif data

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -5039,8 +5039,16 @@ VALUE
 Image_delete_profile(VALUE self, VALUE name)
 {
     Image *image = rm_check_frozen(self);
-    DeleteImageProfile(image, StringValueCStr(name));
 
+#if defined(IMAGEMAGICK_7)
+    ExceptionInfo *exception = AcquireExceptionInfo();
+
+    ProfileImage(image, StringValueCStr(name), NULL, 0, exception);
+    CHECK_EXCEPTION();
+    DestroyExceptionInfo(exception);
+#else
+    ProfileImage(image, StringValueCStr(name), NULL, 0, MagickTrue);
+#endif
     return self;
 }
 

--- a/spec/rmagick/image/profile_bang_spec.rb
+++ b/spec/rmagick/image/profile_bang_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Magick::Image, '#profile!' do
     expect { image.profile!('icc', 'xxx') }.to raise_error(FreezeError)
     expect { image.profile!('*', nil) }.to raise_error(FreezeError)
   end
+
+  it 'delete exif when nil given as profile' do
+    image = described_class.read(IMAGE_WITH_PROFILE).first
+    expect(image.get_exif_by_number).to be_kind_of(Hash)
+    expect(image.get_exif_by_number(305)).to eq({ 305 => "Adobe Photoshop CS Macintosh" })
+
+    image.profile!('*', nil)
+    blob = image.to_blob
+
+    new_image = described_class.from_blob(blob).first
+    expect(new_image.get_exif_by_number).to eq({})
+  end
 end


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1324

Since RMagick 4.x, the using API in `Image#profile!` was changed from `ProfileImage` to `DeleteImageProfile`.
This PR will revert it.