### PR TITLE
Add metadata in gemspec for bug tracker, documentation and changelog URLs

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/rmagick/rmagick'
   s.license = 'MIT'
 
+  s.metadata['bug_tracker_uri'] = 'https://github.com/rmagick/rmagick/issues'
+  s.metadata['documentation_uri'] = 'https://rmagick.github.io/'
+  s.metadata['changelog_uri'] = 'https://github.com/rmagick/rmagick/blob/main/CHANGELOG.md'
+
   tracked_files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   file_exclusion_regex = /\A(doc|benchmarks|examples|spec|Steepfile)/
   files = tracked_files.reject { |file| file[file_exclusion_regex] }


### PR DESCRIPTION
Ref. https://guides.rubygems.org/specification-reference/#metadata