### PR TITLE
Fix makefile generation in nix

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -109,7 +109,8 @@ module RMagick
 
         # Save flags
         $CPPFLAGS   += " #{ENV['CPPFLAGS']} " + PKGConfig.cflags($magick_package).chomp
-        $LOCAL_LIBS += " #{ENV['LIBS']} "     + PKGConfig.libs($magick_package).chomp
+        $CPPFLAGS   += ' -x c++ -std=c++11 -Wno-register'
+        $LOCAL_LIBS += " #{ENV['LIBS']} " + PKGConfig.libs($magick_package).chomp
         $LDFLAGS    += " #{ldflags} #{rpath}"
 
         unless try_link("int main() { }")
@@ -117,18 +118,15 @@ module RMagick
           $LDFLAGS = "#{original_ldflags} #{ldflags}"
         end
 
-        $CPPFLAGS += ' -x c++ -std=c++11 -Wno-register'
-
         configure_archflags_for_osx($magick_package) if RUBY_PLATFORM =~ /darwin/ # osx
 
       elsif RUBY_PLATFORM =~ /mingw/ # mingw
 
         dir_paths = search_paths_for_library_for_windows
         $CPPFLAGS += %( -I"#{dir_paths[:include]}")
+        $CPPFLAGS += ' -x c++ -std=c++11 -Wno-register'
         $LDFLAGS += %( -L"#{dir_paths[:lib]}")
         $LDFLAGS << ' -lucrt' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
-
-        $CPPFLAGS += ' -x c++ -std=c++11 -Wno-register'
 
         have_library(im_version_at_least?('7.0.0') ? 'CORE_RL_MagickCore_' : 'CORE_RL_magick_')
 


### PR DESCRIPTION
'-x c++' should be added before we call try_link(). Otherwise it fails on some versions of clang with:

```
DYLD_FALLBACK_LIBRARY_PATH=.:/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/lib "clang -o conftest -I/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/arm64-darwin22 -I/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby/backward -I/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0 -I../../../../ext/RMagick -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT    -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_CHANNEL_MASK_DEPTH=32 -DMAGICKCORE_QUANTUM_DEPTH=16 -I/nix/store/hgdbh1i3bqlc2ns7279708n3d6d05nqi-imagemagick-7.1.1-19-dev/include/ImageMagick-7 -fdeclspec -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wextra-tokens -Wdeprecated-declarations -Wdivision-by-zero -Wdiv-by-zero -Wimplicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wshorten-64-to-32 -Wwrite-strings -Wold-style-definition -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Wundef  -fno-common -pipe conftest.cpp  -L. -L/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/lib -L. -fstack-protector-strong  -L/nix/store/44gsy016ymd3bac4rblr1sbwsgkyazn5-imagemagick-7.1.1-19/lib -lMagickCore-7.Q16HDRI -Wl,-rpath,/nix/store/44gsy016ymd3bac4rblr1sbwsgkyazn5-imagemagick-7.1.1-19/lib     -L/nix/store/44gsy016ymd3bac4rblr1sbwsgkyazn5-imagemagick-7.1.1-19/lib -lMagickCore-7.Q16HDRI  -lruby-3.2.2  -lpthread  "
In file included from conftest.cpp:1:
In file included from /nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby.h:38:
In file included from /nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby/ruby.h:25:
In file included from /nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby/defines.h:74:
In file included from /nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby/backward/2/bool.h:22:
/nix/store/3ryrxm7jlpprln40mcqagvb366plx182-ruby-3.2.2/include/ruby-3.2.0/ruby/internal/stdbool.h:31:12: fatal error: 'cstdbool' file not found
           ^~~~~~~~~~
1 error generated.
checked program was:
/* begin */
1: #include "ruby.h"
2:
3: int main(int argc, char **argv)
4: {
5:   return !!argv[argc];
6: }
/* end */
```


Unfortunately #1460 didn't fix it for me. The test program built by `try_link("int main() { }")` is also built as c++ (due to redefining `MakeMakefile::CONFTEST_C` ), so the `-x c++` flag needs adding before that.

---

(This is possibly specific to clang under Nix - their clang wrapper doesn't auto-detect c++ mode from the file name, so is missing c++ headers otherwise. [Some more info on their issue tracker](https://github.com/NixOS/nixpkgs/issues/150655) )



