### PR TITLE
Fix performance issue with RVG

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -1262,11 +1262,11 @@ Draw_primitive(VALUE self, VALUE primitive)
 
     if (draw->primitives == (VALUE)0)
     {
-        draw->primitives = primitive;
+        draw->primitives = rb_str_dup(primitive);
     }
     else
     {
-        draw->primitives = rb_str_plus(draw->primitives, rb_str_new2("\n"));
+        draw->primitives = rb_str_concat(draw->primitives, rb_str_new2("\n"));
         draw->primitives = rb_str_concat(draw->primitives, primitive);
     }
 


### PR DESCRIPTION
RVG adds all objects to be drawn as primitives to a Magick::Draw object. This is a multi-line String object.
When many draw commands are executed, there is a performance bottleneck when concating to the string. Fortunately it's easy to fix.

I have a GUI program which draws some big PDF417 2D codes and it takes several seconds to do so. Almost all time is spend in `Magick::Draw#primitive`:

```
$ stackprof stackprof-cpu-myapp.dump 
==================================
  Mode: cpu(1000)
  Samples: 4074 (1.90% miss rate)
  GC: 1146 (28.13%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2412  (59.2%)        2412  (59.2%)     Magick::Draw#primitive
       807  (19.8%)         807  (19.8%)     (sweeping)
       400   (9.8%)         400   (9.8%)     (marking)
       118   (2.9%)         118   (2.9%)     Fox::FXFont#create
       117   (2.9%)          63   (1.5%)     Kernel#require
        39   (1.0%)          39   (1.0%)     Magick::Draw#initialize_copy
        13   (0.3%)          13   (0.3%)     File.file?
        13   (0.3%)          13   (0.3%)     Kernel#sprintf
         8   (0.2%)           8   (0.2%)     Fox::FXWindow#getOwner
      2569  (63.1%)           8   (0.2%)     Magick::RVG::Shape#add_primitives
        14   (0.3%)           7   (0.2%)     Magick::RVG.convert_to_float
        45   (1.1%)           6   (0.1%)     Magick::Draw#dup
        17   (0.4%)           6   (0.1%)     Magick::RVG::Styles#each_value
        17   (0.4%)           6   (0.1%)     Struct#each_pair
         6   (0.1%)           6   (0.1%)     Fox::FXWindow#getParent
         8   (0.2%)           5   (0.1%)     Kernel#require_relative
         5   (0.1%)           5   (0.1%)     File.join
        38   (0.9%)           5   (0.1%)     Enumerable#find
         5   (0.1%)           5   (0.1%)     Zint::Native.ZBarcode_Encode_and_Buffer_Vector
         7   (0.2%)           5   (0.1%)     Magick::RVG::Utility::TextAttributes#push
        26   (0.6%)           4   (0.1%)     Gem::SpecificationRecord#find_active_stub_by_path
         4   (0.1%)           4   (0.1%)     Nokogiri::XML::XPathContext.new
        11   (0.3%)           4   (0.1%)     Array#map
         4   (0.1%)           4   (0.1%)     Kernel#eval
       843  (20.7%)           4   (0.1%)     Magick::RVG::Utility::GraphicContext#method_missing
         5   (0.1%)           4   (0.1%)     Fox::FXApp#run
       784  (19.2%)           3   (0.1%)     Magick::Draw#push
         3   (0.1%)           3   (0.1%)     Array#push
      2587  (63.5%)           3   (0.1%)     Magick::RVG::Group#add_primitives
       869  (21.3%)           3   (0.1%)     Magick::RVG::Utility::GraphicContext#push
```

With this patch the time for adding the draw primitives decreases a lot:

```
stackprof stackprof-cpu-myapp.dump 
==================================
  Mode: cpu(1000)
  Samples: 504 (34.29% miss rate)
  GC: 69 (13.69%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       119  (23.6%)         119  (23.6%)     Fox::FXFont#create
       117  (23.2%)          69  (13.7%)     Kernel#require
        57  (11.3%)          57  (11.3%)     (marking)
        52  (10.3%)          52  (10.3%)     Magick::Draw#initialize_copy
        15   (3.0%)          15   (3.0%)     File.file?
        13   (2.6%)          13   (2.6%)     (sweeping)
         8   (1.6%)           8   (1.6%)     Kernel#sprintf
        10   (2.0%)           6   (1.2%)     Kernel#require_relative
        96  (19.0%)           6   (1.2%)     Magick::RVG::Shape#add_primitives
         6   (1.2%)           6   (1.2%)     Magick::Draw#primitive
         9   (1.8%)           5   (1.0%)     Magick::RVG::Styles#each_value
         7   (1.4%)           5   (1.0%)     Magick::RVG::Utility::TextAttributes#push
         5   (1.0%)           5   (1.0%)     Fox::FXWindow#getParent
         5   (1.0%)           5   (1.0%)     Zint::Native.ZBarcode_Encode_and_Buffer_Vector
        23   (4.6%)           4   (0.8%)     Gem::BasicSpecification#have_file?
       238  (47.2%)           4   (0.8%)     Class#new
         9   (1.8%)           4   (0.8%)     Struct#each_pair
         8   (1.6%)           3   (0.6%)     Magick::RVG.convert_to_float
        10   (2.0%)           3   (0.6%)     Gem::StubSpecification#loaded_spec
         3   (0.6%)           3   (0.6%)     Fox::FXWindow#getOwner
         3   (0.6%)           3   (0.6%)     Kernel#instance_variable_set
         7   (1.4%)           3   (0.6%)     Array#map
         3   (0.6%)           2   (0.4%)     Fox::FXTabBook#recalc
        32   (6.3%)           2   (0.4%)     Mcc2::RmagickDrawer#draw_barcode
         4   (0.8%)           2   (0.4%)     Gem::StubSpecification#name
         2   (0.4%)           2   (0.4%)     Gem::StubSpecification#data
         6   (1.2%)           2   (0.4%)     FFI::Struct#[]
         2   (0.4%)           2   (0.4%)     RubyVM::InstructionSequence.compile
         4   (0.8%)           2   (0.4%)     FFI::StructLayout::Mapped#get
         2   (0.4%)           2   (0.4%)     Magick::Draw#get_type_metrics

```