### PR TITLE
Doc: Fix link to discussion page

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -344,7 +344,7 @@ Web page: https://rmagick.github.io/
     <p>
       Please remember I can't help with Ruby or ImageMagick installation and configuration problems. For help with Ruby, post your questions to
       <code>comp.lang.ruby</code>. For help with ImageMagick, you can post to the
-      <a href="https://www.imagemagick.org/discourse-server/">ImageMagick Discourse Server</a>.
+      <a href="https://github.com/ImageMagick/ImageMagick/discussions">ImageMagick discussions</a>.
     </p>
 
     <p>


### PR DESCRIPTION
Because https://www.imagemagick.org/discourse-server/ is just archive.
So, this will change the link to proper discussion page.