### PR TITLE
Add Ractor support

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -420,6 +420,7 @@ extern const rb_data_type_t rm_enum_data_type;
 extern const rb_data_type_t rm_info_data_type;
 extern const rb_data_type_t rm_image_data_type;
 extern const rb_data_type_t rm_draw_data_type;
+extern const rb_data_type_t rm_pixel_data_type;
 
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */
@@ -1091,7 +1092,6 @@ ATTR_ACCESSOR(Pixel, cyan)
 ATTR_ACCESSOR(Pixel, magenta)
 ATTR_ACCESSOR(Pixel, yellow)
 ATTR_ACCESSOR(Pixel, black)
-extern void   destroy_Pixel(Pixel *);
 extern VALUE  Pixel_alloc(VALUE);
 extern VALUE  Pixel_case_eq(VALUE, VALUE);
 extern VALUE  Pixel_clone(VALUE);

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -418,6 +418,7 @@ EXTERN ID rm_ID_width;             /**< "width" */
 
 extern const rb_data_type_t rm_enum_data_type;
 extern const rb_data_type_t rm_info_data_type;
+extern const rb_data_type_t rm_image_data_type;
 
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */
@@ -504,6 +505,14 @@ extern const rb_data_type_t rm_info_data_type;
         return C_##type##_to_R_##type(ptr->attr);\
     }
 
+#define IMPLEMENT_TYPED_ATTR_READERF(class, attr, field, type, data_type) \
+    {\
+        class *ptr;\
+        rm_check_destroyed(self); \
+        TypedData_Get_Struct(self, class, data_type, ptr);\
+        return C_##type##_to_R_##type(ptr->field);\
+    }
+
 #define IMPLEMENT_TYPED_ATTR_WRITER(class, attr, type, data_type) \
     {\
         class *ptr;\
@@ -516,6 +525,17 @@ extern const rb_data_type_t rm_info_data_type;
         return val;\
     }
 
+#define IMPLEMENT_TYPED_ATTR_WRITERF(class, attr, field, type, data_type) \
+    {\
+        class *ptr;\
+        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
+            rm_check_destroyed(self); \
+        }\
+        rb_check_frozen(self);\
+        TypedData_Get_Struct(self, class, data_type, ptr);\
+        ptr->field = R_##type##_to_C_##type(val);\
+        return self;\
+    }
 
 
 /*

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -422,6 +422,7 @@ extern const rb_data_type_t rm_image_data_type;
 extern const rb_data_type_t rm_draw_data_type;
 extern const rb_data_type_t rm_pixel_data_type;
 extern const rb_data_type_t rm_montage_data_type;
+extern const rb_data_type_t rm_kernel_info_data_type;
 
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -421,6 +421,7 @@ extern const rb_data_type_t rm_info_data_type;
 extern const rb_data_type_t rm_image_data_type;
 extern const rb_data_type_t rm_draw_data_type;
 extern const rb_data_type_t rm_pixel_data_type;
+extern const rb_data_type_t rm_montage_data_type;
 
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -62,6 +62,11 @@
 #undef PACKAGE_TARNAME
 #undef WORDS_BIGENDIAN
 
+#ifndef HAVE_RB_EXT_RACTOR_SAFE
+#undef RUBY_TYPED_FROZEN_SHAREABLE
+#define RUBY_TYPED_FROZEN_SHAREABLE 0
+#endif
+
 #include "extconf.h"
 
 #if defined(IMAGEMAGICK_7)
@@ -411,6 +416,9 @@ EXTERN ID rm_ID_push;              /**< "push" */
 EXTERN ID rm_ID_values;            /**< "values" */
 EXTERN ID rm_ID_width;             /**< "width" */
 
+extern const rb_data_type_t rm_enum_data_type;
+extern const rb_data_type_t rm_info_data_type;
+
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */
 #endif
@@ -486,6 +494,29 @@ EXTERN ID rm_ID_width;             /**< "width" */
         return self;\
     }
 
+#define IMPLEMENT_TYPED_ATTR_READER(class, attr, type, data_type) \
+    {\
+        class *ptr;\
+        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
+            rm_check_destroyed(self); \
+        }\
+        TypedData_Get_Struct(self, class, data_type, ptr);\
+        return C_##type##_to_R_##type(ptr->attr);\
+    }
+
+#define IMPLEMENT_TYPED_ATTR_WRITER(class, attr, type, data_type) \
+    {\
+        class *ptr;\
+        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
+            rm_check_destroyed(self); \
+        }\
+        rb_check_frozen(self);\
+        TypedData_Get_Struct(self, class, data_type, ptr);\
+        ptr->attr = R_##type##_to_C_##type(val);\
+        return val;\
+    }
+
+
 
 /*
  *  Declare attribute accessors
@@ -511,8 +542,6 @@ EXTERN ID rm_ID_width;             /**< "width" */
 #define DEF_CONSTV(constant, val) rb_define_const(Module_Magick, #constant, UINT2NUM(val))
 #endif
 
-
-extern const rb_data_type_t rm_enum_data_type;
 //! Convert a Ruby enum constant back to a C enum member.
 #define VALUE_TO_ENUM(value, e, type) \
    do {\

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -512,6 +512,7 @@ EXTERN ID rm_ID_width;             /**< "width" */
 #endif
 
 
+extern const rb_data_type_t rm_enum_data_type;
 //! Convert a Ruby enum constant back to a C enum member.
 #define VALUE_TO_ENUM(value, e, type) \
    do {\
@@ -519,7 +520,7 @@ EXTERN ID rm_ID_width;             /**< "width" */
    if (CLASS_OF(value) != Class_##type)\
        rb_raise(rb_eTypeError, "wrong enumeration type - expected %s, got %s", \
                 rb_class2name(Class_##type), rb_class2name(CLASS_OF(value)));\
-   Data_Get_Struct(value, MagickEnum, magick_enum);\
+   TypedData_Get_Struct(value, MagickEnum, &rm_enum_data_type, magick_enum);\
    e = (type)(magick_enum->val);\
    } while(0)
 

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -454,51 +454,6 @@ extern const rb_data_type_t rm_kernel_info_data_type;
 #define R_dbl_to_C_dbl(attr) NUM2DBL(attr) /**< C double <- Ruby double */
 
 //! define attribute reader
-#define IMPLEMENT_ATTR_READER(class, attr, type) \
-    {\
-        class *ptr;\
-        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
-            rm_check_destroyed(self); \
-        }\
-        Data_Get_Struct(self, class, ptr);\
-        return C_##type##_to_R_##type(ptr->attr);\
-    }
-
-//! define attribute reader when attribute name is different from the field name
-#define IMPLEMENT_ATTR_READERF(class, attr, field, type) \
-    {\
-        class *ptr;\
-        rm_check_destroyed(self); \
-        Data_Get_Struct(self, class, ptr);\
-        return C_##type##_to_R_##type(ptr->field);\
-    }
-
-//! define attribute writer
-#define IMPLEMENT_ATTR_WRITER(class, attr, type) \
-    {\
-        class *ptr;\
-        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
-            rm_check_destroyed(self); \
-        }\
-        rb_check_frozen(self);\
-        Data_Get_Struct(self, class, ptr);\
-        ptr->attr = R_##type##_to_C_##type(val);\
-        return val;\
-    }
-
-//! define attribute writer when attribute name is different from the field name
-#define IMPLEMENT_ATTR_WRITERF(class, attr, field, type) \
-    {\
-        class *ptr;\
-        if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
-            rm_check_destroyed(self); \
-        }\
-        rb_check_frozen(self);\
-        Data_Get_Struct(self, class, ptr);\
-        ptr->field = R_##type##_to_C_##type(val);\
-        return self;\
-    }
-
 #define IMPLEMENT_TYPED_ATTR_READER(class, attr, type, data_type) \
     {\
         class *ptr;\
@@ -509,6 +464,7 @@ extern const rb_data_type_t rm_kernel_info_data_type;
         return C_##type##_to_R_##type(ptr->attr);\
     }
 
+//! define attribute reader when attribute name is different from the field name
 #define IMPLEMENT_TYPED_ATTR_READERF(class, attr, field, type, data_type) \
     {\
         class *ptr;\
@@ -517,6 +473,7 @@ extern const rb_data_type_t rm_kernel_info_data_type;
         return C_##type##_to_R_##type(ptr->field);\
     }
 
+//! define attribute writer
 #define IMPLEMENT_TYPED_ATTR_WRITER(class, attr, type, data_type) \
     {\
         class *ptr;\
@@ -529,6 +486,7 @@ extern const rb_data_type_t rm_kernel_info_data_type;
         return val;\
     }
 
+//! define attribute writer when attribute name is different from the field name
 #define IMPLEMENT_TYPED_ATTR_WRITERF(class, attr, field, type, data_type) \
     {\
         class *ptr;\

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -419,6 +419,7 @@ EXTERN ID rm_ID_width;             /**< "width" */
 extern const rb_data_type_t rm_enum_data_type;
 extern const rb_data_type_t rm_info_data_type;
 extern const rb_data_type_t rm_image_data_type;
+extern const rb_data_type_t rm_draw_data_type;
 
 #if !defined(min)
 #define min(a, b) ((a)<(b)?(a):(b)) /**< min of two values */

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -13,11 +13,18 @@
 #include "rmagick.h"
 #include "float.h"
 
-static void mark_Draw(void *);
-static void destroy_Draw(void *);
+static void Draw_mark(void *);
+static void Draw_destroy(void *);
+static size_t Draw_memsize(const void *);
 static VALUE new_DrawOptions(void);
-
 static VALUE get_type_metrics(int, VALUE *, VALUE, gvl_function_t);
+
+const rb_data_type_t rm_draw_data_type = {
+    "Magick::Draw",
+    { Draw_mark, Draw_destroy, Draw_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
 
 
 DEFINE_GVL_STUB4(BlobToImage, const ImageInfo *, const void *, const size_t, ExceptionInfo *);
@@ -47,7 +54,7 @@ Draw_affine_eq(VALUE self, VALUE matrix)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Export_AffineMatrix(&draw->info->affine, matrix);
     return matrix;
 }
@@ -65,7 +72,7 @@ Draw_align_eq(VALUE self, VALUE align)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     VALUE_TO_ENUM(align, draw->info->align, AlignType);
     return align;
 }
@@ -83,7 +90,7 @@ Draw_decorate_eq(VALUE self, VALUE decorate)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     VALUE_TO_ENUM(decorate, draw->info->decorate, DecorationType);
     return decorate;
 }
@@ -101,7 +108,7 @@ Draw_density_eq(VALUE self, VALUE density)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     magick_clone_string(&draw->info->density, StringValueCStr(density));
 
     return density;
@@ -120,7 +127,7 @@ Draw_encoding_eq(VALUE self, VALUE encoding)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     magick_clone_string(&draw->info->encoding, StringValueCStr(encoding));
 
     return encoding;
@@ -139,7 +146,7 @@ Draw_fill_eq(VALUE self, VALUE fill)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Color_to_PixelColor(&draw->info->fill, fill);
     return fill;
 }
