### PR TITLE
Remove deprecated #instance_eval calling when block was given with Magick::ImageList#montage, Magick::Image::Info.new and more

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -565,14 +565,14 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
     VALUE val;
 
     Data_Get_Struct(self, Draw, draw);
-    
+
     if (draw->info == NULL)
     {
         ImageInfo *image_info;
 
         image_info = CloneImageInfo(NULL);
         draw->info = CloneDrawInfo(image_info, (DrawInfo *) NULL);
-        DestroyImageInfo(image_info);        
+        DestroyImageInfo(image_info);
     }
     OBJ_TO_MAGICK_STRING(draw->info->geometry, rb_hash_aref(ddraw, CSTR2SYM("geometry")));
 
@@ -853,16 +853,7 @@ VALUE Draw_annotate(
     // allowing the app a chance to modify the object's attributes
     if (rb_block_given_p())
     {
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, self);
-        }
-        else
-        {
-            rb_yield(self);
-        }
+        rb_yield(self);
     }
 
     // Translate & store in Draw structure
@@ -973,7 +964,7 @@ Draw_clone(VALUE self)
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
  *   @param operator [Magick::CompositeOperator] the operator
- * 
+ *
  * @return [Magick::Draw] self
  */
 VALUE
@@ -1394,16 +1385,7 @@ DrawOptions_initialize(VALUE self)
 
     if (rb_block_given_p())
     {
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, self);
-        }
-        else
-        {
-            rb_yield(self);
-        }
+        rb_yield(self);
     }
 
     return self;
@@ -1466,16 +1448,7 @@ PolaroidOptions_initialize(VALUE self)
 
     if (rb_block_given_p())
     {
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, self);
-        }
-        else
-        {
-            rb_yield(self);
-        }
+        rb_yield(self);
     }
 
     return self;

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -429,7 +429,7 @@ ImageList_flatten_images(VALUE self)
  *   Creates {Magick::ImageList::Montage} object, yields to block
  *   if present in {Magick::ImageList::Montage} object's scope.
  *   @yield [Magick::ImageList::Montage]
- * 
+ *
  * @return [Magick::ImageList] a new image list
  */
 VALUE
@@ -444,17 +444,7 @@ ImageList_montage(VALUE self)
     montage_obj = rm_montage_new();
     if (rb_block_given_p())
     {
-        // Run the block in the instance's context, allowing the app to modify the
-        // object's attributes.
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, montage_obj);
-        }
-        else
-        {
-            rb_yield(montage_obj);
-        }
+        rb_yield(montage_obj);
     }
 
     Data_Get_Struct(montage_obj, Montage, montage);

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2388,16 +2388,7 @@ Info_initialize(VALUE self)
 {
     if (rb_block_given_p())
     {
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            // Run the block in self's context
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, self);
-        }
-        else
-        {
-            rb_yield(self);
-        }
+        rb_yield(self);
     }
     return self;
 }

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1025,15 +1025,7 @@ rm_get_optional_arguments(VALUE img)
         argv[0] = img;
         opt_args = rb_class_new_instance(1, argv, optional_method_arguments);
 
-        if (rb_proc_arity(rb_block_proc()) == 0)
-        {
-            rb_warn("passing a block without an image argument is deprecated");
-            rb_obj_instance_eval(0, NULL, opt_args);
-        }
-        else
-        {
-            rb_yield(opt_args);
-        }
+        rb_yield(opt_args);
     }
 
     RB_GC_GUARD(optional_method_arguments);


### PR DESCRIPTION
- ❌ `img.to_blob` { self.quality = 75 }`
- ✔️ `img.to_blob { |image| image.quality = 75 }`