### PR TITLE
Avoid overriding compilation variables

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -95,6 +95,7 @@ module RMagick
         check_partial_imagemagick_versions
 
         original_ldflags = $LDFLAGS.dup
+
         libdir  = `pkg-config --libs-only-L #{$magick_package}`.chomp.sub('-L', '')
         ldflags = "#{ENV['LDFLAGS']} " + `pkg-config --libs #{$magick_package}`.chomp
         rpath   = libdir.empty? ? '' : "-Wl,-rpath,#{libdir}"


### PR DESCRIPTION
* This can cause a lot of headaches and break compilation.
* For instance it causes https://github.com/oracle/truffleruby/issues/2779
* Remove old workaround for Ruby 1.8.5