@@ -160,7 +167,7 @@ Draw_fill_pattern_eq(VALUE self, VALUE pattern)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (draw->info->fill_pattern != NULL)
     {
@@ -195,7 +202,7 @@ Draw_font_eq(VALUE self, VALUE font)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     magick_clone_string(&draw->info->font, StringValueCStr(font));
 
     return font;
@@ -214,7 +221,7 @@ Draw_font_family_eq(VALUE self, VALUE family)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     magick_clone_string(&draw->info->family, StringValueCStr(family));
 
     return family;
@@ -233,7 +240,7 @@ Draw_font_stretch_eq(VALUE self, VALUE stretch)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     VALUE_TO_ENUM(stretch, draw->info->stretch, StretchType);
     return stretch;
 }
@@ -251,7 +258,7 @@ Draw_font_style_eq(VALUE self, VALUE style)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     VALUE_TO_ENUM(style, draw->info->style, StyleType);
     return style;
 }
@@ -271,7 +278,7 @@ Draw_font_weight_eq(VALUE self, VALUE weight)
     size_t w;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (FIXNUM_P(weight))
     {
@@ -337,7 +344,7 @@ Draw_gravity_eq(VALUE self, VALUE grav)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     VALUE_TO_ENUM(grav, draw->info->gravity, GravityType);
 
     return grav;
@@ -356,7 +363,7 @@ Draw_kerning_eq(VALUE self, VALUE kerning)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->kerning = NUM2DBL(kerning);
     return kerning;
 }
@@ -374,7 +381,7 @@ Draw_interline_spacing_eq(VALUE self, VALUE spacing)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->interline_spacing = NUM2DBL(spacing);
     return spacing;
 }
@@ -392,7 +399,7 @@ Draw_interword_spacing_eq(VALUE self, VALUE spacing)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->interword_spacing = NUM2DBL(spacing);
     return spacing;
 }
@@ -493,7 +500,7 @@ Draw_marshal_dump(VALUE self)
     Draw *draw;
     VALUE ddraw;
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     // Raise an exception if the Draw has a non-NULL gradient or element_reference field
     if (draw->info->element_reference.type != UndefinedReference
@@ -552,7 +559,7 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
     Draw *draw;
     VALUE val;
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (draw->info == NULL)
     {
@@ -624,7 +631,7 @@ Draw_pointsize_eq(VALUE self, VALUE pointsize)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->pointsize = NUM2DBL(pointsize);
     return pointsize;
 }
@@ -644,7 +651,7 @@ Draw_rotation_eq(VALUE self, VALUE deg)
     AffineMatrix affine, current;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     degrees = NUM2DBL(deg);
     if (fabs(degrees) > DBL_EPSILON)
@@ -680,7 +687,7 @@ Draw_stroke_eq(VALUE self, VALUE stroke)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Color_to_PixelColor(&draw->info->stroke, stroke);
     return stroke;
 }
@@ -700,7 +707,7 @@ Draw_stroke_pattern_eq(VALUE self, VALUE pattern)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (draw->info->stroke_pattern != NULL)
     {
@@ -736,7 +743,7 @@ Draw_stroke_width_eq(VALUE self, VALUE stroke_width)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->stroke_width = NUM2DBL(stroke_width);
     return stroke_width;
 }
@@ -754,7 +761,7 @@ Draw_text_antialias_eq(VALUE self, VALUE text_antialias)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     draw->info->text_antialias = (MagickBooleanType) RTEST(text_antialias);
     return text_antialias;
 }
@@ -785,7 +792,7 @@ Draw_undercolor_eq(VALUE self, VALUE undercolor)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Color_to_PixelColor(&draw->info->undercolor, undercolor);
     return undercolor;
 }
@@ -828,7 +835,7 @@ VALUE Draw_annotate(
 
     // Save the affine matrix in case it is modified by
     // Draw#rotation=
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     keep = draw->info->affine;
 
     image_arg = rm_cur_image(image_arg);
@@ -993,7 +1000,7 @@ Draw_composite(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "unknown composite operator (%d)", cop);
     }
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     // Create a temp copy of the composite image
     rm_write_temp_image(comp_img, name, sizeof(name));
@@ -1038,7 +1045,7 @@ Draw_draw(VALUE self, VALUE image_arg)
     image_arg = rm_cur_image(image_arg);
     image = rm_check_frozen(image_arg);
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     if (draw->primitives == 0)
     {
         rb_raise(rb_eArgError, "nothing to draw");
@@ -1084,7 +1091,7 @@ Draw_dup(VALUE self)
 
     draw = ALLOC(Draw);
     memset(draw, 0, sizeof(Draw));
-    dup = Data_Wrap_Struct(CLASS_OF(self), mark_Draw, destroy_Draw, draw);
+    dup = TypedData_Wrap_Struct(CLASS_OF(self), &rm_draw_data_type, draw);
     RB_GC_GUARD(dup);
 
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);
@@ -1155,8 +1162,8 @@ VALUE Draw_init_copy(VALUE self, VALUE orig)
 {
     Draw *copy, *original;
 
-    Data_Get_Struct(orig, Draw, original);
-    Data_Get_Struct(self, Draw, copy);
+    TypedData_Get_Struct(orig, Draw, &rm_draw_data_type, original);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, copy);
 
     copy->info = CloneDrawInfo(NULL, original->info);
     if (!copy->info)
@@ -1184,10 +1191,10 @@ Draw_initialize(VALUE self)
     Draw *draw, *draw_options;
     VALUE options;
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     options = new_DrawOptions();
-    Data_Get_Struct(options, Draw, draw_options);
+    TypedData_Get_Struct(options, Draw, &rm_draw_data_type, draw_options);
     draw->info = draw_options->info;
     draw_options->info = NULL;
 
@@ -1208,7 +1215,7 @@ Draw_inspect(VALUE self)
 {
     Draw *draw;
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     return draw->primitives ? draw->primitives : rb_str_new2("(no primitives defined)");
 }
 
@@ -1225,7 +1232,7 @@ VALUE Draw_alloc(VALUE class)
 
     draw = ALLOC(Draw);
     memset(draw, 0, sizeof(Draw));
-    draw_obj = Data_Wrap_Struct(class, mark_Draw, destroy_Draw, draw);
+    draw_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw);
 
     RB_GC_GUARD(draw_obj);
 
