### PR TITLE
Fix potential stack buffer overflows in format_exception and add_format_prefix

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -15833,6 +15833,9 @@ void add_format_prefix(Info *info, VALUE file)
     {
         memset(magic, '\0', sizeof(magic));
         magic_l = p - filename;
+        if (magic_l >= sizeof(magic)) {
+            magic_l = sizeof(magic) - 1;
+        }
         memcpy(magic, filename, magic_l);
 
         exception = AcquireExceptionInfo();

--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -1574,15 +1574,11 @@ rm_check_image_exception(Image *imglist, ErrorRetention retention)
 static void
 format_exception(const ExceptionType severity, const char *reason, const char *description, char *msg)
 {
-    int len;
     memset(msg, 0, ERROR_MSG_SIZE);
-
-    len = snprintf(msg, ERROR_MSG_SIZE, "%s%s%s",
+    snprintf(msg, ERROR_MSG_SIZE, "%s%s%s",
         GetLocaleExceptionMessage(severity, reason),
         description ? ": " : "",
         description ? GetLocaleExceptionMessage(severity, description) : "");
-
-    msg[len] = '\0';
 }
 
 


### PR DESCRIPTION
- rmutil.cpp (format_exception): Remove redundant and unsafe `msg[len] = '\0'` after `snprintf`. `snprintf` already guarantees null-termination within the given buffer size, and using its return value as an index could lead to an out-of-bounds write if the formatted string was truncated.
- rmimage.cpp (add_format_prefix): Clamp `magic_l` to ensure it does not exceed the `magic` buffer size before calling `memcpy`.