### PR TITLE
Fix Draw#{interline_spacing, interword_spacing, kerning} to correctly handle arguments that can be converted to Float

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -405,38 +405,17 @@ module Magick
 
     # IM 6.5.5-8 and later
     def interline_spacing(space)
-      begin
-        Float(space)
-      rescue ArgumentError
-        Kernel.raise ArgumentError, 'invalid value for interline_spacing'
-      rescue TypeError
-        Kernel.raise TypeError, "can't convert #{space.class} into Float"
-      end
-      primitive "interline-spacing #{space}"
+      primitive "interline-spacing #{Float(space)}"
     end
 
     # IM 6.4.8-3 and later
     def interword_spacing(space)
-      begin
-        Float(space)
-      rescue ArgumentError
-        Kernel.raise ArgumentError, 'invalid value for interword_spacing'
-      rescue TypeError
-        Kernel.raise TypeError, "can't convert #{space.class} into Float"
-      end
-      primitive "interword-spacing #{space}"
+      primitive "interword-spacing #{Float(space)}"
     end
 
     # IM 6.4.8-3 and later
     def kerning(space)
-      begin
-        Float(space)
-      rescue ArgumentError
-        Kernel.raise ArgumentError, 'invalid value for kerning'
-      rescue TypeError
-        Kernel.raise TypeError, "can't convert #{space.class} into Float"
-      end
-      primitive "kerning #{space}"
+      primitive "kerning #{Float(space)}"
     end
 
     # Draw a line

--- a/spec/rmagick/draw/interline_spacing_spec.rb
+++ b/spec/rmagick/draw/interline_spacing_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Magick::Draw, '#interline_spacing' do
     expect(draw.inspect).to eq('interline-spacing 40.5')
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.interline_spacing(1/4r)
+    expect(draw.inspect).to eq('interline-spacing 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     # expect { draw.interline_spacing(Float::NAN) }.to raise_error(ArgumentError)
     expect { draw.interline_spacing('nan') }.to raise_error(ArgumentError)
     expect { draw.interline_spacing('xxx') }.to raise_error(ArgumentError)

--- a/spec/rmagick/draw/interword_spacing_spec.rb
+++ b/spec/rmagick/draw/interword_spacing_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Magick::Draw, '#interword_spacing' do
     expect(draw.inspect).to eq('interword-spacing 40.5')
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.interword_spacing(1/4r)
+    expect(draw.inspect).to eq('interword-spacing 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     # expect { draw.interword_spacing(Float::NAN) }.to raise_error(ArgumentError)
     expect { draw.interword_spacing('nan') }.to raise_error(ArgumentError)
     expect { draw.interword_spacing('xxx') }.to raise_error(ArgumentError)

--- a/spec/rmagick/draw/kerning_spec.rb
+++ b/spec/rmagick/draw/kerning_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Magick::Draw, '#kerning' do
     expect(draw.inspect).to eq('kerning 40.5')
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.kerning(1/4r)
+    expect(draw.inspect).to eq('kerning 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     # expect { draw.kerning(Float::NAN) }.to raise_error(ArgumentError)
     expect { draw.kerning('nan') }.to raise_error(ArgumentError)
     expect { draw.kerning('xxx') }.to raise_error(ArgumentError)


### PR DESCRIPTION
For example, it would not work correctly when passed Rational object.

```
draw = Magick::Draw.new
draw.interline_spacing(1/4r)
```