### PR TITLE
Add type casts  for disambiguation

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -442,7 +442,7 @@ extern const rb_data_type_t rm_kernel_info_data_type;
     Define simple attribute accessor methods (boolean, int, string, and double types)
 */
 #define C_boolean_to_R_boolean(attr) (attr) ? Qtrue : Qfalse /**< C boolean -> Ruby boolean */
-#define R_boolean_to_C_boolean(attr) RTEST(attr) /**<  C boolean <- Ruby boolean */
+#define R_boolean_to_C_boolean(attr) (MagickBooleanType)RTEST(attr) /**<  C boolean <- Ruby boolean */
 #define C_int_to_R_int(attr) INT2FIX(attr) /**< C int -> Ruby int */
 #define R_int_to_C_int(attr) NUM2INT(attr) /**< C int <- Ruby int */
 #define C_long_to_R_long(attr) LONG2NUM(attr) /**< C long -> Ruby long */

--- a/ext/RMagick/rmdraw.c
+++ b/ext/RMagick/rmdraw.c
@@ -595,8 +595,8 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
     draw->info->stroke_width = NUM2DBL(rb_hash_aref(ddraw, CSTR2SYM("stroke_width")));
     draw->info->fill_pattern = str_to_image(rb_hash_aref(ddraw, CSTR2SYM("fill_pattern")));
     draw->info->stroke_pattern = str_to_image(rb_hash_aref(ddraw, CSTR2SYM("stroke_pattern")));
-    draw->info->stroke_antialias = RTEST(rb_hash_aref(ddraw, CSTR2SYM("stroke_antialias")));
-    draw->info->text_antialias = RTEST(rb_hash_aref(ddraw, CSTR2SYM("text_antialias")));
+    draw->info->stroke_antialias = (MagickBooleanType)RTEST(rb_hash_aref(ddraw, CSTR2SYM("stroke_antialias")));
+    draw->info->text_antialias = (MagickBooleanType)RTEST(rb_hash_aref(ddraw, CSTR2SYM("text_antialias")));
     draw->info->decorate = (DecorationType) FIX2INT(rb_hash_aref(ddraw, CSTR2SYM("decorate")));
     OBJ_TO_MAGICK_STRING(draw->info->font, rb_hash_aref(ddraw, CSTR2SYM("font")));
     OBJ_TO_MAGICK_STRING(draw->info->family, rb_hash_aref(ddraw, CSTR2SYM("family")));
@@ -612,7 +612,7 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
     val = rb_hash_aref(ddraw, CSTR2SYM("undercolor"));
     Color_to_PixelColor(&draw->info->undercolor, val);
 
-    draw->info->clip_units = FIX2INT(rb_hash_aref(ddraw, CSTR2SYM("clip_units")));
+    draw->info->clip_units = (ClipPathUnits)FIX2INT(rb_hash_aref(ddraw, CSTR2SYM("clip_units")));
 #if defined(IMAGEMAGICK_7)
     draw->info->alpha = NUM2QUANTUM(rb_hash_aref(ddraw, CSTR2SYM("alpha")));
 #else
@@ -1018,7 +1018,7 @@ Draw_composite(int argc, VALUE *argv, VALUE self)
     // Add the temp filename to the filename array.
     // Use Magick storage since we need to keep the list around
     // until destroy_Draw is called.
