### PR TITLE
Remove codes for GraphicsMagick

### DIFF
--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -294,11 +294,7 @@ begin
   # format is a fixed-size image, so I don't need to specify a size.
   puts 'Adding logo image...'
   logo = Magick::Image.read('logo:').first
-  if Magick::Magick_version.include?('GraphicsMagick')
-    logo.resize!(200.0 / logo.rows)
-  else
-    logo.crop!(98, 0, 461, 455).resize!(0.45)
-  end
+  logo.crop!(98, 0, 461, 455).resize!(0.45)
 
   # Create a new Image for the composited montage and logo
   montage_image = Magick::ImageList.new

--- a/examples/find_similar_region.rb
+++ b/examples/find_similar_region.rb
@@ -9,26 +9,19 @@ require 'rmagick'
 img = Magick::Image.read('../doc/ex/images/Flower_Hat.jpg').first
 target = img.crop(21, 94, 118, 126)
 
-begin
-  res = img.find_similar_region(target)
-  if res
-    gc = Magick::Draw.new
-    gc.stroke('red')
-    gc.stroke_width(2)
-    gc.fill('none')
-    gc.rectangle(res[0], res[1], res[0] + target.columns, res[1] + target.rows)
-    gc.draw(img)
-    img.alpha(Magick::DeactivateAlphaChannel)
-    puts "Found similar region. Writing `find_similar_region.gif'..."
-    img.write('find_similar_region.gif')
-  else
-    puts 'No match!'
-  end
-rescue NotImplementedError
-  warn <<-END_MSG
-    The find_similar_region method is not supported by this version of
-    ImageMagick/GraphicsMagick.
-  END_MSG
+res = img.find_similar_region(target)
+if res
+  gc = Magick::Draw.new
+  gc.stroke('red')
+  gc.stroke_width(2)
+  gc.fill('none')
+  gc.rectangle(res[0], res[1], res[0] + target.columns, res[1] + target.rows)
+  gc.draw(img)
+  img.alpha(Magick::DeactivateAlphaChannel)
+  puts "Found similar region. Writing `find_similar_region.gif'..."
+  img.write('find_similar_region.gif')
+else
+  puts 'No match!'
 end
 
 exit

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -1,5 +1,4 @@
-# This routine needs the color_histogram method
-# from either ImageMagick 6.0.0 or GraphicsMagick 1.1
+# This routine needs the color_histogram method from ImageMagick 6.0.0.
 # Specify an image filename as an argument.
 
 require 'rmagick'
@@ -119,33 +118,27 @@ module Magick
     def color_hist(fg, bg)
       img = number_colors > 256 ? quantize(256) : self
 
-      begin
-        hist = img.color_histogram
-      rescue NotImplementedError
-        warn 'The color_histogram method is not supported by this version ' \
-             'of ImageMagick/GraphicsMagick'
-      else
-        pixels = hist.keys.sort_by { |pixel| hist[pixel] }
-        scale = HISTOGRAM_ROWS / (hist.values.max * AIR_FACTOR)
+      hist = img.color_histogram
+      pixels = hist.keys.sort_by { |pixel| hist[pixel] }
+      scale = HISTOGRAM_ROWS / (hist.values.max * AIR_FACTOR)
 
-        histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
-          options.background_color = bg
-          options.border_color = fg
-        end
-
-        x = 0
-        pixels.each do |pixel|
-          column = Array.new(HISTOGRAM_ROWS).fill { Pixel.new }
-          HISTOGRAM_ROWS.times do |y|
-            column[y] = pixel if y >= HISTOGRAM_ROWS - (hist[pixel] * scale)
-          end
-          histogram.store_pixels(x, 0, 1, HISTOGRAM_ROWS, column)
-          x = x.succ
-        end
-
-        histogram['Label'] = 'Color Frequency'
-        histogram
+      histogram = Image.new(HISTOGRAM_COLS, HISTOGRAM_ROWS) do |options|
+        options.background_color = bg
+        options.border_color = fg
       end
+
+      x = 0
+      pixels.each do |pixel|
+        column = Array.new(HISTOGRAM_ROWS).fill { Pixel.new }
+        HISTOGRAM_ROWS.times do |y|
+          column[y] = pixel if y >= HISTOGRAM_ROWS - (hist[pixel] * scale)
+        end
+        histogram.store_pixels(x, 0, 1, HISTOGRAM_ROWS, column)
+        x = x.succ
+      end
+
+      histogram['Label'] = 'Color Frequency'
+      histogram
     end
 
     # Use AnnotateImage to write the stats.

--- a/examples/identify.rb
+++ b/examples/identify.rb
@@ -160,7 +160,7 @@ end
 if ARGV.empty?
   puts <<-END_USAGE
     This example displays information about the specified image file(s)
-    that is similar to ImageMagick/GraphicsMagick's identify command.
+    that is similar to ImageMagick's identify command.
 
     Usage:
     ruby identify.rb filename [filename...]

--- a/examples/import_export.rb
+++ b/examples/import_export.rb
@@ -15,15 +15,9 @@ END_INFO
 img = Magick::Image.read('../doc/ex/images/Gold_Statue.jpg').first
 copy = Magick::Image.new(img.columns, img.rows)
 
-begin
-  img.rows.times do |r|
-    scanline = img.export_pixels(0, r, img.columns, 1, 'RGB')
-    copy.import_pixels(0, r, img.columns, 1, 'RGB', scanline)
-  end
-rescue NotImplementedError
-  warn 'The export_pixels and import_pixels methods are not supported ' \
-       'by this version of ImageMagick/GraphicsMagick'
-  exit
+img.rows.times do |r|
+  scanline = img.export_pixels(0, r, img.columns, 1, 'RGB')
+  copy.import_pixels(0, r, img.columns, 1, 'RGB', scanline)
 end
 
 copy.write('copy.gif')

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -273,8 +273,8 @@ typedef struct
 
 //! Quantum expression adapter.
 /**
- * Both ImageMagick and GraphicsMagick define an enum type for quantum-level
- * expressions, but they're different types. The QuantumExpressionOperator
+ * ImageMagick defines an enum type for quantum-level expressions,
+ * but they're different types. The QuantumExpressionOperator
  * type is an adapter type that can be mapped to either one.
  */
 typedef enum _QuantumExpressionOperator


### PR DESCRIPTION
GraphicsMagick support had been removed at RMagick 2.0.

https://github.com/rmagick/rmagick/blob/6795bc4dd79c768a7982287cb4b4985674682daa/CHANGELOG.md?plain=1#L872