### PR TITLE
Improve HatchFill.new to accept Pixel object as color

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1854,7 +1854,7 @@ module Magick
   class HatchFill
     def initialize(bgcolor, hatchcolor = 'white', dist = 10)
       @bgcolor = bgcolor
-      @hatchpixel = Pixel.from_color(hatchcolor)
+      @hatchpixel = hatchcolor.is_a?(Pixel) ? hatchcolor : Pixel.from_color(hatchcolor)
       @dist = dist
     end
 

--- a/spec/rmagick/image_list/new_image_spec.rb
+++ b/spec/rmagick/image_list/new_image_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::ImageList, "#new_image" do
 
     expect(image_list.length).to eq(1)
     expect(image_list.scene).to eq(0)
-    image_list.new_image(20, 20, Magick::HatchFill.new('black'))
+    image_list.new_image(20, 20, Magick::HatchFill.new(Magick::Pixel.from_color('black'), Magick::Pixel.from_color('white')))
     expect(image_list.length).to eq(2)
     expect(image_list.scene).to eq(1)
     image_list.new_image(20, 20) { |options| options.background_color = 'red' }


### PR DESCRIPTION
The first argument of `HatchFill.new` accepts a Pixel object.
However, the second does not.

So, this patch make arguments same behavior.