### PR TITLE
Rakefile: Fix duplicate release tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@ require 'simplecov'
 require './lib/rmagick/version'
 require 'fileutils'
 require 'English'
+require 'bundler/gem_tasks'
+require 'rake/extensiontask'
+require 'rspec/core/rake_task'
 
 desc "Open an irb session preloaded with this library"
 task :console do
@@ -60,6 +63,7 @@ task push_and_tag: [:build] do
   end
 end
 
+Rake::Task["release"].clear # Remove `release` task in bundler/gem_tasks
 desc 'Release'
 task release: %i[assert_clean_repo push_and_tag]
 
@@ -153,9 +157,6 @@ namespace :rbs do
   end
 end
 
-require 'bundler/gem_tasks'
-require 'rake/extensiontask'
-require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 Rake::ExtensionTask.new('RMagick2') do |ext|


### PR DESCRIPTION
I wanted `rake install` and added it at https://github.com/rmagick/rmagick/pull/1458/files#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0f

However, `bundler/gem_tasks` also has release tasks, which overlap with our own tasks. Each tasks would be executed when invoke `release`