### PR TITLE
Fixed an error with ImageMagick 7.1.2 on Windows when saving images using file descriptor

### DIFF
--- a/.devcontainer/ImageMagick6/devcontainer.json
+++ b/.devcontainer/ImageMagick6/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "../Dockerfile",
     "args": {
       "RUBY_VERSION": "3.3.3",
-      "IMAGEMAGICK_VERSION": "6.9.13-25"
+      "IMAGEMAGICK_VERSION": "6.9.13-27"
     }
   },
   "onCreateCommand": "/setup/setup-repo.sh"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       "RUBY_VERSION": "3.3.3",
-      "IMAGEMAGICK_VERSION": "7.1.1-47"
+      "IMAGEMAGICK_VERSION": "7.1.2-1"
     }
   },
   "onCreateCommand": "/setup/setup-repo.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
         imagemagick-version:
-          - { full: 6.9.13-25, major-minor: '6.9' }
-          - { full: 7.1.1-47, major-minor: '7.1' }
+          - { full: 6.9.13-27, major-minor: '6.9' }
+          - { full: 7.1.2-1, major-minor: '7.1' }
 
     name: Linux, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
@@ -118,8 +118,8 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
         imagemagick-version:
-          - { full: 6.9.13-25, major-minor: '6.9' }
-          - { full: 7.1.1-47, major-minor: '7.1' }
+          - { full: 6.9.13-27, major-minor: '6.9' }
+          - { full: 7.1.2-1, major-minor: '7.1' }
 
     name: macOS, Ruby ${{ matrix.ruby-version }}, IM ${{ matrix.imagemagick-version.major-minor }}
     steps:
@@ -151,14 +151,14 @@ jobs:
       matrix:
         ruby-version: ['3.4']
         imagemagick-version:
-          - { full: 6.9.13-25, major-minor: '6.9' }
-          - { full: 7.1.1-47, major-minor: '7.1' }
+          - { full: 6.9.13-27, major-minor: '6.9' }
+          - { full: 7.1.2-1, major-minor: '7.1' }
         os:
           - { target: windows-latest, arch: 'x64' }
           - { target: windows-11-arm, arch: 'arm64' }
         exclude:
           # ImageMagick 6 has not provided ARM binary. Ref. https://legacy.imagemagick.org/archive/binaries/
-          - imagemagick-version: { full: 6.9.13-25, major-minor: '6.9' }
+          - imagemagick-version: { full: 6.9.13-27, major-minor: '6.9' }
             os: { target: windows-11-arm, arch: 'arm64' }
 
     env:

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -289,6 +289,7 @@ module RMagick
       $defs.push('-DIMAGEMAGICK_7=1') if im_version_at_least?('7.0.0')
       $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_7_0_8=1') if im_version_at_least?('7.0.8')
       $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_7_0_10=1') if im_version_at_least?('7.0.10')
+      $defs.push('-DIMAGEMAGICK_GREATER_THAN_EQUAL_7_1_2=1') if im_version_at_least?('7.1.2')
 
       create_header
     end

--- a/ext/RMagick/rmilist.cpp
+++ b/ext/RMagick/rmilist.cpp
@@ -1204,7 +1204,7 @@ ImageList_write(VALUE self, VALUE file)
         rb_io_check_writable(fptr);
 
         add_format_prefix(info, rm_io_path(file));
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(IMAGEMAGICK_GREATER_THAN_EQUAL_7_1_2)
         SetImageInfoFile(info, NULL);
 #else
         SetImageInfoFile(info, rb_io_stdio_file(fptr));

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -15949,7 +15949,7 @@ Image_write(VALUE self, VALUE file)
         rb_io_check_writable(fptr);
 
         add_format_prefix(info, rm_io_path(file));
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(IMAGEMAGICK_GREATER_THAN_EQUAL_7_1_2)
         SetImageInfoFile(info, NULL);
 #else
         SetImageInfoFile(info, rb_io_stdio_file(fptr));


### PR DESCRIPTION
With ImageMagick 7.1.2-1, it causes following error with CI on Windows.

```
1) Magick::Image#write works
     Failure/Error: image1.write(f) { |options| options.format = 'JPEG' }

     Magick::ImageMagickError:
       unable to open image 'test.0': Permission denied @ error/blob.c/OpenBlob/3596
     # ./spec/rmagick/image/write_spec.rb:43:in `write'
     # ./spec/rmagick/image/write_spec.rb:43:in `block (2 levels) in <top (required)>'

  2) Magick::ImageList#write works
     Failure/Error: image_list.write(f) { |options| options.format = 'JPEG' }

     Magick::ImageMagickError:
       unable to open image 'test.0': Permission denied @ error/blob.c/OpenBlob/3596
     # ./spec/rmagick/image_list/write_spec.rb:26:in `write'
     # ./spec/rmagick/image_list/write_spec.rb:26:in `block (2 levels) in <top (required)>'

  3) Magick::ImageList#write issue #1375
     Failure/Error: image_list.write(f)

     Magick::ImageMagickError:
       unable to open image 'C:/Users/watso/AppData/Local/Temp/out.gif': Permission denied @ error/blob.c/OpenBlob/3596
     # ./spec/rmagick/image_list/write_spec.rb:38:in `write'
     # ./spec/rmagick/image_list/write_spec.rb:38:in `block (3 levels) in <top (required)>'
     # ./spec/rmagick/image_list/write_spec.rb:37:in `open'
     # ./spec/rmagick/image_list/write_spec.rb:37:in `block (2 levels) in <top (required)>'
```

The problem in the test was fixed with https://github.com/rmagick/rmagick/pull/1705.