### PR TITLE
CI: Remove 7.0.11-14 lane in macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
         imagemagick-version:
           - { full: 6.9.12-85, major-minor: '6.9' }
-          - { full: 7.0.11-14, major-minor: '7.0' }
           - { full: 7.1.1-7, major-minor: '7.1' }
 
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}


### PR DESCRIPTION
The latest [github-actions](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md) have been bundled jpeg-turbo library.

However, it causes build error with un-maintenance imagemagick version on macOS by the library.
https://github.com/ImageMagick/ImageMagick/issues/6514

So, this PR will remove 7.0.11-14 lane which is un-maintenance imagemagick version.