### PR TITLE
Reject NAN in Pixel#from_hsla()

### DIFF
--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -739,19 +739,19 @@ Pixel_from_hsla(int argc, VALUE *argv, VALUE klass ATTRIBUTE_UNUSED)
             break;
     }
 
-    if (alpha && (a < 0.0 || a > 1.0))
+    if (alpha && !(a >= 0.0 && a <= 1.0))
     {
         rb_raise(rb_eRangeError, "alpha %g out of range [0.0, 1.0]", a);
     }
-    if (l < 0.0 || l > 255.0)
+    if (!(l >= 0.0 && l <= 255.0))
     {
         rb_raise(rb_eRangeError, "lightness %g out of range [0.0, 255.0]", l);
     }
-    if (s < 0.0 || s > 255.0)
+    if (!(s >= 0.0 && s <= 255.0))
     {
         rb_raise(rb_eRangeError, "saturation %g out of range [0.0, 255.0]", s);
     }
-    if (h < 0.0 || h >= 360.0)
+    if (!(h >= 0.0 && h < 360.0))
     {
         rb_raise(rb_eRangeError, "hue %g out of range [0.0, 360.0)", h);
     }

--- a/spec/rmagick/pixel/from_hsla_spec.rb
+++ b/spec/rmagick/pixel/from_hsla_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Magick::Pixel, '#from_hsla' do
     expect { described_class.from_hsla(360, 0, 0) }.to raise_error(RangeError)
     expect { described_class.from_hsla(0, 256, 0) }.to raise_error(RangeError)
     expect { described_class.from_hsla(0, 0, 256) }.to raise_error(RangeError)
+    expect { described_class.from_hsla(Float::NAN, 0, 0) }.to raise_error(RangeError)
+    expect { described_class.from_hsla(0, Float::NAN, 0) }.to raise_error(RangeError)
+    expect { described_class.from_hsla(0, 0, Float::NAN) }.to raise_error(RangeError)
+    expect { described_class.from_hsla(0, 0, 0, Float::NAN) }.to raise_error(RangeError)
     expect { pixel.to_hsla }.not_to raise_error
 
     args = [200, 125.125, 250.5, 0.6]


### PR DESCRIPTION
It's possible to pass NAN which is silently accepted but yields an invalid colour string.

Found using an experimental hybrid static-dynamic analyzer I'm developing.

BTW: Perhaps the return value of QueryColorCompliance / QueryMagickColor should be checked because there seem to be a few error paths that don't throw an exception.