### PR TITLE
CI: Remove ImageMagick 7.0 lane in macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
         imagemagick-version:
           - { full: 6.9.12-70, major-minor: '6.9' }
-          - { full: 7.0.11-14, major-minor: '7.0' }
+          # - { full: 7.0.11-14, major-minor: '7.0' }
           - { full: 7.1.0-55, major-minor: '7.1' }
 
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}


### PR DESCRIPTION
Seems ImageMagick 7.0.11-14 can not be built with Xcode 14.2.

https://github.com/rmagick/rmagick/actions/runs/3975953985/jobs/6816134886