@@ -1245,7 +1252,7 @@ Draw_primitive(VALUE self, VALUE primitive)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (draw->primitives == (VALUE)0)
     {
@@ -1269,7 +1276,7 @@ Draw_primitive(VALUE self, VALUE primitive)
  * @param drawptr pointer to a Draw object
  */
 static void
-mark_Draw(void *drawptr)
+Draw_mark(void *drawptr)
 {
     Draw *draw = (Draw *)drawptr;
 
@@ -1288,7 +1295,7 @@ mark_Draw(void *drawptr)
  * @param drawptr pointer to a Draw object
  */
 static void
-destroy_Draw(void *drawptr)
+Draw_destroy(void *drawptr)
 {
     Draw *draw = (Draw *)drawptr;
 
@@ -1312,6 +1319,18 @@ destroy_Draw(void *drawptr)
     xfree(drawptr);
 }
 
+/**
+  * Get Draw object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param infoptr pointer to the Draw object
+  */
+static size_t
+Draw_memsize(const void *drawptr)
+{
+    return sizeof(Draw);
+}
 
 /**
  * Allocate & initialize a DrawOptions object.
@@ -1343,7 +1362,7 @@ DrawOptions_alloc(VALUE class)
 
     draw_options = ALLOC(Draw);
     memset(draw_options, 0, sizeof(Draw));
-    draw_options_obj = Data_Wrap_Struct(class, mark_Draw, destroy_Draw, draw_options);
+    draw_options_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw_options);
 
     RB_GC_GUARD(draw_options_obj);
 
@@ -1361,7 +1380,7 @@ DrawOptions_initialize(VALUE self)
 {
     Draw *draw_options;
 
-    Data_Get_Struct(self, Draw, draw_options);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw_options);
     draw_options->info = AcquireDrawInfo();
     if (!draw_options->info)
     {
@@ -1402,7 +1421,7 @@ PolaroidOptions_alloc(VALUE class)
     draw->info = CloneDrawInfo(image_info, (DrawInfo *) NULL);
     (void) DestroyImageInfo(image_info);
 
-    polaroid_obj = Data_Wrap_Struct(class, NULL, destroy_Draw, draw);
+    polaroid_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw);
 
     RB_GC_GUARD(polaroid_obj);
 
@@ -1424,7 +1443,7 @@ PolaroidOptions_initialize(VALUE self)
     ExceptionInfo *exception;
 
     // Default shadow color
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     exception = AcquireExceptionInfo();
     QueryColorCompliance("gray75", AllCompliance, &draw->shadow_color, exception);
@@ -1468,7 +1487,7 @@ PolaroidOptions_shadow_color_eq(VALUE self, VALUE shadow)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Color_to_PixelColor(&draw->shadow_color, shadow);
     return shadow;
 }
@@ -1486,7 +1505,7 @@ PolaroidOptions_border_color_eq(VALUE self, VALUE border)
     Draw *draw;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
     Color_to_PixelColor(&draw->info->border_color, border);
     return border;
 }
@@ -1589,7 +1608,7 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
         rb_raise(rb_eArgError, "no text to measure");
     }
 
-    Data_Get_Struct(self, Draw, draw);
+    TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
     draw->info->text = InterpretImageProperties(NULL, image, text, exception);

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1253,7 +1253,7 @@ Draw_primitive(VALUE self, VALUE primitive)
     }
     else
     {
-        draw->primitives = rb_str_concat(draw->primitives, rb_str_new2("\n"));
+        draw->primitives = rb_str_plus(draw->primitives, rb_str_new2("\n"));
         draw->primitives = rb_str_concat(draw->primitives, primitive);
     }
 

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1572,7 +1572,7 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
     {
         case 1:                   // use default image
             text = rm_str2cstr(argv[0], &text_l);
-            Data_Get_Struct(get_dummy_tm_img(CLASS_OF(self)), Image, image);
+            TypedData_Get_Struct(get_dummy_tm_img(CLASS_OF(self)), Image, &rm_image_data_type, image);
             break;
         case 2:
             t = rm_cur_image(argv[0]);

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -21,11 +21,6 @@ static VALUE Enum_type_inspect(VALUE);
 static void rm_enum_free(void *magick_enum);
 static size_t rm_enum_memsize(const void *magick_enum);
 
-#ifndef HAVE_RB_EXT_RACTOR_SAFE
-#undef RUBY_TYPED_FROZEN_SHAREABLE
-#define RUBY_TYPED_FROZEN_SHAREABLE 0
-#endif
-
 const rb_data_type_t rm_enum_data_type = {
     "Magick::Enum",
     { NULL, rm_enum_free, rm_enum_memsize, },

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -14,6 +14,8 @@
 
 static void GradientFill_free(void *fill);
 static size_t GradientFill_memsize(const void *ptr);
+static void TextureFill_free(void *fill_obj);
+static size_t TextureFill_memsize(const void *ptr);
 
 /** Data associated with a GradientFill */
 typedef struct
@@ -35,6 +37,13 @@ typedef struct
 const rb_data_type_t rm_gradient_fill_data_type = {
     "Magick::GradientFill",
     { NULL, GradientFill_free, GradientFill_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
+
+const rb_data_type_t rm_texture_fill_data_type = {
+    "Magick::TextureFill",
+    { NULL, TextureFill_free, TextureFill_memsize, },
     0, 0,
     RUBY_TYPED_FROZEN_SHAREABLE,
 };
@@ -699,7 +708,7 @@ GradientFill_fill(VALUE self, VALUE image_obj)
  * @param fill_obj the TextureFill
  */
 static void
-free_TextureFill(void *fill_obj)
+TextureFill_free(void *fill_obj)
 {
     rm_TextureFill *fill = (rm_TextureFill *)fill_obj;
 
@@ -711,6 +720,21 @@ free_TextureFill(void *fill_obj)
     xfree(fill);
 }
 
+
+/**
+  * Get TextureFill object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param ptr pointer to the TextureFill object
+  */
+static size_t
+TextureFill_memsize(const void *ptr)
+{
+    return sizeof(rm_TextureFill);
+}
+
+
 /**
  * Create new TextureFill object.
  *
@@ -720,7 +744,7 @@ VALUE
 TextureFill_alloc(VALUE class)
 {
     rm_TextureFill *fill;
-    return Data_Make_Struct(class, rm_TextureFill, NULL, free_TextureFill, fill);
+    return TypedData_Make_Struct(class, rm_TextureFill, &rm_texture_fill_data_type, fill);
 }
 
 /**
@@ -737,7 +761,7 @@ TextureFill_initialize(VALUE self, VALUE texture_arg)
     Image *texture;
     VALUE texture_image;
 
-    Data_Get_Struct(self, rm_TextureFill, fill);
+    TypedData_Get_Struct(self, rm_TextureFill, &rm_texture_fill_data_type, fill);
 
     texture_image = rm_cur_image(texture_arg);
 
@@ -769,7 +793,7 @@ TextureFill_fill(VALUE self, VALUE image_obj)
 #endif
 
     image = rm_check_destroyed(image_obj);
-    Data_Get_Struct(self, rm_TextureFill, fill);
+    TypedData_Get_Struct(self, rm_TextureFill, &rm_texture_fill_data_type, fill);
 
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -12,6 +12,9 @@
 
 #include "rmagick.h"
 
+static void GradientFill_free(void *fill);
+static size_t GradientFill_memsize(const void *ptr);
+
 /** Data associated with a GradientFill */
 typedef struct
 {
@@ -29,21 +32,44 @@ typedef struct
     Image *texture; /**< the texture */
 } rm_TextureFill;
 
+const rb_data_type_t rm_gradient_fill_data_type = {
+    "Magick::GradientFill",
+    { NULL, GradientFill_free, GradientFill_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
+
 
 DEFINE_GVL_STUB2(SyncAuthenticPixels, Image *, ExceptionInfo *);
 
 
 /**
- * Free Fill or Fill subclass object (except for TextureFill).
+ * Free GradientFill or GradientFill subclass object (except for TextureFill).
  *
  * No Ruby usage (internal function)
  *
  * @param fill the fill
  */
-static void free_Fill(void *fill)
+static void
+GradientFill_free(void *fill)
 {
     xfree(fill);
 }
+
+
+/**
+  * Get GradientFill object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param ptr pointer to the GradientFill object
+  */
+static size_t
+GradientFill_memsize(const void *ptr)
+{
+    return sizeof(rm_GradientFill);
+}
+
 
 /**
  * Create new GradientFill object.
@@ -55,7 +81,7 @@ GradientFill_alloc(VALUE class)
 {
     rm_GradientFill *fill;
 
-    return Data_Make_Struct(class, rm_GradientFill, NULL, free_Fill, fill);
+    return TypedData_Make_Struct(class, rm_GradientFill, &rm_gradient_fill_data_type, fill);
 }
 
 
@@ -82,7 +108,7 @@ GradientFill_initialize(
 {
     rm_GradientFill *fill;
 
-    Data_Get_Struct(self, rm_GradientFill, fill);
+    TypedData_Get_Struct(self, rm_GradientFill, &rm_gradient_fill_data_type, fill);
 
     fill->x1 = NUM2DBL(x1);
     fill->y1 = NUM2DBL(y1);
@@ -610,7 +636,7 @@ GradientFill_fill(VALUE self, VALUE image_obj)
     PixelColor start_color, stop_color;
     double x1, y1, x2, y2;          // points on the line
 
-    Data_Get_Struct(self, rm_GradientFill, fill);
+    TypedData_Get_Struct(self, rm_GradientFill, &rm_gradient_fill_data_type, fill);
     image = rm_check_destroyed(image_obj);
 
     x1 = fill->x1;

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -104,7 +104,7 @@ ImageList_animate(int argc, VALUE *argv, VALUE self)
         }
     }
 
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
     GVL_STRUCT_TYPE(AnimateImages) args = { info, images, exception };
@@ -414,7 +414,7 @@ ImageList_display(VALUE self)
 
     // Create a new Info object to use with this call
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     // Convert the images array to an images sequence.
     images = images_from_imagelist(self);
@@ -1110,7 +1110,7 @@ ImageList_to_blob(VALUE self)
     ExceptionInfo *exception;
 
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     // Convert the images array to an images sequence.
     images = images_from_imagelist(self);
@@ -1184,7 +1184,7 @@ ImageList_write(VALUE self, VALUE file)
     ExceptionInfo *exception;
 
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
 
     if (TYPE(file) == T_FILE)

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -488,7 +488,7 @@ ImageList_montage(VALUE self)
         rb_yield(montage_obj);
     }
 
-    Data_Get_Struct(montage_obj, Montage, montage);
+    TypedData_Get_Struct(montage_obj, Montage, &rm_montage_data_type, montage);
 
     images = images_from_imagelist(self);
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4727,7 +4727,7 @@ Image_morphology_channel(VALUE self, VALUE channel_v, VALUE method_v, VALUE iter
         rb_raise(rb_eArgError, "expected String or Magick::KernelInfo");
     }
 
-    Data_Get_Struct(kernel_v, KernelInfo, kernel);
+    TypedData_Get_Struct(kernel_v, KernelInfo, &rm_kernel_info_data_type, kernel);
 
     exception = AcquireExceptionInfo();
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -2297,7 +2297,7 @@ Image_capture(int argc, VALUE *argv, VALUE self ATTRIBUTE_UNUSED)
     // Set info->server_name to the server name
     // Also info->colorspace, depth, dither, interlace, type
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, image_info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, image_info);
 
     // If an error occurs, IM will call our error handler and we raise an exception.
 #if defined(IMAGEMAGICK_7)
@@ -5755,7 +5755,7 @@ Image_display(VALUE self)
     }
 
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
@@ -7266,7 +7266,7 @@ Image_from_blob(VALUE class ATTRIBUTE_UNUSED, VALUE blob_arg)
 
     // Get a new Info object - run the parm block if supplied
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     exception = AcquireExceptionInfo();
     GVL_STRUCT_TYPE(BlobToImage) args = { info,  blob, (size_t)length, exception };
@@ -9867,7 +9867,7 @@ Image_initialize(int argc, VALUE *argv, VALUE self)
 
     // Create a new Info object to use when creating this image.
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     image = rm_acquire_image(info);
     if (!image)
@@ -11517,7 +11517,7 @@ rd_image(VALUE class ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
 
     // Create a new Info structure for this read/ping
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     if (TYPE(file) == T_FILE)
     {
@@ -11703,7 +11703,7 @@ Image_read_inline(VALUE self ATTRIBUTE_UNUSED, VALUE content)
     // Create a new Info structure for this read. About the
     // only useful attribute that can be set is `format'.
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     GVL_STRUCT_TYPE(BlobToImage) args_BlobToImage = { info, blob, blob_l, exception };
     images = (Image *)CALL_FUNC_WITHOUT_GVL(GVL_FUNC(BlobToImage), &args_BlobToImage);
@@ -14480,7 +14480,7 @@ Image_to_blob(VALUE self)
     // both) and the image format by setting the depth and format
     // values in the info parm block.
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     image = rm_check_destroyed(self);
 
@@ -15882,7 +15882,7 @@ Image_write(VALUE self, VALUE file)
     image = rm_check_destroyed(self);
 
     info_obj = rm_info_new();
-    Data_Get_Struct(info_obj, Info, info);
+    TypedData_Get_Struct(info_obj, Info, &rm_info_data_type, info);
 
     if (TYPE(file) == T_FILE)
     {

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -10820,7 +10820,7 @@ Image_polaroid(int argc, VALUE *argv, VALUE self)
     }
 
     options = rm_polaroid_new();
-    Data_Get_Struct(options, Draw, draw);
+    TypedData_Get_Struct(options, Draw, &rm_draw_data_type, draw);
 
     clone = rm_clone_image(image);
     clone->background_color = draw->shadow_color;

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -13926,7 +13926,7 @@ Image_store_pixels(VALUE self, VALUE x_arg, VALUE y_arg, VALUE cols_arg,
                     DestroyExceptionInfo(exception);
                     rb_raise(rb_eTypeError, "Item in array should be a Pixel.");
                 }
-                Data_Get_Struct(new_pixel, Pixel, pixel);
+                TypedData_Get_Struct(new_pixel, Pixel, &rm_pixel_data_type, pixel);
 #if defined(IMAGEMAGICK_7)
                 SetPixelRed(image,   pixel->red,   pixels);
                 SetPixelGreen(image, pixel->green, pixels);

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -12,6 +12,16 @@
 
 #include "rmagick.h"
 
+static void Info_free(void *infoptr);
+static size_t Info_memsize(const void *infoptr);
+
+const rb_data_type_t rm_info_data_type = {
+    "Magick::Image::Info",
+    { NULL, Info_free, Info_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
+
 
 /**
  * Return the value of the specified option.
@@ -28,7 +38,7 @@ get_option(VALUE self, const char *key)
     Info *info;
     const char *value;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     value = GetImageOption(info, key);
     if (value)
@@ -54,7 +64,7 @@ set_option(VALUE self, const char *key, VALUE string)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(string))
     {
@@ -90,7 +100,7 @@ static VALUE set_color_option(VALUE self, const char *option, VALUE color)
     PixelColor pp;
     MagickBooleanType okay;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(color))
     {
@@ -136,7 +146,7 @@ static VALUE get_dbl_option(VALUE self, const char *option)
     double d;
     long n;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     value = GetImageOption(info, option);
     if (!value)
@@ -167,7 +177,7 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(value))
     {
@@ -206,7 +216,7 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
 VALUE
 Info_antialias(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, antialias, boolean);
+    IMPLEMENT_TYPED_ATTR_READER(Info, antialias, boolean, &rm_info_data_type);
 }
 
 /**
@@ -218,7 +228,7 @@ Info_antialias(VALUE self)
 VALUE
 Info_antialias_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, antialias, boolean);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, antialias, boolean, &rm_info_data_type);
 }
 
 /** Maximum length of a format (@see Info_aref) */
@@ -272,7 +282,7 @@ Info_aref(int argc, VALUE *argv, VALUE self)
 
     }
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     value = GetImageOption(info, fkey);
     if (!value)
     {
@@ -311,7 +321,7 @@ Info_aset(int argc, VALUE *argv, VALUE self)
     long format_l, key_l;
     char ckey[MaxTextExtent];
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     switch (argc)
     {
@@ -401,7 +411,7 @@ Info_authenticate(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 #if defined(IMAGEMAGICK_7)
     return C_str_to_R_str(GetImageOption(info, "authenticate"));
 #else
@@ -422,7 +432,7 @@ Info_authenticate_eq(VALUE self, VALUE passwd_arg)
     Info *info;
     char *passwd = NULL;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (!NIL_P(passwd_arg))
     {
@@ -465,7 +475,7 @@ Info_background_color(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return rm_pixelcolor_to_color_name_info(info, &info->background_color);
 }
 
@@ -481,7 +491,7 @@ Info_background_color_eq(VALUE self, VALUE bc_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     Color_to_PixelColor(&info->background_color, bc_arg);
 
     return bc_arg;
@@ -498,7 +508,7 @@ Info_border_color(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return rm_pixelcolor_to_color_name_info(info, &info->border_color);
 }
 
@@ -513,7 +523,7 @@ Info_border_color_eq(VALUE self, VALUE bc_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     Color_to_PixelColor(&info->border_color, bc_arg);
 
     return bc_arg;
@@ -572,7 +582,7 @@ Info_channel(int argc, VALUE *argv, VALUE self)
         raise_ChannelType_error(argv[argc-1]);
     }
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     info->channel = channels;
     return self;
@@ -589,7 +599,7 @@ Info_colorspace(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return ColorspaceType_find(info->colorspace);
 }
 
@@ -604,7 +614,7 @@ Info_colorspace_eq(VALUE self, VALUE colorspace)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(colorspace, info->colorspace, ColorspaceType);
     return colorspace;
 }
@@ -640,7 +650,7 @@ Info_compression(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return CompressionType_find(info->compression);
 }
 
@@ -655,7 +665,7 @@ Info_compression_eq(VALUE self, VALUE type)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(type, info->compression, CompressionType);
     return type;
 }
@@ -681,7 +691,7 @@ Info_define(int argc, VALUE *argv, VALUE self)
     unsigned int okay;
     VALUE fmt_arg;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     switch (argc)
     {
@@ -728,7 +738,7 @@ Info_delay(VALUE self)
     const char *delay;
     char *p;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     delay = GetImageOption(info, "delay");
     if (delay)
@@ -771,7 +781,7 @@ Info_delay_eq(VALUE self, VALUE string)
     Info *info;
     int not_num;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(string))
     {
@@ -803,7 +813,7 @@ Info_delay_eq(VALUE self, VALUE string)
 VALUE
 Info_density(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, density, str);
+    IMPLEMENT_TYPED_ATTR_READER(Info, density, str, &rm_info_data_type);
 }
 
 /**
@@ -820,7 +830,7 @@ Info_density_eq(VALUE self, VALUE density_arg)
     VALUE density;
     char *dens;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(density_arg))
     {
@@ -851,7 +861,7 @@ Info_density_eq(VALUE self, VALUE density_arg)
 VALUE
 Info_depth(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, depth, int);
+    IMPLEMENT_TYPED_ATTR_READER(Info, depth, int, &rm_info_data_type);
 }
 
 /**
@@ -866,7 +876,7 @@ Info_depth_eq(VALUE self, VALUE depth)
     Info *info;
     unsigned long d;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     d = NUM2ULONG(depth);
     switch (d)
     {
@@ -950,7 +960,7 @@ Info_dispose(VALUE self)
     ID dispose_id;
     const char *dispose;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     dispose_id = rb_intern("UndefinedDispose");
 
@@ -985,7 +995,7 @@ Info_dispose_eq(VALUE self, VALUE disp)
     const char *option;
     int x;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(disp))
     {
@@ -1017,7 +1027,7 @@ Info_dispose_eq(VALUE self, VALUE disp)
 VALUE
 Info_dither(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, dither, boolean);
+    IMPLEMENT_TYPED_ATTR_READER(Info, dither, boolean, &rm_info_data_type);
 }
 
 /**
@@ -1029,7 +1039,7 @@ Info_dither(VALUE self)
 VALUE
 Info_dither_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, dither, boolean);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, dither, boolean, &rm_info_data_type);
 }
 
 
@@ -1043,7 +1053,7 @@ Info_endian(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return EndianType_find(info->endian);
 }
 
@@ -1065,7 +1075,7 @@ Info_endian_eq(VALUE self, VALUE endian)
         VALUE_TO_ENUM(endian, type, EndianType);
     }
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     info->endian = type;
     return endian;
 }
@@ -1080,7 +1090,7 @@ Info_endian_eq(VALUE self, VALUE endian)
 VALUE
 Info_extract(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, extract, str);
+    IMPLEMENT_TYPED_ATTR_READER(Info, extract, str, &rm_info_data_type);
 }
 
 /**
@@ -1097,7 +1107,7 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
     char *extr;
     VALUE extract;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(extract_arg))
     {
@@ -1133,7 +1143,7 @@ Info_filename(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return rb_str_new2(info->filename);
 }
 
@@ -1150,7 +1160,7 @@ Info_filename_eq(VALUE self, VALUE filename)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     // Allow "nil" - remove current filename
     if (NIL_P(filename) || StringValueCStr(filename) == NULL)
@@ -1201,7 +1211,7 @@ Info_fill_eq(VALUE self, VALUE color)
 VALUE
 Info_font(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, font, str);
+    IMPLEMENT_TYPED_ATTR_READER(Info, font, str, &rm_info_data_type);
 }
 
 /**
@@ -1215,7 +1225,7 @@ Info_font_eq(VALUE self, VALUE font_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     if (NIL_P(font_arg) || StringValueCStr(font_arg) == NULL)
     {
         magick_free(info->font);
@@ -1240,7 +1250,7 @@ VALUE Info_format(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     if (*info->magick)
     {
         const MagickInfo *magick_info;
@@ -1270,7 +1280,7 @@ Info_format_eq(VALUE self, VALUE magick)
     char *mgk;
     ExceptionInfo *exception;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     mgk = StringValueCStr(magick);
 
@@ -1297,7 +1307,7 @@ Info_format_eq(VALUE self, VALUE magick)
 VALUE
 Info_fuzz(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, fuzz, dbl);
+    IMPLEMENT_TYPED_ATTR_READER(Info, fuzz, dbl, &rm_info_data_type);
 }
 
 /**
@@ -1313,7 +1323,7 @@ Info_fuzz_eq(VALUE self, VALUE fuzz)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     info->fuzz = rm_fuzz_to_dbl(fuzz);
     return fuzz;
 }
@@ -1380,7 +1390,7 @@ VALUE Info_gravity(VALUE self)
     const char *gravity;
     ID gravity_id;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     gravity_id = rb_intern("UndefinedGravity");
 
@@ -1416,7 +1426,7 @@ Info_gravity_eq(VALUE self, VALUE grav)
     const char *option;
     int x;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(grav))
     {
@@ -1451,7 +1461,7 @@ Info_image_type(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return ImageType_find(info->type);
 }
 
@@ -1466,7 +1476,7 @@ Info_image_type_eq(VALUE self, VALUE type)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(type, info->type, ImageType);
     return type;
 }
@@ -1481,7 +1491,7 @@ Info_interlace(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return InterlaceType_find(info->interlace);
 }
 
@@ -1496,7 +1506,7 @@ Info_interlace_eq(VALUE self, VALUE inter)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(inter, info->interlace, InterlaceType);
     return inter;
 }
@@ -1533,7 +1543,7 @@ Info_matte_color(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return rm_pixelcolor_to_color_name_info(info, &info->matte_color);
 }
 
@@ -1548,7 +1558,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     Color_to_PixelColor(&info->matte_color, matte_arg);
 
     return matte_arg;
@@ -1562,7 +1572,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
 VALUE
 Info_monochrome(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, monochrome, boolean);
+    IMPLEMENT_TYPED_ATTR_READER(Info, monochrome, boolean, &rm_info_data_type);
 }
 
 /**
@@ -1574,7 +1584,7 @@ Info_monochrome(VALUE self)
 VALUE
 Info_monochrome_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, monochrome, boolean);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, monochrome, boolean, &rm_info_data_type);
 }
 
 /**
@@ -1585,7 +1595,7 @@ Info_monochrome_eq(VALUE self, VALUE val)
 VALUE
 Info_number_scenes(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, number_scenes, ulong);
+    IMPLEMENT_TYPED_ATTR_READER(Info, number_scenes, ulong, &rm_info_data_type);
 }
 
 /**
@@ -1597,7 +1607,7 @@ Info_number_scenes(VALUE self)
 VALUE
 Info_number_scenes_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, number_scenes, ulong);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, number_scenes, ulong, &rm_info_data_type);
 }
 
 /**
@@ -1610,7 +1620,7 @@ Info_orientation(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return OrientationType_find(info->orientation);
 }
 
@@ -1626,7 +1636,7 @@ Info_orientation_eq(VALUE self, VALUE inter)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(inter, info->orientation, OrientationType);
     return inter;
 }
@@ -1644,7 +1654,7 @@ Info_origin(VALUE self)
     Info *info;
     const char *origin;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     origin = GetImageOption(info, "origin");
     return origin ? rb_str_new2(origin) : Qnil;
@@ -1669,7 +1679,7 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
     VALUE origin_str;
     char *origin;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(origin_arg))
     {
@@ -1705,7 +1715,7 @@ Info_page(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return info->page ? rb_str_new2(info->page) : Qnil;
 
 }
@@ -1725,7 +1735,7 @@ Info_page_eq(VALUE self, VALUE page_arg)
     VALUE geom_str;
     char *geometry;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     if (NIL_P(page_arg))
     {
         magick_free(info->page);
@@ -1755,7 +1765,7 @@ Info_page_eq(VALUE self, VALUE page_arg)
 VALUE
 Info_pointsize(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, pointsize, dbl);
+    IMPLEMENT_TYPED_ATTR_READER(Info, pointsize, dbl, &rm_info_data_type);
 }
 
 /**
@@ -1767,7 +1777,7 @@ Info_pointsize(VALUE self)
 VALUE
 Info_pointsize_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, pointsize, dbl);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, pointsize, dbl, &rm_info_data_type);
 }
 
 /**
@@ -1778,7 +1788,7 @@ Info_pointsize_eq(VALUE self, VALUE val)
 VALUE
 Info_quality(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, quality, ulong);
+    IMPLEMENT_TYPED_ATTR_READER(Info, quality, ulong, &rm_info_data_type);
 }
 
 /**
@@ -1790,7 +1800,7 @@ Info_quality(VALUE self)
 VALUE
 Info_quality_eq(VALUE self, VALUE val)
 {
-    IMPLEMENT_ATTR_WRITER(Info, quality, ulong);
+    IMPLEMENT_TYPED_ATTR_WRITER(Info, quality, ulong, &rm_info_data_type);
 }
 
 /**
@@ -1803,7 +1813,7 @@ Info_sampling_factor(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     if (info->sampling_factor)
     {
         return rb_str_new2(info->sampling_factor);
@@ -1827,7 +1837,7 @@ Info_sampling_factor_eq(VALUE self, VALUE sampling_factor)
     char *sampling_factor_p = NULL;
     long sampling_factor_len = 0;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (!NIL_P(sampling_factor))
     {
@@ -1858,7 +1868,7 @@ Info_scene(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return  ULONG2NUM(info->scene);
 }
 
@@ -1875,7 +1885,7 @@ Info_scene_eq(VALUE self, VALUE scene)
     Info *info;
     char buf[25];
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     info->scene = NUM2ULONG(scene);
 
     snprintf(buf, sizeof(buf), "%"RMIuSIZE"", info->scene);
@@ -1893,7 +1903,7 @@ Info_scene_eq(VALUE self, VALUE scene)
 VALUE
 Info_server_name(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, server_name, str);
+    IMPLEMENT_TYPED_ATTR_READER(Info, server_name, str, &rm_info_data_type);
 }
 
 
@@ -1908,7 +1918,7 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     if (NIL_P(server_arg) || StringValueCStr(server_arg) == NULL)
     {
         magick_free(info->server_name);
@@ -1933,7 +1943,7 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
 VALUE
 Info_size(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Info, size, str);
+    IMPLEMENT_TYPED_ATTR_READER(Info, size, str, &rm_info_data_type);
 }
 
 /**
@@ -1950,7 +1960,7 @@ Info_size_eq(VALUE self, VALUE size_arg)
     VALUE size;
     char *sz;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (NIL_P(size_arg))
     {
@@ -2036,7 +2046,7 @@ Info_texture_eq(VALUE self, VALUE texture)
     Image *image;
     char name[MaxTextExtent];
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     // Delete any existing texture file
     if (info->texture)
@@ -2074,7 +2084,7 @@ Info_tile_offset(VALUE self)
     Info *info;
     const char *tile_offset;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     tile_offset = GetImageOption(info, "tile-offset");
 
@@ -2108,7 +2118,7 @@ Info_tile_offset_eq(VALUE self, VALUE offset)
         rb_raise(rb_eArgError, "invalid tile offset geometry: %s", tile_offset);
     }
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     DeleteImageOption(info, "tile-offset");
     SetImageOption(info, "tile-offset", tile_offset);
@@ -2130,7 +2140,7 @@ Info_transparent_color(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return rm_pixelcolor_to_color_name_info(info, &info->transparent_color);
 }
 
@@ -2146,7 +2156,7 @@ Info_transparent_color_eq(VALUE self, VALUE tc_arg)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     Color_to_PixelColor(&info->transparent_color, tc_arg);
 
     return tc_arg;
@@ -2178,7 +2188,7 @@ Info_undefine(VALUE self, VALUE format, VALUE key)
 
     snprintf(fkey, sizeof(fkey), "%.60s:%.*s", format_p, (int)(MaxTextExtent-61), key_p);
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     DeleteImageOption(info, fkey);
 
     return self;
@@ -2218,7 +2228,7 @@ Info_units(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     return ResolutionType_find(info->units);
 }
 
@@ -2233,7 +2243,7 @@ Info_units_eq(VALUE self, VALUE units)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
     VALUE_TO_ENUM(units, info->units, ResolutionType);
     return units;
 }
@@ -2248,7 +2258,7 @@ Info_view(VALUE self)
 {
     Info *info;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 #if defined(IMAGEMAGICK_7)
     return C_str_to_R_str(GetImageOption(info, "fpx:view"));
 #else
@@ -2268,7 +2278,7 @@ Info_view_eq(VALUE self, VALUE view_arg)
     Info *info;
     char *view = NULL;
 
-    Data_Get_Struct(self, Info, info);
+    TypedData_Get_Struct(self, Info, &rm_info_data_type, info);
 
     if (!NIL_P(view_arg))
     {
@@ -2308,7 +2318,7 @@ Info_view_eq(VALUE self, VALUE view_arg)
  * @param infoptr pointer to the Info object
  */
 static void
-destroy_Info(void *infoptr)
+Info_free(void *infoptr)
 {
     Info *info = (Info *)infoptr;
 
@@ -2322,6 +2332,18 @@ destroy_Info(void *infoptr)
     DestroyImageInfo(info);
 }
 
+/**
+  * Get Info object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param infoptr pointer to the Info object
+  */
+static size_t
+Info_memsize(const void *infoptr)
+{
+    return sizeof(Info);
+}
 
 /**
  * Create an Image::Info object.
@@ -2342,7 +2364,7 @@ Info_alloc(VALUE class)
     {
         rb_raise(rb_eNoMemError, "not enough memory to initialize Info object");
     }
-    info_obj = Data_Wrap_Struct(class, NULL, destroy_Info, info);
+    info_obj = TypedData_Wrap_Struct(class, &rm_info_data_type, info);
 
     RB_GC_GUARD(info_obj);
 

--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -10,6 +10,15 @@
 
 #include "rmagick.h"
 
+static void rm_kernel_info_destroy(void *kernel);
+static size_t rm_kernel_info_memsize(const void *ptr);
+
+const rb_data_type_t rm_kernel_info_data_type = {
+    "Magick::KernelInfo",
+    { NULL, rm_kernel_info_destroy, rm_kernel_info_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
 
 /* UnityAddKernelInfo() was private function until IM 6.9 */
 MagickExport void UnityAddKernelInfo(KernelInfo *kernel, const double scale);
@@ -37,6 +46,19 @@ rm_kernel_info_destroy(void *kernel)
 }
 
 /**
+  * Get KernelInfo object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param ptr pointer to the KernelInfo object
+  */
+static size_t
+rm_kernel_info_memsize(const void *ptr)
+{
+    return sizeof(KernelInfo);
+}
+
+/**
  * Create a KernelInfo object.
  *
  * @return [Magick::KernelInfo] a new KernelInfo object
@@ -44,7 +66,7 @@ rm_kernel_info_destroy(void *kernel)
 VALUE
 KernelInfo_alloc(VALUE class)
 {
-    return Data_Wrap_Struct(class, NULL, rm_kernel_info_destroy, NULL);
+    return TypedData_Wrap_Struct(class, &rm_kernel_info_data_type, NULL);
 }
 
 /**
@@ -156,7 +178,7 @@ VALUE
 KernelInfo_clone(VALUE self)
 {
     KernelInfo *kernel = CloneKernelInfo((KernelInfo*)DATA_PTR(self));
-    return Data_Wrap_Struct(Class_KernelInfo, NULL, rm_kernel_info_destroy, kernel);
+    return TypedData_Wrap_Struct(Class_KernelInfo, &rm_kernel_info_data_type, kernel);
 }
 
 /**
@@ -202,5 +224,5 @@ KernelInfo_builtin(VALUE self, VALUE what, VALUE geometry)
         rb_raise(rb_eRuntimeError, "failed to acquire builtin kernel");
     }
 
-    return Data_Wrap_Struct(self, NULL, rm_kernel_info_destroy, kernel);
+    return TypedData_Wrap_Struct(self, &rm_kernel_info_data_type, kernel);
 }

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -234,6 +234,10 @@ static void set_managed_memory(void)
 void
 Init_RMagick2(void)
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+
     Module_Magick = rb_define_module("Magick");
 
     set_managed_memory();

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -12,8 +12,15 @@
 
 #include "rmagick.h"
 
+static void Montage_destroy(void *obj);
+static size_t Montage_memsize(const void *obj);
 
-
+const rb_data_type_t rm_montage_data_type = {
+    "Magick::ImageList::Montage",
+    { NULL, Montage_destroy, Montage_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
 
 
 /**
@@ -28,7 +35,7 @@
  * @param obj the montage object
  */
 static void
-destroy_Montage(void *obj)
+Montage_destroy(void *obj)
 {
     Montage *montage = obj;
 
@@ -45,6 +52,20 @@ destroy_Montage(void *obj)
         montage->info = NULL;
     }
     xfree(montage);
+}
+
+
+/**
+  * Get Montage object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param ptr pointer to the Montage object
+  */
+static size_t
+Montage_memsize(const void *ptr)
+{
+    return sizeof(Montage);
 }
 
 
@@ -79,7 +100,7 @@ Montage_alloc(VALUE class)
     montage = ALLOC(Montage);
     montage->info = montage_info;
     montage->compose = OverCompositeOp;
-    montage_obj = Data_Wrap_Struct(class, NULL, destroy_Montage, montage);
+    montage_obj = TypedData_Wrap_Struct(class, &rm_montage_data_type, montage);
 
     RB_GC_GUARD(montage_obj);
 
@@ -98,7 +119,7 @@ Montage_background_color_eq(VALUE self, VALUE color)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     Color_to_PixelColor(&montage->info->background_color, color);
     return color;
 }
@@ -115,7 +136,7 @@ Montage_border_color_eq(VALUE self, VALUE color)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     Color_to_PixelColor(&montage->info->border_color, color);
     return color;
 }
@@ -132,7 +153,7 @@ Montage_border_width_eq(VALUE self, VALUE width)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     montage->info->border_width = NUM2ULONG(width);
     return width;
 }
@@ -149,7 +170,7 @@ Montage_compose_eq(VALUE self, VALUE compose)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     VALUE_TO_ENUM(compose, montage->compose, CompositeOperator);
     return compose;
 }
@@ -166,7 +187,7 @@ Montage_filename_eq(VALUE self, VALUE filename)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     strlcpy(montage->info->filename, StringValueCStr(filename), sizeof(montage->info->filename));
     return filename;
 }
@@ -183,7 +204,7 @@ Montage_fill_eq(VALUE self, VALUE color)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     Color_to_PixelColor(&montage->info->fill, color);
     return color;
 }
