### PR TITLE
Revert "CI: Fix parser gem version in order to run rubocop with Ruby 2.3 (#1422)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,4 @@
 source 'https://rubygems.org'
 
-# Used in rubocop.
-# The latest version depends on methods introduced in Ruby 2.5.
-# We might be able to remove this dependency in the future if we will stop Ruby 2.3 support.
-gem 'parser', '= 3.2.2.4'
-
 # Specify your gem's dependencies in rmagick.gemspec
 gemspec


### PR DESCRIPTION
The parser gem has still supported Ruby 2.0+
https://github.com/whitequark/parser/pull/986

This reverts commit 6f906a811a2530f7ae512340ae35ac92e2f2428c.