### PR TITLE
Improve installer in order to avoid SEGV within pkg-config command

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -123,57 +123,59 @@ module RMagick
       exit(1)
     end
 
-    def detect_imagemagick_package(packages)
-      packages.each do |package|
-        return package if system "pkg-config --exists #{package}"
+    def detect_imagemagick_packages(packages)
+      existed_packages = packages.map do |package|
+        if system "pkg-config --exists #{package}"
+          package
+        end
       end
-      nil
+      existed_packages.compact
     end
 
-    def detect_im6_package
+    def detect_im6_packages
       packages = %w[
-        ImageMagick-6.Q8
-        ImageMagick-6.Q16
-        ImageMagick-6.Q32
-        ImageMagick-6.Q64
-        ImageMagick-6.Q8HDRI
-        ImageMagick-6.Q16HDRI
-        ImageMagick-6.Q32HDRI
         ImageMagick-6.Q64HDRI
+        ImageMagick-6.Q32HDRI
+        ImageMagick-6.Q16HDRI
+        ImageMagick-6.Q8HDRI
+        ImageMagick-6.Q64
+        ImageMagick-6.Q32
+        ImageMagick-6.Q16
+        ImageMagick-6.Q8
       ]
-      @detect_im6_package ||= detect_imagemagick_package(packages)
+      @detect_im6_packages ||= detect_imagemagick_packages(packages)
     end
 
-    def detect_im7_package
+    def detect_im7_packages
       packages = %w[
-        ImageMagick-7.Q8
-        ImageMagick-7.Q16
-        ImageMagick-7.Q32
-        ImageMagick-7.Q64
-        ImageMagick-7.Q8HDRI
-        ImageMagick-7.Q16HDRI
-        ImageMagick-7.Q32HDRI
         ImageMagick-7.Q64HDRI
+        ImageMagick-7.Q32HDRI
+        ImageMagick-7.Q16HDRI
+        ImageMagick-7.Q8HDRI
+        ImageMagick-7.Q64
+        ImageMagick-7.Q32
+        ImageMagick-7.Q16
+        ImageMagick-7.Q8
       ]
-      @detect_im7_package ||= detect_imagemagick_package(packages)
+      @detect_im7_packages ||= detect_imagemagick_packages(packages)
     end
 
     def im6_package_exists?
-      package = detect_im6_package
-      package ? true : false
+      package = detect_im6_packages
+      package.empty? ? false : true
     end
 
     def im7_package_exists?
-      package = detect_im7_package
-      package ? true : false
+      package = detect_im7_packages
+      package.empty? ? false : true
     end
 
     def determine_imagemagick_package
-      packages = [detect_im7_package, detect_im6_package].compact
+      packages = [detect_im7_packages, detect_im6_packages].flatten
 
       if packages.empty?
         # ImageMagick 6.7 does not have package file like ImageMagick-6.Q16.pc
-        packages = [detect_imagemagick_package(['ImageMagick'])].compact
+        packages = detect_imagemagick_packages(['ImageMagick'])
       end
 
       if packages.empty?
@@ -183,10 +185,10 @@ module RMagick
       if im6_package_exists? && im7_package_exists?
         checking_for('forced use of ImageMagick 6') do
           if ENV['USE_IMAGEMAGICK_6']
-            packages = [detect_im6_package]
+            packages = detect_im6_packages
             true
           else
-            packages = [detect_im7_package]
+            packages = detect_im7_packages
             false
           end
         end

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -9,6 +9,33 @@ module RMagick
     RMAGICK_VERS = ::Magick::VERSION
     MIN_RUBY_VERS = ::Magick::MIN_RUBY_VERSION
 
