### PR TITLE
Check for errors from ParseGeometry()

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -11357,19 +11357,21 @@ Image_random_threshold_channel(int argc, VALUE *argv, VALUE self)
 #if defined(IMAGEMAGICK_7)
     {
         GeometryInfo geometry_info;
+
         if (ParseGeometry(thresholds, &geometry_info) == NoValue && *thresholds)
         {
-            DestroyExceptionInfo(exception);
-            DestroyImage(new_image);
-            rb_raise(rb_eArgError, "invalid geometry string");
+            (void) ThrowMagickException(exception, GetMagickModule(), OptionError,
+                                        "InvalidArgument", "'%s'", thresholds);
         }
-
-        BEGIN_CHANNEL_MASK(new_image, channels);
+        else
         {
-            GVL_STRUCT_TYPE(RandomThresholdImage) args = { new_image, geometry_info.rho, geometry_info.sigma, exception };
-            CALL_FUNC_WITHOUT_GVL(GVL_FUNC(RandomThresholdImage), &args);
+            BEGIN_CHANNEL_MASK(new_image, channels);
+            {
+                GVL_STRUCT_TYPE(RandomThresholdImage) args = { new_image, geometry_info.rho, geometry_info.sigma, exception };
+                CALL_FUNC_WITHOUT_GVL(GVL_FUNC(RandomThresholdImage), &args);
+            }
+            END_CHANNEL_MASK(new_image);
         }
-        END_CHANNEL_MASK(new_image);
     }
 #else
     GVL_STRUCT_TYPE(RandomThresholdImageChannel) args = { new_image, channels, thresholds, exception };

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -11355,15 +11355,22 @@ Image_random_threshold_channel(int argc, VALUE *argv, VALUE self)
     exception = AcquireExceptionInfo();
 
 #if defined(IMAGEMAGICK_7)
-    BEGIN_CHANNEL_MASK(new_image, channels);
     {
         GeometryInfo geometry_info;
+        if (ParseGeometry(thresholds, &geometry_info) == NoValue && *thresholds)
+        {
+            DestroyExceptionInfo(exception);
+            DestroyImage(new_image);
+            rb_raise(rb_eArgError, "invalid geometry string");
+        }
 
-        ParseGeometry(thresholds, &geometry_info);
-        GVL_STRUCT_TYPE(RandomThresholdImage) args = { new_image, geometry_info.rho, geometry_info.sigma, exception };
-        CALL_FUNC_WITHOUT_GVL(GVL_FUNC(RandomThresholdImage), &args);
+        BEGIN_CHANNEL_MASK(new_image, channels);
+        {
+            GVL_STRUCT_TYPE(RandomThresholdImage) args = { new_image, geometry_info.rho, geometry_info.sigma, exception };
+            CALL_FUNC_WITHOUT_GVL(GVL_FUNC(RandomThresholdImage), &args);
+        }
+        END_CHANNEL_MASK(new_image);
     }
-    END_CHANNEL_MASK(new_image);
 #else
     GVL_STRUCT_TYPE(RandomThresholdImageChannel) args = { new_image, channels, thresholds, exception };
     CALL_FUNC_WITHOUT_GVL(GVL_FUNC(RandomThresholdImageChannel), &args);

--- a/ext/RMagick/rmkinfo.cpp
+++ b/ext/RMagick/rmkinfo.cpp
@@ -180,12 +180,17 @@ KernelInfo_builtin(VALUE self, VALUE what, VALUE geometry)
     KernelInfo *kernel;
     KernelInfoType kernel_type;
     GeometryInfo info;
+    const char *geom_str;
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception;
 #endif
 
     VALUE_TO_ENUM(what, kernel_type, KernelInfoType);
-    ParseGeometry(StringValueCStr(geometry), &info);
+    geom_str = StringValueCStr(geometry);
+    if (ParseGeometry(geom_str, &info) == NoValue && *geom_str)
+    {
+        rb_raise(rb_eArgError, "invalid geometry string");
+    }
 
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();

