### PR TITLE
Drop ImageMagick 6.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,10 @@ jobs:
       matrix:
         ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         imagemagick-version:
-          - { full: 6.7.7-10, major-minor: '6.7' }
           - { full: 6.8.9-10, major-minor: '6.8' }
           - { full: 6.9.13-7, major-minor: '6.9' }
           - { full: 7.0.11-14, major-minor: '7.0' }
           - { full: 7.1.1-29, major-minor: '7.1' }
-        exclude:
-          # Ghostscript 9.55.0 causes error with Ruby 3.3 + ImageMagick 6.7 when run Magick::Draw tests.
-          # It disable running tests with Ruby 3.3 + ImageMagick 6.7 because it might be difficult to support old ImageMagick.
-          - ruby-version: '3.3'
-            imagemagick-version: { major-minor: '6.7' }
 
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## RMagick 6.0.0 (development)
+
+Improvements
+
+- Drop ImageMagick 6.7 support (#1539)
+- Loosen ImageMagick version check between compiled and runtime (#1526)
+
 ## RMagick 5.5.0
 
 Improvements

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can get Ruby from <https://www.ruby-lang.org>.
 Ruby must be able to build C-Extensions (e.g. MRI, Rubinius, not JRuby)
 
 **ImageMagick**
-- Version 6.7.7 or later (6.x.x).
+- Version 6.8.9 or later (6.x.x).
 - Version 7.0.8 or later (7.x.x). Require RMagick 4.1.0 or later.
 
 You can get ImageMagick from <https://imagemagick.org>.

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -26,11 +26,6 @@ sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
   liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev libxml2-dev \
   libtiff5-dev libwebp-dev liblqr-1-0-dev vim gsfonts ghostscript
 
-if [ ! -d /usr/include/freetype ]; then
-  # If `/usr/include/freetype` is not existed, ImageMagick 6.7 configuration fails about Freetype.
-  sudo ln -sf /usr/include/freetype2 /usr/include/freetype
-fi
-
 project_dir=$(pwd)
 build_dir="${project_dir}/build-ImageMagick/ImageMagick-${IMAGEMAGICK_VERSION}"
 if [ -v CONFIGURE_OPTIONS ]; then

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -16,9 +16,6 @@ module RMagick
     RMAGICK_VERS = ::Magick::VERSION
     MIN_RUBY_VERS = ::Magick::MIN_RUBY_VERSION
 
-    # ImageMagick 6.7 package
-    IM6_7_PACKAGES = ['ImageMagick'].freeze
-
     # ImageMagick 6.8+ packages
     IM6_PACKAGES = %w[
       ImageMagick-6.Q64HDRI
@@ -180,11 +177,6 @@ module RMagick
 
     def determine_imagemagick_package
       packages = [installed_im7_packages, installed_im6_packages].flatten
-
-      if packages.empty?
-        # ImageMagick 6.7 does not have package file like ImageMagick-6.Q16.pc
-        packages = detect_imagemagick_packages(IM6_7_PACKAGES)
-      end
 
       if packages.empty?
         exit_failure "Can't install RMagick #{RMAGICK_VERS}. Can't find ImageMagick with pkg-config\n"
@@ -394,7 +386,6 @@ module RMagick
       $defs.push("-DRUBY_VERSION_STRING=\"ruby #{RUBY_VERSION}\"")
       $defs.push("-DRMAGICK_VERSION_STRING=\"RMagick #{RMAGICK_VERS}\"")
 
-      $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9=1') if im_version_at_least?('6.8.9')
       $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_6_9_0=1') if im_version_at_least?('6.9.0')
       $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_6_9_10=1') if im_version_at_least?('6.9.10')
       $defs.push('-DIMAGEMAGICK_7=1') if im_version_at_least?('7.0.0')

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -310,10 +310,8 @@ typedef enum _QuantumExpressionOperator
     AbsQuantumOperator, /**< abs */
     ExponentialQuantumOperator, /**< exponential */
     MedianQuantumOperator, /**< median */
-    SumQuantumOperator /**< sum */
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
-    , RootMeanSquareQuantumOperator /** root mean square */
-#endif
+    SumQuantumOperator, /**< sum */
+    RootMeanSquareQuantumOperator /** root mean square */
 } QuantumExpressionOperator ;
 
 

--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -1019,10 +1019,8 @@ Init_RMagick2(void)
         ENUMERATOR(ShapeAlphaChannel)
         ENUMERATOR(TransparentAlphaChannel)
         ENUMERATOR(BackgroundAlphaChannel)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(AssociateAlphaChannel)
         ENUMERATOR(DisassociateAlphaChannel)
-#endif
 #if defined(IMAGEMAGICK_7)
         ENUMERATOR(OnAlphaChannel)
         ENUMERATOR(OffAlphaChannel)
@@ -1090,7 +1088,6 @@ Init_RMagick2(void)
         ENUMERATOR(Rec709YCbCrColorspace)
         ENUMERATOR(LogColorspace)
         ENUMERATOR(CMYColorspace)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(LuvColorspace)
         ENUMERATOR(HCLColorspace)
         ENUMERATOR(LCHColorspace)
@@ -1103,7 +1100,6 @@ Init_RMagick2(void)
         ENUMERATOR(HCLpColorspace)
         ENUMERATOR(YDbDrColorspace)
         ENUMERATORV(XyYColorspace, xyYColorspace)
-#endif
 #if defined(IMAGEMAGICK_7)
 #if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_7_0_8)
         ENUMERATOR(LinearGRAYColorspace)
@@ -1196,9 +1192,7 @@ Init_RMagick2(void)
         ENUMERATOR(UndefinedCompositeOp)
         ENUMERATOR(VividLightCompositeOp)
         ENUMERATOR(XorCompositeOp)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(HardMixCompositeOp)
-#endif
 #if defined(IMAGEMAGICK_7)
         ENUMERATOR(CopyAlphaCompositeOp)
 #else
@@ -1318,9 +1312,7 @@ Init_RMagick2(void)
         ENUMERATOR(RobidouxSharpFilter)
         ENUMERATOR(CosineFilter)
         ENUMERATOR(SplineFilter)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(LanczosRadiusFilter)
-#endif
         ENUMERATORV(WelchFilter, WelshFilter)
         ENUMERATORV(HannFilter, HanningFilter)
     END_ENUM
@@ -1412,9 +1404,7 @@ Init_RMagick2(void)
         ENUMERATOR(RootMeanSquaredErrorMetric)
         ENUMERATOR(NormalizedCrossCorrelationErrorMetric)
         ENUMERATOR(FuzzErrorMetric)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(PerceptualHashErrorMetric)
-#endif
 #if defined(IMAGEMAGICK_7)
         ENUMERATOR(UndefinedErrorMetric)
         ENUMERATOR(MeanErrorPerPixelErrorMetric)
@@ -1546,9 +1536,7 @@ Init_RMagick2(void)
         ENUMERATOR(ExponentialQuantumOperator)
         ENUMERATOR(MedianQuantumOperator)
         ENUMERATOR(SumQuantumOperator)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(RootMeanSquareQuantumOperator)
-#endif
     END_ENUM
 
     // RenderingIntent
@@ -1673,9 +1661,7 @@ Init_RMagick2(void)
         ENUMERATOR(CorrelateNormalizeValue)
         ENUMERATOR(AreaValue)
         ENUMERATOR(DecimalValue)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
         ENUMERATOR(SeparatorValue)
-#endif
         ENUMERATOR(AllValues)
     END_ENUM
 
@@ -1744,9 +1730,7 @@ Init_RMagick2(void)
       ENUMERATOR(OctagonalKernel)
       ENUMERATOR(EuclideanKernel)
       ENUMERATOR(UserDefinedKernel)
-#if defined(IMAGEMAGICK_GREATER_THAN_EQUAL_6_8_9)
       ENUMERATOR(BinomialKernel)
-#endif
     END_ENUM
 
     /*-----------------------------------------------------------------------*/

--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -3,5 +3,5 @@
 module Magick
   VERSION = '5.5.0'
   MIN_RUBY_VERSION = '2.3.0'
-  MIN_IM_VERSION = '6.7.7'
+  MIN_IM_VERSION = '6.8.9'
 end

--- a/spec/rmagick/image/channel_mean_spec.rb
+++ b/spec/rmagick/image/channel_mean_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Magick::Image, "#channel_mean" do
 
     mean_and_stddev = image.channel_mean(Magick::RedChannel)
     expected_stddev = value_by_version(
-      "6.7": 100.1757830016816,
       "6.8": 100.1757830016816,
       "6.9": 115.6730305646048,
       "7.0": 115.6730305646048,
@@ -20,7 +19,6 @@ RSpec.describe Magick::Image, "#channel_mean" do
 
     mean_and_stddev = image.channel_mean(Magick::GreenChannel)
     expected_stddev = value_by_version(
-      "6.7": 66.22122016393234,
       "6.8": 66.22122016393234,
       "6.9": 76.46567857542362,
       "7.0": 76.46567857542362,
@@ -36,7 +34,6 @@ RSpec.describe Magick::Image, "#channel_mean" do
 
     mean_and_stddev = image.channel_mean(Magick::RedChannel, Magick::GreenChannel)
     expected_stddev = value_by_version(
-      "6.7": 84.91300695417634,
       "6.8": 84.91300695417634,
       "6.9": 96.06935457001421,
       "7.0": 96.06935457001421,
@@ -52,7 +49,6 @@ RSpec.describe Magick::Image, "#channel_mean" do
 
     mean_and_stddev = image.channel_mean
     expected_stddev = value_by_version(
-      "6.7": 91.23584365076407,
       "6.8": 91.23584365076407,
       "6.9": 103.58337316538109,
       "7.0": 103.58337316538109,


### PR DESCRIPTION
Ubuntu 14.04 installs ImageMagick 6.7 via `apt install` command. https://launchpad.net/ubuntu/trusty/+package/imagemagick

However, Ubuntu 14.04 will be EOL in April 2024.
https://wiki.ubuntu.com/Releases

Finally, we can drop ImageMagick 6.7 support.