### PR TITLE
CI: Support ubuntu 22.04

### DIFF
--- a/spec/rmagick/image/preview_spec.rb
+++ b/spec/rmagick/image/preview_spec.rb
@@ -1,5 +1,5 @@
 describe Magick::Image, '#preview' do
-  it 'works' do
+  it 'works', unsupported_before('6.8.0') do
     hat = described_class.read(IMAGES_DIR + '/Flower_Hat.jpg').first
 
     prev = hat.preview(Magick::RotatePreview)

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Magick::ImageList, "#montage" do
     expect(error).to be_within(delta).of(0.0)
   end
 
-  it "works" do
+  it "works", unsupported_before('6.8.0') do
     image_list1 = described_class.new
 
     image_list1.read(*Dir[IMAGES_DIR + '/Button_*.gif'])


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/5998
Now, seems that `ubuntu-latest` has been ran under ubuntu 22.04 image.
(It may just be a switch in some of the repositories at forked.)

The old ImageMagick fails following error with newer ghostscript.

```
     Magick::ImageMagickError:
       `%s' (%d) "gs" -q -dQUIET -dSAFER -dBATCH -dNOPAUSE -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2 "-sDEVICE=pngalpha" -dTextAlphaBits=4 -dGraphicsAlphaBits=4 "-r72x72" -g132x24  "-sOutputFile=/tmp/magick-C0LV427g--0000001" "-f/tmp/magick-lZG6pHGl" "-f/tmp/magick-OkJdSSuv" @ error/utility.c/SystemCommand/1890
```
(Ref. https://github.com/Watson1978/rmagick/actions/runs/3559587617/jobs/5979044625)

So, this PR will skip the failure specs.