### PR TITLE
Fix SEGV if read incorrect PDF file

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -11600,6 +11600,8 @@ rd_image(VALUE klass ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
     rm_check_exception(exception, images, DestroyOnError);
     DestroyExceptionInfo(exception);
 
+    rm_ensure_result(images);
+
     rm_set_user_artifact(images, info);
     rm_sync_image_options(images, info);
 


### PR DESCRIPTION
This patch will raise a RuntimeError exception if read incorrect PDF file.

```
irb(main):001:0> require 'rmagick'
=> true
irb(main):002:0> Magick::Image.read('s.uploading_0001.pdf')
   **** Error: Couldn't initialise file.
               Output may be incorrect.
   No pages will be processed (FirstPage > LastPage).
(irb):2:in `read': ImageMagick library function failed to return a result. (RuntimeError)
        from (irb):2:in `<main>'
        from /usr/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /usr/bin/irb:25:in `load'
        from /usr/bin/irb:25:in `<main>'
```

The old ghostscript will ignore the error,
however, the new ghostscript will stop reading with incorrect PDF.
Then, ImageMagick will return NULL and caused a SEGV in rmagick land.

Fix https://github.com/rmagick/rmagick/issues/1670