### PR TITLE
CI: Uninstall preinstalled ImageMagick on macOS

### DIFF
--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -16,6 +16,7 @@ if [ ! -v IMAGEMAGICK_VERSION ]; then
 fi
 
 export HOMEBREW_NO_AUTO_UPDATE=true
+brew uninstall --force imagemagick imagemagick@6
 brew install wget ghostscript freetype jpeg little-cms2 libomp libpng libtiff liblqr libtool zlib webp
 
 export LDFLAGS="-L/usr/local/opt/libxml2/lib -L/usr/local/opt/zlib/lib"


### PR DESCRIPTION
We would like to run the test with ImageMagick 6.9 in IM6.9 lane, however, it has been ran with the version that is pre-installed.

https://github.com/rmagick/rmagick/actions/runs/3452753745/jobs/5762871081

<img width="709" alt="スクリーンショット_2022-11-13_7_46_02" src="https://user-images.githubusercontent.com/199156/201497475-a5848f61-565a-4b3c-b7ff-bf4bb51ded98.png">
