### PR TITLE
Spec: Run ractor spec with Ruby 3.1 or later

### DIFF
--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Magick do
     end
   end
 
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
     describe 'Ractor' do
       it 'is supported' do
         expect do


### PR DESCRIPTION
ruby_xmalloc is called when ImageMagick requires memory. 
Seems that it causes lock condition at rb_native_mutex_lock with running ractor on Ruby 3.0 sometimes.

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00000001911b2bc8 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x00000001911ed0c4 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 84
    frame #2: 0x00000001911eaa5c libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 248
    frame #3: 0x0000000104409b64 ruby`rb_native_mutex_lock(lock=0x000000012a00d630) at thread_pthread.c:397:14
    frame #4: 0x00000001044a3564 ruby`vm_lock_enter(cr=0x0000000129e05100, vm=0x000000012a00d600, locked=false, no_barrier=false, lev=0x000000012a00d678) at vm_sync.c:56:9
    frame #5: 0x00000001044a38ec ruby`rb_vm_lock_body at vm_sync.c:173:5
    frame #6: 0x00000001043451ec ruby`rb_vm_lock(file="ractor.c", line=1829) at vm_sync.h:58:9
    frame #7: 0x0000000104344cf8 ruby`ractor_check_blocking(cr=0x0000000129e05100, remained_thread_cnt=1, file="ractor.c", line=1865) at ractor.c:1829:9
    frame #8: 0x0000000104344e4c ruby`rb_ractor_blocking_threads_inc(cr=0x0000000129e05100, file="thread.c", line=1639) at ractor.c:1865:5
    frame #9: 0x000000010440db04 ruby`blocking_region_begin(th=0x0000000129e04990, region=0x000000016bcb7fa4, ubf=(ruby`ubf_select at thread_pthread.c:1303), arg=0x0000000129e04990, fail_if_interrupted=0) at thread.c:1639:9
    frame #10: 0x000000010440d81c ruby`rb_nogvl(func=(ruby`no_gvl_apply2files at file.c:432), data1=0x000000016bcb7ff0, ubf=(ruby`ubf_select at thread_pthread.c:1303), data2=0x0000000129e04990, flags=0) at thread.c:1695:5
    frame #11: 0x000000010440ddbc ruby`rb_thread_call_without_gvl(func=(ruby`no_gvl_apply2files at file.c:432), data1=0x000000016bcb7ff0, ubf=0xffffffffffffffff, data2=0x0000000000000000) at thread.c:1811:12
    frame #12: 0x000000010420bd70 ruby`apply2files(func=(ruby`unlink_internal at file.c:3187), argc=1, argv=0x0000000130028540, arg=0x0000000000000000) at file.c:470:5
    frame #13: 0x00000001042061c4 ruby`rb_file_s_unlink(argc=1, argv=0x0000000130028540, klass=5000238800) at file.c:3210:12
    frame #14: 0x000000010449415c ruby`ractor_safe_call_cfunc_m1(recv=5000238800, argc=1, argv=0x0000000130028540, func=(ruby`rb_file_s_unlink at file.c:3209)) at vm_insnhelper.c:2738:12
    frame #15: 0x000000010448f1b4 ruby`vm_call_cfunc_with_frame(ec=0x0000000129e04e60, reg_cfp=0x00000001301278c8, calling=0x000000016bcb8340) at vm_insnhelper.c:2928:11
    frame #16: 0x000000010447e404 ruby`vm_sendish(ec=0x0000000129e04e60, reg_cfp=0x00000001301278c8, cd=0x0000600002df4f80, block_handler=0, method_explorer=mexp_search_method) at vm_insnhelper.c:4529:15
    frame #17: 0x000000010445d5c4 ruby`vm_exec_core(ec=0x0000000129e04e60, initial=0) at insns.def:789:11
    frame #18: 0x0000000104473f88 ruby`rb_vm_exec(ec=0x0000000129e04e60, mjit_enable_p=true) at vm.c:2162:22
    frame #19: 0x000000010446a4b0 ruby`vm_call0_body(ec=0x0000000129e04e60, calling=0x000000016bcb9df0, argv=0x000000016bcb9f50) at vm_eval.c:176:20
    frame #20: 0x000000010446a28c ruby`rb_vm_call0(ec=0x0000000129e04e60, recv=4757327560, id=3377, argc=1, argv=0x000000016bcb9f50, cme=0x000000012d9e8c60, kw_splat=0) at vm_eval.c:57:12
    frame #21: 0x000000010446ad5c ruby`rb_vm_call_kw(ec=0x0000000129e04e60, recv=4757327560, id=3377, argc=1, argv=0x000000016bcb9f50, me=0x000000012d9e8c60, kw_splat=0) at vm_eval.c:262:12
    frame #22: 0x000000010446b20c ruby`rb_check_funcall_default_kw(recv=4757327560, mid=3377, argc=1, argv=0x000000016bcb9f50, def=52, kw_splat=0) at vm_eval.c:643:12
    frame #23: 0x000000010446b25c ruby`rb_check_funcall(recv=4757327560, mid=3377, argc=1, argv=0x000000016bcb9f50) at vm_eval.c:621:12
    frame #24: 0x0000000104228864 ruby`run_single_final(final=4757327320, objid=38441) at gc.c:3630:12
    frame #25: 0x0000000104210158 ruby`run_finalizer(objspace=0x000000012a009800, obj=4757331720, table=4757327280) at gc.c:3662:2
    frame #26: 0x0000000104228984 ruby`run_final(objspace=0x000000012a009800, zombie=4757331720) at gc.c:3679:2
    frame #27: 0x00000001042105ec ruby`finalize_list(objspace=0x000000012a009800, zombie=4757331720) at gc.c:3693:2
    frame #28: 0x000000010420ff6c ruby`finalize_deferred(objspace=0x000000012a009800) at gc.c:3724:2
    frame #29: 0x0000000104224808 ruby`gc_finalize_deferred(dmy=0x000000012a009800) at gc.c:3736:9
    frame #30: 0x00000001044a82d4 ruby`rb_postponed_job_flush(vm=0x000000012a00d600) at vm_trace.c:1702:21
    frame #31: 0x000000010440e4e8 ruby`rb_threadptr_execute_interrupts(th=0x0000000129e04990, blocking_timing=0) at thread.c:2451:6
    frame #32: 0x000000010440d6b0 ruby`rb_vm_check_ints(ec=0x0000000129e04e60) at vm_core.h:1927:2
    frame #33: 0x00000001044198e4 ruby`unblock_function_set(th=0x0000000129e04990, func=(ruby`ubf_select at thread_pthread.c:1303), arg=0x0000000129e04990, fail_if_interrupted=0) at thread.c:463:6
    frame #34: 0x000000010440dabc ruby`blocking_region_begin(th=0x0000000129e04990, region=0x000000016bcbf244, ubf=(ruby`ubf_select at thread_pthread.c:1303), arg=0x0000000129e04990, fail_if_interrupted=0) at thread.c:1636:9
    frame #35: 0x000000010440e258 ruby`rb_thread_call_with_gvl(func=(ruby`gc_with_gvl at gc.c:8498), data1=0x000000016bcba568) at thread.c:1920:20
    frame #36: 0x000000010422c8d8 ruby`garbage_collect_with_gvl(objspace=0x000000012a009800, reason=512) at gc.c:8515:25
    frame #37: 0x0000000104218090 ruby`objspace_malloc_increase(objspace=0x000000012a009800, mem=0x00006000029c00c0, new_size=192, old_size=0, type=MEMOP_TYPE_MALLOC) at gc.c:10456:6
    frame #38: 0x000000010422c9f4 ruby`objspace_malloc_fixup(objspace=0x000000012a009800, mem=0x00006000029c00c0, size=192) at gc.c:10535:5
    frame #39: 0x00000001042175c8 ruby`objspace_xmalloc0(objspace=0x000000012a009800, size=192) at gc.c:10606:12
    frame #40: 0x0000000104217490 ruby`ruby_xmalloc0(size=192) at gc.c:10825:12
    frame #41: 0x0000000104217430 ruby`ruby_xmalloc_body(size=192) at gc.c:10834:12
    frame #42: 0x0000000104213a08 ruby`ruby_xmalloc(size=192) at gc.c:12801:12
    frame #43: 0x0000000105f2bf74 RMagick2.bundle`rm_malloc(size=192) at rmmain.c:77:12
    frame #44: 0x0000000106429974 libMagickCore-7.Q16HDRI.10.dylib`AcquirePixelCacheNexus(number_threads=1) at cache.c:274:29 [opt]
    frame #45: 0x000000010642e03c libMagickCore-7.Q16HDRI.10.dylib`ClonePixelCacheRepository(clone_info=0x0000000128409800, cache_info=0x000000011a4e4600, exception=0x00006000006a2100) at cache.c:726:15 [opt]
    frame #46: 0x000000010642e5a4 libMagickCore-7.Q16HDRI.10.dylib`GetImagePixelCache(image=0x00000001283fd400, clone=MagickTrue, exception=0x00006000006a2100) at cache.c:1759:24 [opt]
    frame #47: 0x000000010642fbc0 libMagickCore-7.Q16HDRI.10.dylib`SyncImagePixelCache(image=<unavailable>, exception=<unavailable>) at cache.c:5526:28 [opt]
    frame #48: 0x00000001064ad95c libMagickCore-7.Q16HDRI.10.dylib`SetImageStorageClass(image=<unavailable>, storage_class=<unavailable>, exception=<unavailable>) at image.c:2618:10 [opt] [artificial]
    frame #49: 0x00000001064431d0 libMagickCore-7.Q16HDRI.10.dylib`CompositeImage(image=0x00000001283fd400, composite=0x000000011a4eda00, compose=CopyYellowCompositeOp, clip_to_self=MagickTrue, x_offset=-5, y_offset=-5, exception=0x00006000006a2100) at composite.c:1575:7 [opt]
    frame #50: 0x0000000105f0e84c RMagick2.bundle`CompositeImage_gvl(p=0x000000016bcbf340) at rmimage.c:127:1
 ```