### PR TITLE
Drop ruby-mswin environment support on Windows

### DIFF
--- a/doc/ex/font_styles.rb
+++ b/doc/ex/font_styles.rb
@@ -13,7 +13,7 @@ rvg = Magick::RVG.new(200, 250) do |canvas|
   end
 
   canvas.g.styles(font_size: 14, font_weight: 'normal', font_style: 'normal') do |grp|
-    if RUBY_PLATFORM.match?(/mswin|mingw/)
+    if RUBY_PLATFORM.include?('mingw')
       grp.text(8, 120, ":font_family=>'Courier-New'").styles(font_family: 'Courier-New')
     else
       grp.text(8, 120, ":font_family=>'Courier'").styles(font_family: 'Courier')

--- a/doc/ex/get_type_metrics.rb
+++ b/doc/ex/get_type_metrics.rb
@@ -25,7 +25,7 @@ end
 ORIGIN_X = 110
 ORIGIN_Y = 230
 GLYPH = 'g'
-FONT = RUBY_PLATFORM.match?(/mswin|mingw/) ? 'Verdana' : 'Times'
+FONT = RUBY_PLATFORM.include?('mingw') ? 'Verdana' : 'Times'
 
 canvas = Magick::Image.new(410, 320, Magick::HatchFill.new('white', 'lightcyan2'))
 

--- a/doc/ex/text.rb
+++ b/doc/ex/text.rb
@@ -5,7 +5,7 @@ imgl.new_image(190, 190)
 
 sample = Magick::Draw.new
 sample.stroke('transparent')
-if RUBY_PLATFORM.match?(/mswin|mingw/)
+if RUBY_PLATFORM.include?('mingw')
   sample.font_family('Georgia')
 else
   sample.font_family('times')

--- a/doc/ex/text_antialias.rb
+++ b/doc/ex/text_antialias.rb
@@ -7,7 +7,7 @@ gc = Magick::Draw.new
 gc.fill('black')
 gc.stroke('transparent')
 
-if RUBY_PLATFORM.match?(/mswin|mingw/)
+if RUBY_PLATFORM.include?('mingw')
   gc.font_family('Georgia')
   gc.pointsize(152)
 else

--- a/doc/ex/watermark.rb
+++ b/doc/ex/watermark.rb
@@ -9,7 +9,7 @@ gc = Magick::Draw.new
 gc.annotate(mark, 0, 0, 0, -5, 'RMagick') do |options|
   options.gravity = Magick::CenterGravity
   options.pointsize = 32
-  options.font_family = RUBY_PLATFORM.match?(/mswin|mingw/) ? 'Georgia' : 'Times'
+  options.font_family = RUBY_PLATFORM.include?('mingw') ? 'Georgia' : 'Times'
   options.fill = 'white'
   options.stroke = 'none'
 end

--- a/doc/ex/wet_floor.rb
+++ b/doc/ex/wet_floor.rb
@@ -11,7 +11,7 @@ gc.annotate(img, 0, 0, 0, -15, 'RUBY!') do |options|
   options.stroke_width = 2
   options.font_weight = Magick::BoldWeight
   options.gravity = Magick::SouthGravity
-  if RUBY_PLATFORM.match?(/mswin|mingw/)
+  if RUBY_PLATFORM.include?('mingw')
     options.font_family = 'Georgia'
     options.pointsize = 76
   else

--- a/spec/magick_spec.rb
+++ b/spec/magick_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Magick do
           r.take
         end.not_to raise_error
 
-        unless RUBY_PLATFORM.match?(/mswin|mingw/)
+        unless RUBY_PLATFORM.include?('mingw')
           # Skip because it causes "`init_formats': unable to register image format 'DMR'" error on Windows
           expect do
             r = Ractor.new do

--- a/spec/rmagick/class_methods/formats_spec.rb
+++ b/spec/rmagick/class_methods/formats_spec.rb
@@ -1,5 +1,5 @@
 describe Magick, '.formats' do
-  it 'works', unless: -> { RUBY_PLATFORM !~ /mswin|mingw/ } do
+  it 'works', unless: -> { !RUBY_PLATFORM.include?('mingw') } do
     # Skip because it causes "`init_formats': unable to register image format 'DMR'" error on Windows
     expect(described_class.formats).to be_instance_of(Hash)
     described_class.formats.each do |f, v|

--- a/spec/rmagick/class_methods/init_formats_spec.rb
+++ b/spec/rmagick/class_methods/init_formats_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Magick, '.init_formats' do
-  it 'works', unless: -> { RUBY_PLATFORM !~ /mswin|mingw/ } do
+  it 'works', unless: -> { !RUBY_PLATFORM.include?('mingw') } do
     # Skip because it causes "`init_formats': unable to register image format 'DMR'" error on Windows
     expect(described_class.init_formats).to be_instance_of(Hash)
   end


### PR DESCRIPTION
As a Ruby runtime environment on Windows, there is MINGW and MSWIN.

I think almost everyone uses [RubyInstaller](https://rubyinstaller.org/) to run Ruby, and it is MINGW environment.
MSWIN sets up the compiler itself and compiles Ruby from source code to create the environment.
I believe that this is very difficult and only some Ruby committers do that.

I will drop MSWIN support because it become difficult (related to https://github.com/rmagick/rmagick/pull/1585)