### PR TITLE
Fix SEGV in Image/Pixel/Draw #marshal_load on a non-collection argument

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -593,6 +593,8 @@ Draw_marshal_load(VALUE self, VALUE ddraw)
 
     TypedData_Get_Struct(self, Draw, &rm_draw_data_type, draw);
 
+    Check_Type(ddraw, T_HASH);
+
     if (draw->info == NULL)
     {
         ImageInfo *image_info;

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -9056,6 +9056,8 @@ Image_marshal_load(VALUE self, VALUE ary)
 
     TypedData_Get_Struct(self, Image, &rm_image_data_type, image);
 
+    Check_Type(ary, T_ARRAY);
+
     filename = rb_ary_shift(ary);
     blob = rb_ary_shift(ary);
 

--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -1046,6 +1046,9 @@ Pixel_marshal_load(VALUE self, VALUE dpixel)
     Pixel *pixel;
 
     TypedData_Get_Struct(self, Pixel, &rm_pixel_data_type, pixel);
+
+    Check_Type(dpixel, T_HASH);
+
     pixel->red = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("red")));
     pixel->green = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("green")));
     pixel->blue = NUM2QUANTUM(rb_hash_aref(dpixel, CSTR2SYM("blue")));

--- a/spec/rmagick/draw/marshal_load_spec.rb
+++ b/spec/rmagick/draw/marshal_load_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Magick::Draw, '#marshal_load' do
+  it 'round-trips a dumped Draw' do
+    draw = described_class.new
+    draw.fill = Magick::Pixel.from_color('red')
+
+    expect { described_class.new.marshal_load(draw.marshal_dump) }.not_to raise_error
+  end
+
+  # Regression: a non-Hash argument used to be dereferenced as a Hash and crash
+  # the process (SIGSEGV). It must raise TypeError instead.
+  it 'raises TypeError for a non-Hash argument' do
+    draw = described_class.new
+    expect { draw.marshal_load(0) }.to raise_error(TypeError)
+    expect { draw.marshal_load(nil) }.to raise_error(TypeError)
+    expect { draw.marshal_load([]) }.to raise_error(TypeError)
+  end
+end

--- a/spec/rmagick/image/marshal_load_spec.rb
+++ b/spec/rmagick/image/marshal_load_spec.rb
@@ -7,4 +7,13 @@ RSpec.describe Magick::Image, '#marshal_load' do
     expect { image2.marshal_load(image1.marshal_dump) }.not_to raise_error
     expect { image2.marshal_load([1234, 5678]) }.to raise_error(TypeError)
   end
+
+  # Regression: a non-Array argument used to be dereferenced as an Array and
+  # crash the process (SIGSEGV). It must raise TypeError instead.
+  it 'raises TypeError for a non-Array argument' do
+    image = described_class.new(10, 10)
+    expect { image.marshal_load(0) }.to raise_error(TypeError)
+    expect { image.marshal_load(nil) }.to raise_error(TypeError)
+    expect { image.marshal_load({}) }.to raise_error(TypeError)
+  end
 end

--- a/spec/rmagick/pixel/marshal_spec.rb
+++ b/spec/rmagick/pixel/marshal_spec.rb
@@ -9,4 +9,13 @@ RSpec.describe Magick::Pixel, '#marshal' do
     pixel2 = described_class.new
     expect(pixel2.marshal_load(marshal)).to eq(pixel)
   end
+
+  # Regression: a non-Hash argument used to be dereferenced as a Hash and crash
+  # the process (SIGSEGV). It must raise TypeError instead.
+  it 'raises TypeError for a non-Hash argument' do
+    pixel = described_class.new
+    expect { pixel.marshal_load(0) }.to raise_error(TypeError)
+    expect { pixel.marshal_load(nil) }.to raise_error(TypeError)
+    expect { pixel.marshal_load([]) }.to raise_error(TypeError)
+  end
 end


### PR DESCRIPTION
## Problem

`Image_marshal_load` calls `rb_ary_shift()` on its argument, and `Pixel_marshal_load` / `Draw_marshal_load` call `rb_hash_aref()` on theirs, without checking the type.

Ruby's `Marshal.load` reconstructs a `USRMARSHAL` object by calling `Klass.allocate` then `obj.marshal_load(payload)`, where `payload` is decoded straight from the (untrusted) byte stream. A crafted payload whose data object is **not** an `Array`/`Hash` was dereferenced as one and crashed the whole process with a **SIGSEGV**.

```ruby
def usrmarshal(cls, data) = "\x04\bU:".b + (cls.bytesize + 5).chr + cls.b + data
Marshal.load(usrmarshal("Magick::Pixel", "i\x00".b))   # Integer payload => SIGSEGV (before this fix)

Magick::Image.allocate.marshal_load(0)                 # => SIGSEGV (before this fix)
```

## Fix

Add `Check_Type()` at the start of each `marshal_load` to validate the argument type, so these raise `TypeError` instead of crashing:

- `Image_marshal_load`  → `Check_Type(ary, T_ARRAY)`
- `Pixel_marshal_load`  → `Check_Type(dpixel, T_HASH)`
- `Draw_marshal_load`   → `Check_Type(ddraw, T_HASH)`

Legitimate `Marshal` round-trips are unaffected.

> Note: deserializing untrusted `Marshal` data is unsafe in general; the point here is only that RMagick should raise rather than crash the VM.

## Test

Added/extended specs asserting that a non-`Array`/non-`Hash` argument raises `TypeError`, while normal `marshal_load` round-trips keep working:
`spec/rmagick/image/marshal_load_spec.rb`, `spec/rmagick/pixel/marshal_spec.rb`, `spec/rmagick/draw/marshal_load_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)