### PR TITLE
Fix ImageList#<=> that should return nil if can't compare

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1349,16 +1349,18 @@ module Magick
     #   return if A.scene != B.scene
     #   return A.length <=> B.length
     def <=>(other)
-      Kernel.raise TypeError, "#{self.class} required (#{other.class} given)" unless other.is_a? self.class
+      return unless other.is_a? self.class
+
       size = [length, other.length].min
       size.times do |x|
         r = self[x] <=> other[x]
         return r unless r.zero?
       end
-      return 0 if @scene.nil? && other.scene.nil?
 
-      Kernel.raise TypeError, "cannot convert nil into #{other.scene.class}" if @scene.nil? && !other.scene.nil?
-      Kernel.raise TypeError, "cannot convert nil into #{scene.class}" if !@scene.nil? && other.scene.nil?
+      return 0 if @scene.nil? && other.scene.nil?
+      return if @scene.nil? && !other.scene.nil?
+      return if !@scene.nil? && other.scene.nil?
+
       r = scene <=> other.scene
       return r unless r.zero?
 

--- a/spec/rmagick/image_list/spaceship_spec.rb
+++ b/spec/rmagick/image_list/spaceship_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Magick::ImageList, '#<=>' do
     image_list2 << image_list1[9]
     expect(image_list2).not_to eq(image_list1)
 
-    expect { image_list1 <=> 2 }.to raise_error(TypeError)
+    expect(image_list1 <=> 2).to be_nil
     image_list2 = described_class.new
     image_list3 = described_class.new
-    expect { image_list2 <=> image_list1 }.to raise_error(TypeError)
-    expect { image_list1 <=> image_list2 }.to raise_error(TypeError)
-    expect { image_list3 <=> image_list2 }.not_to raise_error
+    expect(image_list2 <=> image_list1).to be_nil
+    expect(image_list1 <=> image_list2).to be_nil
+    expect(image_list3 <=> image_list2).to be 0
   end
 end


### PR DESCRIPTION
Standard Ruby implementation returns nil when it can't compare
```
p "aaa" <=> "xxx"      # => -1
p "aaa" <=> "aaa"      # => 0
p "aaa" <=> Object.new # => nil
```

This patch follows that behaviour.