### PR TITLE
Add `-fomit-frame-pointer` in order to fix compile error with GCC 14

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -129,7 +129,7 @@ module RMagick
         configure_archflags_for_osx($magick_package) if RUBY_PLATFORM.include?('darwin') # osx
 
       end
-      $CPPFLAGS += ' $(optflags) $(debugflags)'
+      $CPPFLAGS += ' $(optflags) $(debugflags) -fomit-frame-pointer'
     end
 
     def exit_failure(msg)


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1615

The `-fno-omit-frame-pointer` is set in the Windows environment, and a flag is added to revert it.
Maybe it's a GCC issue in a Windows environment, but I'm not sure of the details.