### PR TITLE
Rename `operator` variable names for C++

### DIFF
--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -957,7 +957,7 @@ Draw_clone(VALUE self)
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
  *
- * @overload composite(x, y, width, height, image, operator = Magick::OverCompositeOp)
+ * @overload composite(x, y, width, height, image, composite_op = Magick::OverCompositeOp)
  *   - The "image" argument can be either an ImageList object or an Image
  *     argument.
  *   @param x [Float] x position
@@ -966,7 +966,7 @@ Draw_clone(VALUE self)
  *   @param height [Float] the height
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
- *   @param operator [Magick::CompositeOperator] the operator
+ *   @param composite_op [Magick::CompositeOperator] the operator
  *
  * @return [Magick::Draw] self
  */
@@ -976,7 +976,7 @@ Draw_composite(int argc, VALUE *argv, VALUE self)
     Draw *draw;
     const char *op;
     double x, y, width, height;
-    CompositeOperator cop;
+    CompositeOperator composite_op;
     VALUE image;
     Image *comp_img;
     struct TmpFile_Name *tmpfile_name;
@@ -998,16 +998,16 @@ Draw_composite(int argc, VALUE *argv, VALUE self)
     width  = NUM2DBL(argv[2]);
     height = NUM2DBL(argv[3]);
 
-    cop = OverCompositeOp;
+    composite_op = OverCompositeOp;
     if (argc == 6)
     {
-        VALUE_TO_ENUM(argv[5], cop, CompositeOperator);
+        VALUE_TO_ENUM(argv[5], composite_op, CompositeOperator);
     }
 
-    op = CommandOptionToMnemonic(MagickComposeOptions, cop);
+    op = CommandOptionToMnemonic(MagickComposeOptions, composite_op);
     if (rm_strcasecmp("Unrecognized", op) == 0)
     {
-        rb_raise(rb_eArgError, "unknown composite operator (%d)", cop);
+        rb_raise(rb_eArgError, "unknown composite operator (%d)", composite_op);
     }
 
     TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -311,10 +311,10 @@ VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
  * @overload composite_layers(images)
  *   @param images [Magick::ImageList] the source images
  *
- * @overload composite_layers(images, operator)
+ * @overload composite_layers(images, composite_op)
  *   - Default operator is {Magick::OverCompositeOp}
  *   @param images [Magick::ImageList] the source images
- *   @param operator [Magick::CompositeOperator] the operator
+ *   @param composite_op [Magick::CompositeOperator] the operator
  *
  * @return [Magick::ImageList] a new imagelist
  */
@@ -324,13 +324,13 @@ ImageList_composite_layers(int argc, VALUE *argv, VALUE self)
     VALUE source_images;
     Image *dest, *source, *new_images;
     RectangleInfo geometry;
-    CompositeOperator operator = OverCompositeOp;
+    CompositeOperator composite_op = OverCompositeOp;
     ExceptionInfo *exception;
 
     switch (argc)
     {
         case 2:
-            VALUE_TO_ENUM(argv[1], operator, CompositeOperator);
+            VALUE_TO_ENUM(argv[1], composite_op, CompositeOperator);
         case 1:
             source_images = argv[0];
             break;
@@ -356,7 +356,7 @@ ImageList_composite_layers(int argc, VALUE *argv, VALUE self)
                           new_images->gravity, &geometry);
 
     exception = AcquireExceptionInfo();
-    GVL_STRUCT_TYPE(CompositeLayers) args = { new_images, operator, source, geometry.x, geometry.y, exception };
+    GVL_STRUCT_TYPE(CompositeLayers) args = { new_images, composite_op, source, geometry.x, geometry.y, exception };
     CALL_FUNC_WITHOUT_GVL(GVL_FUNC(CompositeLayers), &args);
     rm_split(source);
     rm_check_exception(exception, new_images, DestroyOnError);


### PR DESCRIPTION
The following code is written in places:

```c
CompositeOperator operator = OverCompositeOp;
```

The `operator` has been used by operator overloading in C++.
So, the variable name `operator` causes conflict as operator overloading.

Related to https://github.com/rmagick/rmagick/issues/1419