### PR TITLE
Output the pc_config file path

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -165,6 +165,13 @@ module RMagick
       packages = [installed_im7_packages, installed_im6_packages].flatten
       return if packages.empty?
 
+      msg = "\nDetected ImageMagick packages:\n"
+      Logging.message msg
+      message msg
+      package_paths = packages.map { |package| "- #{PKGConfig.package_config(package).pc_path}" }.join("\n")
+      Logging.message package_paths + "\n\n"
+      message package_paths + "\n\n"
+
       if installed_im6_packages.any? && installed_im7_packages.any?
         checking_for('forced use of ImageMagick 6') do
           if ENV['USE_IMAGEMAGICK_6']
@@ -178,8 +185,7 @@ module RMagick
       end
 
       if packages.length > 1
-        package_lines = packages.map { |package| " - #{package}" }.join("\n")
-        msg = "\nWarning: Found more than one ImageMagick installation. This could cause problems at runtime.\n#{package_lines}\n\n"
+        msg = "\nWarning: Found more than one ImageMagick installation. This could cause problems at runtime.\n\n"
         Logging.message msg
         message msg
       end


### PR DESCRIPTION
It might be easier to understand if it output the pc_config path to be used.

Here is example of output:
```
$ ruby extconf.rb
checking for brew... yes

Detected ImageMagick packages:
- /Users/watson/imagemagick7.1/lib/pkgconfig/ImageMagick-7.Q16HDRI.pc
- /Users/watson/imagemagick6.9/lib/pkgconfig/ImageMagick-6.Q16.pc

checking for forced use of ImageMagick 6... no
```