### PR TITLE
Fix Draw#{fill_opacity, opacity, stroke_opacity} to correctly handle arguments

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -233,11 +233,13 @@ module Magick
       end
     end
 
-    def check_opacity(opacity)
-      return if opacity.is_a?(String) && opacity['%']
+    def to_opacity(opacity)
+      return opacity if opacity.is_a?(String) && opacity.end_with?('%')
 
       value = Float(opacity)
       Kernel.raise ArgumentError, 'opacity must be >= 0 and <= 1.0' if value < 0 || value > 1.0
+
+      value
     end
 
     public
@@ -352,7 +354,7 @@ module Magick
 
     # Specify fill opacity (use "xx%" to indicate percentage)
     def fill_opacity(opacity)
-      check_opacity(opacity)
+      opacity = to_opacity(opacity)
       primitive "fill-opacity #{opacity}"
     end
 
@@ -426,7 +428,7 @@ module Magick
     # Specify drawing fill and stroke opacities. If the value is a string
     # ending with a %, the number will be multiplied by 0.01.
     def opacity(opacity)
-      check_opacity(opacity)
+      opacity = to_opacity(opacity)
       primitive "opacity #{opacity}"
     end
 
@@ -595,7 +597,7 @@ module Magick
     # Specify opacity of stroke drawing color
     #  (use "xx%" to indicate percentage)
     def stroke_opacity(opacity)
-      check_opacity(opacity)
+      opacity = to_opacity(opacity)
       primitive "stroke-opacity #{opacity}"
     end
 

--- a/spec/rmagick/draw/fill_opacity_spec.rb
+++ b/spec/rmagick/draw/fill_opacity_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Magick::Draw, '#fill_opacity' do
     draw.circle(10, '20.5', 30, 40.5)
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.fill_opacity(1/4r)
+    expect(draw.inspect).to eq('fill-opacity 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     expect { draw.fill_opacity(0.0) }.not_to raise_error
     expect { draw.fill_opacity(1.0) }.not_to raise_error
     expect { draw.fill_opacity('0.0') }.not_to raise_error
@@ -25,5 +30,6 @@ RSpec.describe Magick::Draw, '#fill_opacity' do
     expect { draw.fill_opacity('-0.01') }.to raise_error(ArgumentError)
     expect { draw.fill_opacity('1.01') }.to raise_error(ArgumentError)
     expect { draw.fill_opacity('xxx') }.to raise_error(ArgumentError)
+    expect { draw.fill_opacity('%20') }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/draw/opacity_spec.rb
+++ b/spec/rmagick/draw/opacity_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Magick::Draw, '#opacity' do
     expect(draw.inspect).to eq('opacity 0.8')
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.opacity(1/4r)
+    expect(draw.inspect).to eq('opacity 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     expect { draw.opacity(0.0) }.not_to raise_error
     expect { draw.opacity(1.0) }.not_to raise_error
     expect { draw.opacity('0.0') }.not_to raise_error
@@ -18,5 +23,6 @@ RSpec.describe Magick::Draw, '#opacity' do
     expect { draw.opacity('-0.01') }.to raise_error(ArgumentError)
     expect { draw.opacity('1.01') }.to raise_error(ArgumentError)
     expect { draw.opacity('xxx') }.to raise_error(ArgumentError)
+    expect { draw.opacity('%20') }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/draw/stroke_opacity_spec.rb
+++ b/spec/rmagick/draw/stroke_opacity_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Magick::Draw, '#stroke_opacity' do
     expect(draw.inspect).to eq('stroke-opacity 0.8')
     expect { draw.draw(image) }.not_to raise_error
 
+    draw = described_class.new
+    draw.stroke_opacity(1/4r)
+    expect(draw.inspect).to eq('stroke-opacity 0.25')
+    expect { draw.draw(image) }.not_to raise_error
+
     expect { draw.stroke_opacity(0.0) }.not_to raise_error
     expect { draw.stroke_opacity(1.0) }.not_to raise_error
     expect { draw.stroke_opacity('0.0') }.not_to raise_error
@@ -18,5 +23,6 @@ RSpec.describe Magick::Draw, '#stroke_opacity' do
     expect { draw.stroke_opacity('-0.01') }.to raise_error(ArgumentError)
     expect { draw.stroke_opacity('1.01') }.to raise_error(ArgumentError)
     expect { draw.stroke_opacity('xxx') }.to raise_error(ArgumentError)
+    expect { draw.stroke_opacity('%20') }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
Similar with https://github.com/rmagick/rmagick/pull/1491