### PR TITLE
Doc: Use fill_opacity instead of opacity

### DIFF
--- a/doc/ex/opacity.rb
+++ b/doc/ex/opacity.rb
@@ -9,16 +9,16 @@ gc.stroke('blue')
 gc.fill('yellow')
 gc.stroke_width(10)
 
-gc.opacity('25%')
+gc.fill_opacity('25%')
 gc.roundrectangle(20, 20, 60, 90, 5, 5)
 
-gc.opacity('50%')
+gc.fill_opacity('50%')
 gc.roundrectangle(80, 20, 120, 90, 5, 5)
 
-gc.opacity(0.75)
+gc.fill_opacity(0.75)
 gc.roundrectangle(140, 20, 180, 90, 5, 5)
 
-gc.opacity(1)
+gc.fill_opacity(1)
 gc.roundrectangle(200, 20, 240, 90, 5, 5)
 
 gc.font_weight(Magick::NormalWeight)


### PR DESCRIPTION
The all the squares were filled in the same way and opacity could not be confirmed.

Before | After
-- | --
<img src="https://github.com/rmagick/rmagick/assets/199156/dccbdc36-4238-4232-9e58-f1a3b3d64917"> | <img src="https://github.com/rmagick/rmagick/assets/199156/21c0fbe1-4c0b-4313-a928-123b49fbf152">
