### PR TITLE
Fix memory leak in Image#{color_profile=, iptc_profile=} when out of memory

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -2930,6 +2930,7 @@ set_profile(VALUE self, const char *name, VALUE profile)
     info = CloneImageInfo(NULL);
     if (!info)
     {
+        DestroyExceptionInfo(exception);
         rb_raise(rb_eNoMemError, "not enough memory to continue");
     }
 


### PR DESCRIPTION
Prevents a memory leak in case the memory limit policy is reached.

Found using an experimental static-dynamic hybrid analyzer I'm developing.