### PR TITLE
Add observer gem as dependency

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
 
   s.add_runtime_dependency 'pkg-config', '~> 1.4'
+  s.add_runtime_dependency 'observer', '~> 0.1'
 
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake-compiler', '~> 1.0'


### PR DESCRIPTION
The observer gem will be changed bundled gem since Ruby 3.4.0. https://github.com/ruby/ruby/commit/6500f85927135901f365d2ba1186c5c4f2881f8e

To use bundled gem, it  requires to specify the dependency in Gemfile.

This patch will fix following warning with Ruby 3.3.0
```
/Users/watson/prj/rmagick/lib/rmagick_internal.rb:24: warning: observer which will be not part of the default gems since Ruby 3.4.0
```