### PR TITLE
Fix Pixel#<=> which should accept other class instance

### DIFF
--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -1069,6 +1069,10 @@ Pixel_spaceship(VALUE self, VALUE other)
 {
     Pixel *self_pixel, *other_pixel;
 
+    if (CLASS_OF(self) != CLASS_OF(other)) {
+        return Qnil;
+    }
+
     TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, self_pixel);
     TypedData_Get_Struct(other, Pixel, &rm_pixel_data_type, other_pixel);
 
@@ -1096,10 +1100,8 @@ Pixel_spaceship(VALUE self, VALUE other)
     }
 #endif
 
-    // Values are equal, check class.
-
-    return rb_funcall(CLASS_OF(self), rb_intern("<=>"), 1, CLASS_OF(other));
-
+    // Values are equal.
+    return INT2NUM(0);
 }
 
 

--- a/spec/rmagick/pixel/spaceship_spec.rb
+++ b/spec/rmagick/pixel/spaceship_spec.rb
@@ -31,5 +31,7 @@ RSpec.describe Magick::Pixel, '#<=>' do
     expect(pixel <=> pixel2).to eq(1)
     pixel2.alpha += 20
     expect(pixel <=> pixel2).to eq(-1)
+
+    expect(pixel <=> Object.new).to be_nil
   end
 end


### PR DESCRIPTION
Now, Pixel#<=> raises a TypeError exception if other class instance was given.

```
irb(main):001:0> require 'rmagick'
=> true
irb(main):002:0> pixel = Magick::Pixel.from_color('brown')
=> #<Magick::Pixel:0x000000010197dae0>
irb(main):003:0> pixel <=> 1234
(irb):3:in `<=>': wrong argument type Integer (expected Magick::Pixel) (TypeError)
```

However, Ruby built-in classes (ex. String#<=>) accept that.
```
irb(main):001:0> "hello" <=> 1234
=> nil
```

So this patch will fix Pixel#<=> behavior to make more Ruby flavor.