### PR TITLE
Loosen ImageMagick version check between compiled and runtime

### DIFF
--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -1834,13 +1834,18 @@ test_Magick_version(void)
     const char *version_str;
     ID bypass = rb_intern("RMAGICK_BYPASS_VERSION_TEST");
 
+    /* ImageMagick versions are defined as major, minor and patch, each of which are defined as a value in 1 byte. */
+    /* ImageMagick 6.9.12 has `#define MagickLibVersion  0x69C` */
+    /* It use only major and minor versions. */
+    size_t mask_major_minor_version = 0xFFFFFFF0;
+
     if (RTEST(rb_const_defined(rb_cObject, bypass)) && RTEST(rb_const_get(rb_cObject, bypass)))
     {
         return;
     }
 
     version_str = GetMagickVersion(&version_number);
-    if (version_number != MagickLibVersion)
+    if ((version_number & mask_major_minor_version) != (MagickLibVersion & mask_major_minor_version))
     {
         int n, x;
 

--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -1822,27 +1822,17 @@ Init_RMagick2(void)
  * were compiled with.
  *
  * No Ruby usage (internal function)
- *
- * Notes:
- *   - Bypass the test by defining the constant RMAGICK_BYPASS_VERSION_TEST to
- *     'true' at the top level, before requiring 'rmagick'
  */
 static void
 test_Magick_version(void)
 {
     size_t version_number;
     const char *version_str;
-    ID bypass = rb_intern("RMAGICK_BYPASS_VERSION_TEST");
 
     /* ImageMagick versions are defined as major, minor and patch, each of which are defined as a value in 1 byte. */
     /* ImageMagick 6.9.12 has `#define MagickLibVersion  0x69C` */
     /* It use only major and minor versions. */
     size_t mask_major_minor_version = 0xFFFFFFF0;
-
-    if (RTEST(rb_const_defined(rb_cObject, bypass)) && RTEST(rb_const_get(rb_cObject, bypass)))
-    {
-        return;
-    }
 
     version_str = GetMagickVersion(&version_number);
     if ((version_number & mask_major_minor_version) != (MagickLibVersion & mask_major_minor_version))


### PR DESCRIPTION
We have been checked that ImageMagick major, minor and patch versions match when compiled and run.

1. We haven't been switched RMagick functionality with each of the latest ImageMagick patch versions. Therefore, I consider it sufficient to check up to the minor version.
2. If user accidentally updates ImageMagick, and the patch version is updated, an error will occur at runtime, which is inconvenient.
  - It raises exception like `This installation of RMagick was configured with ImageMagick 6.9.12 but ImageMagick 6.9.13-7 is in use. (RuntimeError)`.

And this remove the RMAGICK_BYPASS_VERSION_TEST logic as I don't think anyone uses it.