### PR TITLE
Rakefile: Remove lint task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -194,11 +194,4 @@ if RUBY_PLATFORM.include?('linux')
 end
 
 task spec: :compile
-
-if ENV['STYLE_CHECKS']
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
-  task default: %i[rubocop]
-else
-  task default: %i[spec]
-end
+task default: :spec


### PR DESCRIPTION
We run rubocop command directly.
So, this rake task is unnecessary.