### PR TITLE
Return self with ImageList if Image's method return self

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -127,7 +127,7 @@ Metrics/BlockNesting:
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 460
+  Max: 462
 
 # Offense count: 21
 # Configuration parameters: IgnoredMethods.

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1614,7 +1614,9 @@ module Magick
     # it up the line. Catch a NameError and emit a useful message.
     def method_missing(meth_id, *args, &block)
       if @scene
-        @images[@scene].send(meth_id, *args, &block)
+        img = @images[@scene]
+        new_img = img.send(meth_id, *args, &block)
+        img.object_id == new_img.object_id ? self : new_img
       else
         super
       end


### PR DESCRIPTION
When it call ImageList method via method_missing even if the method return self in Image method, it will return Image object.

```
imgl = Magick::ImageList.new("Flower_Hat.jpg")
p imgl.resize!(0.50).class # => Magick::Image
```

This patch will return ImageList object.