### PR TITLE
Coerce to string where pass object into string interpolation

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -242,6 +242,14 @@ module Magick
       value
     end
 
+    def to_string(obj)
+      return obj if obj.is_a?(String)
+      return obj.to_s if obj.is_a?(Symbol)
+      return obj.to_str if obj.respond_to?(:to_str)
+
+      Kernel.raise TypeError, "no implicit conversion of #{obj.class} into String"
+    end
+
     public
 
     # Apply coordinate transformations to support scaling (s), rotation (r),
@@ -283,7 +291,7 @@ module Magick
 
     # Invoke a clip-path defined by def_clip_path.
     def clip_path(name)
-      primitive "clip-path #{name}"
+      primitive "clip-path #{to_string(name)}"
     end
 
     # Define the clipping rule.
@@ -322,7 +330,7 @@ module Magick
     # (pop) graphic-context".
     def define_clip_path(name)
       push('defs')
-      push("clip-path \"#{name}\"")
+      push("clip-path \"#{to_string(name)}\"")
       push('graphic-context')
       yield
     ensure
@@ -342,7 +350,7 @@ module Magick
     # Let anything through, but the only defined argument
     # is "UTF-8". All others are apparently ignored.
     def encoding(encoding)
-      primitive "encoding #{encoding}"
+      primitive "encoding #{to_string(encoding)}"
     end
 
     # Specify object fill, a color name or pattern name
@@ -365,11 +373,11 @@ module Magick
 
     # Specify text drawing font
     def font(name)
-      primitive "font \'#{name}\'"
+      primitive "font \'#{to_string(name)}\'"
     end
 
     def font_family(name)
-      primitive "font-family \'#{name}\'"
+      primitive "font-family \'#{to_string(name)}\'"
     end
 
     def font_stretch(stretch)
@@ -436,7 +444,7 @@ module Magick
     # primitive requires that the commands be surrounded by quotes or
     # apostrophes. Here we simply use apostrophes.
     def path(cmds)
-      primitive "path '" + cmds + "'"
+      primitive "path '#{to_string(cmds)}'"
     end
 
     # Define a pattern. In the block, call primitive methods to
@@ -444,7 +452,7 @@ module Magick
     # as the argument to the 'fill' or 'stroke' methods
     def pattern(name, x, y, width, height)
       push('defs')
-      push("pattern #{name} " + sprintf('%g %g %g %g', x, y, width, height))
+      push("pattern #{to_string(name)} " + sprintf('%g %g %g %g', x, y, width, height))
       push('graphic-context')
       yield
     ensure

--- a/spec/rmagick/draw/clip_path_spec.rb
+++ b/spec/rmagick/draw/clip_path_spec.rb
@@ -27,5 +27,7 @@ RSpec.describe Magick::Draw, '#clip_path' do
 
     canvas = Magick::Image.new(10, 10)
     draw.draw(canvas)
+
+    expect { draw.clip_path(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/define_clip_path_spec.rb
+++ b/spec/rmagick/draw/define_clip_path_spec.rb
@@ -4,5 +4,7 @@ RSpec.describe Magick::Draw, '#define_clip_path' do
 
     expect { draw.define_clip_path('test') { draw } }.not_to raise_error
     expect(draw.inspect).to eq("push defs\npush clip-path \"test\"\npush graphic-context\npop graphic-context\npop clip-path\npop defs")
+
+    expect { draw.define_clip_path(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/encoding_spec.rb
+++ b/spec/rmagick/draw/encoding_spec.rb
@@ -6,5 +6,7 @@ RSpec.describe Magick::Draw, '#encoding' do
     draw.encoding('UTF-8')
     expect(draw.inspect).to eq('encoding UTF-8')
     expect { draw.draw(image) }.not_to raise_error
+
+    expect { draw.encoding(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/font_family_spec.rb
+++ b/spec/rmagick/draw/font_family_spec.rb
@@ -7,5 +7,7 @@ RSpec.describe Magick::Draw, '#font_family' do
     expect(draw.inspect).to eq("font-family 'sans-serif'")
     draw.text(50, 50, 'Hello world')
     expect { draw.draw(image) }.not_to raise_error
+
+    expect { draw.font_family(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/font_spec.rb
+++ b/spec/rmagick/draw/font_spec.rb
@@ -8,5 +8,7 @@ RSpec.describe Magick::Draw, '#font' do
     expect(draw.inspect).to eq("font '#{font_name}'")
     draw.text(50, 50, 'Hello world')
     expect { draw.draw(image) }.not_to raise_error
+
+    expect { draw.font(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/path_spec.rb
+++ b/spec/rmagick/draw/path_spec.rb
@@ -6,5 +6,7 @@ RSpec.describe Magick::Draw, '#path' do
     draw.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
     expect(draw.inspect).to eq("path 'M110,100 h-75 a75,75 0 1,0 75,-75 z'")
     expect { draw.draw(image) }.not_to raise_error
+
+    expect { draw.path(Object.new) }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/draw/pattern_spec.rb
+++ b/spec/rmagick/draw/pattern_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Magick::Draw, '#pattern' do
     expect { draw.pattern('hat', 0, 'x', 20, 20) {} }.to raise_error(ArgumentError)
     expect { draw.pattern('hat', 0, 0, 'x', 20) {} }.to raise_error(ArgumentError)
     expect { draw.pattern('hat', 0, 0, 20, 'x') {} }.to raise_error(ArgumentError)
+    expect { draw.pattern(Object.new, 'x', 0, 20, 20) }.to raise_error(TypeError)
   end
 end


### PR DESCRIPTION
String interpolation, it will convert object to string using #to_s automatically. Unexpected objects are accepted because all object have #to_s.

```
irb(main):001> "hello #{Object.new}"
=> "hello #<Object:0x000000011dd30770>"
```