### PR TITLE
Improve check whether C++ compiler exists

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -226,9 +226,10 @@ module RMagick
     def assert_can_compile!
       assert_has_dev_libs!
 
-      # Check for compiler. Extract first word so ENV['CXX'] can be a program name with arguments.
-      cxx = (ENV['CXX'] || RbConfig::CONFIG['CXX'] || 'g++').split.first
-      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." unless find_executable(cxx)
+      # Check for C++ compiler. Extract first word so ENV['CXX'] can be a program name with arguments.
+      # Ref. https://bugs.ruby-lang.org/issues/21111
+      cxx = (ENV['CXX'] || RbConfig::CONFIG['CXX']).split.first
+      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." if cxx == "false" || !find_executable(cxx)
     end
 
     def assert_has_dev_libs!

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -229,7 +229,9 @@ module RMagick
       # Check for C++ compiler. Extract first word so ENV['CXX'] can be a program name with arguments.
       # Ref. https://bugs.ruby-lang.org/issues/21111
       cxx = (ENV['CXX'] || RbConfig::CONFIG['CXX']).split.first
-      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." if cxx == "false" || !find_executable(cxx)
+      return if cxx != "false" && find_executable(cxx)
+
+      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." 
     end
 
     def assert_has_dev_libs!

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -231,7 +231,7 @@ module RMagick
       cxx = (ENV['CXX'] || RbConfig::CONFIG['CXX']).split.first
       return if cxx != "false" && find_executable(cxx)
 
-      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details." 
+      exit_failure "No C++ compiler found in ${ENV['PATH']}. See mkmf.log for details."
     end
 
     def assert_has_dev_libs!


### PR DESCRIPTION
Fix https://github.com/rmagick/rmagick/issues/1694

Seems `RbConfig::CONFIG['CXX']` has `"false"` string if C++ compiler is not exists since Ruby 3.0.
https://bugs.ruby-lang.org/issues/21111