--- a/spec/rmagick/image/random_threshold_channel_spec.rb
+++ b/spec/rmagick/image/random_threshold_channel_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Magick::Image, '#random_threshold_channel' do
     expect { image.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { image.random_threshold_channel }.to raise_error(ArgumentError)
     expect { image.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
+    expect { image.random_threshold_channel('invalid', Magick::AllChannels) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/rmagick/image/random_threshold_channel_spec.rb
+++ b/spec/rmagick/image/random_threshold_channel_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe Magick::Image, '#random_threshold_channel' do
     expect { image.random_threshold_channel(threshold, Magick::RedChannel, Magick::BlueChannel) }.not_to raise_error
     expect { image.random_threshold_channel }.to raise_error(ArgumentError)
     expect { image.random_threshold_channel('20%', 2) }.to raise_error(TypeError)
-    expect { image.random_threshold_channel('invalid', Magick::AllChannels) }.to raise_error(ArgumentError)
+    expect { image.random_threshold_channel('invalid', Magick::AllChannels) }.to raise_error(Magick::ImageMagickError)
   end
 end

--- a/spec/rmagick/kernel_info/class_methods/builtin_spec.rb
+++ b/spec/rmagick/kernel_info/class_methods/builtin_spec.rb
@@ -3,10 +3,11 @@
 RSpec.describe Magick::KernelInfo, '.builtin' do
   it 'works' do
     expect(described_class.builtin(Magick::UnityKernel, '')).to be_instance_of(described_class)
-    expect(described_class.builtin(Magick::GaussianKernel, 'Gaussian:10,5')).to be_instance_of(described_class)
-    expect(described_class.builtin(Magick::LoGKernel, 'LoG:10,5')).to be_instance_of(described_class)
-    expect(described_class.builtin(Magick::DoGKernel, 'DoG:10,5')).to be_instance_of(described_class)
-    expect(described_class.builtin(Magick::BlurKernel, 'Blur:10,5,1')).to be_instance_of(described_class)
-    expect(described_class.builtin(Magick::CometKernel, 'Comet:10,5,1')).to be_instance_of(described_class)
+    expect(described_class.builtin(Magick::GaussianKernel, '10,5')).to be_instance_of(described_class)
+    expect(described_class.builtin(Magick::LoGKernel, '10,5')).to be_instance_of(described_class)
+    expect(described_class.builtin(Magick::DoGKernel, '10,5')).to be_instance_of(described_class)
+    expect(described_class.builtin(Magick::BlurKernel, '10,5')).to be_instance_of(described_class)
+    expect(described_class.builtin(Magick::CometKernel, '10,5')).to be_instance_of(described_class)
+    expect { described_class.builtin(Magick::GaussianKernel, 'invalid') }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
That function returns `NoValue` if parsing failed.

Right now this is ignored, which means that typos in the geometry string or other mistakes are uncaught.
In fact, adding this validation shows that the spec test for the kernel methods was actually not correct: a string like `Gaussian:10,5` is not accepted by the parser from ParseGeometry and resulted in the unit geometry. I show this in the standalone C code below too.

For backwards compatibility, I allow the empty string to result in the unit geometry as that's already tested behaviour right now.

Sample C code proving that things like `Gaussian:10,5` result in a unit geometry:
```c
#include <string.h>
#include <stdio.h>
#include <MagickCore/MagickCore.h>
int main() {
    GeometryInfo info;
    MagickStatusType flags;
    const char *strings[] = {"LoG:10,5", "DoG:10,5", "Blur:10,5,1", "Comet:10,5,1", NULL};
    for (int i = 0; strings[i] != NULL; i++) {
        flags = ParseGeometry(strings[i], &info);
        printf("ParseGeometry(\"%s\") -> flags=0x%x  rho=%.1f sigma=%.1f\n",
               strings[i], flags, info.rho, info.sigma);
    }
    return 0;
}
```

Note: this was found by a static-dynamic hybrid analyzer I'm developing.