### PR TITLE
Mark Magick::{Image, Image::Info}#monitor= as deprecated

### DIFF
--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9204,14 +9204,14 @@ Image_modulate(int argc, VALUE *argv, VALUE self)
  *     print "%s is %3.0f%% complete.\n", method, (offset.to_f/span)*100)
  *     true
  *   end
- * @deprecated Magick::Image#monitor= is deprecated. This method will be removed since next major release.
+ * @deprecated Magick::Image#monitor= is deprecated. This method will be removed in RMagick 5.0.
  */
 VALUE
 Image_monitor_eq(VALUE self, VALUE monitor)
 {
     Image *image = rm_check_frozen(self);
 
-    rb_warning("Magick::Image#monitor= is deprecated. This method will be removed since next major release.");
+    rb_warning("Magick::Image#monitor= is deprecated. This method will be removed in RMagick 5.0.");
 
     if (NIL_P(monitor))
     {

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -9204,11 +9204,14 @@ Image_modulate(int argc, VALUE *argv, VALUE self)
  *     print "%s is %3.0f%% complete.\n", method, (offset.to_f/span)*100)
  *     true
  *   end
+ * @deprecated Magick::Image#monitor= is deprecated. This method will be removed since next major release.
  */
 VALUE
 Image_monitor_eq(VALUE self, VALUE monitor)
 {
     Image *image = rm_check_frozen(self);
+
+    rb_warning("Magick::Image#monitor= is deprecated. This method will be removed since next major release.");
 
     if (NIL_P(monitor))
     {

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1560,6 +1560,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
  * @param monitor [Proc] the monitor
  * @return [Proc] monitor
  * @see Image#monitor=
+ * @deprecated Magick::Image::Info#monitor= is deprecated. This method will be removed since next major release.
  */
 VALUE
 Info_monitor_eq(VALUE self, VALUE monitor)
@@ -1567,6 +1568,8 @@ Info_monitor_eq(VALUE self, VALUE monitor)
     Info *info;
 
     Data_Get_Struct(self, Info, info);
+
+    rb_warning("Magick::Image::Info#monitor= is deprecated. This method will be removed since next major release.");
 
     if (NIL_P(monitor))
     {

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -1560,7 +1560,7 @@ Info_matte_color_eq(VALUE self, VALUE matte_arg)
  * @param monitor [Proc] the monitor
  * @return [Proc] monitor
  * @see Image#monitor=
- * @deprecated Magick::Image::Info#monitor= is deprecated. This method will be removed since next major release.
+ * @deprecated Magick::Image::Info#monitor= is deprecated. This method will be removed in RMagick 5.0.
  */
 VALUE
 Info_monitor_eq(VALUE self, VALUE monitor)
@@ -1569,7 +1569,7 @@ Info_monitor_eq(VALUE self, VALUE monitor)
 
     Data_Get_Struct(self, Info, info);
 
-    rb_warning("Magick::Image::Info#monitor= is deprecated. This method will be removed since next major release.");
+    rb_warning("Magick::Image::Info#monitor= is deprecated. This method will be removed in RMagick 5.0.");
 
     if (NIL_P(monitor))
     {


### PR DESCRIPTION
These methods need to be removed to support releasing GVL.
https://github.com/rmagick/rmagick/pull/1352