### PR TITLE
Improve Image#modulate to accept "NN%" form string

### DIFF
--- a/doc/image2.html
+++ b/doc/image2.html
@@ -3075,8 +3075,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
       <h4>Arguments</h4>
 
       <p>
-        The percent change in the brightness, saturation, and hue, represented as Float numbers. For example, 0.25 means "25%". All three arguments may be
-        omitted. The default value of each argument is 1.0, that is, 100%.
+        The percent change in the brightness, saturation, and hue. Must be a non-negative number or a string in the form "NN%". For example, 0.25 means "25%".
+        All three arguments may be omitted. The default value of each argument is 1.0, that is, 100%.
       </p>
 
       <h4>Returns</h4>

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -9582,9 +9582,12 @@ Image_minify_bang(VALUE self)
  * Changes the brightness, saturation, and hue.
  *
  * @overload modulate(brightness = 1.0, saturation = 1.0, hue = 1.0)
- *   @param brightness [Numeric] The percent change in the brightness
- *   @param saturation [Numeric] The percent change in the saturation
- *   @param hue [Numeric] The percent change in the hue
+ *   @param brightness [Numeric, String] The percent change in the brightness.
+ *     Must be a non-negative number or a string in the form "NN%".
+ *   @param saturation [Numeric, String] The percent change in the saturation.
+ *     Must be a non-negative number or a string in the form "NN%".
+ *   @param hue [Numeric, String] The percent change in the hue.
+ *     Must be a non-negative number or a string in the form "NN%".
  *   @return [Magick::Image] a new image
  */
 VALUE
@@ -9603,11 +9606,11 @@ Image_modulate(int argc, VALUE *argv, VALUE self)
     switch (argc)
     {
         case 3:
-            pct_hue        = 100*NUM2DBL(argv[2]);
+            pct_hue        = rm_percentage(argv[2], 1.0) * 100.0;
         case 2:
-            pct_saturation = 100*NUM2DBL(argv[1]);
+            pct_saturation = rm_percentage(argv[1], 1.0) * 100.0;
         case 1:
-            pct_brightness = 100*NUM2DBL(argv[0]);
+            pct_brightness = rm_percentage(argv[0], 1.0) * 100.0;
             break;
         case 0:
             break;

--- a/spec/rmagick/image/modulate_spec.rb
+++ b/spec/rmagick/image/modulate_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe Magick::Image, '#modulate' do
     expect(result).not_to be(image)
 
     expect { image.modulate(0.5) }.not_to raise_error
+    expect { image.modulate('50%') }.not_to raise_error
     expect { image.modulate(0.5, 0.5) }.not_to raise_error
+    expect { image.modulate(0.5, '50%') }.not_to raise_error
     expect { image.modulate(0.5, 0.5, 0.5) }.not_to raise_error
+    expect { image.modulate(0.5, 0.5, '50%') }.not_to raise_error
     expect { image.modulate(0.0, 0.5, 0.5) }.to raise_error(ArgumentError)
     expect { image.modulate(0.5, 0.5, 0.5, 0.5) }.to raise_error(ArgumentError)
-    expect { image.modulate('x', 0.5, 0.5) }.to raise_error(TypeError)
-    expect { image.modulate(0.5, 'x', 0.5) }.to raise_error(TypeError)
-    expect { image.modulate(0.5, 0.5, 'x') }.to raise_error(TypeError)
+    expect { image.modulate('x', 0.5, 0.5) }.to raise_error(ArgumentError)
+    expect { image.modulate(0.5, 'x', 0.5) }.to raise_error(ArgumentError)
+    expect { image.modulate(0.5, 0.5, 'x') }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
By this patch, Image#modulate will accept “NN%” form string like Image#watermark.