### PR TITLE
Doc: Fix file name in documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Things that can go wrong
 The [RMagick installation FAQ][faq] has answers to the most commonly reported
 problems, though may be out of date.
 
-### Can't install RMagick. Can't find libMagick or one of the dependent libraries. Check the mkmf.log file for more detailed information
+### Can't install RMagick. Can't find libMagickCore-XXXX.so or one of the dependent libraries. Check the mkmf.log file for more detailed information
 
 Typically this message means that one or more of the libraries that ImageMagick
 depends on hasn't been installed. Examine the mkmf.log file in the ext/RMagick
@@ -171,15 +171,14 @@ diagnose the problem. Also see [this FAQ][libmagick-faq].
 If you get a message like this:
 
 ```sh
-$DIR/RMagick.rb:11:in `require': libMagick.so.0:
-  cannot open shared object file: No such file or directory -
-  $DIR/RMagick2.so (LoadError)
+... /core_ext/kernel_require.rb>:136:in `require': cannot load such file -- RMagick2.so (LoadError)
+  (snip)
 ```
 
 you probably do not have the directory in which the ImageMagick library
 is installed in your load path. An easy way to fix this is to define
 the directory in the `LD_LIBRARY_PATH` environment variable. For
-example, suppose you installed the ImageMagick library `libMagick.so` in
+example, suppose you installed the ImageMagick library `libMagickCore-XXXX.so` in
 `/usr/local/lib`. (By default this is where it is installed.) Create the
 `LD_LIBRARY_PATH` variable like this:
 

--- a/doc/struct.html
+++ b/doc/struct.html
@@ -1101,7 +1101,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
         >, <code><strong>GradientFill</strong></code
         >, <code><strong>SolidFill</strong></code> and <code><strong>TextureFill</strong></code
         >. These classes are explained below. The <code>HatchFill</code> class is intended as an example of how to write a <code>Fill</code> class and is
-        written in pure Ruby. You can read it in RMagick.rb.
+        written in pure Ruby. You can read it in rmagick_internal.rb.
       </p>
     </div>
 

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -140,7 +140,7 @@ exit
     </p>
 
     <p>
-      Line 1 requires <span class="sup"><a href="#rubygems">2</a></span> the RMagick.rb file, which defines the <b>Magick</b> module. The Magick module contains
+      Line 1 requires <span class="sup"><a href="#rubygems">2</a></span> the rmagick.rb file, which defines the <b>Magick</b> module. The Magick module contains
       3 major classes, <b>ImageList</b>, <b>Image</b>, and <b>Draw</b>. This section - <em>Basic Concepts</em> - describes the ImageList and Image classes. The
       Draw class is explained in the
       <em><a href="#drawing">Drawing on and adding text to images</a></em>

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -349,7 +349,7 @@ EXTERN VALUE Class_Chromaticity;
 EXTERN VALUE Class_Color;
 EXTERN VALUE Class_Font;
 EXTERN VALUE Class_Geometry;
-EXTERN VALUE Class_GeometryValue;   // Defined in RMagick.rb
+EXTERN VALUE Class_GeometryValue;   // Defined in rmagick_internal.rb
 EXTERN VALUE Class_Pixel;
 EXTERN VALUE Class_Point;
 EXTERN VALUE Class_PolaroidOptions;

--- a/ext/RMagick/rmilist.cpp
+++ b/ext/RMagick/rmilist.cpp
@@ -744,7 +744,7 @@ ImageList_optimize_layers(VALUE self, VALUE method)
  * No Ruby usage (internal function)
  *
  * Notes:
- *   - this simply calls ImageList.new() in RMagick.rb
+ *   - this simply calls ImageList.new() in rmagick_internal.rb
  *
  * @return a new imagelist
  */

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# $Id: RMagick.rb,v 1.84 2009/09/15 22:08:41 rmagick Exp $
+# $Id: rmagick_internal.rb,v 1.84 2009/09/15 22:08:41 rmagick Exp $
 #==============================================================================
 #                  Copyright (C) 2009 by Timothy P. Hunter
-#   Name:       RMagick.rb
+#   Name:       rmagick_internal.rb
 #   Author:     Tim Hunter
 #   Purpose:    Extend Ruby to interface with ImageMagick.
 #   Notes:      RMagick2.so defines the classes. The code below adds methods


### PR DESCRIPTION
Because `RMagick.rb` was removed at https://github.com/rmagick/rmagick/pull/1361