### PR TITLE
Rename `class` variable names because it is reserved word in C++

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -42,7 +42,7 @@ rm_yield_handle_exception(VALUE allocated_area, VALUE exc)
  *
  */
 VALUE
-Magick_colors(VALUE class)
+Magick_colors(VALUE klass)
 {
     const ColorInfo **color_info_list;
     size_t number_colors, x;
@@ -63,7 +63,7 @@ Magick_colors(VALUE class)
             rb_rescue(rm_yield_body, Import_ColorInfo(color_info_list[x]), rm_yield_handle_exception, (VALUE)color_info_list);
         }
         magick_free((void *)color_info_list);
-        return class;
+        return klass;
     }
     else
     {
@@ -93,7 +93,7 @@ Magick_colors(VALUE class)
  *
  */
 VALUE
-Magick_fonts(VALUE class)
+Magick_fonts(VALUE klass)
 {
     const TypeInfo **type_info;
     size_t number_types, x;
@@ -112,7 +112,7 @@ Magick_fonts(VALUE class)
             rb_rescue(rm_yield_body, Import_TypeInfo((const TypeInfo *)type_info[x]), rm_yield_handle_exception, (VALUE)type_info);
         }
         magick_free((void *)type_info);
-        return class;
+        return klass;
     }
     else
     {
@@ -170,7 +170,7 @@ MagickInfo_to_format(const MagickInfo *magick_info)
  * @return [Hash] the formats hash.
  */
 VALUE
-Magick_init_formats(VALUE class ATTRIBUTE_UNUSED)
+Magick_init_formats(VALUE klass ATTRIBUTE_UNUSED)
 {
     const MagickInfo **magick_info;
     size_t number_formats, x;
@@ -214,7 +214,7 @@ Magick_init_formats(VALUE class ATTRIBUTE_UNUSED)
  * @return [Numeric] the old limit.
  */
 VALUE
-Magick_limit_resource(int argc, VALUE *argv, VALUE class)
+Magick_limit_resource(int argc, VALUE *argv, VALUE klass)
 {
     VALUE resource, limit;
     ResourceType res = UndefinedResource;
@@ -227,7 +227,7 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
     switch (TYPE(resource))
     {
         case T_NIL:
-            return class;
+            return klass;
 
         case T_SYMBOL:
             id = (ID)SYM2ID(resource);
@@ -265,7 +265,7 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
             str = StringValueCStr(resource);
             if (*str == '\0')
             {
-                return class;
+                return klass;
             }
             else if (rm_strcasecmp("area", str) == 0)
             {
@@ -321,12 +321,12 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
  * @param threshold [Numeric] the number of megabytes to set.
  */
 VALUE
-Magick_set_cache_threshold(VALUE class, VALUE threshold)
+Magick_set_cache_threshold(VALUE klass, VALUE threshold)
 {
     unsigned long thrshld = NUM2ULONG(threshold);
     SetMagickResourceLimit(MemoryResource, (MagickSizeType)thrshld);
     SetMagickResourceLimit(MapResource, (MagickSizeType)(2*thrshld));
-    return class;
+    return klass;
 }
 
 
@@ -354,7 +354,7 @@ Magick_set_cache_threshold(VALUE class, VALUE threshold)
  * @param args [String] the mask of log event.
  */
 VALUE
-Magick_set_log_event_mask(int argc, VALUE *argv, VALUE class)
+Magick_set_log_event_mask(int argc, VALUE *argv, VALUE klass)
 {
     int x;
 
@@ -366,7 +366,7 @@ Magick_set_log_event_mask(int argc, VALUE *argv, VALUE class)
     {
         SetLogEventMask(StringValueCStr(argv[x]));
     }
-    return class;
+    return klass;
 }
 
 /**
@@ -388,9 +388,9 @@ Magick_set_log_event_mask(int argc, VALUE *argv, VALUE class)
  * @param format [String] the format to set.
  */
 VALUE
-Magick_set_log_format(VALUE class, VALUE format)
+Magick_set_log_format(VALUE klass, VALUE format)
 {
     SetLogFormat(StringValueCStr(format));
-    return class;
+    return klass;
 }
 

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -454,47 +454,47 @@ extern const rb_data_type_t rm_kernel_info_data_type;
 #define R_dbl_to_C_dbl(attr) NUM2DBL(attr) /**< C double <- Ruby double */
 
 //! define attribute reader
-#define IMPLEMENT_TYPED_ATTR_READER(class, attr, type, data_type) \
+#define IMPLEMENT_TYPED_ATTR_READER(klass, attr, type, data_type) \
     {\
-        class *ptr;\
+        klass *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
             rm_check_destroyed(self); \
         }\
-        TypedData_Get_Struct(self, class, data_type, ptr);\
+        TypedData_Get_Struct(self, klass, data_type, ptr);\
         return C_##type##_to_R_##type(ptr->attr);\
     }
 
 //! define attribute reader when attribute name is different from the field name
-#define IMPLEMENT_TYPED_ATTR_READERF(class, attr, field, type, data_type) \
+#define IMPLEMENT_TYPED_ATTR_READERF(klass, attr, field, type, data_type) \
     {\
-        class *ptr;\
+        klass *ptr;\
         rm_check_destroyed(self); \
-        TypedData_Get_Struct(self, class, data_type, ptr);\
+        TypedData_Get_Struct(self, klass, data_type, ptr);\
         return C_##type##_to_R_##type(ptr->field);\
     }
 
 //! define attribute writer
-#define IMPLEMENT_TYPED_ATTR_WRITER(class, attr, type, data_type) \
+#define IMPLEMENT_TYPED_ATTR_WRITER(klass, attr, type, data_type) \
     {\
-        class *ptr;\
+        klass *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
             rm_check_destroyed(self); \
         }\
         rb_check_frozen(self);\
-        TypedData_Get_Struct(self, class, data_type, ptr);\
+        TypedData_Get_Struct(self, klass, data_type, ptr);\
         ptr->attr = R_##type##_to_C_##type(val);\
         return val;\
     }
 
 //! define attribute writer when attribute name is different from the field name
-#define IMPLEMENT_TYPED_ATTR_WRITERF(class, attr, field, type, data_type) \
+#define IMPLEMENT_TYPED_ATTR_WRITERF(klass, attr, field, type, data_type) \
     {\
-        class *ptr;\
+        klass *ptr;\
         if (rb_obj_is_kind_of(self, Class_Image) == Qtrue) {\
             rm_check_destroyed(self); \
         }\
         rb_check_frozen(self);\
-        TypedData_Get_Struct(self, class, data_type, ptr);\
+        TypedData_Get_Struct(self, klass, data_type, ptr);\
         ptr->field = R_##type##_to_C_##type(val);\
         return self;\
     }
@@ -504,15 +504,15 @@ extern const rb_data_type_t rm_kernel_info_data_type;
  *  Declare attribute accessors
  */
 //! declare attribute reader
-#define ATTR_READER(class, attr) \
-    extern VALUE class##_##attr(VALUE);
+#define ATTR_READER(klass, attr) \
+    extern VALUE klass##_##attr(VALUE);
 //! declare attribute writer
-#define ATTR_WRITER(class, attr) \
-    extern VALUE class##_##attr##_eq(VALUE, VALUE);
+#define ATTR_WRITER(klass, attr) \
+    extern VALUE klass##_##attr##_eq(VALUE, VALUE);
 //! declare attribute accessor
-#define ATTR_ACCESSOR(class, attr) \
-    ATTR_READER(class, attr)\
-    ATTR_WRITER(class, attr)
+#define ATTR_ACCESSOR(klass, attr) \
+    ATTR_READER(klass, attr)\
+    ATTR_WRITER(klass, attr)
 
 
 //!  Define a Magick module constant
@@ -1081,7 +1081,7 @@ extern VALUE  Enum_spaceship(VALUE, VALUE);
 extern VALUE  Enum_bitwise_or(VALUE, VALUE);
 extern VALUE  Enum_case_eq(VALUE, VALUE);
 extern VALUE  Enum_type_initialize(VALUE, VALUE, VALUE);
-extern VALUE  Enum_find(VALUE class, int val);
+extern VALUE  Enum_find(VALUE, int);
 extern VALUE  Enum_type_each(VALUE);
 extern VALUE  rm_enum_new(VALUE, VALUE, VALUE);
 extern VALUE  ClassType_find(ClassType);
@@ -1209,7 +1209,7 @@ extern void   rm_error_handler(const ExceptionType, const char *, const char *);
 extern void   rm_warning_handler(const ExceptionType, const char *, const char *);
 extern MagickBooleanType rm_should_raise_exception(ExceptionInfo *, const ExceptionRetention);
 extern void   rm_raise_exception(ExceptionInfo *);
-extern VALUE  rm_io_path(VALUE io);
+extern VALUE  rm_io_path(VALUE);
 #if defined(IMAGEMAGICK_6)
 extern void   rm_check_image_exception(Image *, ErrorRetention);
 #endif

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -1235,14 +1235,14 @@ Draw_inspect(VALUE self)
  *
  * @return [Magick::Draw] a new Draw object
  */
-VALUE Draw_alloc(VALUE class)
+VALUE Draw_alloc(VALUE klass)
 {
     Draw *draw;
     VALUE draw_obj;
 
     draw = ALLOC(Draw);
     memset(draw, 0, sizeof(Draw));
-    draw_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw);
+    draw_obj = TypedData_Wrap_Struct(klass, &rm_draw_data_type, draw);
 
     RB_GC_GUARD(draw_obj);
 
@@ -1388,14 +1388,14 @@ new_DrawOptions(void)
  * @return [Magick::Image::DrawOptions] a new DrawOptions object
  */
 VALUE
-DrawOptions_alloc(VALUE class)
+DrawOptions_alloc(VALUE klass)
 {
     Draw *draw_options;
     VALUE draw_options_obj;
 
     draw_options = ALLOC(Draw);
     memset(draw_options, 0, sizeof(Draw));
-    draw_options_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw_options);
+    draw_options_obj = TypedData_Wrap_Struct(klass, &rm_draw_data_type, draw_options);
 
     RB_GC_GUARD(draw_options_obj);
 
@@ -1438,7 +1438,7 @@ DrawOptions_initialize(VALUE self)
  * @return [Magick::Image::PolaroidOptions] a new PolaroidOptions object
  */
 VALUE
-PolaroidOptions_alloc(VALUE class)
+PolaroidOptions_alloc(VALUE klass)
 {
     VALUE polaroid_obj;
     ImageInfo *image_info;
@@ -1452,7 +1452,7 @@ PolaroidOptions_alloc(VALUE class)
     draw->info = CloneDrawInfo(image_info, (DrawInfo *) NULL);
     (void) DestroyImageInfo(image_info);
 
-    polaroid_obj = TypedData_Wrap_Struct(class, &rm_draw_data_type, draw);
+    polaroid_obj = TypedData_Wrap_Struct(klass, &rm_draw_data_type, draw);
 
     RB_GC_GUARD(polaroid_obj);
 

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -40,14 +40,14 @@ const rb_data_type_t rm_enum_data_type = {
 VALUE
 rm_define_enum_type(const char *tag)
 {
-    VALUE class;
+    VALUE klass;
 
-    class = rb_define_class_under(Module_Magick, tag, Class_Enum);\
+    klass = rb_define_class_under(Module_Magick, tag, Class_Enum);\
 
-    rb_define_singleton_method(class, "values", Enum_type_values, 0);
-    rb_define_method(class, "initialize", Enum_type_initialize, 2);
-    rb_define_method(class, "inspect", Enum_type_inspect, 0);
-    return class;
+    rb_define_singleton_method(klass, "values", Enum_type_values, 0);
+    rb_define_method(klass, "initialize", Enum_type_initialize, 2);
+    rb_define_method(klass, "inspect", Enum_type_inspect, 0);
+    return klass;
 }
 
 
@@ -56,19 +56,19 @@ rm_define_enum_type(const char *tag)
  *
  * No Ruby usage (internal function)
  *
- * @param class the subclass
+ * @param klass the subclass
  * @param sym the symbol
  * @param val the value for the symbol
  * @return a new instance of class
  */
 VALUE
-rm_enum_new(VALUE class, VALUE sym, VALUE val)
+rm_enum_new(VALUE klass, VALUE sym, VALUE val)
 {
     VALUE argv[2];
 
     argv[0] = sym;
     argv[1] = val;
-    return rb_obj_freeze(rb_class_new_instance(2, argv, class));
+    return rb_obj_freeze(rb_class_new_instance(2, argv, klass));
 }
 
 /**
@@ -118,12 +118,12 @@ static void rm_enum_free(void *magick_enum)
  * @return [Magick::Enum] a new enumerator
  */
 VALUE
-Enum_alloc(VALUE class)
+Enum_alloc(VALUE klass)
 {
     MagickEnum *magick_enum;
     VALUE enumr;
 
-    enumr = TypedData_Make_Struct(class, MagickEnum, &rm_enum_data_type, magick_enum);
+    enumr = TypedData_Make_Struct(klass, MagickEnum, &rm_enum_data_type, magick_enum);
     rb_obj_freeze(enumr);
 
     return enumr;
@@ -226,16 +226,16 @@ Enum_spaceship(VALUE self, VALUE other)
 VALUE
 Enum_bitwise_or(VALUE self, VALUE another)
 {
-    VALUE new_enum, cls;
+    VALUE new_enum, klass;
     MagickEnum *this, *that, *new_enum_data;
 
-    cls = CLASS_OF(self);
-    if (CLASS_OF(another) != cls)
+    klass = CLASS_OF(self);
+    if (CLASS_OF(another) != klass)
     {
-        rb_raise(rb_eArgError, "Expected class %s but got %s", rb_class2name(cls), rb_class2name(CLASS_OF(another)));
+        rb_raise(rb_eArgError, "Expected class %s but got %s", rb_class2name(klass), rb_class2name(CLASS_OF(another)));
     }
 
-    new_enum = Enum_alloc(cls);
+    new_enum = Enum_alloc(klass);
 
     TypedData_Get_Struct(self, MagickEnum, &rm_enum_data_type, this);
     TypedData_Get_Struct(another, MagickEnum, &rm_enum_data_type, that);
@@ -321,13 +321,13 @@ Enum_type_inspect(VALUE self)
  *   @return [Magick::Enum] self
  */
 static VALUE
-Enum_type_values(VALUE class)
+Enum_type_values(VALUE klass)
 {
     VALUE enumerators, copy;
     VALUE rv;
     int x;
 
-    enumerators = rb_cv_get(class, ENUMERATORS_CLASS_VAR);
+    enumerators = rb_cv_get(klass, ENUMERATORS_CLASS_VAR);
 
     if (rb_block_given_p())
     {
@@ -335,7 +335,7 @@ Enum_type_values(VALUE class)
         {
             rb_yield(rb_ary_entry(enumerators, x));
         }
-        rv = class;
+        rv = klass;
     }
     else
     {
@@ -360,19 +360,19 @@ Enum_type_values(VALUE class)
  *
  * No Ruby usage (internal function)
  *
- * @param class the class type
+ * @param klass the class type
  * @param value the value for enum
  * @return a enumerator
  */
 
 VALUE
-Enum_find(VALUE class, int val)
+Enum_find(VALUE klass, int val)
 {
     VALUE enumerators;
     MagickEnum *magick_enum;
     int x;
 
-    enumerators = rb_cv_get(class, ENUMERATORS_CLASS_VAR);
+    enumerators = rb_cv_get(klass, ENUMERATORS_CLASS_VAR);
     enumerators = rm_check_ary_type(enumerators);
 
     for (x = 0; x < RARRAY_LEN(enumerators); x++)
@@ -398,9 +398,9 @@ Enum_find(VALUE class, int val)
  * @return a new enumerator
  */
 VALUE
-ClassType_find(ClassType cls)
+ClassType_find(ClassType klass)
 {
-    return Enum_find(Class_ClassType, cls);
+    return Enum_find(Class_ClassType, klass);
 }
 
 

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -86,11 +86,11 @@ GradientFill_memsize(const void *ptr)
  * @return [Magick::GradientFill] a new GradientFill object
  */
 VALUE
-GradientFill_alloc(VALUE class)
+GradientFill_alloc(VALUE klass)
 {
     rm_GradientFill *fill;
 
-    return TypedData_Make_Struct(class, rm_GradientFill, &rm_gradient_fill_data_type, fill);
+    return TypedData_Make_Struct(klass, rm_GradientFill, &rm_gradient_fill_data_type, fill);
 }
 
 
@@ -741,10 +741,10 @@ TextureFill_memsize(const void *ptr)
  * @return [Magick::TextureFill] a new TextureFill object
  */
 VALUE
-TextureFill_alloc(VALUE class)
+TextureFill_alloc(VALUE klass)
 {
     rm_TextureFill *fill;
-    return TypedData_Make_Struct(class, rm_TextureFill, &rm_texture_fill_data_type, fill);
+    return TypedData_Make_Struct(klass, rm_TextureFill, &rm_texture_fill_data_type, fill);
 }
 
 /**

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -4339,7 +4339,7 @@ Image_compress_colormap_bang(VALUE self)
  * @return [Magick::Image] a new image
  */
 VALUE
-Image_constitute(VALUE class ATTRIBUTE_UNUSED, VALUE width_arg, VALUE height_arg,
+Image_constitute(VALUE klass ATTRIBUTE_UNUSED, VALUE width_arg, VALUE height_arg,
                  VALUE map_arg, VALUE pixels_arg)
 {
     Image *new_image;
@@ -7261,7 +7261,7 @@ Image_frame(int argc, VALUE *argv, VALUE self)
  * @see Image#to_blob
  */
 VALUE
-Image_from_blob(VALUE class ATTRIBUTE_UNUSED, VALUE blob_arg)
+Image_from_blob(VALUE klass ATTRIBUTE_UNUSED, VALUE blob_arg)
 {
     Image *images;
     Info *info;
@@ -8868,7 +8868,7 @@ Image_liquid_rescale(int argc, VALUE *argv, VALUE self)
  * @see Image#_dump
  */
 VALUE
-Image__load(VALUE class ATTRIBUTE_UNUSED, VALUE str)
+Image__load(VALUE klass ATTRIBUTE_UNUSED, VALUE str)
 {
     Image *image;
     ImageInfo *info;
@@ -9827,11 +9827,11 @@ Image_negate_channel(int argc, VALUE *argv, VALUE self)
  * @return [Magick::Image] a newly allocated image
  */
 VALUE
-Image_alloc(VALUE class)
+Image_alloc(VALUE klass)
 {
     VALUE image_obj;
 
-    image_obj = TypedData_Wrap_Struct(class, &rm_image_data_type, NULL);
+    image_obj = TypedData_Wrap_Struct(klass, &rm_image_data_type, NULL);
 
     RB_GC_GUARD(image_obj);
 
@@ -10550,9 +10550,9 @@ Image_palette_q(VALUE self)
  * @see Image#read
  */
 VALUE
-Image_ping(VALUE class, VALUE file_arg)
+Image_ping(VALUE klass, VALUE file_arg)
 {
-    return rd_image(class, file_arg, GVL_FUNC(PingImage));
+    return rd_image(klass, file_arg, GVL_FUNC(PingImage));
 }
 
 
@@ -11464,9 +11464,9 @@ Image_raise(int argc, VALUE *argv, VALUE self)
  * @return [Array<Magick::Image>] an array of 1 or more new image objects
  */
 VALUE
-Image_read(VALUE class, VALUE file_arg)
+Image_read(VALUE klass, VALUE file_arg)
 {
-    return rd_image(class, file_arg, GVL_FUNC(ReadImage));
+    return rd_image(klass, file_arg, GVL_FUNC(ReadImage));
 }
 
 
@@ -11498,7 +11498,7 @@ typedef GVL_STRUCT_TYPE(PingImage) GVL_STRUCT_TYPE(rd_image);
  *   - Yields to a block to get Image::Info attributes before calling
  *     Read/PingImage
  *
- * @param class the Ruby class for an Image
+ * @param klass the Ruby class for an Image
  * @param file the file containing image data
  * @param reader which image reader to use (ReadImage or PingImage)
  * @return an array of 1 or more new image objects
@@ -11514,7 +11514,7 @@ void sig_handler(int sig ATTRIBUTE_UNUSED)
 #endif
 
 static VALUE
-rd_image(VALUE class ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
+rd_image(VALUE klass ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
 {
     char *filename;
     long filename_l;

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -2350,11 +2350,11 @@ Info_memsize(const void *infoptr)
  *
  * No Ruby usage (internal function)
  *
- * @param class the Ruby class to use
+ * @param klass the Ruby class to use
  * @return a new ImageInfo object
  */
 VALUE
-Info_alloc(VALUE class)
+Info_alloc(VALUE klass)
 {
     Info *info;
     VALUE info_obj;
@@ -2364,7 +2364,7 @@ Info_alloc(VALUE class)
     {
         rb_raise(rb_eNoMemError, "not enough memory to initialize Info object");
     }
-    info_obj = TypedData_Wrap_Struct(class, &rm_info_data_type, info);
+    info_obj = TypedData_Wrap_Struct(klass, &rm_info_data_type, info);
 
     RB_GC_GUARD(info_obj);
 

--- a/ext/RMagick/rmkinfo.c
+++ b/ext/RMagick/rmkinfo.c
@@ -64,9 +64,9 @@ rm_kernel_info_memsize(const void *ptr)
  * @return [Magick::KernelInfo] a new KernelInfo object
  */
 VALUE
-KernelInfo_alloc(VALUE class)
+KernelInfo_alloc(VALUE klass)
 {
-    return TypedData_Wrap_Struct(class, &rm_kernel_info_data_type, NULL);
+    return TypedData_Wrap_Struct(klass, &rm_kernel_info_data_type, NULL);
 }
 
 /**

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -43,17 +43,17 @@ static void features_constant(void);
  */
 //! define Ruby enum
 #define DEF_ENUM(tag) {\
-   VALUE _cls, _enum;\
-   _cls =  Class_##tag = rm_define_enum_type(#tag);
+   VALUE _klass, _enum;\
+   _klass =  Class_##tag = rm_define_enum_type(#tag);
 
 //! define Ruby enumerator elements
 #define ENUMERATOR(val)\
-   _enum = rm_enum_new(_cls, ID2SYM(rb_intern(#val)), INT2NUM(val));\
+   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#val)), INT2NUM(val));\
    rb_define_const(Module_Magick, #val, _enum);
 
 //! define Ruby enumerator elements when name is different from the value
 #define ENUMERATORV(name, val)\
-   _enum = rm_enum_new(_cls, ID2SYM(rb_intern(#name)), INT2NUM(val));\
+   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#name)), INT2NUM(val));\
    rb_define_const(Module_Magick, #name, _enum);
 
 //! end of an enumerator

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -75,7 +75,7 @@ Montage_memsize(const void *ptr)
  * @return [Magick::ImageList::Montage] a new Montage object
  */
 VALUE
-Montage_alloc(VALUE class)
+Montage_alloc(VALUE klass)
 {
     MontageInfo *montage_info;
     Montage *montage;
@@ -100,7 +100,7 @@ Montage_alloc(VALUE class)
     montage = ALLOC(Montage);
     montage->info = montage_info;
     montage->compose = OverCompositeOp;
-    montage_obj = TypedData_Wrap_Struct(class, &rm_montage_data_type, montage);
+    montage_obj = TypedData_Wrap_Struct(klass, &rm_montage_data_type, montage);
 
     RB_GC_GUARD(montage_obj);
 

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -492,13 +492,13 @@ Color_Name_to_PixelColor(PixelColor *color, VALUE name_arg)
  * @return [Magick::Pixel] a new Magick::Pixel object
  */
 VALUE
-Pixel_alloc(VALUE class)
+Pixel_alloc(VALUE klass)
 {
     Pixel *pixel;
 
     pixel = ALLOC(Pixel);
     memset(pixel, '\0', sizeof(Pixel));
-    return TypedData_Wrap_Struct(class, &rm_pixel_data_type, pixel);
+    return TypedData_Wrap_Struct(klass, &rm_pixel_data_type, pixel);
 }
 
 
@@ -679,7 +679,7 @@ Pixel_fcmp(int argc, VALUE *argv, VALUE self)
  * @see Magick::Pixel#to_color
  */
 VALUE
-Pixel_from_color(VALUE class ATTRIBUTE_UNUSED, VALUE name)
+Pixel_from_color(VALUE klass ATTRIBUTE_UNUSED, VALUE name)
 {
     PixelColor pp;
     ExceptionInfo *exception;
@@ -715,7 +715,7 @@ Pixel_from_color(VALUE class ATTRIBUTE_UNUSED, VALUE name)
  *   @return [Magick::Pixel] a new Magick::Pixel object
  */
 VALUE
-Pixel_from_hsla(int argc, VALUE *argv, VALUE class ATTRIBUTE_UNUSED)
+Pixel_from_hsla(int argc, VALUE *argv, VALUE klass ATTRIBUTE_UNUSED)
 {
     double h, s, l, a = 1.0;
     MagickPixel pp;


### PR DESCRIPTION
The name of `class`  can only be used to define a class in C++.

Related to https://github.com/rmagick/rmagick/issues/1419