### PR TITLE
Remove universal build configuration for system bundled ruby in macOS

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -129,10 +129,8 @@ module RMagick
           # if linker does not recognizes '-Wl,-rpath,somewhere' option, it revert to original option
           $LDFLAGS = "#{original_ldflags} #{ldflags}"
         end
-
-        configure_archflags_for_osx($magick_package) if RUBY_PLATFORM.include?('darwin') # osx
-
       end
+
       $CPPFLAGS += ' $(optflags) $(debugflags) -fomit-frame-pointer'
     end
 
@@ -248,26 +246,6 @@ module RMagick
 
       Logging.message msg
       message msg
-    end
-
-    # issue #169
-    # set ARCHFLAGS appropriately for OSX
-    def configure_archflags_for_osx(magick_package)
-      return unless PKGConfig.libs_only_L(magick_package) =~ %r{-L(.+)/lib}
-
-      imagemagick_dir = Regexp.last_match(1)
-      command = Dir.glob(File.join(imagemagick_dir, "bin/*")).find { |file| File.executable? file }
-      fileinfo = `file #{command}`
-
-      # default ARCHFLAGS
-      archs = $ARCH_FLAG.scan(/-arch\s+(\S+)/).flatten
-
-      archflags = []
-      archs.each do |arch|
-        archflags << "-arch #{arch}" if fileinfo.include?(arch)
-      end
-
-      $ARCH_FLAG = archflags.join(' ') unless archflags.empty?
     end
 
     def search_paths_for_windows


### PR DESCRIPTION
macOS  bundles Ruby 2.6, even macOS 15 beta.

```
$ sw_vers
ProductName:		macOS
ProductVersion:		15.0
BuildVersion:		24A5264n

$ /usr/bin/ruby -v
ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin24]
```

RMagick does not support this version.

The configuration for universal build that is not set as expected because $ARCH_FLAG returns an empty string with system bundled ruby.

```
$ irb

WARNING: This version of ruby is included in macOS for compatibility with legacy software.
In future versions of macOS the ruby runtime will not be available by
default, and may require you to install an additional package.

irb(main):001:0> RUBY_VERSION
=> "2.6.10"
irb(main):002:0> require 'mkmf'
=> true
irb(main):003:0> $ARCH_FLAG
=> ""
```