+    # ImageMagick 6.7 package
+    IM6_7_PACKAGES = ['ImageMagick'].freeze
+
+    # ImageMagick 6.8+ packages
+    IM6_PACKAGES = %w[
+      ImageMagick-6.Q64HDRI
+      ImageMagick-6.Q32HDRI
+      ImageMagick-6.Q16HDRI
+      ImageMagick-6.Q8HDRI
+      ImageMagick-6.Q64
+      ImageMagick-6.Q32
+      ImageMagick-6.Q16
+      ImageMagick-6.Q8
+    ].freeze
+
+    # ImageMagick 7 packages
+    IM7_PACKAGES = %w[
+      ImageMagick-7.Q64HDRI
+      ImageMagick-7.Q32HDRI
+      ImageMagick-7.Q16HDRI
+      ImageMagick-7.Q8HDRI
+      ImageMagick-7.Q64
+      ImageMagick-7.Q32
+      ImageMagick-7.Q16
+      ImageMagick-7.Q8
+    ].freeze
+
     attr_reader :headers
 
     def initialize
@@ -129,63 +156,33 @@ module RMagick
       end
     end
 
-    def detect_im6_packages
-      packages = %w[
-        ImageMagick-6.Q64HDRI
-        ImageMagick-6.Q32HDRI
-        ImageMagick-6.Q16HDRI
-        ImageMagick-6.Q8HDRI
-        ImageMagick-6.Q64
-        ImageMagick-6.Q32
-        ImageMagick-6.Q16
-        ImageMagick-6.Q8
-      ]
-      @detect_im6_packages ||= detect_imagemagick_packages(packages)
+    def installed_im6_packages
+      @installed_im6_packages ||= detect_imagemagick_packages(IM6_PACKAGES)
     end
 
-    def detect_im7_packages
-      packages = %w[
-        ImageMagick-7.Q64HDRI
-        ImageMagick-7.Q32HDRI
-        ImageMagick-7.Q16HDRI
-        ImageMagick-7.Q8HDRI
-        ImageMagick-7.Q64
-        ImageMagick-7.Q32
-        ImageMagick-7.Q16
-        ImageMagick-7.Q8
-      ]
-      @detect_im7_packages ||= detect_imagemagick_packages(packages)
-    end
-
-    def im6_package_exists?
-      package = detect_im6_packages
-      package.empty? ? false : true
-    end
-
-    def im7_package_exists?
-      package = detect_im7_packages
-      package.empty? ? false : true
+    def installed_im7_packages
+      @installed_im7_packages ||= detect_imagemagick_packages(IM7_PACKAGES)
     end
 
     def determine_imagemagick_package
-      packages = [detect_im7_packages, detect_im6_packages].flatten
+      packages = [installed_im7_packages, installed_im6_packages].flatten
 
       if packages.empty?
         # ImageMagick 6.7 does not have package file like ImageMagick-6.Q16.pc
-        packages = detect_imagemagick_packages(['ImageMagick'])
+        packages = detect_imagemagick_packages(IM6_7_PACKAGES)
       end
 
       if packages.empty?
         exit_failure "Can't install RMagick #{RMAGICK_VERS}. Can't find ImageMagick with pkg-config\n"
       end
 
-      if im6_package_exists? && im7_package_exists?
+      if installed_im6_packages.any? && installed_im7_packages.any?
         checking_for('forced use of ImageMagick 6') do
           if ENV['USE_IMAGEMAGICK_6']
-            packages = detect_im6_packages
+            packages = installed_im6_packages
             true
           else
-            packages = detect_im7_packages
+            packages = installed_im7_packages
             false
           end
         end

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -124,12 +124,9 @@ module RMagick
     end
 
     def detect_imagemagick_packages(packages)
-      existed_packages = packages.map do |package|
-        if system "pkg-config --exists #{package}"
-          package
-        end
+      packages.select do |package|
+        system "pkg-config --exists #{package}"
       end
-      existed_packages.compact
     end
 
     def detect_im6_packages


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1358

If incorrect pkg-config file installed on the system, `pkg-config --list-all` commands triggers a SEGV and rmagick installation fails.

Therefore, `pkg-config --list-all` should not be used in this PR.