@@ -200,7 +221,7 @@ Montage_font_eq(VALUE self, VALUE font)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     magick_clone_string(&montage->info->font, StringValueCStr(font));
 
     return font;
@@ -223,7 +244,7 @@ Montage_frame_eq(VALUE self, VALUE frame_arg)
     Montage *montage;
     VALUE frame;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     frame = rb_String(frame_arg);
     magick_clone_string(&montage->info->frame, StringValueCStr(frame));
 
@@ -250,7 +271,7 @@ Montage_geometry_eq(VALUE self, VALUE geometry_arg)
     Montage *montage;
     VALUE geometry;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     geometry = rb_String(geometry_arg);
     magick_clone_string(&montage->info->geometry, StringValueCStr(geometry));
 
@@ -271,7 +292,7 @@ Montage_gravity_eq(VALUE self, VALUE gravity)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     VALUE_TO_ENUM(gravity, montage->info->gravity, GravityType);
     return gravity;
 }
@@ -301,7 +322,7 @@ Montage_matte_color_eq(VALUE self, VALUE color)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     Color_to_PixelColor(&montage->info->matte_color, color);
     return color;
 }
@@ -318,7 +339,7 @@ Montage_pointsize_eq(VALUE self, VALUE size)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     montage->info->pointsize = NUM2DBL(size);
     return size;
 }
