### PR TITLE
GitHub: Add new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -1,0 +1,40 @@
+name: Report
+description: Create a report.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A description of the bug or feature.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        List of steps, sample code, failing test or link to a project that reproduces the behavior.
+        Make sure you place a stack trace inside a code (```) block to avoid linking unrelated issues.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: System Configuration
+      description: Tell us about the environment where you are experiencing the bug.
+      value: |
+        - ImageMagick version:
+        - RMagick version:
+        - Ruby version:
+        - Environment (Operating system, version and so on):
+        - Additional information:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false


### PR DESCRIPTION
The template used so far has been obsoleted and it is no longer available.
So, this PR will add new template.