### PR TITLE
Fix Draw#{stroke_dasharray, stroke_miterlimit} to accept object which has #to_f method

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -585,7 +585,7 @@ module Magick
       if list.length.zero?
         primitive 'stroke-dasharray none'
       else
-        list.each do |x|
+        list.map! { |x| Float(x) }.each do |x|
           Kernel.raise ArgumentError, "dash array elements must be > 0 (#{x} given)" if x <= 0
         end
         primitive "stroke-dasharray #{list.join(',')}"
@@ -608,6 +608,7 @@ module Magick
     end
 
     def stroke_miterlimit(value)
+      value = Float(value)
       Kernel.raise ArgumentError, 'miterlimit must be >= 1' if value < 1
       primitive "stroke-miterlimit #{value}"
     end

--- a/spec/rmagick/draw/stroke_dasharray_spec.rb
+++ b/spec/rmagick/draw/stroke_dasharray_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Magick::Draw, '#stroke_dasharray' do
     image = Magick::Image.new(200, 200)
 
     draw.stroke_dasharray(2, 2)
-    expect(draw.inspect).to eq('stroke-dasharray 2,2')
+    expect(draw.inspect).to eq('stroke-dasharray 2.0,2.0')
     draw.stroke_pattern('red')
     draw.stroke_width(2)
     draw.rectangle(10, '10', 100, 100)
@@ -17,5 +17,6 @@ RSpec.describe Magick::Draw, '#stroke_dasharray' do
 
     expect { draw.stroke_dasharray(-0.1) }.to raise_error(ArgumentError)
     expect { draw.stroke_dasharray('x') }.to raise_error(ArgumentError)
+    expect { draw.stroke_dasharray(2, '2') }.not_to raise_error
   end
 end

--- a/spec/rmagick/draw/stroke_miterlimit_spec.rb
+++ b/spec/rmagick/draw/stroke_miterlimit_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe Magick::Draw, '#stroke_miterlimit' do
 
     expect { draw.stroke_miterlimit(0.9) }.to raise_error(ArgumentError)
     expect { draw.stroke_miterlimit('foo') }.to raise_error(ArgumentError)
+    expect { draw.stroke_miterlimit('1.0') }.not_to raise_error
   end
 end


### PR DESCRIPTION
The Draw method implemented in magick_internal.rb can implicitly convert objects with #to_f.