### PR TITLE
Clean up ImageMagick resources on exit to fix ruby_memcheck false leaks

### DIFF
--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -214,6 +214,12 @@ static void set_managed_memory(void)
 
 
 
+static void
+rmagick_terminus(VALUE unused)
+{
+    MagickCoreTerminus();
+}
+
 /**
  * Define the classes and constants.
  *
@@ -231,6 +237,7 @@ Init_RMagick2(void)
     set_managed_memory();
 
     MagickCoreGenesis("RMagick", MagickFalse);
+    rb_set_end_proc(rmagick_terminus, Qnil);
 
     test_Magick_version();
 


### PR DESCRIPTION
If we don't do this, then any lazily initialized ImageMagick data will not get freed and you will get a false leak report from ruby_memcheck. This made ruby_memcheck almost impossible to use, as for example, every call to MagickThrowException lazily initializes the locale splay tree, and so ruby_memcheck reported a leak on that.