### PR TITLE
README: Remove Rubinius

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These prerequisites are required for the latest version of RMagick.
 
 You can get Ruby from <https://www.ruby-lang.org>.
 
-Ruby must be able to build C-Extensions (e.g. MRI, Rubinius, not JRuby)
+Ruby must be able to build C-Extensions (e.g. MRI, not JRuby)
 
 **ImageMagick**
 - Version 6.9 or later (for ImageMagick 6 users).


### PR DESCRIPTION
Because, it can no longer install rbx

```
$ rbenv install rbx-5.0
==> Downloading openssl-1.0.2u.tar.gz...
-> curl -q -fL -o openssl-1.0.2u.tar.gz https://www.openssl.org/source/openssl-1.0.2u.tar.gz
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100    169 100    169   0      0    484      0                              0
  0      0   0      0   0      0      0      0                              0
100  5.10M 100  5.10M   0      0  6.62M      0                              0
==> Installing openssl-1.0.2u...
-> ./config "--prefix=$HOME/.rbenv/versions/rbx-5.0/openssl" "--openssldir=$HOME/.rbenv/versions/rbx-5.0/openssl/ssl" --libdir=lib zlib-dynamic no-ssl3 shared "-Wl,-rpath,$HOME/.rbenv/versions/rbx-5.0/openssl/lib" no-ssl2 no-krb5
-> make -j 24
-> make install_sw
==> Installed openssl-1.0.2u to /home/watson/.rbenv/versions/rbx-5.0
==> Downloading rubinius-5.0.tar.bz2...
-> curl -q -fL -o rubinius-5.0.tar.bz2 https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-5.0.tar.bz2
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 14.42M 100 14.42M   0      0  3.15M      0   00:04   00:04          2.94M
==> Installing rubinius-5.0...

WARNING: rubinius-5.0 is past its end of life and is now unsupported.
It no longer receives bug fixes or critical security updates.

-> ./configure "--prefix=$HOME/.rbenv/versions/rbx-5.0" "--with-lib-dir=$HOME/.rbenv/versions/rbx-5.0/openssl/lib" "--with-include-dir=$HOME/.rbenv/versions/rbx-5.0/openssl/include"

BUILD FAILED (ManjaroLinux 26.0.4 on x86_64 using ruby-build 20260327-2-g63d8d382)

You can inspect the build directory at /tmp/ruby-build.20260415120003.60507.WCIMg7
See the full build log at /tmp/ruby-build.20260415120003.60507.log
```