### PR TITLE
Fix memory leak in `Magick::Draw` for recentry ImageMagick 6 by removing unnecessary `GetDrawInfo()` calling

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1420,8 +1420,6 @@ DrawOptions_initialize(VALUE self)
         rb_raise(rb_eNoMemError, "not enough memory to continue");
     }
 
-    GetDrawInfo(NULL, draw_options->info);
-
     if (rb_block_given_p())
     {
         rb_yield(self);


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1401

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/199156/253791811-d95a04ab-82ea-4379-866d-30224db35872.png"> | <img src="https://github.com/rmagick/rmagick/assets/199156/a0e6ea5f-9c52-4a50-b5ff-ca3846b256b4">

## Test code
```ruby
require 'rmagick'

3000.times do |i|
  img = Magick::Image.new(1000, 1000)

  gc = Magick::Draw.new
  gc.text(0, 67, 'Hello world!!')
  gc.draw(img)
end
```
