### PR TITLE
Added codespaces configurations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+ARG RUBY_VERSION
+
+FROM ruby:${RUBY_VERSION}
+
+ARG IMAGEMAGICK_VERSION
+
+RUN mkdir /setup
+ADD *.sh /setup
+
+ENV IMAGEMAGICK_VERSION ${IMAGEMAGICK_VERSION}
+
+RUN /setup/setup-user.sh
+
+WORKDIR /workspaces/rmagick

--- a/.devcontainer/ImageMagick6/devcontainer.json
+++ b/.devcontainer/ImageMagick6/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "ImageMagick 6",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "RUBY_VERSION": "3.1.2",
+      "IMAGEMAGICK_VERSION": "6.9.12-54"
+    }
+  },
+  "onCreateCommand": "/setup/setup-repo.sh"
+}

--- a/.devcontainer/ImageMagick7/devcontainer.json
+++ b/.devcontainer/ImageMagick7/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "ImageMagick 7",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "RUBY_VERSION": "3.1.2",
+      "IMAGEMAGICK_VERSION": "7.1.0-39"
+    }
+  },
+  "onCreateCommand": "/setup/setup-repo.sh"
+}

--- a/.devcontainer/setup-repo.sh
+++ b/.devcontainer/setup-repo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install sudo
+
+bash /workspaces/rmagick/before_install_linux.sh
+
+cd /workspaces/rmagick
+bundle install --path=vendor/bundle --jobs 4 --retry 3

--- a/.devcontainer/setup-user.sh
+++ b/.devcontainer/setup-user.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+codespaces_bash="$(cat \
+<<'EOF'
+# Codespaces bash prompt theme
+__bash_prompt() {
+    local userpart='`export XIT=$? \
+        && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
+        && echo -n "\[\033[0;36m\][IM ${IMAGEMAGICK_VERSION}]" \
+        && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
+    local gitbranch='`\
+        if [ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
+            export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+            if [ "${BRANCH}" != "" ]; then \
+                echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+                && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                        echo -n " \[\033[1;33m\]✗"; \
+                fi \
+                && echo -n "\[\033[0;36m\]) "; \
+            fi; \
+        fi`'
+    local lightblue='\[\033[1;34m\]'
+    local removecolor='\[\033[0m\]'
+    PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+    unset -f __bash_prompt
+}
+__bash_prompt
+
+__show_notice() {
+  local __message="
+\033[0;32mWelcome to Codespaces! You are using the pre-configured rmagick image.\033[0m
+
+\033[0;35mTests can be executed with:\033[0m bundle exec rake
+\033[0;35mCode style can be checked with:\033[0m STYLE_CHECKS=true bundle exec rubocop
+"
+  echo -e "$__message"
+
+  unset -f __show_notice
+}
+__show_notice
+EOF
+)"
+
+ echo "${codespaces_bash}" >> "/root/.bashrc"


### PR DESCRIPTION
This pull requests add codespaces configuration so that someone could make changes to our code and run the unit tests in the browser without needing to install anything themselves. This is done automatically but they user will need to wait for this. This PR adds two configurations one for ImageMagick 6 and another one for ImageMagick 7. But both configurations are using Ruby 3.1.2. We cannot use the pre-build configuration because we are using a custom configuration but I hope that will become available in the future so users don't need to wait for this.