### PR TITLE
CI: Do not install libxml2 for macOS environment

### DIFF
--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -16,7 +16,7 @@ if [ ! -v IMAGEMAGICK_VERSION ]; then
 fi
 
 export HOMEBREW_NO_AUTO_UPDATE=true
-brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool libxml2 zlib webp
+brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool zlib webp
 
 export LDFLAGS="-L/usr/local/opt/libxml2/lib -L/usr/local/opt/zlib/lib"
 export CPPFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/zlib/include"


### PR DESCRIPTION
Seems that libxml2 in Homebrew has been broken and it fails to build ImageMagick.
https://github.com/rmagick/rmagick/runs/8168706294

Remove libxml installation since we haven't been tested with ImageMagick features that depend on libxml2.