@@ -335,7 +356,7 @@ Montage_shadow_eq(VALUE self, VALUE shadow)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     montage->info->shadow = (MagickBooleanType) RTEST(shadow);
     return shadow;
 }
@@ -352,7 +373,7 @@ Montage_stroke_eq(VALUE self, VALUE color)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     Color_to_PixelColor(&montage->info->stroke, color);
     return color;
 }
@@ -372,7 +393,7 @@ Montage_texture_eq(VALUE self, VALUE texture)
     Image *texture_image;
     char temp_name[MaxTextExtent];
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
 
     // If we had a previously defined temp texture image,
     // remove it now in preparation for this new one.
@@ -411,7 +432,7 @@ Montage_tile_eq(VALUE self, VALUE tile_arg)
     Montage *montage;
     VALUE tile;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     tile = rb_String(tile_arg);
     magick_clone_string(&montage->info->tile, StringValueCStr(tile));
 
@@ -432,7 +453,7 @@ Montage_title_eq(VALUE self, VALUE title)
 {
     Montage *montage;
 
-    Data_Get_Struct(self, Montage, montage);
+    TypedData_Get_Struct(self, Montage, &rm_montage_data_type, montage);
     magick_clone_string(&montage->info->title, StringValueCStr(title));
     return title;
 }

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -19,6 +19,15 @@
 
 static VALUE color_arg_rescue(VALUE, VALUE ATTRIBUTE_UNUSED) ATTRIBUTE_NORETURN;
 static void Color_Name_to_PixelColor(PixelColor *, VALUE);
