### PR TITLE
Windows: Fix RubyInstaller::Runtime::DllDirectory::WinApiError

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -14,7 +14,7 @@ if RUBY_PLATFORM =~ /mingw/i
   begin
     require 'ruby_installer'
     ENV['PATH'].split(File::PATH_SEPARATOR).grep(/ImageMagick/i).each do |path|
-      RubyInstaller::Runtime.add_dll_directory(path)
+      RubyInstaller::Runtime.add_dll_directory(path) if File.exist?(File.join(path, 'CORE_RL_magick_.dll')) || File.exist?(File.join(path, 'CORE_RL_MagickCore_.dll'))
     end
   rescue LoadError
   end


### PR DESCRIPTION
when a directory is specified in the PATH environment variable where ImageMagick is not properly installed, `RubyInstaller::Runtime.add_dll_directory` will raise an exception.

```
C:\tmp>SET PATH=C:\ImageMagick;%PATH% & ruby -r rmagick -e "puts Magick::Version"
C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/ruby_installer/runtime/dll_directory.rb:104:in `add_dll_directory_winapi': AddDllDirectory failed for C:/ImageMagick (RubyInstaller::Runtime::DllDirectory::WinApiError)
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/ruby_installer/runtime/dll_directory.rb:64:in `initialize'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/ruby_installer/runtime/singleton.rb:12:in `new'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/ruby_installer/runtime/singleton.rb:12:in `add_dll_directory'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/rmagick-5.2.0/lib/rmagick_internal.rb:17:in `block in <top (required)>'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/rmagick-5.2.0/lib/rmagick_internal.rb:16:in `each'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/rmagick-5.2.0/lib/rmagick_internal.rb:16:in `<top (required)>'
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/rmagick-5.2.0/lib/rmagick.rb:3:in `<top (required)>'
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
<internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- rmagick (LoadError)
        from <internal:C:/Ruby31-x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
```

This patch will skip directories where required DLLs are not found in order to avoid an exception.