### PR TITLE
Fix report size in rm_kernel_info_memsize

### DIFF
--- a/ext/RMagick/rmkinfo.cpp
+++ b/ext/RMagick/rmkinfo.cpp
@@ -51,7 +51,21 @@ rm_kernel_info_destroy(void *kernel)
 static size_t
 rm_kernel_info_memsize(const void *ptr)
 {
-    return sizeof(KernelInfo);
+    const KernelInfo *kernel = (const KernelInfo *)ptr;
+    size_t size = 0;
+
+    // A KernelInfo may be a linked list of kernels, each owning a values array.
+    while (kernel)
+    {
+        size += sizeof(KernelInfo);
+        if (kernel->values)
+        {
+            size += kernel->width * kernel->height * sizeof(*kernel->values);
+        }
+        kernel = kernel->next;
+    }
+
+    return size;
 }
 
 /**


### PR DESCRIPTION
`rm_kernel_info_memsize` always returned `sizeof(KernelInfo)`, ignoring the heap-allocated values array (width * height doubles) and any chained kernels reachable through ->next. Walk the kernel list and add each node's struct and values array so `ObjectSpace.memsize_of` reflects the real memory footprint.