### PR TITLE
Rakefile: Remove unused task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,6 @@ require 'bundler/gem_tasks'
 require 'rake/extensiontask'
 require 'rspec/core/rake_task'
 
-desc "Open an irb session preloaded with this library"
-task :console do
-  sh "irb -r ./ext/RMagick/extconf.rb -r ./lib/rmagick.rb"
-end
-
 task :config do
   def version
     Magick::VERSION


### PR DESCRIPTION
The C++ code is not recompiled, so the latest state is not loaded. 
It delete the task because it is not used for above reason.