### PR TITLE
Fix missing error check in KernelInfo#clone

### DIFF
--- a/ext/RMagick/rmkinfo.cpp
+++ b/ext/RMagick/rmkinfo.cpp
@@ -162,6 +162,10 @@ VALUE
 KernelInfo_clone(VALUE self)
 {
     KernelInfo *kernel = CloneKernelInfo((KernelInfo*)DATA_PTR(self));
+    if (!kernel)
+    {
+        rb_raise(rb_eNoMemError, "not enough memory to continue");
+    }
     return TypedData_Wrap_Struct(Class_KernelInfo, &rm_kernel_info_data_type, kernel);
 }
 


### PR DESCRIPTION
CloneKernelInfo can actually return NULL on failure (e.g. memory limit policy reached or actually exhausted memory, but mostly the former).

Found using an experimental hybrid static-dynamic analyzer I'm developing.