### PR TITLE
CI: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict the GitHub token permissions only to the required ones.
Even if the attackers will succeed in compromising workflow, they won’t be able to do much.

Ref. https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs