### PR TITLE
Fail explicitly when trying to install on JRuby

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -42,6 +42,7 @@ module RMagick
     def initialize
       @stdout = $stdout.dup
 
+      exit_failure("JRuby is not supported.\nSee https://github.com/jruby/jruby/wiki/C-Extension-Alternatives") if RUBY_ENGINE == 'jruby'
       exit_failure("No longer support MSWIN environment.") if RUBY_PLATFORM.include?('mswin')
 
       setup_pkg_config_path


### PR DESCRIPTION
Since RMagick relies heavily on C extensions, it cannot be installed or run on JRuby environments. 
Previously, users would encounter confusing C compilation errors during the installation process.

Related to https://github.com/rmagick/rmagick/issues/1711, https://github.com/rmagick/rmagick/issues/1783