### PR TITLE
Fix ImageList#sort! that should return self

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -127,7 +127,7 @@ Metrics/BlockNesting:
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 466
+  Max: 469
 
 # Offense count: 21
 # Configuration parameters: IgnoredMethods.

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1392,7 +1392,7 @@ module Magick
 
     %i[
       at each each_index empty? fetch
-      first hash include? index length rindex sort!
+      first hash include? index length rindex
     ].each do |mth|
       module_eval <<-END_SIMPLE_DELEGATES, __FILE__, __LINE__ + 1
         def #{mth}(*args, &block)
@@ -1401,6 +1401,11 @@ module Magick
       END_SIMPLE_DELEGATES
     end
     alias size length
+
+    def sort!(*args, &block)
+      @images.sort!(*args, &block)
+      self
+    end
 
     def clear
       @scene = nil


### PR DESCRIPTION
Standard Ruby implementation of ! method returns self. However, ImageList#sort! has wrong behaviour.

```
imgl = Magick::ImageList.new
p imgl.object_id       # => 60
p imgl.sort!.object_id # => 80
```

This patch follows that behaviour.