### PR TITLE
Suppress exception at installation if ImageMagick is not installed

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -166,10 +166,7 @@ module RMagick
 
     def determine_imagemagick_package
       packages = [installed_im7_packages, installed_im6_packages].flatten
-
-      if packages.empty?
-        exit_failure "Can't install RMagick #{RMAGICK_VERS}. Can't find ImageMagick with pkg-config\n"
-      end
+      return if packages.empty?
 
       if installed_im6_packages.any? && installed_im7_packages.any?
         checking_for('forced use of ImageMagick 6') do
@@ -297,11 +294,10 @@ module RMagick
         $magick_version = Regexp.last_match(1)
         exit_failure failure_message unless $magick_version
       else
-        unless PKGConfig.libs('MagickCore')[/\bl\s*(MagickCore|Magick)6?\b/]
+        unless ($magick_package = determine_imagemagick_package)
           exit_failure failure_message
         end
 
-        $magick_package = determine_imagemagick_package
         $magick_version = PKGConfig.modversion($magick_package)[/^(\d+\.\d+\.\d+)/]
       end
 


### PR DESCRIPTION
If ImageMagick is not installed, installer show the following exception:

```
$ ruby extconf.rb
checking for brew... yes
/Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:504:in `parse_pc': .pc doesn't exist: <MagickCore> (PackageConfig::NotFoundError)
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:348:in `declaration'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:289:in `requires'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:545:in `block in required_packages'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:374:in `collect_requires'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:544:in `required_packages'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:452:in `collect_libs'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:310:in `libs'
	from /Users/watson/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/pkg-config-1.5.6/lib/pkg-config.rb:591:in `libs'
	from extconf.rb:300:in `assert_has_dev_libs!'
	from extconf.rb:281:in `assert_can_compile!'
	from extconf.rb:48:in `initialize'
	from extconf.rb:408:in `new'
	from extconf.rb:408:in `<main>'
```

This patch will show the expected error message:

```
$ ruby extconf.rb
checking for brew... yes

ERROR: Can't install RMagick 6.0.1.
Can't find the ImageMagick library or one of the dependent libraries.
Check the mkmf.log file for more detailed information.
```