### PR TITLE
Use UINT2NUM to define enumerator element

### DIFF
--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -46,12 +46,12 @@ static void features_constant(void);
 
 //! define Ruby enumerator elements
 #define ENUMERATOR(val)\
-   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#val)), INT2NUM(val));\
+   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#val)), rb_ull2inum((unsigned long long)val));\
    rb_define_const(Module_Magick, #val, _enum);
 
 //! define Ruby enumerator elements when name is different from the value
 #define ENUMERATORV(name, val)\
-   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#name)), INT2NUM(val));\
+   _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#name)), rb_ull2inum((unsigned long long)val));\
    rb_define_const(Module_Magick, #name, _enum);
 
 //! end of an enumerator


### PR DESCRIPTION
This should fix following warning on Windows:

```
../../../../ext/RMagick/rmmain.cpp:1041:20: warning: overflow in conversion from 'ChannelType' to 'int' changes value from 'AllChannels' to '-1' [-Woverflow]
 1041 |         ENUMERATOR(AllChannels)
      |                    ^~~~~~~~~~~
../../../../ext/RMagick/rmmain.cpp:49:65: note: in definition of macro 'ENUMERATOR'
   49 |    _enum = rm_enum_new(_klass, ID2SYM(rb_intern(#val)), INT2NUM(val));\
      |                                                                 ^~~
At global scope:
cc1plus.exe: note: unrecognized command-line option '-Wno-dll-attribute-on-redeclaration' may have been intended to silence earlier diagnostics
```