### PR TITLE
Transform image according to Info#colorspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Improvements
 
 Bug Fixes
 
+- Transform image according to Info#colorspace (#1594)
 - Sync Image::Info attributes to image object (#1593)
 - Fix install error on Windows MINGW environment (#1588)
 - Fix header checks in order to use aligned_malloc expectedly (#1579)


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/46

If colorspace is set through Image#colorspace, the image will be transformed properly.
However, if use Info#colorspace, it is not. It should be transformed as well.

```ruby
require 'rmagick'

image = Magick::Image.read('doc/ex/images/Button_0.gif').first
image.colorspace = Magick::GRAYColorspace
image.write('Image_colorspace_eq.gif')

image = Magick::Image.read('doc/ex/images/Button_0.gif') { |info| info.colorspace = Magick::GRAYColorspace }.first
image.write('Info_colorspace_eq.gif')
```

The result with before changing:

- Image_colorspace_eq.gif
  - ![Image_colorspace_eq](https://github.com/rmagick/rmagick/assets/199156/76a22bb7-6504-4b56-923f-ccaf4345fcd7)
- Info_colorspace_eq.gif
  - ![Info_colorspace_eq](https://github.com/rmagick/rmagick/assets/199156/40b91884-1f93-4d2a-a37f-430665345874)
