### PR TITLE
Fix memory leaks if level operations fail in Image#{level_colors, levelize_channel}

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -8675,6 +8675,7 @@ Image_level_colors(int argc, VALUE *argv, VALUE self)
 #endif
     if (!okay)
     {
+        DestroyImage(new_image);
         rb_raise(rb_eRuntimeError, "LevelImageColors failed for unknown reason.");
     }
 
@@ -8756,6 +8757,7 @@ Image_levelize_channel(int argc, VALUE *argv, VALUE self)
 
     if (!okay)
     {
+        DestroyImage(new_image);
         rb_raise(rb_eRuntimeError, "LevelizeImageChannel failed for unknown reason.");
     }
     return rm_image_new(new_image);


### PR DESCRIPTION
Might be more theoretical, although:
- it matches other code patterns
- ImageMagick has a memory limit safety policy setting, so you could actually hit this issue for real

Found using an experimental static-dynamic hybrid analyzer I'm developing.