### PR TITLE
Change method that returns a color name to return a hex string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,33 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Improvements
 
-- Drop ruby-mswin environment support on Windows (#1587)
+- Improve compatibility of Image#pixel_color value for ImageMagick 6 and 7 (#1591)
 - Add missing constants (#1580)
-- Drop Ruby 2.x support (#1540)
-- Drop ImageMagick 6.7 support (#1539)
 - Loosen ImageMagick version check between compiled and runtime (#1526)
 
 Bug Fixes
 
 - Fix install error on Windows MINGW environment (#1588)
 - Fix header checks in order to use aligned_malloc expectedly (#1579)
+
+Breaking Changes
+
+- Change method that returns a color name to return a hex string (#1592)
+  - The following methods return RGBA hex string as color name. The hex string length is according to color depth.
+    - `Image#background_color`
+    - `Image#border_color`
+    - `Image#colormap`
+    - `Image#matte_color`
+    - `Image#transparent_color`
+    - `Info#background_color`
+    - `Info#border_color`
+    - `Info#matte_color`
+    - `Info#transparent_color`
+  - Change default value of argument
+    - The hex argument of `Pixel#to_color` has `true` by default.
+- Drop ruby-mswin environment support on Windows (#1587)
+- Drop Ruby 2.x support (#1540)
+- Drop ImageMagick 6.7 support (#1539)
 
 ## RMagick 5.5.0
 

--- a/doc/struct.html
+++ b/doc/struct.html
@@ -779,7 +779,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
 
         <p>
           <span class="arg">pixel</span>.to_color(<span class="arg">compliance</span>=AllCompliance, <span class="arg">matte</span>=<code>false</code>,
-          <span class="arg">depth</span>=<code>QuantumDepth</code>, <span class="arg">hex</span>=<code>false</code>) -&gt; <em>string</em>
+          <span class="arg">depth</span>=<code>QuantumDepth</code>, <span class="arg">hex</span>=<code>true</code>) -&gt; <em>string</em>
         </p>
       </div>
 

--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -1191,7 +1191,7 @@ rm_set_magick_pixel_packet(Pixel *pixel, MagickPixel *pp)
 /**
  * Return the color name corresponding to the pixel values.
  *
- * @overload to_color(compliance = Magick::AllCompliance, alpha = false, depth = Magick::MAGICKCORE_QUANTUM_DEPTH, hex = false)
+ * @overload to_color(compliance = Magick::AllCompliance, alpha = false, depth = Magick::MAGICKCORE_QUANTUM_DEPTH, hex = true)
  *   @param compliance [Magick::ComplianceType] A ComplianceType constant
  *   @param alpha [Boolean] If false, the pixel's alpha attribute is ignored
  *   @param depth [Numeric] An image depth
@@ -1205,7 +1205,7 @@ Pixel_to_color(int argc, VALUE *argv, VALUE self)
     Image *image;
     Pixel *pixel;
     MagickPixel mpp;
-    MagickBooleanType hex = MagickFalse;
+    MagickBooleanType hex = MagickTrue;
     char name[MaxTextExtent];
     ExceptionInfo *exception;
     ComplianceType compliance = AllCompliance;

--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -589,23 +589,27 @@ rm_cur_image(VALUE img)
 VALUE
 rm_pixelcolor_to_color_name(Image *image, PixelColor *color)
 {
-    PixelColor pp;
-    char name[MaxTextExtent];
-    ExceptionInfo *exception;
+    MagickPixel mpp;
+    char tuple[MaxTextExtent];
 
-    exception = AcquireExceptionInfo();
-
-    pp = *color;
 #if defined(IMAGEMAGICK_7)
-    pp.depth = MAGICKCORE_QUANTUM_DEPTH;
-    pp.colorspace = image->colorspace;
+    mpp = *color;
+    mpp.alpha_trait = BlendPixelTrait;
+    mpp.colorspace = image->colorspace;
+#else
+    rm_init_magickpixel(image, &mpp);
+    mpp.red = GetPixelRed(color);
+    mpp.green = GetPixelGreen(color);
+    mpp.blue = GetPixelBlue(color);
+    mpp.opacity = GetPixelOpacity(color);
+    mpp.index   = (MagickRealType) 0.0;
+    mpp.matte = MagickTrue;
 #endif
+    mpp.depth = MAGICKCORE_QUANTUM_DEPTH;
 
-    QueryColorname(image, &pp, X11Compliance, name, exception);
-    CHECK_EXCEPTION();
-    DestroyExceptionInfo(exception);
+    GetColorTuple(&mpp, MagickTrue, tuple);
 
-    return rb_str_new2(name);
+    return rb_str_new2(tuple);
 }
 
 

--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -605,7 +605,7 @@ rm_pixelcolor_to_color_name(Image *image, PixelColor *color)
     mpp.index   = (MagickRealType) 0.0;
     mpp.matte = MagickTrue;
 #endif
-    mpp.depth = MAGICKCORE_QUANTUM_DEPTH;
+    mpp.depth = image->depth;
 
     GetColorTuple(&mpp, MagickTrue, tuple);
 

--- a/spec/rmagick/image/background_color_spec.rb
+++ b/spec/rmagick/image/background_color_spec.rb
@@ -3,23 +3,33 @@ RSpec.describe Magick::Image, '#background_color' do
     image = described_class.new(100, 100)
 
     expect { image.background_color }.not_to raise_error
-    expect(image.background_color).to eq('white')
+    expected = value_by_version(
+      "6.8": "#FFFFFFFFFFFF",
+      "6.9": "#FFFFFFFFFFFFFFFF",
+      "7.0": "#FFFFFFFFFFFFFFFF",
+      "7.1": "#FFFFFFFFFFFFFFFF"
+    )
+    expect(image.background_color).to eq(expected)
     expect { image.background_color = '#dfdfdf' }.not_to raise_error
     # expect(image.background_color).to eq("rgb(223,223,223)")
     background_color = image.background_color
-    if background_color.length == 13
-      expect(background_color).to eq('#DFDFDFDFDFDF')
-    else
-      expect(background_color).to eq('#DFDFDFDFDFDFFFFF')
-    end
+    expected = value_by_version(
+      "6.8": "#DFDFDFDFDFDF",
+      "6.9": "#DFDFDFDFDFDFFFFF",
+      "7.0": "#DFDFDFDFDFDFFFFF",
+      "7.1": "#DFDFDFDFDFDFFFFF"
+    )
+    expect(background_color).to eq(expected)
     expect { image.background_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2.0, Magick::QuantumRange / 2.0) }.not_to raise_error
     # expect(image.background_color).to eq("rgb(100%,49.9992%,49.9992%)")
     background_color = image.background_color
-    if background_color.length == 13
-      expect(background_color).to eq('#FFFF7FFF7FFF')
-    else
-      expect(background_color).to eq('#FFFF7FFF7FFFFFFF')
-    end
+    expected = value_by_version(
+      "6.8": "#FFFF7FFF7FFF",
+      "6.9": "#FFFF7FFF7FFFFFFF",
+      "7.0": "#FFFF7FFF7FFFFFFF",
+      "7.1": "#FFFF7FFF7FFFFFFF"
+    )
+    expect(background_color).to eq(expected)
     expect { image.background_color = 2 }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/background_color_spec.rb
+++ b/spec/rmagick/image/background_color_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Magick::Image, '#background_color' do
   it 'works' do
-    image = described_class.new(100, 100)
+    image = described_class.new(100, 100) { |info| info.depth = 16 }
 
     expect { image.background_color }.not_to raise_error
     expected = value_by_version(
@@ -31,5 +31,16 @@ RSpec.describe Magick::Image, '#background_color' do
     )
     expect(background_color).to eq(expected)
     expect { image.background_color = 2 }.to raise_error(TypeError)
+
+    image = described_class.new(100, 100) { |info| info.depth = 8 }
+
+    expect { image.background_color }.not_to raise_error
+    expected = value_by_version(
+      "6.8": "#FFFFFF",
+      "6.9": "#FFFFFFFF",
+      "7.0": "#FFFFFFFF",
+      "7.1": "#FFFFFFFF"
+    )
+    expect(image.background_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/border_color_spec.rb
+++ b/spec/rmagick/image/border_color_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Magick::Image, '#border_color' do
   it 'works' do
-    image = described_class.new(100, 100)
+    image = described_class.new(100, 100) { |info| info.depth = 16 }
 
     expect { image.border_color }.not_to raise_error
     # expect(image.border_color).to eq("rgb(223,223,223)")
@@ -31,5 +31,15 @@ RSpec.describe Magick::Image, '#border_color' do
     )
     expect(border_color).to eq(expected)
     expect { image.border_color = 2 }.to raise_error(TypeError)
+
+    image = described_class.new(100, 100) { |info| info.depth = 8 }
+    border_color = image.border_color
+    expected = value_by_version(
+      "6.8": "#DFDFDF",
+      "6.9": "#DFDFDFFF",
+      "7.0": "#DFDFDFFF",
+      "7.1": "#DFDFDFFF"
+    )
+    expect(border_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/border_color_spec.rb
+++ b/spec/rmagick/image/border_color_spec.rb
@@ -5,21 +5,31 @@ RSpec.describe Magick::Image, '#border_color' do
     expect { image.border_color }.not_to raise_error
     # expect(image.border_color).to eq("rgb(223,223,223)")
     border_color = image.border_color
-    if border_color.length == 13
-      expect(border_color).to eq('#DFDFDFDFDFDF')
-    else
-      expect(border_color).to eq('#DFDFDFDFDFDFFFFF')
-    end
+    expected = value_by_version(
+      "6.8": "#DFDFDFDFDFDF",
+      "6.9": "#DFDFDFDFDFDFFFFF",
+      "7.0": "#DFDFDFDFDFDFFFFF",
+      "7.1": "#DFDFDFDFDFDFFFFF"
+    )
+    expect(border_color).to eq(expected)
     expect { image.border_color = 'red' }.not_to raise_error
-    expect(image.border_color).to eq('red')
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(image.border_color).to eq(expected)
     expect { image.border_color = Magick::Pixel.new(Magick::QuantumRange, Magick::QuantumRange / 2, Magick::QuantumRange / 2) }.not_to raise_error
     # expect(image.border_color).to eq("rgb(100%,49.9992%,49.9992%)")
     border_color = image.border_color
-    if border_color.length == 13
-      expect(border_color).to eq('#FFFF7FFF7FFF')
-    else
-      expect(border_color).to eq('#FFFF7FFF7FFFFFFF')
-    end
+    expected = value_by_version(
+      "6.8": "#FFFF7FFF7FFF",
+      "6.9": "#FFFF7FFF7FFFFFFF",
+      "7.0": "#FFFF7FFF7FFFFFFF",
+      "7.1": "#FFFF7FFF7FFFFFFF"
+    )
+    expect(border_color).to eq(expected)
     expect { image.border_color = 2 }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/colormap_spec.rb
+++ b/spec/rmagick/image/colormap_spec.rb
@@ -19,7 +19,13 @@ RSpec.describe Magick::Image, "#colormap" do
     result = pc_image.colormap(0, 'red')
     expect(result).to eq(old_color)
     result = pc_image.colormap(0)
-    expect(result).to eq('red')
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(result).to eq(expected)
 
     pixel = Magick::Pixel.new(Magick::QuantumRange)
     expect { pc_image.colormap(0, pixel) }.not_to raise_error

--- a/spec/rmagick/image/colormap_spec.rb
+++ b/spec/rmagick/image/colormap_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Magick::Image, "#colormap" do
     # IndexError b/c image is DirectClass
     expect { image.colormap(0) }.to raise_error(IndexError)
     # Read PseudoClass image
-    pc_image = described_class.read(IMAGES_DIR + '/Button_0.gif').first
+    pc_image = described_class.read(IMAGES_DIR + '/Button_0.gif') { |info| info.depth = 8 }.first
     expect { pc_image.colormap(0) }.not_to raise_error
     ncolors = pc_image.colors
     expect { pc_image.colormap(ncolors + 1) }.to raise_error(IndexError)
@@ -20,10 +20,10 @@ RSpec.describe Magick::Image, "#colormap" do
     expect(result).to eq(old_color)
     result = pc_image.colormap(0)
     expected = value_by_version(
-      "6.8": "#FFFF00000000",
-      "6.9": "#FFFF00000000FFFF",
-      "7.0": "#FFFF00000000FFFF",
-      "7.1": "#FFFF00000000FFFF"
+      "6.8": "#FF0000",
+      "6.9": "#FF0000FF",
+      "7.0": "#FF0000FF",
+      "7.1": "#FF0000FF"
     )
     expect(result).to eq(expected)
 

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Magick::Image::Info, '#background_color' do
   it 'works' do
     info = described_class.new
+    info.depth = 16
 
     expect { info.background_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
@@ -14,5 +15,17 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     expect(info.background_color).to eq(expected)
     image = Magick::Image.new(20, 20) { |options| options.background_color = 'red' }
     expect(image.background_color).to eq(expected)
+
+    info = described_class.new
+    info.depth = 8
+
+    expect { info.background_color = 'red' }.not_to raise_error
+    expected = value_by_version(
+      "6.8": "#FF0000",
+      "6.9": "#FF0000FF",
+      "7.0": "#FF0000FF",
+      "7.1": "#FF0000FF"
+    )
+    expect(info.background_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/background_color_spec.rb
+++ b/spec/rmagick/image/info/background_color_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe Magick::Image::Info, '#background_color' do
     expect { info.background_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.background_color = red }.not_to raise_error
-    expect(info.background_color).to eq('red')
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(info.background_color).to eq(expected)
     image = Magick::Image.new(20, 20) { |options| options.background_color = 'red' }
-    expect(image.background_color).to eq('red')
+    expect(image.background_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     expect { info.border_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.border_color = red }.not_to raise_error
-    expect(info.border_color).to eq('red')
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(info.border_color).to eq(expected)
     image = Magick::Image.new(20, 20) { |options| options.border_color = 'red' }
-    expect(image.border_color).to eq('red')
+    expect(image.border_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/border_color_spec.rb
+++ b/spec/rmagick/image/info/border_color_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Magick::Image::Info, '#border_color' do
   it 'works' do
     info = described_class.new
+    info.depth = 16
 
     expect { info.border_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
@@ -14,5 +15,17 @@ RSpec.describe Magick::Image::Info, '#border_color' do
     expect(info.border_color).to eq(expected)
     image = Magick::Image.new(20, 20) { |options| options.border_color = 'red' }
     expect(image.border_color).to eq(expected)
+
+    info = described_class.new
+    info.depth = 8
+
+    expect { info.border_color = 'red' }.not_to raise_error
+    expected = value_by_version(
+      "6.8": "#FF0000",
+      "6.9": "#FF0000FF",
+      "7.0": "#FF0000FF",
+      "7.1": "#FF0000FF"
+    )
+    expect(info.border_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Magick::Image::Info, '#matte_color' do
   it 'works' do
     info = described_class.new
+    info.depth = 16
 
     expect { info.matte_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
@@ -15,5 +16,17 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     image = Magick::Image.new(20, 20) { |options| options.matte_color = 'red' }
     expect(image.matte_color).to eq(expected)
     expect { info.matte_color = nil }.to raise_error(TypeError)
+
+    info = described_class.new
+    info.depth = 8
+
+    expect { info.matte_color = 'red' }.not_to raise_error
+    expected = value_by_version(
+      "6.8": "#FF0000",
+      "6.9": "#FF0000FF",
+      "7.0": "#FF0000FF",
+      "7.1": "#FF0000FF"
+    )
+    expect(info.matte_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/matte_color_spec.rb
+++ b/spec/rmagick/image/info/matte_color_spec.rb
@@ -5,9 +5,15 @@ RSpec.describe Magick::Image::Info, '#matte_color' do
     expect { info.matte_color = 'red' }.not_to raise_error
     red = Magick::Pixel.new(Magick::QuantumRange)
     expect { info.matte_color = red }.not_to raise_error
-    expect(info.matte_color).to eq('red')
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(info.matte_color).to eq(expected)
     image = Magick::Image.new(20, 20) { |options| options.matte_color = 'red' }
-    expect(image.matte_color).to eq('red')
+    expect(image.matte_color).to eq(expected)
     expect { info.matte_color = nil }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/info/transparent_color_spec.rb
+++ b/spec/rmagick/image/info/transparent_color_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Magick::Image::Info, '#transparent_color' do
   it 'works' do
     info = described_class.new
+    info.depth = 16
 
     expect { info.transparent_color = 'white' }.not_to raise_error
     expected = value_by_version(
@@ -11,5 +12,17 @@ RSpec.describe Magick::Image::Info, '#transparent_color' do
     )
     expect(info.transparent_color).to eq(expected)
     expect { info.transparent_color = nil }.to raise_error(TypeError)
+
+    info = described_class.new
+    info.depth = 8
+
+    expect { info.transparent_color = 'white' }.not_to raise_error
+    expected = value_by_version(
+      "6.8": "#FFFFFF",
+      "6.9": "#FFFFFFFF",
+      "7.0": "#FFFFFFFF",
+      "7.1": "#FFFFFFFF"
+    )
+    expect(info.transparent_color).to eq(expected)
   end
 end

--- a/spec/rmagick/image/info/transparent_color_spec.rb
+++ b/spec/rmagick/image/info/transparent_color_spec.rb
@@ -3,7 +3,13 @@ RSpec.describe Magick::Image::Info, '#transparent_color' do
     info = described_class.new
 
     expect { info.transparent_color = 'white' }.not_to raise_error
-    expect(info.transparent_color).to eq('white')
+    expected = value_by_version(
+      "6.8": "#FFFFFFFFFFFF",
+      "6.9": "#FFFFFFFFFFFFFFFF",
+      "7.0": "#FFFFFFFFFFFFFFFF",
+      "7.1": "#FFFFFFFFFFFFFFFF"
+    )
+    expect(info.transparent_color).to eq(expected)
     expect { info.transparent_color = nil }.to raise_error(TypeError)
   end
 end

--- a/spec/rmagick/image/pixel_color_spec.rb
+++ b/spec/rmagick/image/pixel_color_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Image, '#pixel_color' do
     expect(result).to be_instance_of(Magick::Pixel)
 
     result = image.pixel_color(0, 0)
-    expect(result.to_color).to eq(image.background_color)
+    expect(result.to_color).to eq('white')
     result = image.pixel_color(0, 0, 'red')
     expect(result.to_color).to eq('white')
     result = image.pixel_color(0, 0)

--- a/spec/rmagick/image/pixel_color_spec.rb
+++ b/spec/rmagick/image/pixel_color_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe Magick::Image, '#pixel_color' do
     expect(result).to be_instance_of(Magick::Pixel)
 
     result = image.pixel_color(0, 0)
-    expect(result.to_color).to eq('white')
+    expect(result.to_color).to eq('#FFFFFFFFFFFF')
     result = image.pixel_color(0, 0, 'red')
-    expect(result.to_color).to eq('white')
+    expect(result.to_color).to eq('#FFFFFFFFFFFF')
     result = image.pixel_color(0, 0)
-    expect(result.to_color).to eq('red')
+    expect(result.to_color).to eq('#FFFF00000000')
 
     blue = Magick::Pixel.new(0, 0, Magick::QuantumRange)
     expect { image.pixel_color(0, 0, blue) }.not_to raise_error
     # If args are out-of-bounds return the background color
     image = described_class.new(10, 10) { |options| options.background_color = 'blue' }
-    expect(image.pixel_color(50, 50).to_color).to eq('blue')
+    expect(image.pixel_color(50, 50).to_color).to eq('#00000000FFFF')
 
     image.class_type = Magick::PseudoClass
     result = image.pixel_color(0, 0, 'red')
-    expect(result.to_color).to eq('blue')
+    expect(result.to_color).to eq('#00000000FFFF')
   end
 
   it 'get/set CYMK color', unsupported_before('6.8.0') do

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::ImageList, "#montage" do
   end
 
   it "works", unsupported_before('6.8.0') do
-    image_list1 = described_class.new
+    image_list1 = described_class.new { |info| info.depth = 16 }
 
     image_list1.read(*Dir[IMAGES_DIR + '/Button_*.gif'])
     image_list2 = image_list1.copy

--- a/spec/rmagick/image_list/montage_spec.rb
+++ b/spec/rmagick/image_list/montage_spec.rb
@@ -41,8 +41,20 @@ RSpec.describe Magick::ImageList, "#montage" do
     expect(image_list2).to eq(image_list1)
 
     montage_image = montage.first
-    expect(montage_image.background_color).to eq('blue')
-    expect(montage_image.border_color).to eq('red')
+    expected = value_by_version(
+      "6.8": "#00000000FFFF",
+      "6.9": "#00000000FFFFFFFF",
+      "7.0": "#00000000FFFFFFFF",
+      "7.1": "#00000000FFFFFFFF"
+    )
+    expect(montage_image.background_color).to eq(expected)
+    expected = value_by_version(
+      "6.8": "#FFFF00000000",
+      "6.9": "#FFFF00000000FFFF",
+      "7.0": "#FFFF00000000FFFF",
+      "7.1": "#FFFF00000000FFFF"
+    )
+    expect(montage_image.border_color).to eq(expected)
 
     # test illegal option arguments
     # looks like IM doesn't diagnose invalid geometry args

--- a/spec/rmagick/pixel/to_color_spec.rb
+++ b/spec/rmagick/pixel/to_color_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Magick::Pixel, '#to_color' do
     expect { pixel.to_color(Magick::AllCompliance, false, 16) }.not_to raise_error
     # test "hex" format
     expect { pixel.to_color(Magick::AllCompliance, false, 8, true) }.not_to raise_error
-    expect { pixel.to_color(Magick::AllCompliance, false, 16, true) }.not_to raise_error
+    expect { pixel.to_color(Magick::AllCompliance, false, 16, false) }.not_to raise_error
 
     expect(pixel.to_color(Magick::AllCompliance, false, 8, true)).to eq('#A52A2A')
-    expect(pixel.to_color(Magick::AllCompliance, false, 16, true)).to eq('#A5A52A2A2A2A')
+    expect(pixel.to_color(Magick::AllCompliance, false, 16, false)).to eq('brown')
 
     expect { pixel.to_color(Magick::AllCompliance, false, 32) }.to raise_error(ArgumentError)
     expect { pixel.to_color(1) }.to raise_error(TypeError)
@@ -26,6 +26,6 @@ RSpec.describe Magick::Pixel, '#to_color' do
     pixel.alpha = 123
 
     expect(pixel.to_color(Magick::AllCompliance, true)).to eq('#A5A52A2A2A2A007B')
-    expect(pixel.to_color(Magick::AllCompliance, false)).to eq('brown')
+    expect(pixel.to_color(Magick::AllCompliance, false)).to eq('#A5A52A2A2A2A')
   end
 end


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1400

The some methods to get color information returned either a hex string or a color name.
Depending on the image settings, the color names were not  returned as expected.

So, this patch will always return hex string as color information.

The methods affected by this change are as follows:
- Image#background_color
- Image#border_color
- Image#colormap
- Image#matte_color
- Image#transparent_color
- Info#background_color
- Info#border_color
- Info#matte_color
- Info#transparent_color

----

- Change default value of hex argument for Pixel#to_color