### PR TITLE
Make ImageMagick 7 the default devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "ImageMagick 7",
   "build": {
-    "dockerfile": "../Dockerfile",
+    "dockerfile": "Dockerfile",
     "args": {
       "RUBY_VERSION": "3.1.2",
       "IMAGEMAGICK_VERSION": "7.1.0-44"


### PR DESCRIPTION
Moving this file makes the ImageMagick 7 devcontainer the default container when someone creates a codespace without configuring it.