### PR TITLE
Rubocop: Fix Style/RedundantParentheses

### DIFF
--- a/examples/identify.rb
+++ b/examples/identify.rb
@@ -114,9 +114,9 @@ module Magick
       puts "\tUnits: #{units}\n"
       size = filesize
       if size >= 1_048_576
-        puts "\tFilesize: #{sprintf('%.1f', (size / 1_048_576.0))}mb\n"
+        puts "\tFilesize: #{sprintf('%.1f', size / 1_048_576.0)}mb\n"
       elsif size >= 1024
-        puts "\tFilesize: #{sprintf('%.0f', (size / 1024.0))}kb\n"
+        puts "\tFilesize: #{sprintf('%.0f', size / 1024.0)}kb\n"
       else
         puts "\tFilesize: #{size}b\n"
       end

--- a/lib/rvg/rvg.rb
+++ b/lib/rvg/rvg.rb
@@ -114,7 +114,7 @@ module Magick
         indent = 0
         primitives.each do |cmd|
           indent -= 1 if cmd['pop ']
-          print(('   ' * indent), cmd, "\n")
+          print('   ' * indent, cmd, "\n")
           indent += 1 if cmd['push ']
         end
       end


### PR DESCRIPTION
This PR will fix following error with rubocop 1.75.5:

```
examples/identify.rb:117:45: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a method argument.
        puts "\tFilesize: #{sprintf('%.1f', (size / 1_048_576.0))}mb\n"
                                            ^^^^^^^^^^^^^^^^^^^^
examples/identify.rb:119:45: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a method argument.
        puts "\tFilesize: #{sprintf('%.0f', (size / 1024.0))}kb\n"
                                            ^^^^^^^^^^^^^^^
lib/rvg/rvg.rb:117:17: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a method argument.
          print(('   ' * indent), cmd, "\n")
                ^^^^^^^^^^^^^^^^
```