### PR TITLE
CI: Fix parser gem version in order to run rubocop with Ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
+# Used in rubocop.
+# The latest version depends on methods introduced in Ruby 2.5.
+# We might be able to remove this dependency in the future if we will stop Ruby 2.3 support.
+gem 'parser', '= 3.2.2.4'
+
 # Specify your gem's dependencies in rmagick.gemspec
 gemspec


### PR DESCRIPTION
The latest version of `parser` gem depends on methods introduced in Ruby 2.5.

It causes following error when run lint lane in CI.
```
undefined method `delete_suffix' for "        END_EXHTMLHEAD":String
/home/runner/work/rmagick/rmagick/vendor/bundle/ruby/2.3.0/gems/parser-3.3.0.0/lib/parser/lexer/literal.rb:250:in `delimiter?'
/home/runner/work/rmagick/rmagick/vendor/bundle/ruby/2.3.0/gems/parser-3.3.0.0/lib/parser/lexer/literal.rb:138:in `nest_and_try_closing'
/home/runner/work/rmagick/rmagick/vendor/bundle/ruby/2.3.0/gems/parser-3.3.0.0/lib/parser/lexer-strings.rb:3[78](https://github.com/Watson1978/rmagick/actions/runs/7414039270/job/20211269955#step:4:79)9:in `advance'
:
```
https://github.com/Watson1978/rmagick/actions/runs/7414039270/job/20211269955