### PR TITLE
Remove unnecessary minimum ruby version check

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -279,20 +279,11 @@ module RMagick
     end
 
     def assert_can_compile!
-      assert_minimum_ruby_version!
       assert_has_dev_libs!
 
       # Check for compiler. Extract first word so ENV['CXX'] can be a program name with arguments.
       cxx = (ENV['CXX'] || RbConfig::CONFIG['CXX'] || 'g++').split.first
       exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." unless find_executable(cxx)
-    end
-
-    def assert_minimum_ruby_version!
-      supported = checking_for("Ruby version >= #{MIN_RUBY_VERS}") do
-        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(MIN_RUBY_VERS)
-      end
-
-      exit_failure "Can't install RMagick #{RMAGICK_VERS}. Ruby #{MIN_RUBY_VERS} or later required.\n" unless supported
     end
 
     def assert_has_dev_libs!


### PR DESCRIPTION
If use old ruby to install, it show the following message.

```
$ gem install ./rmagick-6.0.1.gem
ERROR:  Error installing ./rmagick-6.0.1.gem:
	There are no versions of rmagick (= 6.0.1) compatible with your Ruby & RubyGems
	rmagick requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```

It is in https://github.com/rubygems/rubygems/blob/a15e2cb599e1415d0e9577eb7ca2d0df985a4c38/lib/rubygems/request_set.rb#L199

The supported ruby version check is invoked at rubygems system at first before calling assert_minimum_ruby_version!.

So, this patch will remove redundant version check.