### PR TITLE
Remove pkg-config command dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,33 +71,33 @@ sudo yum install gcc ImageMagick-devel make which
 On Arch Linux, you can run:
 
 ```sh
-pacman -Syy pkg-config imagemagick
+pacman -Syy imagemagick
 ```
 
 #### Alpine Linux
 On Alpine Linux, you can run:
 
 ```
-apk add pkgconfig imagemagick imagemagick-dev imagemagick-libs
+apk add imagemagick imagemagick-dev imagemagick-libs
 ```
 
 or you can run if you would like to use ImageMagick 6:
 
 ```
-apk add pkgconfig imagemagick6 imagemagick6-dev imagemagick6-libs
+apk add imagemagick6 imagemagick6-dev imagemagick6-libs
 ```
 
 ### macOS
 On macOS, you can run:
 
 ```sh
-brew install pkg-config imagemagick
+brew install imagemagick
 ```
 
 or you can run if you would like to use ImageMagick 6:
 
 ```sh
-brew install pkg-config imagemagick@6
+brew install imagemagick@6
 ```
 
 ### Windows
@@ -163,15 +163,6 @@ depends on hasn't been installed. Examine the mkmf.log file in the ext/RMagick
 subdirectory of the installation directory for any error messages. These
 messages typically contain enough additional information for you to be able to
 diagnose the problem. Also see [this FAQ][libmagick-faq].
-
-On OS X with Homebrew, try (re)installing pkg-config:
-
-```sh
-brew uninstall pkg-config
-brew install pkg-config
-brew unlink pkg-config
-brew link pkg-config
-```
 
 ### Cannot open shared object file
 

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -16,7 +16,7 @@ if [ ! -v IMAGEMAGICK_VERSION ]; then
 fi
 
 export HOMEBREW_NO_AUTO_UPDATE=true
-brew install wget pkg-config ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool zlib webp
+brew install wget ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool zlib webp
 
 export LDFLAGS="-L/usr/local/opt/libxml2/lib -L/usr/local/opt/zlib/lib"
 export CPPFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/zlib/include"

--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Magick::MIN_RUBY_VERSION}"
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
+  s.add_runtime_dependency 'pkg-config', '~> 1.4'
+
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake-compiler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
RMagick installation fails if pkg-config command is not installed.
Therefore, we remove the dependency on the command and instead use the ruby gem to get the same functionality.