### PR TITLE
Rubocop: Fix Lint/SuppressedException

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,12 +193,6 @@ Lint/RescueException:
   Exclude:
     - 'lib/rmagick_internal.rb'
 
-# Offense count: 1
-# Configuration parameters: AllowComments, AllowNil.
-Lint/SuppressedException:
-  Exclude:
-    - 'lib/rmagick_internal.rb'
-
 # Offense count: 39
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -11,12 +11,9 @@
 #==============================================================================
 
 if RUBY_PLATFORM.match?(/mingw/i)
-  begin
-    require 'ruby_installer'
-    ENV['PATH'].split(File::PATH_SEPARATOR).grep(/ImageMagick/i).each do |path|
-      RubyInstaller::Runtime.add_dll_directory(path) if File.exist?(File.join(path, 'CORE_RL_magick_.dll')) || File.exist?(File.join(path, 'CORE_RL_MagickCore_.dll'))
-    end
-  rescue LoadError
+  require 'ruby_installer'
+  ENV['PATH'].split(File::PATH_SEPARATOR).grep(/ImageMagick/i).each do |path|
+    RubyInstaller::Runtime.add_dll_directory(path) if File.exist?(File.join(path, 'CORE_RL_magick_.dll')) || File.exist?(File.join(path, 'CORE_RL_MagickCore_.dll'))
   end
 end
 


### PR DESCRIPTION
Before Ruby 2.4 in RubyInstaller (https://rubyinstaller.org/), it raises a LoadError exception because it does not have `ruby_installer.rb`.

Remove unnecessary `rescue` due to be stopped support. https://github.com/rmagick/rmagick/pull/1540