### PR TITLE
Update build script to use fonts correctly

### DIFF
--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -15,10 +15,10 @@ fi
 
 export HOMEBREW_NO_AUTO_UPDATE=true
 brew uninstall --force imagemagick imagemagick@6
-brew install wget ghostscript freetype libtool jpeg little-cms2 openexr libomp libpng libtiff liblqr zlib webp zstd
+brew install wget ghostscript freetype libtool jpeg jpeg-xl little-cms2 openexr libomp libpng libtiff liblqr zlib webp zstd
 
-export LDFLAGS="-L$(brew --prefix jpeg)/lib -L$(brew --prefix little-cms2)/lib -L$(brew --prefix openexr)/lib -L$(brew --prefix libomp)/lib -L$(brew --prefix libpng)/lib -L$(brew --prefix libtiff)/lib -L$(brew --prefix liblqr)/lib -L$(brew --prefix zlib)/lib -L$(brew --prefix webp)/lib -L$(brew --prefix zstd)/lib"
-export CPPFLAGS="-I$(brew --prefix jpeg)/include -I$(brew --prefix openexr)/include/OpenEXR -I$(brew --prefix libtiff)/include -I$(brew --prefix zlib)/include -I$(brew --prefix zstd)/include -I$(brew --prefix glib)/include/glib-2.0 -I$(brew --prefix glib)/lib/glib-2.0/include"
+export LDFLAGS="-L$(brew --prefix jpeg)/lib -I$(brew --prefix jpeg-xl)/lib -L$(brew --prefix little-cms2)/lib -L$(brew --prefix openexr)/lib -L$(brew --prefix libomp)/lib -L$(brew --prefix libpng)/lib -L$(brew --prefix libtiff)/lib -L$(brew --prefix liblqr)/lib -L$(brew --prefix zlib)/lib -L$(brew --prefix webp)/lib -L$(brew --prefix zstd)/lib"
+export CPPFLAGS="-I$(brew --prefix jpeg)/include -I$(brew --prefix jpeg-xl)/include -I$(brew --prefix openexr)/include/OpenEXR -I$(brew --prefix libtiff)/include -I$(brew --prefix zlib)/include -I$(brew --prefix zstd)/include -I$(brew --prefix glib)/include/glib-2.0 -I$(brew --prefix glib)/lib/glib-2.0/include"
 
 project_dir=$(pwd)
 build_dir="${project_dir}/build-ImageMagick/ImageMagick-${IMAGEMAGICK_VERSION}"
@@ -41,7 +41,11 @@ build_imagemagick() {
   fi
 
   cd "${build_dir}"
-  ./configure --prefix=/usr/local "${options}" --without-raw
+  ./configure \
+    --prefix=/usr/local \
+    "${options}" \
+    --with-gs-font-dir=/opt/homebrew/share/ghostscript/fonts \
+    --without-raw
   make -j
 }
 


### PR DESCRIPTION
This PR specifies installed dir of ghostscript font .

(Related to https://github.com/rmagick/rmagick/issues/279)