+static void Pixel_destroy(void *);
+static size_t Pixel_memsize(const void *);
+
+const rb_data_type_t rm_pixel_data_type = {
+    "Magick::Pixel",
+    { NULL, Pixel_destroy, Pixel_memsize, },
+    0, 0,
+    RUBY_TYPED_FROZEN_SHAREABLE,
+};
 
 
 /**
@@ -26,12 +35,27 @@ static void Color_Name_to_PixelColor(PixelColor *, VALUE);
  *
  * No Ruby usage (internal function)
  *
- * @param pixel the Pixel object to destroy
+ * @param ptr the Pixel object to destroy
  */
-void
-destroy_Pixel(Pixel *pixel)
+static void
+Pixel_destroy(void *ptr)
 {
+    Pixel *pixel = (Pixel *)ptr;
     xfree(pixel);
+}
+
+
+/**
+  * Get Pixel object size.
+  *
+  * No Ruby usage (internal function)
+  *
+  * @param ptr pointer to the Pixel object
+  */
+static size_t
+Pixel_memsize(const void *ptr)
+{
+    return sizeof(Pixel);
 }
 
 
@@ -43,7 +67,7 @@ destroy_Pixel(Pixel *pixel)
 VALUE
 Pixel_red(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Pixel, red, int);
+    IMPLEMENT_TYPED_ATTR_READER(Pixel, red, int, &rm_pixel_data_type);
 }
 
 /**
@@ -54,7 +78,7 @@ Pixel_red(VALUE self)
 VALUE
 Pixel_green(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Pixel, green, int);
+    IMPLEMENT_TYPED_ATTR_READER(Pixel, green, int, &rm_pixel_data_type);
 }
 
 /**
@@ -65,7 +89,7 @@ Pixel_green(VALUE self)
 VALUE
 Pixel_blue(VALUE self)
 {
-    IMPLEMENT_ATTR_READER(Pixel, blue, int);
+    IMPLEMENT_TYPED_ATTR_READER(Pixel, blue, int, &rm_pixel_data_type);
 }
 
 /**
@@ -77,7 +101,7 @@ VALUE
 Pixel_alpha(VALUE self)
 {
     Pixel *pixel;
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 #if defined(IMAGEMAGICK_7)
     return C_int_to_R_int(pixel->alpha);
 #else
@@ -102,7 +126,7 @@ Pixel_red_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->red = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -126,7 +150,7 @@ Pixel_green_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->green = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -150,7 +174,7 @@ Pixel_blue_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->blue = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -174,7 +198,7 @@ Pixel_alpha_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 #if defined(IMAGEMAGICK_7)
     pixel->alpha = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
@@ -198,7 +222,7 @@ Pixel_cyan(VALUE self)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     return INT2NUM(pixel->red);
 }
 
@@ -219,7 +243,7 @@ Pixel_cyan_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->red = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -236,7 +260,7 @@ Pixel_magenta(VALUE self)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     return INT2NUM(pixel->green);
 }
 
@@ -257,7 +281,7 @@ Pixel_magenta_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->green = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -274,7 +298,7 @@ Pixel_yellow(VALUE self)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     return INT2NUM(pixel->blue);
 }
 
@@ -295,7 +319,7 @@ Pixel_yellow_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->blue = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -312,7 +336,7 @@ Pixel_black(VALUE self)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     return INT2NUM(pixel->black);
 }
 
@@ -333,7 +357,7 @@ Pixel_black_eq(VALUE self, VALUE v)
     Pixel *pixel;
 
     rb_check_frozen(self);
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->black = APP2QUANTUM(v);
     rb_funcall(self, rm_ID_changed, 0);
     rb_funcall(self, rm_ID_notify_observers, 1, self);
@@ -376,7 +400,7 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
     if (CLASS_OF(color) == Class_Pixel)
     {
         memset(pp, 0, sizeof(*pp));
-        Data_Get_Struct(color, Pixel, pixel);
+        TypedData_Get_Struct(color, Pixel, &rm_pixel_data_type, pixel);
         pp->red     = pixel->red;
         pp->green   = pixel->green;
         pp->blue    = pixel->blue;
@@ -415,7 +439,7 @@ Color_to_Pixel(Pixel *pp, VALUE color)
     {
         Pixel *pixel;
 
-        Data_Get_Struct(color, Pixel, pixel);
+        TypedData_Get_Struct(color, Pixel, &rm_pixel_data_type, pixel);
         memcpy(pp, pixel, sizeof(Pixel));
     }
     else
@@ -474,7 +498,7 @@ Pixel_alloc(VALUE class)
 
     pixel = ALLOC(Pixel);
     memset(pixel, '\0', sizeof(Pixel));
-    return Data_Wrap_Struct(class, NULL, destroy_Pixel, pixel);
+    return TypedData_Wrap_Struct(class, &rm_pixel_data_type, pixel);
 }
 
 
@@ -492,8 +516,8 @@ Pixel_case_eq(VALUE self, VALUE other)
     {
         Pixel *this, *that;
 
-        Data_Get_Struct(self, Pixel, this);
-        Data_Get_Struct(other, Pixel, that);
+        TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, this);
+        TypedData_Get_Struct(other, Pixel, &rm_pixel_data_type, that);
         return (this->red == that->red
             && this->blue == that->blue
             && this->green == that->green
@@ -547,7 +571,7 @@ Pixel_dup(VALUE self)
 
     pixel = ALLOC(Pixel);
     memset(pixel, '\0', sizeof(Pixel));
-    dup = Data_Wrap_Struct(CLASS_OF(self), NULL, destroy_Pixel, pixel);
+    dup = TypedData_Wrap_Struct(CLASS_OF(self), &rm_pixel_data_type, pixel);
     RB_GC_GUARD(dup);
 
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);
@@ -785,7 +809,7 @@ Pixel_from_MagickPixel(const MagickPixel *pp)
 #endif
     pixel->black   = pp->index;
 
-    return Data_Wrap_Struct(Class_Pixel, NULL, destroy_Pixel, pixel);
+    return TypedData_Wrap_Struct(Class_Pixel, &rm_pixel_data_type, pixel);
 }
 
 
@@ -817,7 +841,7 @@ Pixel_from_PixelPacket(const PixelPacket *pp)
     pixel->black   = 0;
 #endif
 
-    return Data_Wrap_Struct(Class_Pixel, NULL, destroy_Pixel, pixel);
+    return TypedData_Wrap_Struct(Class_Pixel, &rm_pixel_data_type, pixel);
 }
 
 
@@ -849,7 +873,7 @@ Pixel_from_PixelColor(const PixelColor *pp)
     pixel->black   = 0;
 #endif
 
-    return Data_Wrap_Struct(Class_Pixel, NULL, destroy_Pixel, pixel);
+    return TypedData_Wrap_Struct(Class_Pixel, &rm_pixel_data_type, pixel);
 }
 
 
@@ -864,7 +888,7 @@ Pixel_hash(VALUE self)
     Pixel *pixel;
     unsigned int hash;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 
     hash  = ScaleQuantumToChar(pixel->red)   << 24;
     hash += ScaleQuantumToChar(pixel->green) << 16;
@@ -892,8 +916,8 @@ Pixel_init_copy(VALUE self, VALUE orig)
 {
     Pixel *copy, *original;
 
-    Data_Get_Struct(orig, Pixel, original);
-    Data_Get_Struct(self, Pixel, copy);
+    TypedData_Get_Struct(orig, Pixel, &rm_pixel_data_type, original);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, copy);
 
     *copy = *original;
 
@@ -916,7 +940,7 @@ Pixel_initialize(int argc, VALUE *argv, VALUE self)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 
 #if defined(IMAGEMAGICK_7)
     pixel->alpha = OpaqueAlpha;
@@ -972,7 +996,7 @@ Pixel_intensity(VALUE self)
     Pixel *pixel;
     Quantum intensity;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 
     intensity = ROUND_TO_QUANTUM((0.299*pixel->red)
                                 + (0.587*pixel->green)
@@ -993,7 +1017,7 @@ Pixel_marshal_dump(VALUE self)
     Pixel *pixel;
     VALUE dpixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     dpixel = rb_hash_new();
     rb_hash_aset(dpixel, CSTR2SYM("red"), QUANTUM2NUM(pixel->red));
     rb_hash_aset(dpixel, CSTR2SYM("green"), QUANTUM2NUM(pixel->green));
@@ -1021,7 +1045,7 @@ Pixel_marshal_load(VALUE self, VALUE dpixel)
 {
     Pixel *pixel;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     pixel->red = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("red")));
     pixel->green = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("green")));
     pixel->blue = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("blue")));
@@ -1045,8 +1069,8 @@ Pixel_spaceship(VALUE self, VALUE other)
 {
     Pixel *this, *that;
 
-    Data_Get_Struct(self, Pixel, this);
-    Data_Get_Struct(other, Pixel, that);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, this);
+    TypedData_Get_Struct(other, Pixel, &rm_pixel_data_type, that);
 
     if (this->red != that->red)
     {
@@ -1093,7 +1117,7 @@ Pixel_to_hsla(VALUE self)
     Pixel *pixel;
     VALUE hsla;
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 
     ConvertRGBToHSL(pixel->red, pixel->green, pixel->blue, &hue, &sat, &lum);
     hue *= 360.0;
@@ -1218,7 +1242,7 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
             rb_raise(rb_eArgError, "wrong number of arguments (%d for 0 to 2)", argc);
     }
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
 
     info = CloneImageInfo(NULL);
     image = rm_acquire_image(info);
@@ -1284,7 +1308,7 @@ Pixel_to_s(VALUE self)
     Pixel *pixel;
     char buff[100];
 
-    Data_Get_Struct(self, Pixel, pixel);
+    TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
     snprintf(buff, sizeof(buff), "red=" QuantumFormat ", green=" QuantumFormat ", blue=" QuantumFormat ", alpha=" QuantumFormat,
             pixel->red, pixel->green, pixel->blue,
 #if defined(IMAGEMAGICK_7)

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -274,7 +274,7 @@ rm_check_destroyed(VALUE obj)
 {
     Image *image;
 
-    Data_Get_Struct(obj, Image, image);
+    TypedData_Get_Struct(obj, Image, &rm_image_data_type, image);
     if (!image)
     {
         rb_raise(Class_DestroyedImageError, "destroyed image");

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -23,8 +23,6 @@ static void handle_exception(ExceptionInfo *, Image *, ErrorRetention);
 
 
 DEFINE_GVL_STUB5(CloneImage, const Image *, const size_t, const size_t, const MagickBooleanType, ExceptionInfo *);
-DEFINE_GVL_STUB1(DeleteImageRegistry, const char *);
-DEFINE_GVL_STUB4(SetImageRegistry, const RegistryType, const char *, const void *, ExceptionInfo *);
 
 
 /**
@@ -785,8 +783,7 @@ rm_write_temp_image(Image *image, char *temp_name, size_t temp_name_l)
     snprintf(temp_name, temp_name_l, "mpri:%d", id);
 
     // Omit "mpri:" from filename to form the key
-    GVL_STRUCT_TYPE(SetImageRegistry) args = { ImageRegistryType, temp_name+5, image, exception };
-    okay = (MagickBooleanType)CALL_FUNC_WITHOUT_GVL(GVL_FUNC(SetImageRegistry), &args);
+    okay = (MagickBooleanType)SetImageRegistry(ImageRegistryType, temp_name+5, image, exception);
     CHECK_EXCEPTION();
     DestroyExceptionInfo(exception);
     if (!okay)
@@ -808,8 +805,7 @@ rm_write_temp_image(Image *image, char *temp_name, size_t temp_name_l)
 void
 rm_delete_temp_image(char *temp_name)
 {
-    GVL_STRUCT_TYPE(DeleteImageRegistry) args = { temp_name+5 };
-    MagickBooleanType okay = (MagickBooleanType)CALL_FUNC_WITHOUT_GVL(GVL_FUNC(DeleteImageRegistry), &args);
+    MagickBooleanType okay = DeleteImageRegistry(temp_name+5);
 
     if (!okay)
     {

--- a/lib/rmagick.rb
+++ b/lib/rmagick.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'rmagick_internal.rb'

--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Magick
   VERSION = '5.0.0'
   MIN_RUBY_VERSION = '2.3.0'

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -75,7 +75,7 @@ module Magick
   MinimumGeometry  = GeometryValue.new(:MinimumGeometry, 6).freeze
 
   class Geometry
-    FLAGS = ['', '%', '!', '<', '>', '@', '^']
+    FLAGS = ['', '%', '!', '<', '>', '@', '^'].map(&:freeze).freeze
     RFLAGS = {
       '%' => PercentGeometry,
       '!' => AspectGeometry,
@@ -83,7 +83,7 @@ module Magick
       '>' => GreaterGeometry,
       '@' => AreaGeometry,
       '^' => MinimumGeometry
-    }
+    }.freeze
 
     attr_accessor :width, :height, :x, :y, :flag
 

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # $Id: RMagick.rb,v 1.84 2009/09/15 22:08:41 rmagick Exp $
 #==============================================================================
 #                  Copyright (C) 2009 by Timothy P. Hunter
@@ -75,7 +77,7 @@ module Magick
   MinimumGeometry  = GeometryValue.new(:MinimumGeometry, 6).freeze
 
   class Geometry
-    FLAGS = ['', '%', '!', '<', '>', '@', '^'].map(&:freeze).freeze
+    FLAGS = ['', '%', '!', '<', '>', '@', '^'].freeze
     RFLAGS = {
       '%' => PercentGeometry,
       '!' => AspectGeometry,
@@ -139,7 +141,7 @@ module Magick
 
     # Convert object to a geometry string
     def to_s
-      str = ''
+      str = String.new
       if @width > 0
         fmt = @width.truncate == @width ? '%d' : '%.2f'
         str << sprintf(fmt, @width)

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -772,12 +772,6 @@ module Magick
     module Post_ObjectData_Descriptor
       Confirmed_ObjectData_Size              = '9:10'
     end
-
-    # Make all constants above immutable
-    constants.each do |record|
-      rec = const_get(record)
-      rec.constants.each { |ds| rec.const_get(ds).freeze }
-    end
   end # module Magick::IPTC
 
   # Ruby-level Magick::Image methods

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -25,7 +25,6 @@ require 'observer'
 require 'RMagick2.so'
 
 module Magick
-  @formats = nil
   IMAGEMAGICK_VERSION = Magick::Magick_version.split[1].split('-').first
 
   class << self
@@ -53,13 +52,13 @@ module Magick
     #   => {"3FR"=>" r-+", "3G2"=>" r-+", "3GP"=>" r-+", "A"=>"*rw+",
     #   ...
     def formats
-      @formats ||= init_formats
+      formats = init_formats
 
       if block_given?
-        @formats.each { |k, v| yield k, v }
+        formats.each { |k, v| yield k, v }
         self
       else
-        @formats
+        formats
       end
     end
   end

--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -64,4 +64,33 @@ RSpec.describe Magick do
       expect(Magick::MinimumGeometry.to_i).to eq(6)
     end
   end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    describe 'Ractor' do
+      it 'is supported' do
+        expect do
+          r = Ractor.new do
+            img = Magick::ImageList.new
+            img.new_image(200, 200, Magick::GradientFill.new(100, 50, 100, 50, 'khaki1', 'turquoise'))
+            img.resize(20, 20)
+          end
+          r.take
+        end.not_to raise_error
+
+        expect do
+          r = Ractor.new do
+            img = Magick::ImageList.new
+            img.new_image(40, 40, Magick::HatchFill.new('white', 'lightcyan2'))
+            gc = Magick::Draw.new
+
+            gc.font_weight(Magick::NormalWeight)
+            gc.font_style(Magick::NormalStyle)
+            gc.text(5, 20, "'20,20'")
+            gc.draw(img)
+          end
+          r.take
+        end.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe Magick do
           end
           r.take
         end.not_to raise_error
+
+        expect do
+          r = Ractor.new do
+            Magick.formats # rubocop:disable RSpec/DescribedClass
+          end
+          r.take
+        end.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
[Ractor](https://docs.ruby-lang.org/en/3.0/Ractor.html) was introduced at Ruby 3.0.
This PR will support `Ractor` feature.

See [Appendix F. Ractor support](https://github.com/ruby/ruby/blob/v3_0_0/doc/extension.rdoc#appendix-f-ractor-support-) for details.

### Sample without Ractor
```ruby
require 'rmagick'

1000.times do
  img = Magick::Image.read('Flower_Hat.jpg').first
  thumbnail = img.resize_to_fit(76, 76)
end

1000.times do
  img = Magick::Image.read('Flower_Hat.jpg').first
  thumbnail = img.resize_to_fill(76, 76)
end
```

### Sample with Ractor
```ruby
require 'rmagick'

r1 = Ractor.new do
  1000.times do
    img = Magick::Image.read('Flower_Hat.jpg').first
    thumbnail = img.resize_to_fit(76, 76)
  end
end

r2 = Ractor.new do
  1000.times do
    img = Magick::Image.read('Flower_Hat.jpg').first
    thumbnail = img.resize_to_fill(76, 76)
  end
end

r1.take
r2.take
```

Without Ractor | With Ractor
-- | --
3.233 sec | 1.698 sec

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 6.0.2-2-MANJARO
  - AMD Ryzen 7 5800H
  - gcc version 12.2.0
  - Ruby 3.1.2

### Without Ractor

```
$ time ruby resize.rb
ruby resize.rb  3.14s user 0.09s system 99% cpu 3.233 total
```

### With Ractor

```
$ time ruby resize_with_ractor.rb
<internal:ractor>:267: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
ruby resize_with_ractor.rb  3.10s user 0.10s system 188% cpu 1.698 total
```


### NOTE
I have not confirmed `Magick::RVG` behavior with Ractor.
So, `Magick::RVG` may not work with Ractor