### PR TITLE
Fix memory leak when string conversion raises

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -5355,16 +5355,17 @@ VALUE
 Image_delete_profile(VALUE self, VALUE name)
 {
     Image *image = rm_check_frozen(self);
+    char *profile_name = StringValueCStr(name);
 
 #if defined(IMAGEMAGICK_7)
     ExceptionInfo *exception = AcquireExceptionInfo();
 
-    GVL_STRUCT_TYPE(ProfileImage) args = { image, StringValueCStr(name), NULL, 0, exception };
+    GVL_STRUCT_TYPE(ProfileImage) args = { image, profile_name, NULL, 0, exception };
     CALL_FUNC_WITHOUT_GVL(GVL_FUNC(ProfileImage), &args);
     CHECK_EXCEPTION();
     DestroyExceptionInfo(exception);
 #else
-    GVL_STRUCT_TYPE(ProfileImage) args = { image, StringValueCStr(name), NULL, 0, MagickTrue };
+    GVL_STRUCT_TYPE(ProfileImage) args = { image, profile_name, NULL, 0, MagickTrue };
     CALL_FUNC_WITHOUT_GVL(GVL_FUNC(ProfileImage), &args);
 #endif
     return self;

--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -473,8 +473,8 @@ Color_Name_to_PixelColor(PixelColor *color, VALUE name_arg)
     char *name;
     ExceptionInfo *exception;
 
-    exception = AcquireExceptionInfo();
     name = StringValueCStr(name_arg);
+    exception = AcquireExceptionInfo();
     okay = QueryColorCompliance(name, AllCompliance, color, exception);
     DestroyExceptionInfo(exception);
     if (!okay)
@@ -683,15 +683,16 @@ Pixel_from_color(VALUE klass ATTRIBUTE_UNUSED, VALUE name)
     PixelColor pp;
     ExceptionInfo *exception;
     MagickBooleanType okay;
+    char *color = StringValueCStr(name);
 
     exception = AcquireExceptionInfo();
-    okay = QueryColorCompliance(StringValueCStr(name), AllCompliance, &pp, exception);
+    okay = QueryColorCompliance(color, AllCompliance, &pp, exception);
     CHECK_EXCEPTION();
     DestroyExceptionInfo(exception);
 
     if (!okay)
     {
-        rb_raise(rb_eArgError, "invalid color name: %s", StringValueCStr(name));
+        rb_raise(rb_eArgError, "invalid color name: %s", color);
     }
 
     return Pixel_from_PixelColor(&pp);


### PR DESCRIPTION
`StringValueCStr()` can raise (`TypeError` for non-strings, `ArgumentError` for strings containing a NUL byte).
When it was evaluated after `AcquireExceptionInfo()`, the raised exception unwound past `DestroyExceptionInfo()`, leaking the `ExceptionInfo` on every call.

Move the `StringValueCStr()` conversions before `AcquireExceptionInfo()` in `Color_Name_to_PixelColor()`, `Pixel_from_color()` and `Image_delete_profile()` so the conversion error is handled before any ImageMagick memory is allocated.