### PR TITLE
Fix memory leak in Image#gamma_correct

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -7647,7 +7647,7 @@ Image_gamma_correct(int argc, VALUE *argv, VALUE self)
     }
 
 #if defined(IMAGEMAGICK_7)
-    CHECK_EXCEPTION();
+    rm_check_exception(exception, new_image, DestroyOnError);
     DestroyExceptionInfo(exception);
 #else
     rm_check_image_exception(new_image, DestroyOnError);


### PR DESCRIPTION
`CHECK_EXCEPTION()` doesn't free the new image when `GammaImage()` fails.

Example Valgrind report:
```
42,696 (13,512 direct, 29,184 indirect) bytes in 1 blocks are definitely lost in loss record 30,273 of 30,317
  malloc (at /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  rb_nogvl (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
 *rm_clone_image (rmutil.cpp:1473)
 *Image_gamma_correct (rmimage.cpp:7601)
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  rb_vm_exec (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  rb_vm_exec (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  rb_yield (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  rb_vm_exec (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  rb_yield (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  <unknown stack frame>
  rb_vm_exec (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  <unknown stack frame>
  ruby_run_node (at /usr/lib/x86_64-linux-gnu/libruby-3.2.so.3.2.3)
  <unknown stack frame>
  (below main) (libc_start_call_main.h:58)
```

Found using an experimental static-dynamic hybrid analyzer I'm developing.