### PR TITLE
Fix Magick::GradientFill#fill and Magick::TextureFill#fill to accept ImageList object

### DIFF
--- a/ext/RMagick/rmfill.cpp
+++ b/ext/RMagick/rmfill.cpp
@@ -634,7 +634,7 @@ h_diagonal_fill(
  * Call GradientFill with the start and stop colors specified when this fill
  * object was created.
  *
- * @param image_obj [Magick::Image] the image to fill
+ * @param image_obj [Magick::Image, Magick::ImageList] the image to fill
  * @return [Magick::GradientFill] self
  */
 VALUE
@@ -646,7 +646,7 @@ GradientFill_fill(VALUE self, VALUE image_obj)
     double x1, y1, x2, y2;          // points on the line
 
     TypedData_Get_Struct(self, rm_GradientFill, &rm_gradient_fill_data_type, fill);
-    image = rm_check_destroyed(image_obj);
+    image = rm_check_destroyed(rm_cur_image(image_obj));
 
     x1 = fill->x1;
     y1 = fill->y1;
@@ -780,7 +780,7 @@ TextureFill_initialize(VALUE self, VALUE texture_arg)
  * Call TextureFill with the texture specified when this fill object was
  * created.
  *
- * @param image_obj [Magick::Image] the image to fill
+ * @param image_obj [Magick::Image, Magick::ImageList] the image to fill
  * @return [Magick::TextureFill] self
  */
 VALUE
@@ -792,7 +792,7 @@ TextureFill_fill(VALUE self, VALUE image_obj)
     ExceptionInfo *exception;
 #endif
 
-    image = rm_check_destroyed(image_obj);
+    image = rm_check_destroyed(rm_cur_image(image_obj));
     TypedData_Get_Struct(self, rm_TextureFill, &rm_texture_fill_data_type, fill);
 
 #if defined(IMAGEMAGICK_7)

--- a/spec/rmagick/gradient_fill/fill_spec.rb
+++ b/spec/rmagick/gradient_fill/fill_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe Magick::GradientFill, '#fill' do
     gradient = described_class.new(0, 100, 100, 200, '#900', '#000')
     obj = gradient.fill(image)
     expect(obj).to eq(gradient)
+
+    imgl = Magick::ImageList.new
+    imgl.new_image(10, 10)
+
+    gradient = described_class.new(0, 0, 0, 0, '#900', '#000')
+    obj = gradient.fill(imgl)
+    expect(obj).to eq(gradient)
   end
 end

--- a/spec/rmagick/texture_fill/fill_spec.rb
+++ b/spec/rmagick/texture_fill/fill_spec.rb
@@ -6,5 +6,11 @@ RSpec.describe Magick::TextureFill, '#fill' do
     image = Magick::Image.new(10, 10)
     obj = texture.fill(image)
     expect(obj).to eq(texture)
+
+    imgl = Magick::ImageList.new
+    imgl.new_image(10, 10)
+
+    obj = texture.fill(imgl)
+    expect(obj).to eq(texture)
   end
 end


### PR DESCRIPTION
Magick::HatchFill#fill accepts Magick::ImageList object.
```
irb(main):001:0> require 'rmagick'
=> true
irb(main):002:0> imgl = Magick::ImageList.new
=>
[]
...
irb(main):003:0> imgl.new_image(10, 10)
=>
[  10x10 DirectClass 16-bit]
scene=0
irb(main):004:0> gradient = Magick::HatchFill.new('white', 'lightcyan2')
irb(main):005:0> gradient.fill(imgl)
=> 10
```

However, Magick::GradientFill#fill does not accept it.
```
irb(main):001:0> require 'rmagick'
=> true
irb(main):002:0> imgl = Magick::ImageList.new
=>
[]
...
irb(main):003:0> imgl.new_image(10, 10)
=>
[  10x10 DirectClass 16-bit]
scene=0
irb(main):004:0> gradient = Magick::GradientFill.new(0, 0, 0, 0, '#900', '#000')
irb(main):005:0> gradient.fill(imgl)
(irb):5:in `fill': wrong argument type Magick::ImageList (expected Magick::Image) (TypeError)
```

Fix inconsistent behaviour.