### PR TITLE
Image_gray_q changes the colour space of the image, instead of returning whether it's grayscale

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -284,7 +284,6 @@ module RMagick
         _aligned_msize
       ]
       imagemagick_api = [
-        'SetImageGray', # 6.9.1-10
         'SetMagickAlignedMemoryMethods' # 7.0.9-0
       ]
 

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -7929,6 +7929,13 @@ has_image_attribute(VALUE self, MagickBooleanType (attr_test)(const Image *))
 }
 #endif
 
+static MagickBooleanType
+Image_is_gray_colorspace_type(const Image *image, ExceptionInfo *exception)
+{
+    ColorspaceType colorspace = GetImageColorspaceType(image, exception);
+    return (colorspace == GRAYColorspace || colorspace == LinearGRAYColorspace) ? MagickTrue : MagickFalse;
+}
+
 
 /**
  * Return true if all the pixels in the image have the same red, green, and blue intensities.
@@ -7938,11 +7945,7 @@ has_image_attribute(VALUE self, MagickBooleanType (attr_test)(const Image *))
 VALUE
 Image_gray_q(VALUE self)
 {
-#if defined(HAVE_SETIMAGEGRAY)
-    return has_attribute(self, (MagickBooleanType (*)(const Image *, ExceptionInfo *))SetImageGray);
-#else
-    return has_attribute(self, IsGrayImage);
-#endif
+    return has_attribute(self, Image_is_gray_colorspace_type);
 }
 
 


### PR DESCRIPTION
Uses a wrapper for `GetImageColorspaceType()` that checks whether the color space is one of the grayscale types.
~~Keeping the old behaviour for older versions just for safety.~~ EDIT: unconditionally using the other function seems to be the only way to get CI green... :thinking-face:
Checking `image->colorspace` directly seems wrong because you can have an image in the RGB color space that just so happens to be grayscale.

Fix #1787 