### PR TITLE
Mark Magick.trace_proc= as deprecated

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -83,7 +83,11 @@ module Magick
     #   Magick.trace_proc = proc do |which, description, id, method|
     #     ...
     #   end
+    #
+    # @deprecated Magick.trace_proc= is deprecated. This method will be removed since next major release.
     def trace_proc=(p)
+      warn 'Magick.trace_proc= is deprecated. This method will be removed since next major release.'
+
       if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
         at_exit { @trace_proc = nil }
         @exit_block_set_up = true

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -84,9 +84,9 @@ module Magick
     #     ...
     #   end
     #
-    # @deprecated Magick.trace_proc= is deprecated. This method will be removed since next major release.
+    # @deprecated Magick.trace_proc= is deprecated. This method will be removed in RMagick 5.0.
     def trace_proc=(p)
-      warn 'Magick.trace_proc= is deprecated. This method will be removed since next major release.'
+      warn 'Magick.trace_proc= is deprecated. This method will be removed in RMagick 5.0.'
 
       if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
         at_exit { @trace_proc = nil }


### PR DESCRIPTION
This method needs to be removed to support Ractor feature.
https://github.com/rmagick/rmagick/pull/1351