### PR TITLE
Add type casting of function pointer for C++

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -138,6 +138,8 @@ module RMagick
                    else
                      ' -std=c99'
                    end
+      ruby_version = RUBY_VERSION.split('.')
+      $CPPFLAGS += " -DRUBY_VERSION_MAJOR=#{ruby_version[0]} -DRUBY_VERSION_MINOR=#{ruby_version[1]}"
     end
 
     def exit_failure(msg)

--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -14,8 +14,6 @@
 
 
 
-static VALUE rm_yield_handle_exception(VALUE, VALUE) ATTRIBUTE_NORETURN;
-
 static VALUE
 rm_yield_body(VALUE object)
 {
@@ -60,7 +58,7 @@ Magick_colors(VALUE klass)
     {
         for (x = 0; x < number_colors; x++)
         {
-            rb_rescue(rm_yield_body, Import_ColorInfo(color_info_list[x]), rm_yield_handle_exception, (VALUE)color_info_list);
+            rb_rescue(RESCUE_FUNC(rm_yield_body), Import_ColorInfo(color_info_list[x]), RESCUE_EXCEPTION_HANDLER_FUNC(rm_yield_handle_exception), (VALUE)color_info_list);
         }
         magick_free((void *)color_info_list);
         return klass;
@@ -109,7 +107,7 @@ Magick_fonts(VALUE klass)
     {
         for (x = 0; x < number_types; x++)
         {
-            rb_rescue(rm_yield_body, Import_TypeInfo((const TypeInfo *)type_info[x]), rm_yield_handle_exception, (VALUE)type_info);
+            rb_rescue(RESCUE_FUNC(rm_yield_body), Import_TypeInfo((const TypeInfo *)type_info[x]), RESCUE_EXCEPTION_HANDLER_FUNC(rm_yield_handle_exception), (VALUE)type_info);
         }
         magick_free((void *)type_info);
         return klass;
@@ -393,4 +391,3 @@ Magick_set_log_format(VALUE klass, VALUE format)
     SetLogFormat(StringValueCStr(format));
     return klass;
 }
-

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1214,5 +1214,12 @@ extern VALUE  rm_io_path(VALUE);
 extern void   rm_check_image_exception(Image *, ErrorRetention);
 #endif
 
+#if (RUBY_VERSION_MAJOR == 2 && RUBY_VERSION_MINOR < 7)
+    #define RESCUE_FUNC(func)                   (VALUE (*)(ANYARGS))(func)
+    #define RESCUE_EXCEPTION_HANDLER_FUNC(func) (VALUE (*)(ANYARGS))(func)
+#else
+    #define RESCUE_FUNC(func)                   (VALUE(*)(VALUE))(func)
+    #define RESCUE_EXCEPTION_HANDLER_FUNC(func) (VALUE(*)(VALUE, VALUE))(func)
 #endif
 
+#endif

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -44,9 +44,9 @@ rm_define_enum_type(const char *tag)
 
     klass = rb_define_class_under(Module_Magick, tag, Class_Enum);\
 
-    rb_define_singleton_method(klass, "values", Enum_type_values, 0);
-    rb_define_method(klass, "initialize", Enum_type_initialize, 2);
-    rb_define_method(klass, "inspect", Enum_type_inspect, 0);
+    rb_define_singleton_method(klass, "values", RUBY_METHOD_FUNC(Enum_type_values), 0);
+    rb_define_method(klass, "initialize", RUBY_METHOD_FUNC(Enum_type_initialize), 2);
+    rb_define_method(klass, "inspect", RUBY_METHOD_FUNC(Enum_type_inspect), 0);
     return klass;
 }
 

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -11539,7 +11539,7 @@ rd_image(VALUE klass ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
     else
     {
         // Convert arg to string. If an exception occurs raise an error condition.
-        file = rb_rescue(rb_String, file, file_arg_rescue, file);
+        file = rb_rescue(RESCUE_FUNC(rb_String), file, RESCUE_EXCEPTION_HANDLER_FUNC(file_arg_rescue), file);
 
         filename = rm_str2cstr(file, &filename_l);
         filename_l = min(filename_l, MaxTextExtent-1);
@@ -15808,7 +15808,7 @@ void add_format_prefix(Info *info, VALUE file)
     {
         FilePathStringValue(file);
     }
-    file = rb_rescue(rb_String, file, file_arg_rescue, file);
+    file = rb_rescue(RESCUE_FUNC(rb_String), file, RESCUE_EXCEPTION_HANDLER_FUNC(file_arg_rescue), file);
 
     filename = rm_str2cstr(file, &filename_l);
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -268,13 +268,13 @@ Init_RMagick2(void)
     /* Module Magick methods                                                 */
     /*-----------------------------------------------------------------------*/
 
-    rb_define_module_function(Module_Magick, "colors", Magick_colors, 0);
-    rb_define_module_function(Module_Magick, "fonts", Magick_fonts, 0);
-    rb_define_module_function(Module_Magick, "init_formats", Magick_init_formats, 0);
-    rb_define_module_function(Module_Magick, "limit_resource", Magick_limit_resource, -1);
-    rb_define_module_function(Module_Magick, "set_cache_threshold", Magick_set_cache_threshold, 1);
-    rb_define_module_function(Module_Magick, "set_log_event_mask", Magick_set_log_event_mask, -1);
-    rb_define_module_function(Module_Magick, "set_log_format", Magick_set_log_format, 1);
+    rb_define_module_function(Module_Magick, "colors", RUBY_METHOD_FUNC(Magick_colors), 0);
+    rb_define_module_function(Module_Magick, "fonts", RUBY_METHOD_FUNC(Magick_fonts), 0);
+    rb_define_module_function(Module_Magick, "init_formats", RUBY_METHOD_FUNC(Magick_init_formats), 0);
+    rb_define_module_function(Module_Magick, "limit_resource", RUBY_METHOD_FUNC(Magick_limit_resource), -1);
+    rb_define_module_function(Module_Magick, "set_cache_threshold", RUBY_METHOD_FUNC(Magick_set_cache_threshold), 1);
+    rb_define_module_function(Module_Magick, "set_log_event_mask", RUBY_METHOD_FUNC(Magick_set_log_event_mask), -1);
+    rb_define_module_function(Module_Magick, "set_log_format", RUBY_METHOD_FUNC(Magick_set_log_format), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::Image methods                                           */
@@ -286,338 +286,338 @@ Init_RMagick2(void)
     rb_define_alias(Class_Image, "__display__", "display");
 
     rb_define_alloc_func(Class_Image, Image_alloc);
-    rb_define_method(Class_Image, "initialize", Image_initialize, -1);
+    rb_define_method(Class_Image, "initialize", RUBY_METHOD_FUNC(Image_initialize), -1);
 
-    rb_define_singleton_method(Class_Image, "constitute", Image_constitute, 4);
-    rb_define_singleton_method(Class_Image, "_load", Image__load, 1);
-    rb_define_singleton_method(Class_Image, "capture", Image_capture, -1);
-    rb_define_singleton_method(Class_Image, "ping", Image_ping, 1);
-    rb_define_singleton_method(Class_Image, "read", Image_read, 1);
-    rb_define_singleton_method(Class_Image, "read_inline", Image_read_inline, 1);
-    rb_define_singleton_method(Class_Image, "from_blob", Image_from_blob, 1);
+    rb_define_singleton_method(Class_Image, "constitute", RUBY_METHOD_FUNC(Image_constitute), 4);
+    rb_define_singleton_method(Class_Image, "_load", RUBY_METHOD_FUNC(Image__load), 1);
+    rb_define_singleton_method(Class_Image, "capture", RUBY_METHOD_FUNC(Image_capture), -1);
+    rb_define_singleton_method(Class_Image, "ping", RUBY_METHOD_FUNC(Image_ping), 1);
+    rb_define_singleton_method(Class_Image, "read", RUBY_METHOD_FUNC(Image_read), 1);
+    rb_define_singleton_method(Class_Image, "read_inline", RUBY_METHOD_FUNC(Image_read_inline), 1);
+    rb_define_singleton_method(Class_Image, "from_blob", RUBY_METHOD_FUNC(Image_from_blob), 1);
 
     // Define the attributes
-    rb_define_method(Class_Image, "background_color", Image_background_color, 0);
-    rb_define_method(Class_Image, "background_color=", Image_background_color_eq, 1);
-    rb_define_method(Class_Image, "base_columns", Image_base_columns, 0);
-    rb_define_method(Class_Image, "base_filename", Image_base_filename, 0);
-    rb_define_method(Class_Image, "base_rows", Image_base_rows, 0);
-    rb_define_method(Class_Image, "bias", Image_bias, 0);
-    rb_define_method(Class_Image, "bias=", Image_bias_eq, 1);
-    rb_define_method(Class_Image, "black_point_compensation", Image_black_point_compensation, 0);
-    rb_define_method(Class_Image, "black_point_compensation=", Image_black_point_compensation_eq, 1);
-    rb_define_method(Class_Image, "border_color", Image_border_color, 0);
-    rb_define_method(Class_Image, "border_color=", Image_border_color_eq, 1);
-    rb_define_method(Class_Image, "bounding_box", Image_bounding_box, 0);
-    rb_define_method(Class_Image, "chromaticity", Image_chromaticity, 0);
-    rb_define_method(Class_Image, "chromaticity=", Image_chromaticity_eq, 1);
-    rb_define_method(Class_Image, "color_profile", Image_color_profile, 0);
-    rb_define_method(Class_Image, "color_profile=", Image_color_profile_eq, 1);
-    rb_define_method(Class_Image, "colors", Image_colors, 0);
-    rb_define_method(Class_Image, "colorspace", Image_colorspace, 0);
-    rb_define_method(Class_Image, "colorspace=", Image_colorspace_eq, 1);
-    rb_define_method(Class_Image, "columns", Image_columns, 0);
-    rb_define_method(Class_Image, "compose", Image_compose, 0);
-    rb_define_method(Class_Image, "compose=", Image_compose_eq, 1);
-    rb_define_method(Class_Image, "compression", Image_compression, 0);
-    rb_define_method(Class_Image, "compression=", Image_compression_eq, 1);
-    rb_define_method(Class_Image, "delay", Image_delay, 0);
-    rb_define_method(Class_Image, "delay=", Image_delay_eq, 1);
-    rb_define_method(Class_Image, "density", Image_density, 0);
-    rb_define_method(Class_Image, "density=", Image_density_eq, 1);
-    rb_define_method(Class_Image, "depth", Image_depth, 0);
-    rb_define_method(Class_Image, "directory", Image_directory, 0);
-    rb_define_method(Class_Image, "dispose", Image_dispose, 0);
-    rb_define_method(Class_Image, "dispose=", Image_dispose_eq, 1);
-    rb_define_method(Class_Image, "endian", Image_endian, 0);
-    rb_define_method(Class_Image, "endian=", Image_endian_eq, 1);
-    rb_define_method(Class_Image, "extract_info", Image_extract_info, 0);
-    rb_define_method(Class_Image, "extract_info=", Image_extract_info_eq, 1);
-    rb_define_method(Class_Image, "filename", Image_filename, 0);
-    rb_define_method(Class_Image, "filesize", Image_filesize, 0);
-    rb_define_method(Class_Image, "filter", Image_filter, 0);
-    rb_define_method(Class_Image, "filter=", Image_filter_eq, 1);
-    rb_define_method(Class_Image, "format", Image_format, 0);
-    rb_define_method(Class_Image, "format=", Image_format_eq, 1);
-    rb_define_method(Class_Image, "fuzz", Image_fuzz, 0);
-    rb_define_method(Class_Image, "fuzz=", Image_fuzz_eq, 1);
-    rb_define_method(Class_Image, "gamma", Image_gamma, 0);
-    rb_define_method(Class_Image, "gamma=", Image_gamma_eq, 1);
-    rb_define_method(Class_Image, "geometry", Image_geometry, 0);
-    rb_define_method(Class_Image, "geometry=", Image_geometry_eq, 1);
-    rb_define_method(Class_Image, "gravity", Image_gravity, 0);
-    rb_define_method(Class_Image, "gravity=", Image_gravity_eq, 1);
-    rb_define_method(Class_Image, "image_type", Image_image_type, 0);
-    rb_define_method(Class_Image, "image_type=", Image_image_type_eq, 1);
-    rb_define_method(Class_Image, "interlace", Image_interlace, 0);
-    rb_define_method(Class_Image, "interlace=", Image_interlace_eq, 1);
-    rb_define_method(Class_Image, "iptc_profile", Image_iptc_profile, 0);
-    rb_define_method(Class_Image, "iptc_profile=", Image_iptc_profile_eq, 1);
-    rb_define_method(Class_Image, "iterations", Image_iterations, 0);        // do not document! Only used by Image#iterations=
-    rb_define_method(Class_Image, "iterations=", Image_iterations_eq, 1);        // do not document! Only used by Image#iterations=
-    rb_define_method(Class_Image, "matte_color", Image_matte_color, 0);
-    rb_define_method(Class_Image, "matte_color=", Image_matte_color_eq, 1);
-    rb_define_method(Class_Image, "mean_error_per_pixel", Image_mean_error_per_pixel, 0);
-    rb_define_method(Class_Image, "mime_type", Image_mime_type, 0);
-    rb_define_method(Class_Image, "montage", Image_montage, 0);
-    rb_define_method(Class_Image, "normalized_mean_error", Image_normalized_mean_error, 0);
-    rb_define_method(Class_Image, "normalized_maximum_error", Image_normalized_maximum_error, 0);
-    rb_define_method(Class_Image, "number_colors", Image_number_colors, 0);
-    rb_define_method(Class_Image, "offset", Image_offset, 0);
-    rb_define_method(Class_Image, "offset=", Image_offset_eq, 1);
-    rb_define_method(Class_Image, "orientation", Image_orientation, 0);
-    rb_define_method(Class_Image, "orientation=", Image_orientation_eq, 1);
-    rb_define_method(Class_Image, "page", Image_page, 0);
-    rb_define_method(Class_Image, "page=", Image_page_eq, 1);
-    rb_define_method(Class_Image, "pixel_interpolation_method", Image_pixel_interpolation_method, 0);
-    rb_define_method(Class_Image, "pixel_interpolation_method=", Image_pixel_interpolation_method_eq, 1);
-    rb_define_method(Class_Image, "quality", Image_quality, 0);
-    rb_define_method(Class_Image, "quantum_depth", Image_quantum_depth, 0);
-    rb_define_method(Class_Image, "rendering_intent", Image_rendering_intent, 0);
-    rb_define_method(Class_Image, "rendering_intent=", Image_rendering_intent_eq, 1);
-    rb_define_method(Class_Image, "rows", Image_rows, 0);
-    rb_define_method(Class_Image, "scene", Image_scene, 0);
-    rb_define_method(Class_Image, "start_loop", Image_start_loop, 0);
-    rb_define_method(Class_Image, "start_loop=", Image_start_loop_eq, 1);
-    rb_define_method(Class_Image, "class_type", Image_class_type, 0);
-    rb_define_method(Class_Image, "class_type=", Image_class_type_eq, 1);
-    rb_define_method(Class_Image, "ticks_per_second", Image_ticks_per_second, 0);
-    rb_define_method(Class_Image, "ticks_per_second=", Image_ticks_per_second_eq, 1);
-    rb_define_method(Class_Image, "total_colors", Image_total_colors, 0);
-    rb_define_method(Class_Image, "total_ink_density", Image_total_ink_density, 0);
-    rb_define_method(Class_Image, "transparent_color", Image_transparent_color, 0);
-    rb_define_method(Class_Image, "transparent_color=", Image_transparent_color_eq, 1);
-    rb_define_method(Class_Image, "units", Image_units, 0);
-    rb_define_method(Class_Image, "units=", Image_units_eq, 1);
-    rb_define_method(Class_Image, "virtual_pixel_method", Image_virtual_pixel_method, 0);
-    rb_define_method(Class_Image, "virtual_pixel_method=", Image_virtual_pixel_method_eq, 1);
-    rb_define_method(Class_Image, "x_resolution", Image_x_resolution, 0);
-    rb_define_method(Class_Image, "x_resolution=", Image_x_resolution_eq, 1);
-    rb_define_method(Class_Image, "y_resolution", Image_y_resolution, 0);
-    rb_define_method(Class_Image, "y_resolution=", Image_y_resolution_eq, 1);
+    rb_define_method(Class_Image, "background_color", RUBY_METHOD_FUNC(Image_background_color), 0);
+    rb_define_method(Class_Image, "background_color=", RUBY_METHOD_FUNC(Image_background_color_eq), 1);
+    rb_define_method(Class_Image, "base_columns", RUBY_METHOD_FUNC(Image_base_columns), 0);
+    rb_define_method(Class_Image, "base_filename", RUBY_METHOD_FUNC(Image_base_filename), 0);
+    rb_define_method(Class_Image, "base_rows", RUBY_METHOD_FUNC(Image_base_rows), 0);
+    rb_define_method(Class_Image, "bias", RUBY_METHOD_FUNC(Image_bias), 0);
+    rb_define_method(Class_Image, "bias=", RUBY_METHOD_FUNC(Image_bias_eq), 1);
+    rb_define_method(Class_Image, "black_point_compensation", RUBY_METHOD_FUNC(Image_black_point_compensation), 0);
+    rb_define_method(Class_Image, "black_point_compensation=", RUBY_METHOD_FUNC(Image_black_point_compensation_eq), 1);
+    rb_define_method(Class_Image, "border_color", RUBY_METHOD_FUNC(Image_border_color), 0);
+    rb_define_method(Class_Image, "border_color=", RUBY_METHOD_FUNC(Image_border_color_eq), 1);
+    rb_define_method(Class_Image, "bounding_box", RUBY_METHOD_FUNC(Image_bounding_box), 0);
+    rb_define_method(Class_Image, "chromaticity", RUBY_METHOD_FUNC(Image_chromaticity), 0);
+    rb_define_method(Class_Image, "chromaticity=", RUBY_METHOD_FUNC(Image_chromaticity_eq), 1);
+    rb_define_method(Class_Image, "color_profile", RUBY_METHOD_FUNC(Image_color_profile), 0);
+    rb_define_method(Class_Image, "color_profile=", RUBY_METHOD_FUNC(Image_color_profile_eq), 1);
+    rb_define_method(Class_Image, "colors", RUBY_METHOD_FUNC(Image_colors), 0);
+    rb_define_method(Class_Image, "colorspace", RUBY_METHOD_FUNC(Image_colorspace), 0);
+    rb_define_method(Class_Image, "colorspace=", RUBY_METHOD_FUNC(Image_colorspace_eq), 1);
+    rb_define_method(Class_Image, "columns", RUBY_METHOD_FUNC(Image_columns), 0);
+    rb_define_method(Class_Image, "compose", RUBY_METHOD_FUNC(Image_compose), 0);
+    rb_define_method(Class_Image, "compose=", RUBY_METHOD_FUNC(Image_compose_eq), 1);
+    rb_define_method(Class_Image, "compression", RUBY_METHOD_FUNC(Image_compression), 0);
+    rb_define_method(Class_Image, "compression=", RUBY_METHOD_FUNC(Image_compression_eq), 1);
+    rb_define_method(Class_Image, "delay", RUBY_METHOD_FUNC(Image_delay), 0);
+    rb_define_method(Class_Image, "delay=", RUBY_METHOD_FUNC(Image_delay_eq), 1);
+    rb_define_method(Class_Image, "density", RUBY_METHOD_FUNC(Image_density), 0);
+    rb_define_method(Class_Image, "density=", RUBY_METHOD_FUNC(Image_density_eq), 1);
+    rb_define_method(Class_Image, "depth", RUBY_METHOD_FUNC(Image_depth), 0);
+    rb_define_method(Class_Image, "directory", RUBY_METHOD_FUNC(Image_directory), 0);
+    rb_define_method(Class_Image, "dispose", RUBY_METHOD_FUNC(Image_dispose), 0);
+    rb_define_method(Class_Image, "dispose=", RUBY_METHOD_FUNC(Image_dispose_eq), 1);
+    rb_define_method(Class_Image, "endian", RUBY_METHOD_FUNC(Image_endian), 0);
+    rb_define_method(Class_Image, "endian=", RUBY_METHOD_FUNC(Image_endian_eq), 1);
+    rb_define_method(Class_Image, "extract_info", RUBY_METHOD_FUNC(Image_extract_info), 0);
+    rb_define_method(Class_Image, "extract_info=", RUBY_METHOD_FUNC(Image_extract_info_eq), 1);
+    rb_define_method(Class_Image, "filename", RUBY_METHOD_FUNC(Image_filename), 0);
+    rb_define_method(Class_Image, "filesize", RUBY_METHOD_FUNC(Image_filesize), 0);
+    rb_define_method(Class_Image, "filter", RUBY_METHOD_FUNC(Image_filter), 0);
+    rb_define_method(Class_Image, "filter=", RUBY_METHOD_FUNC(Image_filter_eq), 1);
+    rb_define_method(Class_Image, "format", RUBY_METHOD_FUNC(Image_format), 0);
+    rb_define_method(Class_Image, "format=", RUBY_METHOD_FUNC(Image_format_eq), 1);
+    rb_define_method(Class_Image, "fuzz", RUBY_METHOD_FUNC(Image_fuzz), 0);
+    rb_define_method(Class_Image, "fuzz=", RUBY_METHOD_FUNC(Image_fuzz_eq), 1);
+    rb_define_method(Class_Image, "gamma", RUBY_METHOD_FUNC(Image_gamma), 0);
+    rb_define_method(Class_Image, "gamma=", RUBY_METHOD_FUNC(Image_gamma_eq), 1);
+    rb_define_method(Class_Image, "geometry", RUBY_METHOD_FUNC(Image_geometry), 0);
+    rb_define_method(Class_Image, "geometry=", RUBY_METHOD_FUNC(Image_geometry_eq), 1);
+    rb_define_method(Class_Image, "gravity", RUBY_METHOD_FUNC(Image_gravity), 0);
+    rb_define_method(Class_Image, "gravity=", RUBY_METHOD_FUNC(Image_gravity_eq), 1);
+    rb_define_method(Class_Image, "image_type", RUBY_METHOD_FUNC(Image_image_type), 0);
+    rb_define_method(Class_Image, "image_type=", RUBY_METHOD_FUNC(Image_image_type_eq), 1);
+    rb_define_method(Class_Image, "interlace", RUBY_METHOD_FUNC(Image_interlace), 0);
+    rb_define_method(Class_Image, "interlace=", RUBY_METHOD_FUNC(Image_interlace_eq), 1);
+    rb_define_method(Class_Image, "iptc_profile", RUBY_METHOD_FUNC(Image_iptc_profile), 0);
+    rb_define_method(Class_Image, "iptc_profile=", RUBY_METHOD_FUNC(Image_iptc_profile_eq), 1);
+    rb_define_method(Class_Image, "iterations", RUBY_METHOD_FUNC(Image_iterations), 0);        // do not document! Only used by Image#iterations=
+    rb_define_method(Class_Image, "iterations=", RUBY_METHOD_FUNC(Image_iterations_eq), 1);        // do not document! Only used by Image#iterations=
+    rb_define_method(Class_Image, "matte_color", RUBY_METHOD_FUNC(Image_matte_color), 0);
+    rb_define_method(Class_Image, "matte_color=", RUBY_METHOD_FUNC(Image_matte_color_eq), 1);
+    rb_define_method(Class_Image, "mean_error_per_pixel", RUBY_METHOD_FUNC(Image_mean_error_per_pixel), 0);
+    rb_define_method(Class_Image, "mime_type", RUBY_METHOD_FUNC(Image_mime_type), 0);
+    rb_define_method(Class_Image, "montage", RUBY_METHOD_FUNC(Image_montage), 0);
+    rb_define_method(Class_Image, "normalized_mean_error", RUBY_METHOD_FUNC(Image_normalized_mean_error), 0);
+    rb_define_method(Class_Image, "normalized_maximum_error", RUBY_METHOD_FUNC(Image_normalized_maximum_error), 0);
+    rb_define_method(Class_Image, "number_colors", RUBY_METHOD_FUNC(Image_number_colors), 0);
+    rb_define_method(Class_Image, "offset", RUBY_METHOD_FUNC(Image_offset), 0);
+    rb_define_method(Class_Image, "offset=", RUBY_METHOD_FUNC(Image_offset_eq), 1);
+    rb_define_method(Class_Image, "orientation", RUBY_METHOD_FUNC(Image_orientation), 0);
+    rb_define_method(Class_Image, "orientation=", RUBY_METHOD_FUNC(Image_orientation_eq), 1);
+    rb_define_method(Class_Image, "page", RUBY_METHOD_FUNC(Image_page), 0);
+    rb_define_method(Class_Image, "page=", RUBY_METHOD_FUNC(Image_page_eq), 1);
+    rb_define_method(Class_Image, "pixel_interpolation_method", RUBY_METHOD_FUNC(Image_pixel_interpolation_method), 0);
+    rb_define_method(Class_Image, "pixel_interpolation_method=", RUBY_METHOD_FUNC(Image_pixel_interpolation_method_eq), 1);
+    rb_define_method(Class_Image, "quality", RUBY_METHOD_FUNC(Image_quality), 0);
+    rb_define_method(Class_Image, "quantum_depth", RUBY_METHOD_FUNC(Image_quantum_depth), 0);
+    rb_define_method(Class_Image, "rendering_intent", RUBY_METHOD_FUNC(Image_rendering_intent), 0);
+    rb_define_method(Class_Image, "rendering_intent=", RUBY_METHOD_FUNC(Image_rendering_intent_eq), 1);
+    rb_define_method(Class_Image, "rows", RUBY_METHOD_FUNC(Image_rows), 0);
+    rb_define_method(Class_Image, "scene", RUBY_METHOD_FUNC(Image_scene), 0);
+    rb_define_method(Class_Image, "start_loop", RUBY_METHOD_FUNC(Image_start_loop), 0);
+    rb_define_method(Class_Image, "start_loop=", RUBY_METHOD_FUNC(Image_start_loop_eq), 1);
+    rb_define_method(Class_Image, "class_type", RUBY_METHOD_FUNC(Image_class_type), 0);
+    rb_define_method(Class_Image, "class_type=", RUBY_METHOD_FUNC(Image_class_type_eq), 1);
+    rb_define_method(Class_Image, "ticks_per_second", RUBY_METHOD_FUNC(Image_ticks_per_second), 0);
+    rb_define_method(Class_Image, "ticks_per_second=", RUBY_METHOD_FUNC(Image_ticks_per_second_eq), 1);
+    rb_define_method(Class_Image, "total_colors", RUBY_METHOD_FUNC(Image_total_colors), 0);
+    rb_define_method(Class_Image, "total_ink_density", RUBY_METHOD_FUNC(Image_total_ink_density), 0);
+    rb_define_method(Class_Image, "transparent_color", RUBY_METHOD_FUNC(Image_transparent_color), 0);
+    rb_define_method(Class_Image, "transparent_color=", RUBY_METHOD_FUNC(Image_transparent_color_eq), 1);
+    rb_define_method(Class_Image, "units", RUBY_METHOD_FUNC(Image_units), 0);
+    rb_define_method(Class_Image, "units=", RUBY_METHOD_FUNC(Image_units_eq), 1);
+    rb_define_method(Class_Image, "virtual_pixel_method", RUBY_METHOD_FUNC(Image_virtual_pixel_method), 0);
+    rb_define_method(Class_Image, "virtual_pixel_method=", RUBY_METHOD_FUNC(Image_virtual_pixel_method_eq), 1);
+    rb_define_method(Class_Image, "x_resolution", RUBY_METHOD_FUNC(Image_x_resolution), 0);
+    rb_define_method(Class_Image, "x_resolution=", RUBY_METHOD_FUNC(Image_x_resolution_eq), 1);
+    rb_define_method(Class_Image, "y_resolution", RUBY_METHOD_FUNC(Image_y_resolution), 0);
+    rb_define_method(Class_Image, "y_resolution=", RUBY_METHOD_FUNC(Image_y_resolution_eq), 1);
 
-    rb_define_method(Class_Image, "adaptive_blur", Image_adaptive_blur, -1);
-    rb_define_method(Class_Image, "adaptive_blur_channel", Image_adaptive_blur_channel, -1);
-    rb_define_method(Class_Image, "adaptive_resize", Image_adaptive_resize, -1);
-    rb_define_method(Class_Image, "adaptive_sharpen", Image_adaptive_sharpen, -1);
-    rb_define_method(Class_Image, "adaptive_sharpen_channel", Image_adaptive_sharpen_channel, -1);
-    rb_define_method(Class_Image, "adaptive_threshold", Image_adaptive_threshold, -1);
-    rb_define_method(Class_Image, "add_compose_mask", Image_add_compose_mask, 1);
-    rb_define_method(Class_Image, "add_noise", Image_add_noise, 1);
-    rb_define_method(Class_Image, "add_noise_channel", Image_add_noise_channel, -1);
-    rb_define_method(Class_Image, "add_profile", Image_add_profile, 1);
-    rb_define_method(Class_Image, "affine_transform", Image_affine_transform, 1);
-    rb_define_method(Class_Image, "remap", Image_remap, -1);
-    rb_define_method(Class_Image, "alpha", Image_alpha, -1);
-    rb_define_method(Class_Image, "alpha?", Image_alpha_q, 0);
-    rb_define_method(Class_Image, "[]", Image_aref, 1);
-    rb_define_method(Class_Image, "[]=", Image_aset, 2);
-    rb_define_method(Class_Image, "auto_gamma_channel", Image_auto_gamma_channel, -1);
-    rb_define_method(Class_Image, "auto_level_channel", Image_auto_level_channel, -1);
-    rb_define_method(Class_Image, "auto_orient", Image_auto_orient, 0);
-    rb_define_method(Class_Image, "auto_orient!", Image_auto_orient_bang, 0);
-    rb_define_method(Class_Image, "properties", Image_properties, 0);
-    rb_define_method(Class_Image, "bilevel_channel", Image_bilevel_channel, -1);
-    rb_define_method(Class_Image, "black_threshold", Image_black_threshold, -1);
-    rb_define_method(Class_Image, "blend", Image_blend, -1);
-    rb_define_method(Class_Image, "blue_shift", Image_blue_shift, -1);
-    rb_define_method(Class_Image, "blur_image", Image_blur_image, -1);
-    rb_define_method(Class_Image, "blur_channel", Image_blur_channel, -1);
-    rb_define_method(Class_Image, "border", Image_border, 3);
-    rb_define_method(Class_Image, "border!", Image_border_bang, 3);
-    rb_define_method(Class_Image, "change_geometry", Image_change_geometry, 1);
-    rb_define_method(Class_Image, "change_geometry!", Image_change_geometry, 1);
-    rb_define_method(Class_Image, "changed?", Image_changed_q, 0);
-    rb_define_method(Class_Image, "channel", Image_channel, 1);
+    rb_define_method(Class_Image, "adaptive_blur", RUBY_METHOD_FUNC(Image_adaptive_blur), -1);
+    rb_define_method(Class_Image, "adaptive_blur_channel", RUBY_METHOD_FUNC(Image_adaptive_blur_channel), -1);
+    rb_define_method(Class_Image, "adaptive_resize", RUBY_METHOD_FUNC(Image_adaptive_resize), -1);
+    rb_define_method(Class_Image, "adaptive_sharpen", RUBY_METHOD_FUNC(Image_adaptive_sharpen), -1);
+    rb_define_method(Class_Image, "adaptive_sharpen_channel", RUBY_METHOD_FUNC(Image_adaptive_sharpen_channel), -1);
+    rb_define_method(Class_Image, "adaptive_threshold", RUBY_METHOD_FUNC(Image_adaptive_threshold), -1);
+    rb_define_method(Class_Image, "add_compose_mask", RUBY_METHOD_FUNC(Image_add_compose_mask), 1);
+    rb_define_method(Class_Image, "add_noise", RUBY_METHOD_FUNC(Image_add_noise), 1);
+    rb_define_method(Class_Image, "add_noise_channel", RUBY_METHOD_FUNC(Image_add_noise_channel), -1);
+    rb_define_method(Class_Image, "add_profile", RUBY_METHOD_FUNC(Image_add_profile), 1);
+    rb_define_method(Class_Image, "affine_transform", RUBY_METHOD_FUNC(Image_affine_transform), 1);
+    rb_define_method(Class_Image, "remap", RUBY_METHOD_FUNC(Image_remap), -1);
+    rb_define_method(Class_Image, "alpha", RUBY_METHOD_FUNC(Image_alpha), -1);
+    rb_define_method(Class_Image, "alpha?", RUBY_METHOD_FUNC(Image_alpha_q), 0);
+    rb_define_method(Class_Image, "[]", RUBY_METHOD_FUNC(Image_aref), 1);
+    rb_define_method(Class_Image, "[]=", RUBY_METHOD_FUNC(Image_aset), 2);
+    rb_define_method(Class_Image, "auto_gamma_channel", RUBY_METHOD_FUNC(Image_auto_gamma_channel), -1);
+    rb_define_method(Class_Image, "auto_level_channel", RUBY_METHOD_FUNC(Image_auto_level_channel), -1);
+    rb_define_method(Class_Image, "auto_orient", RUBY_METHOD_FUNC(Image_auto_orient), 0);
+    rb_define_method(Class_Image, "auto_orient!", RUBY_METHOD_FUNC(Image_auto_orient_bang), 0);
+    rb_define_method(Class_Image, "properties", RUBY_METHOD_FUNC(Image_properties), 0);
+    rb_define_method(Class_Image, "bilevel_channel", RUBY_METHOD_FUNC(Image_bilevel_channel), -1);
+    rb_define_method(Class_Image, "black_threshold", RUBY_METHOD_FUNC(Image_black_threshold), -1);
+    rb_define_method(Class_Image, "blend", RUBY_METHOD_FUNC(Image_blend), -1);
+    rb_define_method(Class_Image, "blue_shift", RUBY_METHOD_FUNC(Image_blue_shift), -1);
+    rb_define_method(Class_Image, "blur_image", RUBY_METHOD_FUNC(Image_blur_image), -1);
+    rb_define_method(Class_Image, "blur_channel", RUBY_METHOD_FUNC(Image_blur_channel), -1);
+    rb_define_method(Class_Image, "border", RUBY_METHOD_FUNC(Image_border), 3);
+    rb_define_method(Class_Image, "border!", RUBY_METHOD_FUNC(Image_border_bang), 3);
+    rb_define_method(Class_Image, "change_geometry", RUBY_METHOD_FUNC(Image_change_geometry), 1);
+    rb_define_method(Class_Image, "change_geometry!", RUBY_METHOD_FUNC(Image_change_geometry), 1);
+    rb_define_method(Class_Image, "changed?", RUBY_METHOD_FUNC(Image_changed_q), 0);
+    rb_define_method(Class_Image, "channel", RUBY_METHOD_FUNC(Image_channel), 1);
     // An alias for compare_channel
-    rb_define_method(Class_Image, "channel_compare", Image_compare_channel, -1);
-    rb_define_method(Class_Image, "check_destroyed", Image_check_destroyed, 0);
-    rb_define_method(Class_Image, "compare_channel", Image_compare_channel, -1);
-    rb_define_method(Class_Image, "channel_depth", Image_channel_depth, -1);
-    rb_define_method(Class_Image, "channel_extrema", Image_channel_extrema, -1);
-    rb_define_method(Class_Image, "channel_mean", Image_channel_mean, -1);
-    rb_define_method(Class_Image, "channel_entropy", Image_channel_entropy, -1);
-    rb_define_method(Class_Image, "charcoal", Image_charcoal, -1);
-    rb_define_method(Class_Image, "chop", Image_chop, 4);
-    rb_define_method(Class_Image, "clut_channel", Image_clut_channel, -1);
-    rb_define_method(Class_Image, "clone", Image_clone, 0);
-    rb_define_method(Class_Image, "color_flood_fill", Image_color_flood_fill, 5);
-    rb_define_method(Class_Image, "color_histogram", Image_color_histogram, 0);
-    rb_define_method(Class_Image, "colorize", Image_colorize, -1);
-    rb_define_method(Class_Image, "colormap", Image_colormap, -1);
-    rb_define_method(Class_Image, "composite", Image_composite, -1);
-    rb_define_method(Class_Image, "composite!", Image_composite_bang, -1);
-    rb_define_method(Class_Image, "composite_affine", Image_composite_affine, 2);
-    rb_define_method(Class_Image, "composite_channel", Image_composite_channel, -1);
-    rb_define_method(Class_Image, "composite_channel!", Image_composite_channel_bang, -1);
-    rb_define_method(Class_Image, "composite_mathematics", Image_composite_mathematics, -1);
-    rb_define_method(Class_Image, "composite_tiled", Image_composite_tiled, -1);
-    rb_define_method(Class_Image, "composite_tiled!", Image_composite_tiled_bang, -1);
-    rb_define_method(Class_Image, "compress_colormap!", Image_compress_colormap_bang, 0);
-    rb_define_method(Class_Image, "contrast", Image_contrast, -1);
-    rb_define_method(Class_Image, "contrast_stretch_channel", Image_contrast_stretch_channel, -1);
-    rb_define_method(Class_Image, "convolve", Image_convolve, 2);
-    rb_define_method(Class_Image, "convolve_channel", Image_convolve_channel, -1);
-    rb_define_method(Class_Image, "morphology", Image_morphology, 3);
-    rb_define_method(Class_Image, "morphology_channel", Image_morphology_channel, 4);
-    rb_define_method(Class_Image, "copy", Image_copy, 0);
-    rb_define_method(Class_Image, "crop", Image_crop, -1);
-    rb_define_method(Class_Image, "crop!", Image_crop_bang, -1);
-    rb_define_method(Class_Image, "cycle_colormap", Image_cycle_colormap, 1);
-    rb_define_method(Class_Image, "decipher", Image_decipher, 1);
-    rb_define_method(Class_Image, "define", Image_define, 2);
-    rb_define_method(Class_Image, "deskew", Image_deskew, -1);
-    rb_define_method(Class_Image, "delete_compose_mask", Image_delete_compose_mask, 0);
-    rb_define_method(Class_Image, "delete_profile", Image_delete_profile, 1);
-    rb_define_method(Class_Image, "despeckle", Image_despeckle, 0);
-    rb_define_method(Class_Image, "destroy!", Image_destroy_bang, 0);
-    rb_define_method(Class_Image, "destroyed?", Image_destroyed_q, 0);
-    rb_define_method(Class_Image, "difference", Image_difference, 1);
-    rb_define_method(Class_Image, "dispatch", Image_dispatch, -1);
-    rb_define_method(Class_Image, "displace", Image_displace, -1);
-    rb_define_method(Class_Image, "display", Image_display, 0);
-    rb_define_method(Class_Image, "dissolve", Image_dissolve, -1);
-    rb_define_method(Class_Image, "distort", Image_distort, -1);
-    rb_define_method(Class_Image, "distortion_channel", Image_distortion_channel, -1);
-    rb_define_method(Class_Image, "_dump", Image__dump, 1);
-    rb_define_method(Class_Image, "dup", Image_dup, 0);
-    rb_define_method(Class_Image, "each_profile", Image_each_profile, 0);
-    rb_define_method(Class_Image, "edge", Image_edge, -1);
-    rb_define_method(Class_Image, "emboss", Image_emboss, -1);
-    rb_define_method(Class_Image, "encipher", Image_encipher, 1);
-    rb_define_method(Class_Image, "enhance", Image_enhance, 0);
-    rb_define_method(Class_Image, "equalize", Image_equalize, 0);
-    rb_define_method(Class_Image, "equalize_channel", Image_equalize_channel, -1);
-    rb_define_method(Class_Image, "erase!", Image_erase_bang, 0);
-    rb_define_method(Class_Image, "excerpt", Image_excerpt, 4);
-    rb_define_method(Class_Image, "excerpt!", Image_excerpt_bang, 4);
-    rb_define_method(Class_Image, "export_pixels", Image_export_pixels, -1);
-    rb_define_method(Class_Image, "export_pixels_to_str", Image_export_pixels_to_str, -1);
-    rb_define_method(Class_Image, "extent", Image_extent, -1);
-    rb_define_method(Class_Image, "find_similar_region", Image_find_similar_region, -1);
-    rb_define_method(Class_Image, "flip", Image_flip, 0);
-    rb_define_method(Class_Image, "flip!", Image_flip_bang, 0);
-    rb_define_method(Class_Image, "flop", Image_flop, 0);
-    rb_define_method(Class_Image, "flop!", Image_flop_bang, 0);
-    rb_define_method(Class_Image, "frame", Image_frame, -1);
-    rb_define_method(Class_Image, "function_channel", Image_function_channel, -1);
-    rb_define_method(Class_Image, "fx", Image_fx, -1);
-    rb_define_method(Class_Image, "gamma_channel", Image_gamma_channel, -1);
-    rb_define_method(Class_Image, "gamma_correct", Image_gamma_correct, -1);
-    rb_define_method(Class_Image, "gaussian_blur", Image_gaussian_blur, -1);
-    rb_define_method(Class_Image, "gaussian_blur_channel", Image_gaussian_blur_channel, -1);
-    rb_define_method(Class_Image, "get_pixels", Image_get_pixels, 4);
-    rb_define_method(Class_Image, "gray?", Image_gray_q, 0);
-    rb_define_method(Class_Image, "grey?", Image_gray_q, 0);
-    rb_define_method(Class_Image, "histogram?", Image_histogram_q, 0);
-    rb_define_method(Class_Image, "implode", Image_implode, -1);
-    rb_define_method(Class_Image, "import_pixels", Image_import_pixels, -1);
-    rb_define_method(Class_Image, "initialize_copy", Image_init_copy, 1);
-    rb_define_method(Class_Image, "inspect", Image_inspect, 0);
-    rb_define_method(Class_Image, "level2", Image_level2, -1);
-    rb_define_method(Class_Image, "level_channel", Image_level_channel, -1);
-    rb_define_method(Class_Image, "level_colors", Image_level_colors, -1);
-    rb_define_method(Class_Image, "levelize_channel", Image_levelize_channel, -1);
-    rb_define_method(Class_Image, "linear_stretch", Image_linear_stretch, -1);
-    rb_define_method(Class_Image, "liquid_rescale", Image_liquid_rescale, -1);
-    rb_define_method(Class_Image, "magnify", Image_magnify, 0);
-    rb_define_method(Class_Image, "magnify!", Image_magnify_bang, 0);
-    rb_define_method(Class_Image, "marshal_dump", Image_marshal_dump, 0);
-    rb_define_method(Class_Image, "marshal_load", Image_marshal_load, 1);
-    rb_define_method(Class_Image, "mask", Image_mask, -1);
-    rb_define_method(Class_Image, "matte_flood_fill", Image_matte_flood_fill, -1);
-    rb_define_method(Class_Image, "median_filter", Image_median_filter, -1);
-    rb_define_method(Class_Image, "minify", Image_minify, 0);
-    rb_define_method(Class_Image, "minify!", Image_minify_bang, 0);
-    rb_define_method(Class_Image, "modulate", Image_modulate, -1);
-    rb_define_method(Class_Image, "monochrome?", Image_monochrome_q, 0);
-    rb_define_method(Class_Image, "motion_blur", Image_motion_blur, -1);
-    rb_define_method(Class_Image, "negate", Image_negate, -1);
-    rb_define_method(Class_Image, "negate_channel", Image_negate_channel, -1);
-    rb_define_method(Class_Image, "normalize", Image_normalize, 0);
-    rb_define_method(Class_Image, "normalize_channel", Image_normalize_channel, -1);
-    rb_define_method(Class_Image, "oil_paint", Image_oil_paint, -1);
-    rb_define_method(Class_Image, "opaque", Image_opaque, 2);
-    rb_define_method(Class_Image, "opaque_channel", Image_opaque_channel, -1);
-    rb_define_method(Class_Image, "opaque?", Image_opaque_q, 0);
-    rb_define_method(Class_Image, "ordered_dither", Image_ordered_dither, -1);
-    rb_define_method(Class_Image, "paint_transparent", Image_paint_transparent, -1);
-    rb_define_method(Class_Image, "palette?", Image_palette_q, 0);
-    rb_define_method(Class_Image, "pixel_color", Image_pixel_color, -1);
-    rb_define_method(Class_Image, "polaroid", Image_polaroid, -1);
-    rb_define_method(Class_Image, "posterize", Image_posterize, -1);
-//  rb_define_method(Class_Image, "plasma", Image_plasma, 6);
-    rb_define_method(Class_Image, "preview", Image_preview, 1);
-    rb_define_method(Class_Image, "profile!", Image_profile_bang, 2);
-    rb_define_method(Class_Image, "quantize", Image_quantize, -1);
-    rb_define_method(Class_Image, "quantum_operator", Image_quantum_operator, -1);
-    rb_define_method(Class_Image, "radial_blur", Image_radial_blur, 1);
-    rb_define_method(Class_Image, "radial_blur_channel", Image_radial_blur_channel, -1);
-    rb_define_method(Class_Image, "raise", Image_raise, -1);
-    rb_define_method(Class_Image, "random_threshold_channel", Image_random_threshold_channel, -1);
-    rb_define_method(Class_Image, "recolor", Image_recolor, 1);
-    rb_define_method(Class_Image, "reduce_noise", Image_reduce_noise, 1);
-    rb_define_method(Class_Image, "resample", Image_resample, -1);
-    rb_define_method(Class_Image, "resample!", Image_resample_bang, -1);
-    rb_define_method(Class_Image, "resize", Image_resize, -1);
-    rb_define_method(Class_Image, "resize!", Image_resize_bang, -1);
-    rb_define_method(Class_Image, "roll", Image_roll, 2);
-    rb_define_method(Class_Image, "rotate", Image_rotate, -1);
-    rb_define_method(Class_Image, "rotate!", Image_rotate_bang, -1);
-    rb_define_method(Class_Image, "sample", Image_sample, -1);
-    rb_define_method(Class_Image, "sample!", Image_sample_bang, -1);
-    rb_define_method(Class_Image, "scale", Image_scale, -1);
-    rb_define_method(Class_Image, "scale!", Image_scale_bang, -1);
-    rb_define_method(Class_Image, "segment", Image_segment, -1);
-    rb_define_method(Class_Image, "selective_blur_channel", Image_selective_blur_channel, -1);
-    rb_define_method(Class_Image, "separate", Image_separate, -1);
-    rb_define_method(Class_Image, "sepiatone", Image_sepiatone, -1);
-    rb_define_method(Class_Image, "set_channel_depth", Image_set_channel_depth, 2);
-    rb_define_method(Class_Image, "shade", Image_shade, -1);
-    rb_define_method(Class_Image, "shadow", Image_shadow, -1);
-    rb_define_method(Class_Image, "sharpen", Image_sharpen, -1);
-    rb_define_method(Class_Image, "sharpen_channel", Image_sharpen_channel, -1);
-    rb_define_method(Class_Image, "shave", Image_shave, 2);
-    rb_define_method(Class_Image, "shave!", Image_shave_bang, 2);
-    rb_define_method(Class_Image, "shear", Image_shear, 2);
-    rb_define_method(Class_Image, "sigmoidal_contrast_channel", Image_sigmoidal_contrast_channel, -1);
-    rb_define_method(Class_Image, "signature", Image_signature, 0);
-    rb_define_method(Class_Image, "sketch", Image_sketch, -1);
-    rb_define_method(Class_Image, "solarize", Image_solarize, -1);
-    rb_define_method(Class_Image, "<=>", Image_spaceship, 1);
-    rb_define_method(Class_Image, "sparse_color", Image_sparse_color, -1);
-    rb_define_method(Class_Image, "splice", Image_splice, -1);
-    rb_define_method(Class_Image, "spread", Image_spread, -1);
-    rb_define_method(Class_Image, "stegano", Image_stegano, 2);
-    rb_define_method(Class_Image, "stereo", Image_stereo, 1);
-    rb_define_method(Class_Image, "strip!", Image_strip_bang, 0);
-    rb_define_method(Class_Image, "store_pixels", Image_store_pixels, 5);
-    rb_define_method(Class_Image, "swirl", Image_swirl, 1);
-    rb_define_method(Class_Image, "texture_flood_fill", Image_texture_flood_fill, 5);
-    rb_define_method(Class_Image, "threshold", Image_threshold, 1);
-    rb_define_method(Class_Image, "thumbnail", Image_thumbnail, -1);
-    rb_define_method(Class_Image, "thumbnail!", Image_thumbnail_bang, -1);
-    rb_define_method(Class_Image, "tint", Image_tint, -1);
-    rb_define_method(Class_Image, "to_color", Image_to_color, 1);
-    rb_define_method(Class_Image, "to_blob", Image_to_blob, 0);
-    rb_define_method(Class_Image, "transparent", Image_transparent, -1);
-    rb_define_method(Class_Image, "transparent_chroma", Image_transparent_chroma, -1);
-    rb_define_method(Class_Image, "transpose", Image_transpose, 0);
-    rb_define_method(Class_Image, "transpose!", Image_transpose_bang, 0);
-    rb_define_method(Class_Image, "transverse", Image_transverse, 0);
-    rb_define_method(Class_Image, "transverse!", Image_transverse_bang, 0);
-    rb_define_method(Class_Image, "trim", Image_trim, -1);
-    rb_define_method(Class_Image, "trim!", Image_trim_bang, -1);
-    rb_define_method(Class_Image, "undefine", Image_undefine, 1);
-    rb_define_method(Class_Image, "unique_colors", Image_unique_colors, 0);
-    rb_define_method(Class_Image, "unsharp_mask", Image_unsharp_mask, -1);
-    rb_define_method(Class_Image, "unsharp_mask_channel", Image_unsharp_mask_channel, -1);
-    rb_define_method(Class_Image, "vignette", Image_vignette, -1);
-    rb_define_method(Class_Image, "watermark", Image_watermark, -1);
-    rb_define_method(Class_Image, "wave", Image_wave, -1);
-    rb_define_method(Class_Image, "wet_floor", Image_wet_floor, -1);
-    rb_define_method(Class_Image, "white_threshold", Image_white_threshold, -1);
-    rb_define_method(Class_Image, "write", Image_write, 1);
+    rb_define_method(Class_Image, "channel_compare", RUBY_METHOD_FUNC(Image_compare_channel), -1);
+    rb_define_method(Class_Image, "check_destroyed", RUBY_METHOD_FUNC(Image_check_destroyed), 0);
+    rb_define_method(Class_Image, "compare_channel", RUBY_METHOD_FUNC(Image_compare_channel), -1);
+    rb_define_method(Class_Image, "channel_depth", RUBY_METHOD_FUNC(Image_channel_depth), -1);
+    rb_define_method(Class_Image, "channel_extrema", RUBY_METHOD_FUNC(Image_channel_extrema), -1);
+    rb_define_method(Class_Image, "channel_mean", RUBY_METHOD_FUNC(Image_channel_mean), -1);
+    rb_define_method(Class_Image, "channel_entropy", RUBY_METHOD_FUNC(Image_channel_entropy), -1);
+    rb_define_method(Class_Image, "charcoal", RUBY_METHOD_FUNC(Image_charcoal), -1);
+    rb_define_method(Class_Image, "chop", RUBY_METHOD_FUNC(Image_chop), 4);
+    rb_define_method(Class_Image, "clut_channel", RUBY_METHOD_FUNC(Image_clut_channel), -1);
+    rb_define_method(Class_Image, "clone", RUBY_METHOD_FUNC(Image_clone), 0);
+    rb_define_method(Class_Image, "color_flood_fill", RUBY_METHOD_FUNC(Image_color_flood_fill), 5);
+    rb_define_method(Class_Image, "color_histogram", RUBY_METHOD_FUNC(Image_color_histogram), 0);
+    rb_define_method(Class_Image, "colorize", RUBY_METHOD_FUNC(Image_colorize), -1);
+    rb_define_method(Class_Image, "colormap", RUBY_METHOD_FUNC(Image_colormap), -1);
+    rb_define_method(Class_Image, "composite", RUBY_METHOD_FUNC(Image_composite), -1);
+    rb_define_method(Class_Image, "composite!", RUBY_METHOD_FUNC(Image_composite_bang), -1);
+    rb_define_method(Class_Image, "composite_affine", RUBY_METHOD_FUNC(Image_composite_affine), 2);
+    rb_define_method(Class_Image, "composite_channel", RUBY_METHOD_FUNC(Image_composite_channel), -1);
+    rb_define_method(Class_Image, "composite_channel!", RUBY_METHOD_FUNC(Image_composite_channel_bang), -1);
+    rb_define_method(Class_Image, "composite_mathematics", RUBY_METHOD_FUNC(Image_composite_mathematics), -1);
+    rb_define_method(Class_Image, "composite_tiled", RUBY_METHOD_FUNC(Image_composite_tiled), -1);
+    rb_define_method(Class_Image, "composite_tiled!", RUBY_METHOD_FUNC(Image_composite_tiled_bang), -1);
+    rb_define_method(Class_Image, "compress_colormap!", RUBY_METHOD_FUNC(Image_compress_colormap_bang), 0);
+    rb_define_method(Class_Image, "contrast", RUBY_METHOD_FUNC(Image_contrast), -1);
+    rb_define_method(Class_Image, "contrast_stretch_channel", RUBY_METHOD_FUNC(Image_contrast_stretch_channel), -1);
+    rb_define_method(Class_Image, "convolve", RUBY_METHOD_FUNC(Image_convolve), 2);
+    rb_define_method(Class_Image, "convolve_channel", RUBY_METHOD_FUNC(Image_convolve_channel), -1);
+    rb_define_method(Class_Image, "morphology", RUBY_METHOD_FUNC(Image_morphology), 3);
+    rb_define_method(Class_Image, "morphology_channel", RUBY_METHOD_FUNC(Image_morphology_channel), 4);
+    rb_define_method(Class_Image, "copy", RUBY_METHOD_FUNC(Image_copy), 0);
+    rb_define_method(Class_Image, "crop", RUBY_METHOD_FUNC(Image_crop), -1);
+    rb_define_method(Class_Image, "crop!", RUBY_METHOD_FUNC(Image_crop_bang), -1);
+    rb_define_method(Class_Image, "cycle_colormap", RUBY_METHOD_FUNC(Image_cycle_colormap), 1);
+    rb_define_method(Class_Image, "decipher", RUBY_METHOD_FUNC(Image_decipher), 1);
+    rb_define_method(Class_Image, "define", RUBY_METHOD_FUNC(Image_define), 2);
+    rb_define_method(Class_Image, "deskew", RUBY_METHOD_FUNC(Image_deskew), -1);
+    rb_define_method(Class_Image, "delete_compose_mask", RUBY_METHOD_FUNC(Image_delete_compose_mask), 0);
+    rb_define_method(Class_Image, "delete_profile", RUBY_METHOD_FUNC(Image_delete_profile), 1);
+    rb_define_method(Class_Image, "despeckle", RUBY_METHOD_FUNC(Image_despeckle), 0);
+    rb_define_method(Class_Image, "destroy!", RUBY_METHOD_FUNC(Image_destroy_bang), 0);
+    rb_define_method(Class_Image, "destroyed?", RUBY_METHOD_FUNC(Image_destroyed_q), 0);
+    rb_define_method(Class_Image, "difference", RUBY_METHOD_FUNC(Image_difference), 1);
+    rb_define_method(Class_Image, "dispatch", RUBY_METHOD_FUNC(Image_dispatch), -1);
+    rb_define_method(Class_Image, "displace", RUBY_METHOD_FUNC(Image_displace), -1);
+    rb_define_method(Class_Image, "display", RUBY_METHOD_FUNC(Image_display), 0);
+    rb_define_method(Class_Image, "dissolve", RUBY_METHOD_FUNC(Image_dissolve), -1);
+    rb_define_method(Class_Image, "distort", RUBY_METHOD_FUNC(Image_distort), -1);
+    rb_define_method(Class_Image, "distortion_channel", RUBY_METHOD_FUNC(Image_distortion_channel), -1);
+    rb_define_method(Class_Image, "_dump", RUBY_METHOD_FUNC(Image__dump), 1);
+    rb_define_method(Class_Image, "dup", RUBY_METHOD_FUNC(Image_dup), 0);
+    rb_define_method(Class_Image, "each_profile", RUBY_METHOD_FUNC(Image_each_profile), 0);
+    rb_define_method(Class_Image, "edge", RUBY_METHOD_FUNC(Image_edge), -1);
+    rb_define_method(Class_Image, "emboss", RUBY_METHOD_FUNC(Image_emboss), -1);
+    rb_define_method(Class_Image, "encipher", RUBY_METHOD_FUNC(Image_encipher), 1);
+    rb_define_method(Class_Image, "enhance", RUBY_METHOD_FUNC(Image_enhance), 0);
+    rb_define_method(Class_Image, "equalize", RUBY_METHOD_FUNC(Image_equalize), 0);
+    rb_define_method(Class_Image, "equalize_channel", RUBY_METHOD_FUNC(Image_equalize_channel), -1);
+    rb_define_method(Class_Image, "erase!", RUBY_METHOD_FUNC(Image_erase_bang), 0);
+    rb_define_method(Class_Image, "excerpt", RUBY_METHOD_FUNC(Image_excerpt), 4);
+    rb_define_method(Class_Image, "excerpt!", RUBY_METHOD_FUNC(Image_excerpt_bang), 4);
+    rb_define_method(Class_Image, "export_pixels", RUBY_METHOD_FUNC(Image_export_pixels), -1);
+    rb_define_method(Class_Image, "export_pixels_to_str", RUBY_METHOD_FUNC(Image_export_pixels_to_str), -1);
+    rb_define_method(Class_Image, "extent", RUBY_METHOD_FUNC(Image_extent), -1);
+    rb_define_method(Class_Image, "find_similar_region", RUBY_METHOD_FUNC(Image_find_similar_region), -1);
+    rb_define_method(Class_Image, "flip", RUBY_METHOD_FUNC(Image_flip), 0);
+    rb_define_method(Class_Image, "flip!", RUBY_METHOD_FUNC(Image_flip_bang), 0);
+    rb_define_method(Class_Image, "flop", RUBY_METHOD_FUNC(Image_flop), 0);
+    rb_define_method(Class_Image, "flop!", RUBY_METHOD_FUNC(Image_flop_bang), 0);
+    rb_define_method(Class_Image, "frame", RUBY_METHOD_FUNC(Image_frame), -1);
+    rb_define_method(Class_Image, "function_channel", RUBY_METHOD_FUNC(Image_function_channel), -1);
+    rb_define_method(Class_Image, "fx", RUBY_METHOD_FUNC(Image_fx), -1);
+    rb_define_method(Class_Image, "gamma_channel", RUBY_METHOD_FUNC(Image_gamma_channel), -1);
+    rb_define_method(Class_Image, "gamma_correct", RUBY_METHOD_FUNC(Image_gamma_correct), -1);
+    rb_define_method(Class_Image, "gaussian_blur", RUBY_METHOD_FUNC(Image_gaussian_blur), -1);
+    rb_define_method(Class_Image, "gaussian_blur_channel", RUBY_METHOD_FUNC(Image_gaussian_blur_channel), -1);
+    rb_define_method(Class_Image, "get_pixels", RUBY_METHOD_FUNC(Image_get_pixels), 4);
+    rb_define_method(Class_Image, "gray?", RUBY_METHOD_FUNC(Image_gray_q), 0);
+    rb_define_method(Class_Image, "grey?", RUBY_METHOD_FUNC(Image_gray_q), 0);
+    rb_define_method(Class_Image, "histogram?", RUBY_METHOD_FUNC(Image_histogram_q), 0);
+    rb_define_method(Class_Image, "implode", RUBY_METHOD_FUNC(Image_implode), -1);
+    rb_define_method(Class_Image, "import_pixels", RUBY_METHOD_FUNC(Image_import_pixels), -1);
+    rb_define_method(Class_Image, "initialize_copy", RUBY_METHOD_FUNC(Image_init_copy), 1);
+    rb_define_method(Class_Image, "inspect", RUBY_METHOD_FUNC(Image_inspect), 0);
+    rb_define_method(Class_Image, "level2", RUBY_METHOD_FUNC(Image_level2), -1);
+    rb_define_method(Class_Image, "level_channel", RUBY_METHOD_FUNC(Image_level_channel), -1);
+    rb_define_method(Class_Image, "level_colors", RUBY_METHOD_FUNC(Image_level_colors), -1);
+    rb_define_method(Class_Image, "levelize_channel", RUBY_METHOD_FUNC(Image_levelize_channel), -1);
+    rb_define_method(Class_Image, "linear_stretch", RUBY_METHOD_FUNC(Image_linear_stretch), -1);
+    rb_define_method(Class_Image, "liquid_rescale", RUBY_METHOD_FUNC(Image_liquid_rescale), -1);
+    rb_define_method(Class_Image, "magnify", RUBY_METHOD_FUNC(Image_magnify), 0);
+    rb_define_method(Class_Image, "magnify!", RUBY_METHOD_FUNC(Image_magnify_bang), 0);
+    rb_define_method(Class_Image, "marshal_dump", RUBY_METHOD_FUNC(Image_marshal_dump), 0);
+    rb_define_method(Class_Image, "marshal_load", RUBY_METHOD_FUNC(Image_marshal_load), 1);
+    rb_define_method(Class_Image, "mask", RUBY_METHOD_FUNC(Image_mask), -1);
+    rb_define_method(Class_Image, "matte_flood_fill", RUBY_METHOD_FUNC(Image_matte_flood_fill), -1);
+    rb_define_method(Class_Image, "median_filter", RUBY_METHOD_FUNC(Image_median_filter), -1);
+    rb_define_method(Class_Image, "minify", RUBY_METHOD_FUNC(Image_minify), 0);
+    rb_define_method(Class_Image, "minify!", RUBY_METHOD_FUNC(Image_minify_bang), 0);
+    rb_define_method(Class_Image, "modulate", RUBY_METHOD_FUNC(Image_modulate), -1);
+    rb_define_method(Class_Image, "monochrome?", RUBY_METHOD_FUNC(Image_monochrome_q), 0);
+    rb_define_method(Class_Image, "motion_blur", RUBY_METHOD_FUNC(Image_motion_blur), -1);
+    rb_define_method(Class_Image, "negate", RUBY_METHOD_FUNC(Image_negate), -1);
+    rb_define_method(Class_Image, "negate_channel", RUBY_METHOD_FUNC(Image_negate_channel), -1);
+    rb_define_method(Class_Image, "normalize", RUBY_METHOD_FUNC(Image_normalize), 0);
+    rb_define_method(Class_Image, "normalize_channel", RUBY_METHOD_FUNC(Image_normalize_channel), -1);
+    rb_define_method(Class_Image, "oil_paint", RUBY_METHOD_FUNC(Image_oil_paint), -1);
+    rb_define_method(Class_Image, "opaque", RUBY_METHOD_FUNC(Image_opaque), 2);
+    rb_define_method(Class_Image, "opaque_channel", RUBY_METHOD_FUNC(Image_opaque_channel), -1);
+    rb_define_method(Class_Image, "opaque?", RUBY_METHOD_FUNC(Image_opaque_q), 0);
+    rb_define_method(Class_Image, "ordered_dither", RUBY_METHOD_FUNC(Image_ordered_dither), -1);
+    rb_define_method(Class_Image, "paint_transparent", RUBY_METHOD_FUNC(Image_paint_transparent), -1);
+    rb_define_method(Class_Image, "palette?", RUBY_METHOD_FUNC(Image_palette_q), 0);
+    rb_define_method(Class_Image, "pixel_color", RUBY_METHOD_FUNC(Image_pixel_color), -1);
+    rb_define_method(Class_Image, "polaroid", RUBY_METHOD_FUNC(Image_polaroid), -1);
+    rb_define_method(Class_Image, "posterize", RUBY_METHOD_FUNC(Image_posterize), -1);
+//  rb_define_method(Class_Image, "plasma", RUBY_METHOD_FUNC(Image_plasma), 6);
+    rb_define_method(Class_Image, "preview", RUBY_METHOD_FUNC(Image_preview), 1);
+    rb_define_method(Class_Image, "profile!", RUBY_METHOD_FUNC(Image_profile_bang), 2);
+    rb_define_method(Class_Image, "quantize", RUBY_METHOD_FUNC(Image_quantize), -1);
+    rb_define_method(Class_Image, "quantum_operator", RUBY_METHOD_FUNC(Image_quantum_operator), -1);
+    rb_define_method(Class_Image, "radial_blur", RUBY_METHOD_FUNC(Image_radial_blur), 1);
+    rb_define_method(Class_Image, "radial_blur_channel", RUBY_METHOD_FUNC(Image_radial_blur_channel), -1);
+    rb_define_method(Class_Image, "raise", RUBY_METHOD_FUNC(Image_raise), -1);
+    rb_define_method(Class_Image, "random_threshold_channel", RUBY_METHOD_FUNC(Image_random_threshold_channel), -1);
+    rb_define_method(Class_Image, "recolor", RUBY_METHOD_FUNC(Image_recolor), 1);
+    rb_define_method(Class_Image, "reduce_noise", RUBY_METHOD_FUNC(Image_reduce_noise), 1);
+    rb_define_method(Class_Image, "resample", RUBY_METHOD_FUNC(Image_resample), -1);
+    rb_define_method(Class_Image, "resample!", RUBY_METHOD_FUNC(Image_resample_bang), -1);
+    rb_define_method(Class_Image, "resize", RUBY_METHOD_FUNC(Image_resize), -1);
+    rb_define_method(Class_Image, "resize!", RUBY_METHOD_FUNC(Image_resize_bang), -1);
+    rb_define_method(Class_Image, "roll", RUBY_METHOD_FUNC(Image_roll), 2);
+    rb_define_method(Class_Image, "rotate", RUBY_METHOD_FUNC(Image_rotate), -1);
+    rb_define_method(Class_Image, "rotate!", RUBY_METHOD_FUNC(Image_rotate_bang), -1);
+    rb_define_method(Class_Image, "sample", RUBY_METHOD_FUNC(Image_sample), -1);
+    rb_define_method(Class_Image, "sample!", RUBY_METHOD_FUNC(Image_sample_bang), -1);
+    rb_define_method(Class_Image, "scale", RUBY_METHOD_FUNC(Image_scale), -1);
+    rb_define_method(Class_Image, "scale!", RUBY_METHOD_FUNC(Image_scale_bang), -1);
+    rb_define_method(Class_Image, "segment", RUBY_METHOD_FUNC(Image_segment), -1);
+    rb_define_method(Class_Image, "selective_blur_channel", RUBY_METHOD_FUNC(Image_selective_blur_channel), -1);
+    rb_define_method(Class_Image, "separate", RUBY_METHOD_FUNC(Image_separate), -1);
+    rb_define_method(Class_Image, "sepiatone", RUBY_METHOD_FUNC(Image_sepiatone), -1);
+    rb_define_method(Class_Image, "set_channel_depth", RUBY_METHOD_FUNC(Image_set_channel_depth), 2);
+    rb_define_method(Class_Image, "shade", RUBY_METHOD_FUNC(Image_shade), -1);
+    rb_define_method(Class_Image, "shadow", RUBY_METHOD_FUNC(Image_shadow), -1);
+    rb_define_method(Class_Image, "sharpen", RUBY_METHOD_FUNC(Image_sharpen), -1);
+    rb_define_method(Class_Image, "sharpen_channel", RUBY_METHOD_FUNC(Image_sharpen_channel), -1);
+    rb_define_method(Class_Image, "shave", RUBY_METHOD_FUNC(Image_shave), 2);
+    rb_define_method(Class_Image, "shave!", RUBY_METHOD_FUNC(Image_shave_bang), 2);
+    rb_define_method(Class_Image, "shear", RUBY_METHOD_FUNC(Image_shear), 2);
+    rb_define_method(Class_Image, "sigmoidal_contrast_channel", RUBY_METHOD_FUNC(Image_sigmoidal_contrast_channel), -1);
+    rb_define_method(Class_Image, "signature", RUBY_METHOD_FUNC(Image_signature), 0);
+    rb_define_method(Class_Image, "sketch", RUBY_METHOD_FUNC(Image_sketch), -1);
+    rb_define_method(Class_Image, "solarize", RUBY_METHOD_FUNC(Image_solarize), -1);
+    rb_define_method(Class_Image, "<=>", RUBY_METHOD_FUNC(Image_spaceship), 1);
+    rb_define_method(Class_Image, "sparse_color", RUBY_METHOD_FUNC(Image_sparse_color), -1);
+    rb_define_method(Class_Image, "splice", RUBY_METHOD_FUNC(Image_splice), -1);
+    rb_define_method(Class_Image, "spread", RUBY_METHOD_FUNC(Image_spread), -1);
+    rb_define_method(Class_Image, "stegano", RUBY_METHOD_FUNC(Image_stegano), 2);
+    rb_define_method(Class_Image, "stereo", RUBY_METHOD_FUNC(Image_stereo), 1);
+    rb_define_method(Class_Image, "strip!", RUBY_METHOD_FUNC(Image_strip_bang), 0);
+    rb_define_method(Class_Image, "store_pixels", RUBY_METHOD_FUNC(Image_store_pixels), 5);
+    rb_define_method(Class_Image, "swirl", RUBY_METHOD_FUNC(Image_swirl), 1);
+    rb_define_method(Class_Image, "texture_flood_fill", RUBY_METHOD_FUNC(Image_texture_flood_fill), 5);
+    rb_define_method(Class_Image, "threshold", RUBY_METHOD_FUNC(Image_threshold), 1);
+    rb_define_method(Class_Image, "thumbnail", RUBY_METHOD_FUNC(Image_thumbnail), -1);
+    rb_define_method(Class_Image, "thumbnail!", RUBY_METHOD_FUNC(Image_thumbnail_bang), -1);
+    rb_define_method(Class_Image, "tint", RUBY_METHOD_FUNC(Image_tint), -1);
+    rb_define_method(Class_Image, "to_color", RUBY_METHOD_FUNC(Image_to_color), 1);
+    rb_define_method(Class_Image, "to_blob", RUBY_METHOD_FUNC(Image_to_blob), 0);
+    rb_define_method(Class_Image, "transparent", RUBY_METHOD_FUNC(Image_transparent), -1);
+    rb_define_method(Class_Image, "transparent_chroma", RUBY_METHOD_FUNC(Image_transparent_chroma), -1);
+    rb_define_method(Class_Image, "transpose", RUBY_METHOD_FUNC(Image_transpose), 0);
+    rb_define_method(Class_Image, "transpose!", RUBY_METHOD_FUNC(Image_transpose_bang), 0);
+    rb_define_method(Class_Image, "transverse", RUBY_METHOD_FUNC(Image_transverse), 0);
+    rb_define_method(Class_Image, "transverse!", RUBY_METHOD_FUNC(Image_transverse_bang), 0);
+    rb_define_method(Class_Image, "trim", RUBY_METHOD_FUNC(Image_trim), -1);
+    rb_define_method(Class_Image, "trim!", RUBY_METHOD_FUNC(Image_trim_bang), -1);
+    rb_define_method(Class_Image, "undefine", RUBY_METHOD_FUNC(Image_undefine), 1);
+    rb_define_method(Class_Image, "unique_colors", RUBY_METHOD_FUNC(Image_unique_colors), 0);
+    rb_define_method(Class_Image, "unsharp_mask", RUBY_METHOD_FUNC(Image_unsharp_mask), -1);
+    rb_define_method(Class_Image, "unsharp_mask_channel", RUBY_METHOD_FUNC(Image_unsharp_mask_channel), -1);
+    rb_define_method(Class_Image, "vignette", RUBY_METHOD_FUNC(Image_vignette), -1);
+    rb_define_method(Class_Image, "watermark", RUBY_METHOD_FUNC(Image_watermark), -1);
+    rb_define_method(Class_Image, "wave", RUBY_METHOD_FUNC(Image_wave), -1);
+    rb_define_method(Class_Image, "wet_floor", RUBY_METHOD_FUNC(Image_wet_floor), -1);
+    rb_define_method(Class_Image, "white_threshold", RUBY_METHOD_FUNC(Image_white_threshold), -1);
+    rb_define_method(Class_Image, "write", RUBY_METHOD_FUNC(Image_write), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::ImageList methods                                       */
@@ -627,23 +627,23 @@ Init_RMagick2(void)
 
     // Define an alias for Object#display before we override it
     rb_define_alias(Class_ImageList, "__display__", "display");
-    rb_define_method(Class_ImageList, "remap", ImageList_remap, -1);
-    rb_define_method(Class_ImageList, "animate", ImageList_animate, -1);
-    rb_define_method(Class_ImageList, "append", ImageList_append, 1);
-    rb_define_method(Class_ImageList, "average", ImageList_average, 0);
-    rb_define_method(Class_ImageList, "coalesce", ImageList_coalesce, 0);
-    rb_define_method(Class_ImageList, "combine", ImageList_combine, -1);
-    rb_define_method(Class_ImageList, "composite_layers", ImageList_composite_layers, -1);
-    rb_define_method(Class_ImageList, "deconstruct", ImageList_deconstruct, 0);
-    rb_define_method(Class_ImageList, "display", ImageList_display, 0);
-    rb_define_method(Class_ImageList, "flatten_images", ImageList_flatten_images, 0);
-    rb_define_method(Class_ImageList, "montage", ImageList_montage, 0);
-    rb_define_method(Class_ImageList, "morph", ImageList_morph, 1);
-    rb_define_method(Class_ImageList, "mosaic", ImageList_mosaic, 0);
-    rb_define_method(Class_ImageList, "optimize_layers", ImageList_optimize_layers, 1);
-    rb_define_method(Class_ImageList, "quantize", ImageList_quantize, -1);
-    rb_define_method(Class_ImageList, "to_blob", ImageList_to_blob, 0);
-    rb_define_method(Class_ImageList, "write", ImageList_write, 1);
+    rb_define_method(Class_ImageList, "remap", RUBY_METHOD_FUNC(ImageList_remap), -1);
+    rb_define_method(Class_ImageList, "animate", RUBY_METHOD_FUNC(ImageList_animate), -1);
+    rb_define_method(Class_ImageList, "append", RUBY_METHOD_FUNC(ImageList_append), 1);
+    rb_define_method(Class_ImageList, "average", RUBY_METHOD_FUNC(ImageList_average), 0);
+    rb_define_method(Class_ImageList, "coalesce", RUBY_METHOD_FUNC(ImageList_coalesce), 0);
+    rb_define_method(Class_ImageList, "combine", RUBY_METHOD_FUNC(ImageList_combine), -1);
+    rb_define_method(Class_ImageList, "composite_layers", RUBY_METHOD_FUNC(ImageList_composite_layers), -1);
+    rb_define_method(Class_ImageList, "deconstruct", RUBY_METHOD_FUNC(ImageList_deconstruct), 0);
+    rb_define_method(Class_ImageList, "display", RUBY_METHOD_FUNC(ImageList_display), 0);
+    rb_define_method(Class_ImageList, "flatten_images", RUBY_METHOD_FUNC(ImageList_flatten_images), 0);
+    rb_define_method(Class_ImageList, "montage", RUBY_METHOD_FUNC(ImageList_montage), 0);
+    rb_define_method(Class_ImageList, "morph", RUBY_METHOD_FUNC(ImageList_morph), 1);
+    rb_define_method(Class_ImageList, "mosaic", RUBY_METHOD_FUNC(ImageList_mosaic), 0);
+    rb_define_method(Class_ImageList, "optimize_layers", RUBY_METHOD_FUNC(ImageList_optimize_layers), 1);
+    rb_define_method(Class_ImageList, "quantize", RUBY_METHOD_FUNC(ImageList_quantize), -1);
+    rb_define_method(Class_ImageList, "to_blob", RUBY_METHOD_FUNC(ImageList_to_blob), 0);
+    rb_define_method(Class_ImageList, "write", RUBY_METHOD_FUNC(ImageList_write), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::Draw methods                                            */
@@ -653,44 +653,44 @@ Init_RMagick2(void)
     rb_define_alloc_func(Class_Draw, Draw_alloc);
 
     // Define the attributes
-    rb_define_method(Class_Draw, "affine=", Draw_affine_eq, 1);
-    rb_define_method(Class_Draw, "align=", Draw_align_eq, 1);
-    rb_define_method(Class_Draw, "decorate=", Draw_decorate_eq, 1);
-    rb_define_method(Class_Draw, "density=", Draw_density_eq, 1);
-    rb_define_method(Class_Draw, "encoding=", Draw_encoding_eq, 1);
-    rb_define_method(Class_Draw, "fill=", Draw_fill_eq, 1);
-    rb_define_method(Class_Draw, "fill_pattern=", Draw_fill_pattern_eq, 1);
-    rb_define_method(Class_Draw, "font=", Draw_font_eq, 1);
-    rb_define_method(Class_Draw, "font_family=", Draw_font_family_eq, 1);
-    rb_define_method(Class_Draw, "font_stretch=", Draw_font_stretch_eq, 1);
-    rb_define_method(Class_Draw, "font_style=", Draw_font_style_eq, 1);
-    rb_define_method(Class_Draw, "font_weight=", Draw_font_weight_eq, 1);
-    rb_define_method(Class_Draw, "gravity=", Draw_gravity_eq, 1);
-    rb_define_method(Class_Draw, "interline_spacing=", Draw_interline_spacing_eq, 1);
-    rb_define_method(Class_Draw, "interword_spacing=", Draw_interword_spacing_eq, 1);
-    rb_define_method(Class_Draw, "kerning=", Draw_kerning_eq, 1);
-    rb_define_method(Class_Draw, "pointsize=", Draw_pointsize_eq, 1);
-    rb_define_method(Class_Draw, "rotation=", Draw_rotation_eq, 1);
-    rb_define_method(Class_Draw, "stroke=", Draw_stroke_eq, 1);
-    rb_define_method(Class_Draw, "stroke_pattern=", Draw_stroke_pattern_eq, 1);
-    rb_define_method(Class_Draw, "stroke_width=", Draw_stroke_width_eq, 1);
-    rb_define_method(Class_Draw, "text_antialias=", Draw_text_antialias_eq, 1);
-    rb_define_method(Class_Draw, "tile=", Draw_tile_eq, 1);
-    rb_define_method(Class_Draw, "undercolor=", Draw_undercolor_eq, 1);
+    rb_define_method(Class_Draw, "affine=", RUBY_METHOD_FUNC(Draw_affine_eq), 1);
+    rb_define_method(Class_Draw, "align=", RUBY_METHOD_FUNC(Draw_align_eq), 1);
+    rb_define_method(Class_Draw, "decorate=", RUBY_METHOD_FUNC(Draw_decorate_eq), 1);
+    rb_define_method(Class_Draw, "density=", RUBY_METHOD_FUNC(Draw_density_eq), 1);
+    rb_define_method(Class_Draw, "encoding=", RUBY_METHOD_FUNC(Draw_encoding_eq), 1);
+    rb_define_method(Class_Draw, "fill=", RUBY_METHOD_FUNC(Draw_fill_eq), 1);
+    rb_define_method(Class_Draw, "fill_pattern=", RUBY_METHOD_FUNC(Draw_fill_pattern_eq), 1);
+    rb_define_method(Class_Draw, "font=", RUBY_METHOD_FUNC(Draw_font_eq), 1);
+    rb_define_method(Class_Draw, "font_family=", RUBY_METHOD_FUNC(Draw_font_family_eq), 1);
+    rb_define_method(Class_Draw, "font_stretch=", RUBY_METHOD_FUNC(Draw_font_stretch_eq), 1);
+    rb_define_method(Class_Draw, "font_style=", RUBY_METHOD_FUNC(Draw_font_style_eq), 1);
+    rb_define_method(Class_Draw, "font_weight=", RUBY_METHOD_FUNC(Draw_font_weight_eq), 1);
+    rb_define_method(Class_Draw, "gravity=", RUBY_METHOD_FUNC(Draw_gravity_eq), 1);
+    rb_define_method(Class_Draw, "interline_spacing=", RUBY_METHOD_FUNC(Draw_interline_spacing_eq), 1);
+    rb_define_method(Class_Draw, "interword_spacing=", RUBY_METHOD_FUNC(Draw_interword_spacing_eq), 1);
+    rb_define_method(Class_Draw, "kerning=", RUBY_METHOD_FUNC(Draw_kerning_eq), 1);
+    rb_define_method(Class_Draw, "pointsize=", RUBY_METHOD_FUNC(Draw_pointsize_eq), 1);
+    rb_define_method(Class_Draw, "rotation=", RUBY_METHOD_FUNC(Draw_rotation_eq), 1);
+    rb_define_method(Class_Draw, "stroke=", RUBY_METHOD_FUNC(Draw_stroke_eq), 1);
+    rb_define_method(Class_Draw, "stroke_pattern=", RUBY_METHOD_FUNC(Draw_stroke_pattern_eq), 1);
+    rb_define_method(Class_Draw, "stroke_width=", RUBY_METHOD_FUNC(Draw_stroke_width_eq), 1);
+    rb_define_method(Class_Draw, "text_antialias=", RUBY_METHOD_FUNC(Draw_text_antialias_eq), 1);
+    rb_define_method(Class_Draw, "tile=", RUBY_METHOD_FUNC(Draw_tile_eq), 1);
+    rb_define_method(Class_Draw, "undercolor=", RUBY_METHOD_FUNC(Draw_undercolor_eq), 1);
 
-    rb_define_method(Class_Draw, "annotate", Draw_annotate, 6);
-    rb_define_method(Class_Draw, "clone", Draw_clone, 0);
-    rb_define_method(Class_Draw, "composite", Draw_composite, -1);
-    rb_define_method(Class_Draw, "draw", Draw_draw, 1);
-    rb_define_method(Class_Draw, "dup", Draw_dup, 0);
-    rb_define_method(Class_Draw, "get_type_metrics", Draw_get_type_metrics, -1);
-    rb_define_method(Class_Draw, "get_multiline_type_metrics", Draw_get_multiline_type_metrics, -1);
-    rb_define_method(Class_Draw, "initialize", Draw_initialize, 0);
-    rb_define_method(Class_Draw, "initialize_copy", Draw_init_copy, 1);
-    rb_define_method(Class_Draw, "inspect", Draw_inspect, 0);
-    rb_define_method(Class_Draw, "marshal_dump", Draw_marshal_dump, 0);
-    rb_define_method(Class_Draw, "marshal_load", Draw_marshal_load, 1);
-    rb_define_method(Class_Draw, "primitive", Draw_primitive, 1);
+    rb_define_method(Class_Draw, "annotate", RUBY_METHOD_FUNC(Draw_annotate), 6);
+    rb_define_method(Class_Draw, "clone", RUBY_METHOD_FUNC(Draw_clone), 0);
+    rb_define_method(Class_Draw, "composite", RUBY_METHOD_FUNC(Draw_composite), -1);
+    rb_define_method(Class_Draw, "draw", RUBY_METHOD_FUNC(Draw_draw), 1);
+    rb_define_method(Class_Draw, "dup", RUBY_METHOD_FUNC(Draw_dup), 0);
+    rb_define_method(Class_Draw, "get_type_metrics", RUBY_METHOD_FUNC(Draw_get_type_metrics), -1);
+    rb_define_method(Class_Draw, "get_multiline_type_metrics", RUBY_METHOD_FUNC(Draw_get_multiline_type_metrics), -1);
+    rb_define_method(Class_Draw, "initialize", RUBY_METHOD_FUNC(Draw_initialize), 0);
+    rb_define_method(Class_Draw, "initialize_copy", RUBY_METHOD_FUNC(Draw_init_copy), 1);
+    rb_define_method(Class_Draw, "inspect", RUBY_METHOD_FUNC(Draw_inspect), 0);
+    rb_define_method(Class_Draw, "marshal_dump", RUBY_METHOD_FUNC(Draw_marshal_dump), 0);
+    rb_define_method(Class_Draw, "marshal_load", RUBY_METHOD_FUNC(Draw_marshal_load), 1);
+    rb_define_method(Class_Draw, "primitive", RUBY_METHOD_FUNC(Draw_primitive), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::DrawOptions is identical to Magick::Draw but with       */
@@ -702,29 +702,29 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_DrawOptions, DrawOptions_alloc);
 
-    rb_define_method(Class_DrawOptions, "initialize", DrawOptions_initialize, 0);
+    rb_define_method(Class_DrawOptions, "initialize", RUBY_METHOD_FUNC(DrawOptions_initialize), 0);
 
-    rb_define_method(Class_DrawOptions, "affine=", Draw_affine_eq, 1);
-    rb_define_method(Class_DrawOptions, "align=", Draw_align_eq, 1);
-    rb_define_method(Class_DrawOptions, "decorate=", Draw_decorate_eq, 1);
-    rb_define_method(Class_DrawOptions, "density=", Draw_density_eq, 1);
-    rb_define_method(Class_DrawOptions, "encoding=", Draw_encoding_eq, 1);
-    rb_define_method(Class_DrawOptions, "fill=", Draw_fill_eq, 1);
-    rb_define_method(Class_DrawOptions, "fill_pattern=", Draw_fill_pattern_eq, 1);
-    rb_define_method(Class_DrawOptions, "font=", Draw_font_eq, 1);
-    rb_define_method(Class_DrawOptions, "font_family=", Draw_font_family_eq, 1);
-    rb_define_method(Class_DrawOptions, "font_stretch=", Draw_font_stretch_eq, 1);
-    rb_define_method(Class_DrawOptions, "font_style=", Draw_font_style_eq, 1);
-    rb_define_method(Class_DrawOptions, "font_weight=", Draw_font_weight_eq, 1);
-    rb_define_method(Class_DrawOptions, "gravity=", Draw_gravity_eq, 1);
-    rb_define_method(Class_DrawOptions, "pointsize=", Draw_pointsize_eq, 1);
-    rb_define_method(Class_DrawOptions, "rotation=", Draw_rotation_eq, 1);
-    rb_define_method(Class_DrawOptions, "stroke=", Draw_stroke_eq, 1);
-    rb_define_method(Class_DrawOptions, "stroke_pattern=", Draw_stroke_pattern_eq, 1);
-    rb_define_method(Class_DrawOptions, "stroke_width=", Draw_stroke_width_eq, 1);
-    rb_define_method(Class_DrawOptions, "text_antialias=", Draw_text_antialias_eq, 1);
-    rb_define_method(Class_DrawOptions, "tile=", Draw_tile_eq, 1);
-    rb_define_method(Class_DrawOptions, "undercolor=", Draw_undercolor_eq, 1);
+    rb_define_method(Class_DrawOptions, "affine=", RUBY_METHOD_FUNC(Draw_affine_eq), 1);
+    rb_define_method(Class_DrawOptions, "align=", RUBY_METHOD_FUNC(Draw_align_eq), 1);
+    rb_define_method(Class_DrawOptions, "decorate=", RUBY_METHOD_FUNC(Draw_decorate_eq), 1);
+    rb_define_method(Class_DrawOptions, "density=", RUBY_METHOD_FUNC(Draw_density_eq), 1);
+    rb_define_method(Class_DrawOptions, "encoding=", RUBY_METHOD_FUNC(Draw_encoding_eq), 1);
+    rb_define_method(Class_DrawOptions, "fill=", RUBY_METHOD_FUNC(Draw_fill_eq), 1);
+    rb_define_method(Class_DrawOptions, "fill_pattern=", RUBY_METHOD_FUNC(Draw_fill_pattern_eq), 1);
+    rb_define_method(Class_DrawOptions, "font=", RUBY_METHOD_FUNC(Draw_font_eq), 1);
+    rb_define_method(Class_DrawOptions, "font_family=", RUBY_METHOD_FUNC(Draw_font_family_eq), 1);
+    rb_define_method(Class_DrawOptions, "font_stretch=", RUBY_METHOD_FUNC(Draw_font_stretch_eq), 1);
+    rb_define_method(Class_DrawOptions, "font_style=", RUBY_METHOD_FUNC(Draw_font_style_eq), 1);
+    rb_define_method(Class_DrawOptions, "font_weight=", RUBY_METHOD_FUNC(Draw_font_weight_eq), 1);
+    rb_define_method(Class_DrawOptions, "gravity=", RUBY_METHOD_FUNC(Draw_gravity_eq), 1);
+    rb_define_method(Class_DrawOptions, "pointsize=", RUBY_METHOD_FUNC(Draw_pointsize_eq), 1);
+    rb_define_method(Class_DrawOptions, "rotation=", RUBY_METHOD_FUNC(Draw_rotation_eq), 1);
+    rb_define_method(Class_DrawOptions, "stroke=", RUBY_METHOD_FUNC(Draw_stroke_eq), 1);
+    rb_define_method(Class_DrawOptions, "stroke_pattern=", RUBY_METHOD_FUNC(Draw_stroke_pattern_eq), 1);
+    rb_define_method(Class_DrawOptions, "stroke_width=", RUBY_METHOD_FUNC(Draw_stroke_width_eq), 1);
+    rb_define_method(Class_DrawOptions, "text_antialias=", RUBY_METHOD_FUNC(Draw_text_antialias_eq), 1);
+    rb_define_method(Class_DrawOptions, "tile=", RUBY_METHOD_FUNC(Draw_tile_eq), 1);
+    rb_define_method(Class_DrawOptions, "undercolor=", RUBY_METHOD_FUNC(Draw_undercolor_eq), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::Pixel                                                   */
@@ -737,46 +737,46 @@ Init_RMagick2(void)
 
     // Magick::Pixel has 3 constructors: "new" "from_color", "from_hsla"
     rb_define_alloc_func(Class_Pixel, Pixel_alloc);
-    rb_define_singleton_method(Class_Pixel, "from_color", Pixel_from_color, 1);
-    rb_define_singleton_method(Class_Pixel, "from_hsla", Pixel_from_hsla, -1);
+    rb_define_singleton_method(Class_Pixel, "from_color", RUBY_METHOD_FUNC(Pixel_from_color), 1);
+    rb_define_singleton_method(Class_Pixel, "from_hsla", RUBY_METHOD_FUNC(Pixel_from_hsla), -1);
 
     // Define the RGBA attributes
-    rb_define_method(Class_Pixel, "red", Pixel_red, 0);
-    rb_define_method(Class_Pixel, "red=", Pixel_red_eq, 1);
-    rb_define_method(Class_Pixel, "green", Pixel_green, 0);
-    rb_define_method(Class_Pixel, "green=", Pixel_green_eq, 1);
-    rb_define_method(Class_Pixel, "blue", Pixel_blue, 0);
-    rb_define_method(Class_Pixel, "blue=", Pixel_blue_eq, 1);
-    rb_define_method(Class_Pixel, "alpha", Pixel_alpha, 0);
-    rb_define_method(Class_Pixel, "alpha=", Pixel_alpha_eq, 1);
+    rb_define_method(Class_Pixel, "red", RUBY_METHOD_FUNC(Pixel_red), 0);
+    rb_define_method(Class_Pixel, "red=", RUBY_METHOD_FUNC(Pixel_red_eq), 1);
+    rb_define_method(Class_Pixel, "green", RUBY_METHOD_FUNC(Pixel_green), 0);
+    rb_define_method(Class_Pixel, "green=", RUBY_METHOD_FUNC(Pixel_green_eq), 1);
+    rb_define_method(Class_Pixel, "blue", RUBY_METHOD_FUNC(Pixel_blue), 0);
+    rb_define_method(Class_Pixel, "blue=", RUBY_METHOD_FUNC(Pixel_blue_eq), 1);
+    rb_define_method(Class_Pixel, "alpha", RUBY_METHOD_FUNC(Pixel_alpha), 0);
+    rb_define_method(Class_Pixel, "alpha=", RUBY_METHOD_FUNC(Pixel_alpha_eq), 1);
 
     // Define the CMYK attributes
-    rb_define_method(Class_Pixel, "cyan", Pixel_cyan, 0);
-    rb_define_method(Class_Pixel, "cyan=", Pixel_cyan_eq, 1);
-    rb_define_method(Class_Pixel, "magenta", Pixel_magenta, 0);
-    rb_define_method(Class_Pixel, "magenta=", Pixel_magenta_eq, 1);
-    rb_define_method(Class_Pixel, "yellow", Pixel_yellow, 0);
-    rb_define_method(Class_Pixel, "yellow=", Pixel_yellow_eq, 1);
-    rb_define_method(Class_Pixel, "black", Pixel_black, 0);
-    rb_define_method(Class_Pixel, "black=", Pixel_black_eq, 1);
+    rb_define_method(Class_Pixel, "cyan", RUBY_METHOD_FUNC(Pixel_cyan), 0);
+    rb_define_method(Class_Pixel, "cyan=", RUBY_METHOD_FUNC(Pixel_cyan_eq), 1);
+    rb_define_method(Class_Pixel, "magenta", RUBY_METHOD_FUNC(Pixel_magenta), 0);
+    rb_define_method(Class_Pixel, "magenta=", RUBY_METHOD_FUNC(Pixel_magenta_eq), 1);
+    rb_define_method(Class_Pixel, "yellow", RUBY_METHOD_FUNC(Pixel_yellow), 0);
+    rb_define_method(Class_Pixel, "yellow=", RUBY_METHOD_FUNC(Pixel_yellow_eq), 1);
+    rb_define_method(Class_Pixel, "black", RUBY_METHOD_FUNC(Pixel_black), 0);
+    rb_define_method(Class_Pixel, "black=", RUBY_METHOD_FUNC(Pixel_black_eq), 1);
 
 
     // Define the instance methods
-    rb_define_method(Class_Pixel, "<=>", Pixel_spaceship, 1);
-    rb_define_method(Class_Pixel, "===", Pixel_case_eq, 1);
-    rb_define_method(Class_Pixel, "eql?", Pixel_eql_q, 1);
-    rb_define_method(Class_Pixel, "initialize", Pixel_initialize, -1);
-    rb_define_method(Class_Pixel, "initialize_copy", Pixel_init_copy, 1);
-    rb_define_method(Class_Pixel, "clone", Pixel_clone, 0);
-    rb_define_method(Class_Pixel, "dup", Pixel_dup, 0);
-    rb_define_method(Class_Pixel, "fcmp", Pixel_fcmp, -1);
-    rb_define_method(Class_Pixel, "hash", Pixel_hash, 0);
-    rb_define_method(Class_Pixel, "intensity", Pixel_intensity, 0);
-    rb_define_method(Class_Pixel, "marshal_dump", Pixel_marshal_dump, 0);
-    rb_define_method(Class_Pixel, "marshal_load", Pixel_marshal_load, 1);
-    rb_define_method(Class_Pixel, "to_color", Pixel_to_color, -1);
-    rb_define_method(Class_Pixel, "to_hsla", Pixel_to_hsla, 0);
-    rb_define_method(Class_Pixel, "to_s", Pixel_to_s, 0);
+    rb_define_method(Class_Pixel, "<=>", RUBY_METHOD_FUNC(Pixel_spaceship), 1);
+    rb_define_method(Class_Pixel, "===", RUBY_METHOD_FUNC(Pixel_case_eq), 1);
+    rb_define_method(Class_Pixel, "eql?", RUBY_METHOD_FUNC(Pixel_eql_q), 1);
+    rb_define_method(Class_Pixel, "initialize", RUBY_METHOD_FUNC(Pixel_initialize), -1);
+    rb_define_method(Class_Pixel, "initialize_copy", RUBY_METHOD_FUNC(Pixel_init_copy), 1);
+    rb_define_method(Class_Pixel, "clone", RUBY_METHOD_FUNC(Pixel_clone), 0);
+    rb_define_method(Class_Pixel, "dup", RUBY_METHOD_FUNC(Pixel_dup), 0);
+    rb_define_method(Class_Pixel, "fcmp", RUBY_METHOD_FUNC(Pixel_fcmp), -1);
+    rb_define_method(Class_Pixel, "hash", RUBY_METHOD_FUNC(Pixel_hash), 0);
+    rb_define_method(Class_Pixel, "intensity", RUBY_METHOD_FUNC(Pixel_intensity), 0);
+    rb_define_method(Class_Pixel, "marshal_dump", RUBY_METHOD_FUNC(Pixel_marshal_dump), 0);
+    rb_define_method(Class_Pixel, "marshal_load", RUBY_METHOD_FUNC(Pixel_marshal_load), 1);
+    rb_define_method(Class_Pixel, "to_color", RUBY_METHOD_FUNC(Pixel_to_color), -1);
+    rb_define_method(Class_Pixel, "to_hsla", RUBY_METHOD_FUNC(Pixel_to_hsla), 0);
+    rb_define_method(Class_Pixel, "to_s", RUBY_METHOD_FUNC(Pixel_to_s), 0);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::ImageList::Montage methods                              */
@@ -786,27 +786,27 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_Montage, Montage_alloc);
 
-    rb_define_method(Class_Montage, "initialize", Montage_initialize, 0);
-    rb_define_method(Class_Montage, "freeze", rm_no_freeze, 0);
+    rb_define_method(Class_Montage, "initialize", RUBY_METHOD_FUNC(Montage_initialize), 0);
+    rb_define_method(Class_Montage, "freeze", RUBY_METHOD_FUNC(rm_no_freeze), 0);
 
     // These accessors supply optional arguments for Magick::ImageList::Montage.new
-    rb_define_method(Class_Montage, "background_color=", Montage_background_color_eq, 1);
-    rb_define_method(Class_Montage, "border_color=", Montage_border_color_eq, 1);
-    rb_define_method(Class_Montage, "border_width=", Montage_border_width_eq, 1);
-    rb_define_method(Class_Montage, "compose=", Montage_compose_eq, 1);
-    rb_define_method(Class_Montage, "filename=", Montage_filename_eq, 1);
-    rb_define_method(Class_Montage, "fill=", Montage_fill_eq, 1);
-    rb_define_method(Class_Montage, "font=", Montage_font_eq, 1);
-    rb_define_method(Class_Montage, "frame=", Montage_frame_eq, 1);
-    rb_define_method(Class_Montage, "geometry=", Montage_geometry_eq, 1);
-    rb_define_method(Class_Montage, "gravity=", Montage_gravity_eq, 1);
-    rb_define_method(Class_Montage, "matte_color=", Montage_matte_color_eq, 1);
-    rb_define_method(Class_Montage, "pointsize=", Montage_pointsize_eq, 1);
-    rb_define_method(Class_Montage, "shadow=", Montage_shadow_eq, 1);
-    rb_define_method(Class_Montage, "stroke=", Montage_stroke_eq, 1);
-    rb_define_method(Class_Montage, "texture=", Montage_texture_eq, 1);
-    rb_define_method(Class_Montage, "tile=", Montage_tile_eq, 1);
-    rb_define_method(Class_Montage, "title=", Montage_title_eq, 1);
+    rb_define_method(Class_Montage, "background_color=", RUBY_METHOD_FUNC(Montage_background_color_eq), 1);
+    rb_define_method(Class_Montage, "border_color=", RUBY_METHOD_FUNC(Montage_border_color_eq), 1);
+    rb_define_method(Class_Montage, "border_width=", RUBY_METHOD_FUNC(Montage_border_width_eq), 1);
+    rb_define_method(Class_Montage, "compose=", RUBY_METHOD_FUNC(Montage_compose_eq), 1);
+    rb_define_method(Class_Montage, "filename=", RUBY_METHOD_FUNC(Montage_filename_eq), 1);
+    rb_define_method(Class_Montage, "fill=", RUBY_METHOD_FUNC(Montage_fill_eq), 1);
+    rb_define_method(Class_Montage, "font=", RUBY_METHOD_FUNC(Montage_font_eq), 1);
+    rb_define_method(Class_Montage, "frame=", RUBY_METHOD_FUNC(Montage_frame_eq), 1);
+    rb_define_method(Class_Montage, "geometry=", RUBY_METHOD_FUNC(Montage_geometry_eq), 1);
+    rb_define_method(Class_Montage, "gravity=", RUBY_METHOD_FUNC(Montage_gravity_eq), 1);
+    rb_define_method(Class_Montage, "matte_color=", RUBY_METHOD_FUNC(Montage_matte_color_eq), 1);
+    rb_define_method(Class_Montage, "pointsize=", RUBY_METHOD_FUNC(Montage_pointsize_eq), 1);
+    rb_define_method(Class_Montage, "shadow=", RUBY_METHOD_FUNC(Montage_shadow_eq), 1);
+    rb_define_method(Class_Montage, "stroke=", RUBY_METHOD_FUNC(Montage_stroke_eq), 1);
+    rb_define_method(Class_Montage, "texture=", RUBY_METHOD_FUNC(Montage_texture_eq), 1);
+    rb_define_method(Class_Montage, "tile=", RUBY_METHOD_FUNC(Montage_tile_eq), 1);
+    rb_define_method(Class_Montage, "title=", RUBY_METHOD_FUNC(Montage_title_eq), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::Image::Info                                             */
@@ -816,104 +816,104 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_Info, Info_alloc);
 
-    rb_define_method(Class_Info, "initialize", Info_initialize, 0);
-    rb_define_method(Class_Info, "channel", Info_channel, -1);
-    rb_define_method(Class_Info, "freeze", rm_no_freeze, 0);
-    rb_define_method(Class_Info, "define", Info_define, -1);
-    rb_define_method(Class_Info, "[]=", Info_aset, -1);
-    rb_define_method(Class_Info, "[]", Info_aref, -1);
-    rb_define_method(Class_Info, "undefine", Info_undefine, 2);
+    rb_define_method(Class_Info, "initialize", RUBY_METHOD_FUNC(Info_initialize), 0);
+    rb_define_method(Class_Info, "channel", RUBY_METHOD_FUNC(Info_channel), -1);
+    rb_define_method(Class_Info, "freeze", RUBY_METHOD_FUNC(rm_no_freeze), 0);
+    rb_define_method(Class_Info, "define", RUBY_METHOD_FUNC(Info_define), -1);
+    rb_define_method(Class_Info, "[]=", RUBY_METHOD_FUNC(Info_aset), -1);
+    rb_define_method(Class_Info, "[]", RUBY_METHOD_FUNC(Info_aref), -1);
+    rb_define_method(Class_Info, "undefine", RUBY_METHOD_FUNC(Info_undefine), 2);
 
     // Define the attributes
-    rb_define_method(Class_Info, "antialias", Info_antialias, 0);
-    rb_define_method(Class_Info, "antialias=", Info_antialias_eq, 1);
-    rb_define_method(Class_Info, "attenuate", Info_attenuate, 0);
-    rb_define_method(Class_Info, "attenuate=", Info_attenuate_eq, 1);
-    rb_define_method(Class_Info, "authenticate", Info_authenticate, 0);
-    rb_define_method(Class_Info, "authenticate=", Info_authenticate_eq, 1);
-    rb_define_method(Class_Info, "background_color", Info_background_color, 0);
-    rb_define_method(Class_Info, "background_color=", Info_background_color_eq, 1);
-    rb_define_method(Class_Info, "border_color", Info_border_color, 0);
-    rb_define_method(Class_Info, "border_color=", Info_border_color_eq, 1);
-    rb_define_method(Class_Info, "caption", Info_caption, 0);
-    rb_define_method(Class_Info, "caption=", Info_caption_eq, 1);
-    rb_define_method(Class_Info, "colorspace", Info_colorspace, 0);
-    rb_define_method(Class_Info, "colorspace=", Info_colorspace_eq, 1);
-    rb_define_method(Class_Info, "comment", Info_comment, 0);
-    rb_define_method(Class_Info, "comment=", Info_comment_eq, 1);
-    rb_define_method(Class_Info, "compression", Info_compression, 0);
-    rb_define_method(Class_Info, "compression=", Info_compression_eq, 1);
-    rb_define_method(Class_Info, "delay", Info_delay, 0);
-    rb_define_method(Class_Info, "delay=", Info_delay_eq, 1);
-    rb_define_method(Class_Info, "density", Info_density, 0);
-    rb_define_method(Class_Info, "density=", Info_density_eq, 1);
-    rb_define_method(Class_Info, "depth", Info_depth, 0);
-    rb_define_method(Class_Info, "depth=", Info_depth_eq, 1);
-    rb_define_method(Class_Info, "dispose", Info_dispose, 0);
-    rb_define_method(Class_Info, "dispose=", Info_dispose_eq, 1);
-    rb_define_method(Class_Info, "dither", Info_dither, 0);
-    rb_define_method(Class_Info, "dither=", Info_dither_eq, 1);
-    rb_define_method(Class_Info, "endian", Info_endian, 0);
-    rb_define_method(Class_Info, "endian=", Info_endian_eq, 1);
-    rb_define_method(Class_Info, "extract", Info_extract, 0);
-    rb_define_method(Class_Info, "extract=", Info_extract_eq, 1);
-    rb_define_method(Class_Info, "filename", Info_filename, 0);
-    rb_define_method(Class_Info, "filename=", Info_filename_eq, 1);
-    rb_define_method(Class_Info, "fill", Info_fill, 0);
-    rb_define_method(Class_Info, "fill=", Info_fill_eq, 1);
-    rb_define_method(Class_Info, "font", Info_font, 0);
-    rb_define_method(Class_Info, "font=", Info_font_eq, 1);
-    rb_define_method(Class_Info, "format", Info_format, 0);
-    rb_define_method(Class_Info, "format=", Info_format_eq, 1);
-    rb_define_method(Class_Info, "fuzz", Info_fuzz, 0);
-    rb_define_method(Class_Info, "fuzz=", Info_fuzz_eq, 1);
-    rb_define_method(Class_Info, "gravity", Info_gravity, 0);
-    rb_define_method(Class_Info, "gravity=", Info_gravity_eq, 1);
-    rb_define_method(Class_Info, "image_type", Info_image_type, 0);
-    rb_define_method(Class_Info, "image_type=", Info_image_type_eq, 1);
-    rb_define_method(Class_Info, "interlace", Info_interlace, 0);
-    rb_define_method(Class_Info, "interlace=", Info_interlace_eq, 1);
-    rb_define_method(Class_Info, "label", Info_label, 0);
-    rb_define_method(Class_Info, "label=", Info_label_eq, 1);
-    rb_define_method(Class_Info, "matte_color", Info_matte_color, 0);
-    rb_define_method(Class_Info, "matte_color=", Info_matte_color_eq, 1);
-    rb_define_method(Class_Info, "monochrome", Info_monochrome, 0);
-    rb_define_method(Class_Info, "monochrome=", Info_monochrome_eq, 1);
-    rb_define_method(Class_Info, "number_scenes", Info_number_scenes, 0);
-    rb_define_method(Class_Info, "number_scenes=", Info_number_scenes_eq, 1);
-    rb_define_method(Class_Info, "orientation", Info_orientation, 0);
-    rb_define_method(Class_Info, "orientation=", Info_orientation_eq, 1);
-    rb_define_method(Class_Info, "origin", Info_origin, 0);         // new in 6.3.1
-    rb_define_method(Class_Info, "origin=", Info_origin_eq, 1);         // new in 6.3.1
-    rb_define_method(Class_Info, "page", Info_page, 0);
-    rb_define_method(Class_Info, "page=", Info_page_eq, 1);
-    rb_define_method(Class_Info, "pointsize", Info_pointsize, 0);
-    rb_define_method(Class_Info, "pointsize=", Info_pointsize_eq, 1);
-    rb_define_method(Class_Info, "quality", Info_quality, 0);
-    rb_define_method(Class_Info, "quality=", Info_quality_eq, 1);
-    rb_define_method(Class_Info, "sampling_factor", Info_sampling_factor, 0);
-    rb_define_method(Class_Info, "sampling_factor=", Info_sampling_factor_eq, 1);
-    rb_define_method(Class_Info, "scene", Info_scene, 0);
-    rb_define_method(Class_Info, "scene=", Info_scene_eq, 1);
-    rb_define_method(Class_Info, "server_name", Info_server_name, 0);
-    rb_define_method(Class_Info, "server_name=", Info_server_name_eq, 1);
-    rb_define_method(Class_Info, "size", Info_size, 0);
-    rb_define_method(Class_Info, "size=", Info_size_eq, 1);
-    rb_define_method(Class_Info, "stroke", Info_stroke, 0);
-    rb_define_method(Class_Info, "stroke=", Info_stroke_eq, 1);
-    rb_define_method(Class_Info, "stroke_width", Info_stroke_width, 0);
-    rb_define_method(Class_Info, "stroke_width=", Info_stroke_width_eq, 1);
-    rb_define_method(Class_Info, "texture=", Info_texture_eq, 1);
-    rb_define_method(Class_Info, "tile_offset", Info_tile_offset, 0);
-    rb_define_method(Class_Info, "tile_offset=", Info_tile_offset_eq, 1);
-    rb_define_method(Class_Info, "transparent_color", Info_transparent_color, 0);
-    rb_define_method(Class_Info, "transparent_color=", Info_transparent_color_eq, 1);
-    rb_define_method(Class_Info, "undercolor", Info_undercolor, 0);
-    rb_define_method(Class_Info, "undercolor=", Info_undercolor_eq, 1);
-    rb_define_method(Class_Info, "units", Info_units, 0);
-    rb_define_method(Class_Info, "units=", Info_units_eq, 1);
-    rb_define_method(Class_Info, "view", Info_view, 0);
-    rb_define_method(Class_Info, "view=", Info_view_eq, 1);
+    rb_define_method(Class_Info, "antialias", RUBY_METHOD_FUNC(Info_antialias), 0);
+    rb_define_method(Class_Info, "antialias=", RUBY_METHOD_FUNC(Info_antialias_eq), 1);
+    rb_define_method(Class_Info, "attenuate", RUBY_METHOD_FUNC(Info_attenuate), 0);
+    rb_define_method(Class_Info, "attenuate=", RUBY_METHOD_FUNC(Info_attenuate_eq), 1);
+    rb_define_method(Class_Info, "authenticate", RUBY_METHOD_FUNC(Info_authenticate), 0);
+    rb_define_method(Class_Info, "authenticate=", RUBY_METHOD_FUNC(Info_authenticate_eq), 1);
+    rb_define_method(Class_Info, "background_color", RUBY_METHOD_FUNC(Info_background_color), 0);
+    rb_define_method(Class_Info, "background_color=", RUBY_METHOD_FUNC(Info_background_color_eq), 1);
+    rb_define_method(Class_Info, "border_color", RUBY_METHOD_FUNC(Info_border_color), 0);
+    rb_define_method(Class_Info, "border_color=", RUBY_METHOD_FUNC(Info_border_color_eq), 1);
+    rb_define_method(Class_Info, "caption", RUBY_METHOD_FUNC(Info_caption), 0);
+    rb_define_method(Class_Info, "caption=", RUBY_METHOD_FUNC(Info_caption_eq), 1);
+    rb_define_method(Class_Info, "colorspace", RUBY_METHOD_FUNC(Info_colorspace), 0);
+    rb_define_method(Class_Info, "colorspace=", RUBY_METHOD_FUNC(Info_colorspace_eq), 1);
+    rb_define_method(Class_Info, "comment", RUBY_METHOD_FUNC(Info_comment), 0);
+    rb_define_method(Class_Info, "comment=", RUBY_METHOD_FUNC(Info_comment_eq), 1);
+    rb_define_method(Class_Info, "compression", RUBY_METHOD_FUNC(Info_compression), 0);
+    rb_define_method(Class_Info, "compression=", RUBY_METHOD_FUNC(Info_compression_eq), 1);
+    rb_define_method(Class_Info, "delay", RUBY_METHOD_FUNC(Info_delay), 0);
+    rb_define_method(Class_Info, "delay=", RUBY_METHOD_FUNC(Info_delay_eq), 1);
+    rb_define_method(Class_Info, "density", RUBY_METHOD_FUNC(Info_density), 0);
+    rb_define_method(Class_Info, "density=", RUBY_METHOD_FUNC(Info_density_eq), 1);
+    rb_define_method(Class_Info, "depth", RUBY_METHOD_FUNC(Info_depth), 0);
+    rb_define_method(Class_Info, "depth=", RUBY_METHOD_FUNC(Info_depth_eq), 1);
+    rb_define_method(Class_Info, "dispose", RUBY_METHOD_FUNC(Info_dispose), 0);
+    rb_define_method(Class_Info, "dispose=", RUBY_METHOD_FUNC(Info_dispose_eq), 1);
+    rb_define_method(Class_Info, "dither", RUBY_METHOD_FUNC(Info_dither), 0);
+    rb_define_method(Class_Info, "dither=", RUBY_METHOD_FUNC(Info_dither_eq), 1);
+    rb_define_method(Class_Info, "endian", RUBY_METHOD_FUNC(Info_endian), 0);
+    rb_define_method(Class_Info, "endian=", RUBY_METHOD_FUNC(Info_endian_eq), 1);
+    rb_define_method(Class_Info, "extract", RUBY_METHOD_FUNC(Info_extract), 0);
+    rb_define_method(Class_Info, "extract=", RUBY_METHOD_FUNC(Info_extract_eq), 1);
+    rb_define_method(Class_Info, "filename", RUBY_METHOD_FUNC(Info_filename), 0);
+    rb_define_method(Class_Info, "filename=", RUBY_METHOD_FUNC(Info_filename_eq), 1);
+    rb_define_method(Class_Info, "fill", RUBY_METHOD_FUNC(Info_fill), 0);
+    rb_define_method(Class_Info, "fill=", RUBY_METHOD_FUNC(Info_fill_eq), 1);
+    rb_define_method(Class_Info, "font", RUBY_METHOD_FUNC(Info_font), 0);
+    rb_define_method(Class_Info, "font=", RUBY_METHOD_FUNC(Info_font_eq), 1);
+    rb_define_method(Class_Info, "format", RUBY_METHOD_FUNC(Info_format), 0);
+    rb_define_method(Class_Info, "format=", RUBY_METHOD_FUNC(Info_format_eq), 1);
+    rb_define_method(Class_Info, "fuzz", RUBY_METHOD_FUNC(Info_fuzz), 0);
+    rb_define_method(Class_Info, "fuzz=", RUBY_METHOD_FUNC(Info_fuzz_eq), 1);
+    rb_define_method(Class_Info, "gravity", RUBY_METHOD_FUNC(Info_gravity), 0);
+    rb_define_method(Class_Info, "gravity=", RUBY_METHOD_FUNC(Info_gravity_eq), 1);
+    rb_define_method(Class_Info, "image_type", RUBY_METHOD_FUNC(Info_image_type), 0);
+    rb_define_method(Class_Info, "image_type=", RUBY_METHOD_FUNC(Info_image_type_eq), 1);
+    rb_define_method(Class_Info, "interlace", RUBY_METHOD_FUNC(Info_interlace), 0);
+    rb_define_method(Class_Info, "interlace=", RUBY_METHOD_FUNC(Info_interlace_eq), 1);
+    rb_define_method(Class_Info, "label", RUBY_METHOD_FUNC(Info_label), 0);
+    rb_define_method(Class_Info, "label=", RUBY_METHOD_FUNC(Info_label_eq), 1);
+    rb_define_method(Class_Info, "matte_color", RUBY_METHOD_FUNC(Info_matte_color), 0);
+    rb_define_method(Class_Info, "matte_color=", RUBY_METHOD_FUNC(Info_matte_color_eq), 1);
+    rb_define_method(Class_Info, "monochrome", RUBY_METHOD_FUNC(Info_monochrome), 0);
+    rb_define_method(Class_Info, "monochrome=", RUBY_METHOD_FUNC(Info_monochrome_eq), 1);
+    rb_define_method(Class_Info, "number_scenes", RUBY_METHOD_FUNC(Info_number_scenes), 0);
+    rb_define_method(Class_Info, "number_scenes=", RUBY_METHOD_FUNC(Info_number_scenes_eq), 1);
+    rb_define_method(Class_Info, "orientation", RUBY_METHOD_FUNC(Info_orientation), 0);
+    rb_define_method(Class_Info, "orientation=", RUBY_METHOD_FUNC(Info_orientation_eq), 1);
+    rb_define_method(Class_Info, "origin", RUBY_METHOD_FUNC(Info_origin), 0);         // new in 6.3.1
+    rb_define_method(Class_Info, "origin=", RUBY_METHOD_FUNC(Info_origin_eq), 1);         // new in 6.3.1
+    rb_define_method(Class_Info, "page", RUBY_METHOD_FUNC(Info_page), 0);
+    rb_define_method(Class_Info, "page=", RUBY_METHOD_FUNC(Info_page_eq), 1);
+    rb_define_method(Class_Info, "pointsize", RUBY_METHOD_FUNC(Info_pointsize), 0);
+    rb_define_method(Class_Info, "pointsize=", RUBY_METHOD_FUNC(Info_pointsize_eq), 1);
+    rb_define_method(Class_Info, "quality", RUBY_METHOD_FUNC(Info_quality), 0);
+    rb_define_method(Class_Info, "quality=", RUBY_METHOD_FUNC(Info_quality_eq), 1);
+    rb_define_method(Class_Info, "sampling_factor", RUBY_METHOD_FUNC(Info_sampling_factor), 0);
+    rb_define_method(Class_Info, "sampling_factor=", RUBY_METHOD_FUNC(Info_sampling_factor_eq), 1);
+    rb_define_method(Class_Info, "scene", RUBY_METHOD_FUNC(Info_scene), 0);
+    rb_define_method(Class_Info, "scene=", RUBY_METHOD_FUNC(Info_scene_eq), 1);
+    rb_define_method(Class_Info, "server_name", RUBY_METHOD_FUNC(Info_server_name), 0);
+    rb_define_method(Class_Info, "server_name=", RUBY_METHOD_FUNC(Info_server_name_eq), 1);
+    rb_define_method(Class_Info, "size", RUBY_METHOD_FUNC(Info_size), 0);
+    rb_define_method(Class_Info, "size=", RUBY_METHOD_FUNC(Info_size_eq), 1);
+    rb_define_method(Class_Info, "stroke", RUBY_METHOD_FUNC(Info_stroke), 0);
+    rb_define_method(Class_Info, "stroke=", RUBY_METHOD_FUNC(Info_stroke_eq), 1);
+    rb_define_method(Class_Info, "stroke_width", RUBY_METHOD_FUNC(Info_stroke_width), 0);
+    rb_define_method(Class_Info, "stroke_width=", RUBY_METHOD_FUNC(Info_stroke_width_eq), 1);
+    rb_define_method(Class_Info, "texture=", RUBY_METHOD_FUNC(Info_texture_eq), 1);
+    rb_define_method(Class_Info, "tile_offset", RUBY_METHOD_FUNC(Info_tile_offset), 0);
+    rb_define_method(Class_Info, "tile_offset=", RUBY_METHOD_FUNC(Info_tile_offset_eq), 1);
+    rb_define_method(Class_Info, "transparent_color", RUBY_METHOD_FUNC(Info_transparent_color), 0);
+    rb_define_method(Class_Info, "transparent_color=", RUBY_METHOD_FUNC(Info_transparent_color_eq), 1);
+    rb_define_method(Class_Info, "undercolor", RUBY_METHOD_FUNC(Info_undercolor), 0);
+    rb_define_method(Class_Info, "undercolor=", RUBY_METHOD_FUNC(Info_undercolor_eq), 1);
+    rb_define_method(Class_Info, "units", RUBY_METHOD_FUNC(Info_units), 0);
+    rb_define_method(Class_Info, "units=", RUBY_METHOD_FUNC(Info_units_eq), 1);
+    rb_define_method(Class_Info, "view", RUBY_METHOD_FUNC(Info_view), 0);
+    rb_define_method(Class_Info, "view=", RUBY_METHOD_FUNC(Info_view_eq), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::KernelInfo                                              */
@@ -923,14 +923,14 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_KernelInfo, KernelInfo_alloc);
 
-    rb_define_method(Class_KernelInfo, "initialize", KernelInfo_initialize, 1);
-    rb_define_method(Class_KernelInfo, "unity_add", KernelInfo_unity_add, 1);
-    rb_define_method(Class_KernelInfo, "scale", KernelInfo_scale, 2);
-    rb_define_method(Class_KernelInfo, "scale_geometry", KernelInfo_scale_geometry, 1);
-    rb_define_method(Class_KernelInfo, "clone", KernelInfo_clone, 0);
-    rb_define_method(Class_KernelInfo, "dup", KernelInfo_clone, 0);
+    rb_define_method(Class_KernelInfo, "initialize", RUBY_METHOD_FUNC(KernelInfo_initialize), 1);
+    rb_define_method(Class_KernelInfo, "unity_add", RUBY_METHOD_FUNC(KernelInfo_unity_add), 1);
+    rb_define_method(Class_KernelInfo, "scale", RUBY_METHOD_FUNC(KernelInfo_scale), 2);
+    rb_define_method(Class_KernelInfo, "scale_geometry", RUBY_METHOD_FUNC(KernelInfo_scale_geometry), 1);
+    rb_define_method(Class_KernelInfo, "clone", RUBY_METHOD_FUNC(KernelInfo_clone), 0);
+    rb_define_method(Class_KernelInfo, "dup", RUBY_METHOD_FUNC(KernelInfo_clone), 0);
 
-    rb_define_singleton_method(Class_KernelInfo, "builtin", KernelInfo_builtin, 2);
+    rb_define_singleton_method(Class_KernelInfo, "builtin", RUBY_METHOD_FUNC(KernelInfo_builtin), 2);
 
 
     /*-----------------------------------------------------------------------*/
@@ -941,31 +941,31 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_PolaroidOptions, PolaroidOptions_alloc);
 
-    rb_define_method(Class_PolaroidOptions, "initialize", PolaroidOptions_initialize, 0);
+    rb_define_method(Class_PolaroidOptions, "initialize", RUBY_METHOD_FUNC(PolaroidOptions_initialize), 0);
 
     // Define the attributes
-    rb_define_method(Class_PolaroidOptions, "shadow_color=", PolaroidOptions_shadow_color_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "border_color=", PolaroidOptions_border_color_eq, 1);
+    rb_define_method(Class_PolaroidOptions, "shadow_color=", RUBY_METHOD_FUNC(PolaroidOptions_shadow_color_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "border_color=", RUBY_METHOD_FUNC(PolaroidOptions_border_color_eq), 1);
 
     // The other attribute writer methods are implemented by Draw's functions
-    rb_define_method(Class_PolaroidOptions, "align=", Draw_align_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "decorate=", Draw_decorate_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "density=", Draw_density_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "encoding=", Draw_encoding_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "fill=", Draw_fill_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "fill_pattern=", Draw_fill_pattern_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "font=", Draw_font_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "font_family=", Draw_font_family_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "font_stretch=", Draw_font_stretch_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "font_style=", Draw_font_style_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "font_weight=", Draw_font_weight_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "gravity=", Draw_gravity_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "pointsize=", Draw_pointsize_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "stroke=", Draw_stroke_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "stroke_pattern=", Draw_stroke_pattern_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "stroke_width=", Draw_stroke_width_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "text_antialias=", Draw_text_antialias_eq, 1);
-    rb_define_method(Class_PolaroidOptions, "undercolor=", Draw_undercolor_eq, 1);
+    rb_define_method(Class_PolaroidOptions, "align=", RUBY_METHOD_FUNC(Draw_align_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "decorate=", RUBY_METHOD_FUNC(Draw_decorate_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "density=", RUBY_METHOD_FUNC(Draw_density_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "encoding=", RUBY_METHOD_FUNC(Draw_encoding_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "fill=", RUBY_METHOD_FUNC(Draw_fill_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "fill_pattern=", RUBY_METHOD_FUNC(Draw_fill_pattern_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "font=", RUBY_METHOD_FUNC(Draw_font_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "font_family=", RUBY_METHOD_FUNC(Draw_font_family_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "font_stretch=", RUBY_METHOD_FUNC(Draw_font_stretch_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "font_style=", RUBY_METHOD_FUNC(Draw_font_style_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "font_weight=", RUBY_METHOD_FUNC(Draw_font_weight_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "gravity=", RUBY_METHOD_FUNC(Draw_gravity_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "pointsize=", RUBY_METHOD_FUNC(Draw_pointsize_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "stroke=", RUBY_METHOD_FUNC(Draw_stroke_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "stroke_pattern=", RUBY_METHOD_FUNC(Draw_stroke_pattern_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "stroke_width=", RUBY_METHOD_FUNC(Draw_stroke_width_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "text_antialias=", RUBY_METHOD_FUNC(Draw_text_antialias_eq), 1);
+    rb_define_method(Class_PolaroidOptions, "undercolor=", RUBY_METHOD_FUNC(Draw_undercolor_eq), 1);
 
 
     /*-----------------------------------------------------------------------*/
@@ -977,16 +977,16 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_GradientFill, GradientFill_alloc);
 
-    rb_define_method(Class_GradientFill, "initialize", GradientFill_initialize, 6);
-    rb_define_method(Class_GradientFill, "fill", GradientFill_fill, 1);
+    rb_define_method(Class_GradientFill, "initialize", RUBY_METHOD_FUNC(GradientFill_initialize), 6);
+    rb_define_method(Class_GradientFill, "fill", RUBY_METHOD_FUNC(GradientFill_fill), 1);
 
     // class Magick::TextureFill
     Class_TextureFill = rb_define_class_under(Module_Magick, "TextureFill", rb_cObject);
 
     rb_define_alloc_func(Class_TextureFill, TextureFill_alloc);
 
-    rb_define_method(Class_TextureFill, "initialize", TextureFill_initialize, 1);
-    rb_define_method(Class_TextureFill, "fill", TextureFill_fill, 1);
+    rb_define_method(Class_TextureFill, "initialize", RUBY_METHOD_FUNC(TextureFill_initialize), 1);
+    rb_define_method(Class_TextureFill, "fill", RUBY_METHOD_FUNC(TextureFill_fill), 1);
 
     /*-----------------------------------------------------------------------*/
     /* Class Magick::ImageMagickError < StandardError                        */
@@ -994,7 +994,7 @@ Init_RMagick2(void)
     /*-----------------------------------------------------------------------*/
 
     Class_ImageMagickError = rb_define_class_under(Module_Magick, "ImageMagickError", rb_eStandardError);
-    rb_define_method(Class_ImageMagickError, "initialize", ImageMagickError_initialize, -1);
+    rb_define_method(Class_ImageMagickError, "initialize", RUBY_METHOD_FUNC(ImageMagickError_initialize), -1);
     rb_define_attr(Class_ImageMagickError, MAGICK_LOC, True, False);
 
     Class_FatalImageMagickError = rb_define_class_under(Module_Magick, "FatalImageMagickError", rb_eStandardError);
@@ -1025,12 +1025,12 @@ Init_RMagick2(void)
 
     rb_define_alloc_func(Class_Enum, Enum_alloc);
 
-    rb_define_method(Class_Enum, "initialize", Enum_initialize, 2);
-    rb_define_method(Class_Enum, "to_s", Enum_to_s, 0);
-    rb_define_method(Class_Enum, "to_i", Enum_to_i, 0);
-    rb_define_method(Class_Enum, "<=>", Enum_spaceship, 1);
-    rb_define_method(Class_Enum, "===", Enum_case_eq, 1);
-    rb_define_method(Class_Enum, "|", Enum_bitwise_or, 1);
+    rb_define_method(Class_Enum, "initialize", RUBY_METHOD_FUNC(Enum_initialize), 2);
+    rb_define_method(Class_Enum, "to_s", RUBY_METHOD_FUNC(Enum_to_s), 0);
+    rb_define_method(Class_Enum, "to_i", RUBY_METHOD_FUNC(Enum_to_i), 0);
+    rb_define_method(Class_Enum, "<=>", RUBY_METHOD_FUNC(Enum_spaceship), 1);
+    rb_define_method(Class_Enum, "===", RUBY_METHOD_FUNC(Enum_case_eq), 1);
+    rb_define_method(Class_Enum, "|", RUBY_METHOD_FUNC(Enum_bitwise_or), 1);
 
     // AlignType constants
     DEF_ENUM(AlignType)
@@ -1795,18 +1795,18 @@ Init_RMagick2(void)
     // Magick::Primary
     Class_Primary = rb_struct_define_under(Module_Magick, "Primary",
                                            "x", "y", "z", NULL);
-    rb_define_method(Class_Primary, "to_s", PrimaryInfo_to_s, 0);
+    rb_define_method(Class_Primary, "to_s", RUBY_METHOD_FUNC(PrimaryInfo_to_s), 0);
 
     // Magick::Chromaticity
     Class_Chromaticity = rb_struct_define_under(Module_Magick, "Chromaticity",
                                                 "red_primary", "green_primary",
                                                 "blue_primary", "white_point", NULL);
-    rb_define_method(Class_Chromaticity, "to_s", ChromaticityInfo_to_s, 0);
+    rb_define_method(Class_Chromaticity, "to_s", RUBY_METHOD_FUNC(ChromaticityInfo_to_s), 0);
 
     // Magick::Color
     Class_Color = rb_struct_define_under(Module_Magick, "Color",
                                          "name", "compliance", "color", NULL);
-    rb_define_method(Class_Color, "to_s", Color_to_s, 0);
+    rb_define_method(Class_Color, "to_s", RUBY_METHOD_FUNC(Color_to_s), 0);
 
     // Magick::Point
     Class_Point = rb_struct_define_under(Module_Magick, "Point",
@@ -1815,26 +1815,26 @@ Init_RMagick2(void)
     // Magick::Rectangle
     Class_Rectangle = rb_struct_define_under(Module_Magick, "Rectangle",
                                              "width", "height", "x", "y", NULL);
-    rb_define_method(Class_Rectangle, "to_s", RectangleInfo_to_s, 0);
+    rb_define_method(Class_Rectangle, "to_s", RUBY_METHOD_FUNC(RectangleInfo_to_s), 0);
 
     // Magick::Segment
     Class_Segment = rb_struct_define_under(Module_Magick, "Segment",
                                            "x1", "y1", "x2", "y2", NULL);
-    rb_define_method(Class_Segment, "to_s", SegmentInfo_to_s, 0);
+    rb_define_method(Class_Segment, "to_s", RUBY_METHOD_FUNC(SegmentInfo_to_s), 0);
 
     // Magick::Font
     Class_Font = rb_struct_define_under(Module_Magick, "Font",
                                         "name", "description",
                                         "family", "style", "stretch", "weight",
                                         "encoding", "foundry", "format", NULL);
-    rb_define_method(Class_Font, "to_s", Font_to_s, 0);
+    rb_define_method(Class_Font, "to_s", RUBY_METHOD_FUNC(Font_to_s), 0);
 
     // Magick::TypeMetric
     Class_TypeMetric = rb_struct_define_under(Module_Magick, "TypeMetric",
                                               "pixels_per_em", "ascent", "descent",
                                               "width", "height", "max_advance", "bounds",
                                               "underline_position", "underline_thickness", NULL);
-    rb_define_method(Class_TypeMetric, "to_s", TypeMetric_to_s, 0);
+    rb_define_method(Class_TypeMetric, "to_s", RUBY_METHOD_FUNC(TypeMetric_to_s), 0);
 
 
     /*-----------------------------------------------------------------------*/

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -414,7 +414,7 @@ Color_to_PixelColor(PixelColor *pp, VALUE color)
     else
     {
         // require 'to_str' here instead of just 'to_s'.
-        color = rb_rescue(rb_str_to_str, color, color_arg_rescue, color);
+        color = rb_rescue(RESCUE_FUNC(rb_str_to_str), color, RESCUE_EXCEPTION_HANDLER_FUNC(color_arg_rescue), color);
         Color_Name_to_PixelColor(pp, color);
     }
 }

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -373,7 +373,7 @@ rm_percentage(VALUE arg, double max)
         char *pct_str;
         long pct_long;
 
-        arg = rb_rescue(rb_str_to_str, arg, rescue_not_str, arg);
+        arg = rb_rescue(RESCUE_FUNC(rb_str_to_str), arg, RESCUE_EXCEPTION_HANDLER_FUNC(rescue_not_str), arg);
         pct_str = StringValueCStr(arg);
         errno = 0;
         pct_long = strtol(pct_str, &end, 10);
@@ -454,7 +454,7 @@ rescue_not_dbl(VALUE ignored ATTRIBUTE_UNUSED, VALUE raised_exc ATTRIBUTE_UNUSED
 int
 rm_check_num2dbl(VALUE obj)
 {
-    return FIX2INT(rb_rescue(check_num2dbl, obj, rescue_not_dbl, (VALUE)0));
+    return FIX2INT(rb_rescue(RESCUE_FUNC(check_num2dbl), obj, RESCUE_EXCEPTION_HANDLER_FUNC(rescue_not_dbl), (VALUE)0));
 }
 
 
@@ -472,7 +472,7 @@ rm_str_to_pct(VALUE str)
     long pct;
     char *pct_str, *end;
 
-    str = rb_rescue(rb_str_to_str, str, rescue_not_str, str);
+    str = rb_rescue(RESCUE_FUNC(rb_str_to_str), str, RESCUE_EXCEPTION_HANDLER_FUNC(rescue_not_str), str);
     pct_str = StringValueCStr(str);
     errno = 0;
     pct = strtol(pct_str, &end, 10);
@@ -516,7 +516,7 @@ rm_fuzz_to_dbl(VALUE fuzz_arg)
         char *fuzz_str;
 
         // Convert to string, issue error message if failure.
-        fuzz_arg = rb_rescue(rb_str_to_str, fuzz_arg, rescue_not_str, fuzz_arg);
+        fuzz_arg = rb_rescue(RESCUE_FUNC(rb_str_to_str), fuzz_arg, RESCUE_EXCEPTION_HANDLER_FUNC(rescue_not_str), fuzz_arg);
         fuzz_str = StringValueCStr(fuzz_arg);
         errno = 0;
         fuzz = strtod(fuzz_str, &end);


### PR DESCRIPTION
In C++, type checking is strictly enforced when function pointer is given as an argument if functions have `ANYARGS` type.

Related to https://github.com/rmagick/rmagick/issues/1419