### PR TITLE
CI: Update ImageMagick download URL and fix build error in macOS env

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -41,7 +41,7 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  wget "https://imagemagick.org/archive/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -31,7 +31,7 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  wget "https://imagemagick.org/archive/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
   mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -19,7 +19,7 @@ export HOMEBREW_NO_AUTO_UPDATE=true
 brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool libxml2 zlib webp
 
 export LDFLAGS="-L/usr/local/opt/libxml2/lib -L/usr/local/opt/zlib/lib"
-export CPPFLAGS="-I/usr/local/opt/libxml2/include/libxml2 -I/usr/local/opt/zlib/include"
+export CPPFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/zlib/include"
 
 project_dir=$(pwd)
 build_dir="${project_dir}/build-ImageMagick/ImageMagick-${IMAGEMAGICK_VERSION}"


### PR DESCRIPTION
Looks like the ImageMagick download URL was changed recently.