### PR TITLE
Generate compile_flags.txt for clangd for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tmp
 *.def
 Makefile
 extconf.h
+compile_flags.txt
 build-ImageMagick/
 doc/node_modules/
 doc/package-lock.json

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -413,6 +413,22 @@ module RMagick
       print_summary
     end
 
+    def create_compile_flags_txt
+      cppflags = $CPPFLAGS.split(' ')
+      include_flags = cppflags.select { |flag| flag.start_with?('-I') }
+      define_flags = cppflags.select { |flag| flag.start_with?('-D') } + $defs
+
+      File.open('compile_flags.txt', 'w') do |f|
+        include_flags.each { |flag| f.puts(flag) }
+        f.puts "-I#{Dir.pwd}"
+        f.puts "-I#{RbConfig::CONFIG['rubyhdrdir']}"
+        f.puts "-I#{RbConfig::CONFIG['rubyhdrdir']}/ruby/backward"
+        f.puts "-I#{RbConfig::CONFIG['rubyarchhdrdir']}"
+        f.puts "-std=c++11"
+        define_flags.each { |flag| f.puts(flag) }
+      end
+    end
+
     def magick_command
       @magick_command ||= if find_executable('magick')
                             'magick'
@@ -451,3 +467,4 @@ at_exit do
   message msg + "\n"
 end
 extconf.create_makefile_file
+extconf.create_compile_flags_txt


### PR DESCRIPTION
You can use appropriate code completion via clangd, etc.

If you use Visual Studio Code, you can use [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) extension.