### PR TITLE
Add OnAlphaChannel and OffAlphaChannel to the AlphaChannelOption enumeration.

### DIFF
--- a/doc/image1.html
+++ b/doc/image1.html
@@ -1480,11 +1480,11 @@ img = Image.read_inline(content)
 
     <h4>Arguments</h4>
 
-    <p>One of the following values of the AlphaChannelType
+    <p>One of the following values of the AlphaChannelOption
     enumeration:</p>
 
     <dl>
-      <dt>ActivateAlphaChannel</dt>
+      <dt>OnAlphaChannel</dt>
 
       <dd class="imquote">Enable the images use of transparency. If
       transparency data did not exist, allocate the data and set to
@@ -1505,7 +1505,7 @@ img = Image.read_inline(content)
       into a transparent shaped image ready to be colored
       appropriately. The color channels are not modified.</dd>
 
-      <dt>DeactivateAlphaChannel</dt>
+      <dt>OffAlphaChannel</dt>
 
       <dd class="imquote">Disables the image's transparency
       channel. Does not delete or change the existing data, just

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -1057,6 +1057,13 @@ Init_RMagick2(void)
         ENUMERATOR(AssociateAlphaChannel)
         ENUMERATOR(DisassociateAlphaChannel)
 #endif
+#if defined(IMAGEMAGICK_7)
+        ENUMERATOR(OnAlphaChannel)
+        ENUMERATOR(OffAlphaChannel)
+#else
+        ENUMERATORV(OnAlphaChannel, ActivateAlphaChannel)
+        ENUMERATORV(OffAlphaChannel, DeactivateAlphaChannel)
+#endif
     END_ENUM
 
     // AnchorType constants (for Draw#text_anchor - these are not defined by ImageMagick)


### PR DESCRIPTION
This PR adds the missing `OnAlphaChannel` and `OffAlphaChannel` values to the `AlphaChannelOption` enumeration to fix the issue reported in #1376.