### PR TITLE
CI: Add actions/cache@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v3
+    - name: Cache ImageMagick built objects
+      uses: actions/cache@v3
+      with:
+        path: ./build-ImageMagick
+        key: v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
+        restore-keys: |
+          v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@master
       with:
@@ -68,6 +75,13 @@ jobs:
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
     - uses: actions/checkout@v3
+    - name: Cache ImageMagick built objects
+      uses: actions/cache@v3
+      with:
+        path: ./build-ImageMagick
+        key: v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
+        restore-keys: |
+          v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@master
       with:

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -24,7 +24,7 @@ sudo apt-get autoremove -y imagemagick* libmagick* --purge
 # install build tools, ImageMagick delegates
 sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
   liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
-  libtiff5-dev libwebp-dev liblqr-1-0-dev vim gsfonts ghostscript ccache
+  libtiff5-dev libwebp-dev liblqr-1-0-dev vim gsfonts ghostscript
 
 if [ ! -d /usr/include/freetype ]; then
   # If `/usr/include/freetype` is not existed, ImageMagick 6.7 configuration fails about Freetype.
@@ -52,7 +52,7 @@ build_imagemagick() {
   fi
 
   cd "${build_dir}"
-  CC="ccache cc" CXX="ccache c++" ./configure --prefix=/usr "${options}"
+  ./configure --prefix=/usr "${options}"
   make -j
 }
 


### PR DESCRIPTION
When we have been using actions/cache@v1, it sometimes went bad.
 But v3 may be more stable.

ref. https://github.com/rmagick/rmagick/pull/1195, https://github.com/rmagick/rmagick/pull/1208