### PR TITLE
Rubocop: Fix Lint/UselessConstantScoping

### DIFF
--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -27,12 +27,16 @@ module Magick
   end
 
   class Image
-    private
-
     HISTOGRAM_COLS = 256
+    private_constant :HISTOGRAM_COLS
     HISTOGRAM_ROWS = 200
+    private_constant :HISTOGRAM_ROWS
     MAX_QUANTUM = 255
+    private_constant :MAX_QUANTUM
     AIR_FACTOR = 1.025
+    private_constant :AIR_FACTOR
+
+    private
 
     # The alpha frequencies are shown as white dots.
     def alpha_hist(freqs, scale, fg, bg)

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -54,6 +54,8 @@ module Magick
     include Describable
     include Duplicatable
 
+    WORD_SEP = / / # Regexp to separate words
+
     private
 
     # background_fill defaults to 'none'. If background_fill has been set to something
@@ -119,8 +121,6 @@ module Magick
     end
 
     public
-
-    WORD_SEP = / / # Regexp to separate words
 
     # The background image specified by background_image=
     attr_reader :background_image


### PR DESCRIPTION
Fix Lint/UselessConstantScoping error.
This cop was introduced at https://github.com/rubocop/rubocop/releases/tag/v1.72.0