### PR TITLE
Fix SEGV in Draw#primitive on non-String argument

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -1257,6 +1257,7 @@ Draw_primitive(VALUE self, VALUE primitive)
     Draw *draw;
 
     rb_check_frozen(self);
+    StringValue(primitive);
     TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
     if (draw->primitives == (VALUE)0)

--- a/spec/rmagick/draw/primitive_spec.rb
+++ b/spec/rmagick/draw/primitive_spec.rb
@@ -8,4 +8,31 @@ RSpec.describe Magick::Draw, '#primitive' do
     expect { draw.primitive('12345') }.not_to raise_error
     expect { draw.primitive(nil) }.to raise_error(TypeError)
   end
+
+  describe 'argument type validation' do
+    [nil, 123, :symbol, [1, 2], 1.5, true, { a: 1 }].each do |bad|
+      it "raises TypeError for #{bad.inspect} on the first call" do
+        draw = described_class.new
+        expect { draw.primitive(bad) }.to raise_error(TypeError)
+      end
+
+      it "raises TypeError for #{bad.inspect} on a subsequent call" do
+        draw = described_class.new
+        draw.primitive('fill red')
+        expect { draw.primitive(bad) }.to raise_error(TypeError)
+      end
+    end
+
+    it 'accepts a String' do
+      draw = described_class.new
+      expect { draw.primitive('fill red') }.not_to raise_error
+    end
+
+    it 'accepts an object that responds to #to_str' do
+      stringish = Object.new
+      def stringish.to_str = 'fill red'
+      draw = described_class.new
+      expect { draw.primitive(stringish) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Draw#primitive` passed its argument straight to `rb_str_dup()`/`rb_str_concat()` without checking the type. A non-String argument (`Integer`, `Symbol`, `nil`, `Array`, ...) was therefore dereferenced as if it were a `String` object, crashing the whole process with a **SIGSEGV** instead of raising `TypeError`.

```ruby
Magick::Draw.new.primitive(123)   # => SIGSEGV (before this fix)
```

The crash only occurred on the *first* `primitive` call (the `rb_str_dup` branch, when `primitives == 0`); a subsequent call went through `rb_str_concat`, which already raised for some types. That is why the existing spec — which called valid primitives before passing `nil` — did not catch it.

## Fix

Add `StringValue(primitive)` so the argument is coerced/validated before use. Non-String arguments now raise `TypeError`; objects responding to `#to_str` are still accepted.

## Test

Extended `spec/rmagick/draw/primitive_spec.rb` to assert `TypeError` for non-String arguments on both the first and subsequent calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)