### PR TITLE
CI: Fix IM 7.0 build error on macOS

### DIFF
--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -43,7 +43,7 @@ build_imagemagick() {
   fi
 
   cd "${build_dir}"
-  ./configure --prefix=/usr/local "${options}"
+  ./configure --prefix=/usr/local "${options}" --without-raw
   make -j
 }
 


### PR DESCRIPTION
GitHub's macOS images now install libraw by default.
If libraw exists ImageMagick will be configured to use it, however ImageMagick 7.0 will cause a build error.

RMagick tests has not been used RAW files, so this PR disable libraw to solve build errors.