-    tmpfile_name = magick_malloc(sizeof(struct TmpFile_Name) + rm_strnlen_s(name, sizeof(name)));
+    tmpfile_name = (struct TmpFile_Name *)magick_malloc(sizeof(struct TmpFile_Name) + rm_strnlen_s(name, sizeof(name)));
     strcpy(tmpfile_name->name, name);
     tmpfile_name->next = draw->tmpfile_ary;
     draw->tmpfile_ary = tmpfile_name;

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -485,7 +485,7 @@ ComplianceType_find(ComplianceType compliance)
     if ((compliance & (SVGCompliance|X11Compliance|XPMCompliance))
         == (SVGCompliance|X11Compliance|XPMCompliance))
     {
-        c = SVGCompliance|X11Compliance|XPMCompliance;
+        c = (ComplianceType)(SVGCompliance|X11Compliance|XPMCompliance);
     }
     else if (compliance & SVGCompliance)
     {

--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -135,7 +135,7 @@ VALUE
 ImageList_append(VALUE self, VALUE stack_arg)
 {
     Image *images, *new_image;
-    unsigned int stack;
+    MagickBooleanType stack;
     ExceptionInfo *exception;
 
     // Convert the image array to an image sequence.
@@ -143,7 +143,7 @@ ImageList_append(VALUE self, VALUE stack_arg)
 
     // If stack == true, stack rectangular images top-to-bottom,
     // otherwise left-to-right.
-    stack = RTEST(stack_arg);
+    stack = (MagickBooleanType)RTEST(stack_arg);
 
     exception = AcquireExceptionInfo();
     GVL_STRUCT_TYPE(AppendImages) args = { images, stack, exception };
@@ -260,20 +260,20 @@ VALUE ImageList_combine(int argc, VALUE *argv, VALUE self)
     {
         case 5:
             if (colorspace == CMYKColorspace)
-                channel |= AlphaChannel;
+                channel = (ChannelType)(channel | AlphaChannel);
             else
                 rb_raise(rb_eArgError, "invalid number of images in this image list");
         case 4:
             if (colorspace == CMYKColorspace)
-                channel |= IndexChannel;
+                channel = (ChannelType)(channel | IndexChannel);
             else
-                channel |= AlphaChannel;
+                channel = (ChannelType)(channel | AlphaChannel);
         case 3:
-            channel |= GreenChannel;
-            channel |= BlueChannel;
+            channel = (ChannelType)(channel | GreenChannel);
+            channel = (ChannelType)(channel | BlueChannel);
             break;
         case 2:
-            channel |= AlphaChannel;
+            channel = (ChannelType)(channel | AlphaChannel);
             break;
         case 1:
             break;
@@ -970,7 +970,7 @@ ImageList_quantize(int argc, VALUE *argv, VALUE self)
             if (rb_obj_is_kind_of(argv[2], Class_DitherMethod))
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
-                quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
+                quantize_info.dither = (MagickBooleanType)(quantize_info.dither_method != NoDitherMethod);
             }
             else
             {
@@ -1155,7 +1155,7 @@ ImageList_to_blob(VALUE self)
         return Qnil;
     }
 
-    blob_str = rb_str_new(blob, (long)length);
+    blob_str = rb_str_new((const char *)blob, (long)length);
     magick_free((void*)blob);
 
     RB_GC_GUARD(info_obj);

--- a/ext/RMagick/rmimage.c
+++ b/ext/RMagick/rmimage.c
@@ -757,7 +757,7 @@ Image_add_noise_channel(int argc, VALUE *argv, VALUE self)
     }
 
     VALUE_TO_ENUM(argv[0], noise_type, NoiseType);
-    channels &= ~OpacityChannel;
+    channels = (ChannelType)(channels & ~OpacityChannel);
 
     exception = AcquireExceptionInfo();
 #if defined(IMAGEMAGICK_7)
@@ -4507,7 +4507,7 @@ VALUE
 Image_contrast(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
-    unsigned int sharpen = 0;
+    MagickBooleanType sharpen = MagickFalse;
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception;
 #endif
@@ -4519,7 +4519,7 @@ Image_contrast(int argc, VALUE *argv, VALUE self)
     }
     else if (argc == 1)
     {
-        sharpen = RTEST(argv[0]);
+        sharpen = (MagickBooleanType)RTEST(argv[0]);
     }
 
     new_image = rm_clone_image(image);
@@ -5937,7 +5937,7 @@ Image_distort(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 3:
-            bestfit = RTEST(argv[2]);
+            bestfit = (MagickBooleanType)RTEST(argv[2]);
         case 2:
             // Ensure pts is an array
             pts = rb_Array(argv[1]);
@@ -8647,7 +8647,7 @@ Image_level_colors(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 3:
-            invert = RTEST(argv[2]);
+            invert = (MagickBooleanType)RTEST(argv[2]);
 
         case 2:
             Color_to_MagickPixel(image, &white_color, argv[1]);
@@ -9728,7 +9728,7 @@ VALUE
 Image_negate(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
-    unsigned int grayscale = MagickFalse;
+    MagickBooleanType grayscale = MagickFalse;
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception;
 #endif
@@ -9736,7 +9736,7 @@ Image_negate(int argc, VALUE *argv, VALUE self)
     image = rm_check_destroyed(self);
     if (argc == 1)
     {
-        grayscale = RTEST(argv[0]);
+        grayscale = (MagickBooleanType)RTEST(argv[0]);
     }
     else if (argc > 1)
     {
@@ -9783,7 +9783,7 @@ Image_negate_channel(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     ChannelType channels;
-    unsigned int grayscale = MagickFalse;
+    MagickBooleanType grayscale = MagickFalse;
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception;
 #endif
@@ -9798,7 +9798,7 @@ Image_negate_channel(int argc, VALUE *argv, VALUE self)
     }
     else if (argc == 1)
     {
-        grayscale = RTEST(argv[0]);
+        grayscale = (MagickBooleanType)RTEST(argv[0]);
     }
 
     new_image = rm_clone_image(image);
@@ -10250,7 +10250,7 @@ Image_opaque_channel(int argc, VALUE *argv, VALUE self)
                 rb_raise(rb_eArgError, "fuzz must be >= 0.0 (%g given)", fuzz);
             }
         case 3:
-            invert = RTEST(argv[2]);
+            invert = (MagickBooleanType)RTEST(argv[2]);
         case 2:
             // Allow color name or Pixel
             Color_to_MagickPixel(image, &fill_pp, argv[1]);
@@ -10478,11 +10478,11 @@ Image_paint_transparent(int argc, VALUE *argv, VALUE self)
         case 3:
             if (TYPE(argv[argc - 1]) == T_HASH)
             {
-                invert = RTEST(argv[1]);
+                invert = (MagickBooleanType)RTEST(argv[1]);
             }
             else
             {
-                invert = RTEST(argv[2]);
+                invert = (MagickBooleanType)RTEST(argv[2]);
             }
         case 2:
             alpha = get_named_alpha_value(argv[argc - 1]);
@@ -11201,7 +11201,7 @@ Image_quantize(int argc, VALUE *argv, VALUE self)
             {
                 VALUE_TO_ENUM(argv[2], quantize_info.dither_method, DitherMethod);
 #if defined(IMAGEMAGICK_6)
-                quantize_info.dither = quantize_info.dither_method != NoDitherMethod;
+                quantize_info.dither = (MagickBooleanType)(quantize_info.dither_method != NoDitherMethod);
 #endif
             }
             else
@@ -11414,7 +11414,7 @@ Image_raise(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     RectangleInfo rect;
-    int raised = MagickTrue;      // default
+    MagickBooleanType raised = MagickTrue;      // default
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception;
 #endif
@@ -11427,7 +11427,7 @@ Image_raise(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 3:
-            raised = RTEST(argv[2]);
+            raised = (MagickBooleanType)RTEST(argv[2]);
         case 2:
             rect.height = NUM2ULONG(argv[1]);
         case 1:
@@ -12668,7 +12668,7 @@ VALUE
 Image_separate(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_images;
-    ChannelType channels = 0;
+    ChannelType channels = UndefinedChannel;
     ExceptionInfo *exception;
 
     image = rm_check_destroyed(self);
@@ -12757,8 +12757,8 @@ VALUE
 Image_segment(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
-    int colorspace              = RGBColorspace;    // These are the Magick++ defaults
-    unsigned int verbose        = MagickFalse;
+    ColorspaceType colorspace   = RGBColorspace;    // These are the Magick++ defaults
+    MagickBooleanType verbose   = MagickFalse;
     double cluster_threshold    = 1.0;
     double smoothing_threshold  = 1.5;
 #if defined(IMAGEMAGICK_7)
@@ -12769,7 +12769,7 @@ Image_segment(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 4:
-            verbose = RTEST(argv[3]);
+            verbose = (MagickBooleanType)RTEST(argv[3]);
         case 3:
             smoothing_threshold = NUM2DBL(argv[2]);
         case 2:
@@ -12909,7 +12909,7 @@ Image_shade(int argc, VALUE *argv, VALUE self)
 {
     Image *image, *new_image;
     double azimuth = 30.0, elevation = 30.0;
-    unsigned int shading = MagickFalse;
+    MagickBooleanType shading = MagickFalse;
     ExceptionInfo *exception;
 
     image = rm_check_destroyed(self);
@@ -12920,7 +12920,7 @@ Image_shade(int argc, VALUE *argv, VALUE self)
         case 2:
             azimuth = NUM2DBL(argv[1]);
         case 1:
-            shading = RTEST(argv[0]);
+            shading = (MagickBooleanType)RTEST(argv[0]);
         case 0:
             break;
         default:
@@ -14548,7 +14548,7 @@ Image_to_blob(VALUE self)
         return Qnil;
     }
 
-    blob_str = rb_str_new(blob, length);
+    blob_str = rb_str_new((const char *)blob, length);
 
     magick_free((void*)blob);
 
@@ -14739,11 +14739,11 @@ Image_transparent_chroma(int argc, VALUE *argv, VALUE self)
         case 4:
             if (TYPE(argv[argc - 1]) == T_HASH)
             {
-                invert = RTEST(argv[3]);
+                invert = (MagickBooleanType)RTEST(argv[3]);
             }
             else
             {
-                invert = RTEST(argv[2]);
+                invert = (MagickBooleanType)RTEST(argv[2]);
             }
         case 3:
             alpha = get_named_alpha_value(argv[argc - 1]);
@@ -15822,7 +15822,7 @@ void add_format_prefix(Info *info, VALUE file)
     // If the filename starts with a prefix, and it's a valid image format
     // prefix, then check for a conflict. If it's not a valid format prefix,
     // ignore it.
-    p = memchr(filename, ':', (size_t)filename_l);
+    p = (char *)memchr(filename, ':', (size_t)filename_l);
     if (p)
     {
         memset(magic, '\0', sizeof(magic));
@@ -16311,7 +16311,7 @@ ChannelType extract_channels(int *argc, VALUE *argv)
     VALUE arg;
     ChannelType channels, ch_arg;
 
-    channels = 0;
+    channels = UndefinedChannel;
     while (*argc > 0)
     {
         arg = argv[(*argc)-1];
@@ -16322,7 +16322,7 @@ ChannelType extract_channels(int *argc, VALUE *argv)
             break;
         }
         VALUE_TO_ENUM(arg, ch_arg, ChannelType);
-        channels |= ch_arg;
+        channels = (ChannelType)(channels | ch_arg);
         *argc -= 1;
     }
 

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -37,7 +37,7 @@ const rb_data_type_t rm_montage_data_type = {
 static void
 Montage_destroy(void *obj)
 {
-    Montage *montage = obj;
+    Montage *montage = (Montage *)obj;
 
     // If we saved a temporary texture image, delete it now.
     if (montage->info && montage->info->texture != NULL)

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -1207,13 +1207,13 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
     char name[MaxTextExtent];
     ExceptionInfo *exception;
     ComplianceType compliance = AllCompliance;
-    unsigned int alpha = MagickFalse;
+    MagickBooleanType alpha = MagickFalse;
     unsigned int depth = MAGICKCORE_QUANTUM_DEPTH;
 
     switch (argc)
     {
         case 4:
-            hex = RTEST(argv[3]);
+            hex = (MagickBooleanType)RTEST(argv[3]);
         case 3:
             depth = NUM2UINT(argv[2]);
 
@@ -1233,7 +1233,7 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
                     break;
             }
        case 2:
-            alpha = RTEST(argv[1]);
+            alpha = (MagickBooleanType)RTEST(argv[1]);
         case 1:
             VALUE_TO_ENUM(argv[0], compliance, ComplianceType);
         case 0:

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -456,8 +456,8 @@ Export_TypeInfo(TypeInfo *ti, VALUE st)
     {
         CloneString((char **)&(ti->family), StringValueCStr(m));
     }
-    m = rb_ary_entry(members, 3); ti->style   = m == Qnil ? 0 : FIX2INT(Enum_to_i(m));
-    m = rb_ary_entry(members, 4); ti->stretch = m == Qnil ? 0 : FIX2INT(Enum_to_i(m));
+    m = rb_ary_entry(members, 3); ti->style   = m == Qnil ? UndefinedStyle : (StyleType)FIX2INT(Enum_to_i(m));
+    m = rb_ary_entry(members, 4); ti->stretch = m == Qnil ? UndefinedStretch : (StretchType)FIX2INT(Enum_to_i(m));
     m = rb_ary_entry(members, 5); ti->weight  = m == Qnil ? 0 : FIX2INT(m);
 
     m = rb_ary_entry(members, 6);

--- a/ext/RMagick/rmutil.c
+++ b/ext/RMagick/rmutil.c
@@ -1332,7 +1332,7 @@ rm_exif_by_entry(Image *image)
         return Qnil;
     }
 
-    str = xmalloc(len);
+    str = (char *)xmalloc(len);
     len = 0;
 
     // Copy the exif properties and values into the string.
@@ -1450,7 +1450,7 @@ rm_exif_by_number(Image *image)
         return Qnil;
     }
 
-    str = xmalloc(len);
+    str = (char *)xmalloc(len);
     len = 0;
 
     // Copy the exif properties and values into the string.


### PR DESCRIPTION
The C++ compiler requires strict type for cast.

Related to https://github.com/rmagick/rmagick/issues/1419