### PR TITLE
CI: fix for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,41 @@ jobs:
       run: |
         bundle exec rake rbs:validate && bundle exec steep check
 
+  # Seems that old imagemagick depend on ghostscript 9.x for handling fonts.
+  # However, ubuntu 24.04 has ghostscript 10.x, which is too new for old imagemagick.
+  test-linux-for-old-imagemagick:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        ruby-version: ['3.0']
+        imagemagick-version:
+          - { full: 6.8.9-10, major-minor: '6.8' }
+          - { full: 7.0.11-14, major-minor: '7.0' }
+
+    name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache ImageMagick built objects
+      uses: actions/cache@v4
+      with:
+        path: ./build-ImageMagick
+        key: v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
+        restore-keys: |
+          v1-${{ runner.os }}-imagemagick-${{ matrix.imagemagick-version.full }}
+    - name: Update/Install packages
+      run: |
+        export IMAGEMAGICK_VERSION=${{ matrix.imagemagick-version.full }}
+        ./before_install_linux.sh
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@master
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Build and test with Rake
+      run: |
+        bundle exec rake
+
   test-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -47,9 +82,7 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4.0-preview2']
         imagemagick-version:
-          - { full: 6.8.9-10, major-minor: '6.8' }
           - { full: 6.9.13-17, major-minor: '6.9' }
-          - { full: 7.0.11-14, major-minor: '7.0' }
           - { full: 7.1.1-39, major-minor: '7.1' }
 
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -21,7 +21,7 @@ sudo apt-get autoremove -y imagemagick* libmagick* --purge
 # install build tools, ImageMagick delegates
 sudo apt-get install -y build-essential libx11-dev libxext-dev zlib1g-dev \
   liblcms2-dev libpng-dev libjpeg-dev libfreetype6-dev \
-  libtiff5-dev libwebp-dev liblqr-1-0-dev vim gsfonts ghostscript
+  libtiff5-dev libwebp-dev liblqr-1-0-dev libglib2.0-dev gsfonts ghostscript
 
 project_dir=$(pwd)
 build_dir="${project_dir}/build-ImageMagick/ImageMagick-${IMAGEMAGICK_VERSION}"


### PR DESCRIPTION
ubuntu-latest now uses ubuntu 24.04 image.
CI no longer works as expected with ubuntu 24.04, so this will be fixed.