### PR TITLE
Fix heap overflow from integer overflow in dispatch/export_pixels geometry

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -5631,6 +5631,41 @@ Image_displace(int argc, VALUE *argv, VALUE self)
 
 
 /**
+ * Compute columns * rows * map_length for a pixel buffer, raising RangeError on
+ * overflow.
+ *
+ * The product is used to size the buffer that ImageMagick fills based on the
+ * (caller-supplied) columns and rows. If the multiplication wrapped around, the
+ * buffer would be allocated too small and ImageMagick would write out of bounds.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param columns the number of columns
+ * @param rows the number of rows
+ * @param map_length the number of channels per pixel (length of the map string)
+ * @return columns * rows * map_length
+ * @throw RangeError if the multiplication overflows
+ */
+static size_t
+pixel_buffer_count(size_t columns, size_t rows, size_t map_length)
+{
+    size_t pixels;
+
+    if (columns != 0 && rows > SIZE_MAX / columns)
+    {
+        rb_raise(rb_eRangeError, "pixel buffer dimensions too large (%" RMIuSIZE "x%" RMIuSIZE ")", columns, rows);
+    }
+    pixels = columns * rows;
+    if (map_length != 0 && pixels > SIZE_MAX / map_length)
+    {
+        rb_raise(rb_eRangeError, "pixel buffer dimensions too large (%" RMIuSIZE "x%" RMIuSIZE " map=%" RMIuSIZE ")",
+                 columns, rows, map_length);
+    }
+    return pixels * map_length;
+}
+
+
+/**
  * Extract pixel data from the image and returns it as an array of pixels. The "x", "y", "width" and
  * "height" parameters specify the rectangle to be extracted. The "map" parameter reflects the
  * expected ordering of the pixel array. It can be any combination or order of R = red, G = green,
@@ -5685,7 +5720,7 @@ Image_dispatch(int argc, VALUE *argv, VALUE self)
     }
 
     // Compute the size of the pixel array and allocate the memory.
-    npixels = columns * rows * mapL;
+    npixels = pixel_buffer_count(columns, rows, mapL);
     pixels.v = stg_type == QuantumPixel ? (void *) ALLOC_N(Quantum, npixels)
                : (void *) ALLOC_N(double, npixels);
 
@@ -6636,7 +6671,7 @@ Image_export_pixels(int argc, VALUE *argv, VALUE self)
     }
 
 
-    npixels = (long)(cols * rows * strlen(map));
+    npixels = (long)pixel_buffer_count(cols, rows, strlen(map));
     pixels = ALLOC_N(Quantum, npixels);
     if (!pixels)    // app recovered from exception
     {
@@ -6804,7 +6839,7 @@ Image_export_pixels_to_str(int argc, VALUE *argv, VALUE self)
     }
 
 
-    npixels = cols * rows * strlen(map);
+    npixels = pixel_buffer_count(cols, rows, strlen(map));
     switch (type)
     {
         case CharPixel:
@@ -6833,6 +6868,10 @@ Image_export_pixels_to_str(int argc, VALUE *argv, VALUE self)
 
     // Allocate a string long enough to hold the exported pixel data.
     // Get a pointer to the buffer.
+    if (npixels != 0 && sz > (size_t)LONG_MAX / npixels)
+    {
+        rb_raise(rb_eRangeError, "pixel buffer dimensions too large");
+    }
     string = rb_str_new2("");
     rb_str_resize(string, (long)(sz * npixels));
 

--- a/spec/rmagick/image/dispatch_spec.rb
+++ b/spec/rmagick/image/dispatch_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe Magick::Image, '#dispatch' do
       image.dispatch(0, 0, 20, 20, 'RGBA', false, false)
     end.to raise_error(ArgumentError)
   end
+
+  # Regression: columns * rows * map_length is computed in unsigned arithmetic.
+  # A geometry that overflows it used to under-allocate the pixel buffer, so
+  # ImageMagick wrote out of bounds (SIGSEGV / heap corruption). It must raise
+  # RangeError instead.
+  it 'raises RangeError when the geometry overflows the buffer size' do
+    image = described_class.new(8, 8)
+
+    expect { image.dispatch(0, 0, 2**32, 2**32, 'R') }.to raise_error(RangeError)
+    expect { image.dispatch(0, 0, 2**48, 2**16, 'R') }.to raise_error(RangeError)
+  end
 end

--- a/spec/rmagick/image/export_pixels_spec.rb
+++ b/spec/rmagick/image/export_pixels_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe Magick::Image, '#export_pixels' do
     expect { image.export_pixels(0, 0, 10, 10, 'I', 2) }.to raise_error(ArgumentError)
   end
 
+  # Regression: cols * rows * map_length is computed in unsigned arithmetic.
+  # A geometry that overflows it used to under-allocate the pixel buffer, so
+  # ImageMagick wrote out of bounds (SIGSEGV / heap corruption). It must raise
+  # RangeError instead.
+  it 'raises RangeError when the geometry overflows the buffer size' do
+    image = described_class.new(8, 8)
+
+    expect { image.export_pixels(0, 0, 2**32, 2**32, 'R') }.to raise_error(RangeError)
+    expect { image.export_pixels(0, 0, 2**48, 2**16, 'R') }.to raise_error(RangeError)
+  end
+
   it 'works with float types' do
     image = described_class.read(File.join(IMAGES_DIR, 'Flower_Hat.jpg')).first
 

--- a/spec/rmagick/image/export_pixels_to_str_spec.rb
+++ b/spec/rmagick/image/export_pixels_to_str_spec.rb
@@ -41,4 +41,15 @@ RSpec.describe Magick::Image, '#export_pixels_to_str' do
     # last arg s/b StorageType
     expect { image.export_pixels_to_str(0, 0, 10, 10, 'I', 2) }.to raise_error(TypeError)
   end
+
+  # Regression: cols * rows * map_length (and that times the storage-type size)
+  # is computed in unsigned arithmetic. A geometry that overflows it used to
+  # under-allocate the string buffer, so ImageMagick wrote out of bounds
+  # (SIGSEGV / heap corruption). It must raise RangeError instead.
+  it 'raises RangeError when the geometry overflows the buffer size' do
+    image = described_class.new(8, 8)
+
+    expect { image.export_pixels_to_str(0, 0, 2**32, 2**32, 'R', Magick::CharPixel) }.to raise_error(RangeError)
+    expect { image.export_pixels_to_str(0, 0, 2**61, 1, 'R', Magick::DoublePixel) }.to raise_error(RangeError)
+  end
 end


### PR DESCRIPTION
## Problem

`Image#dispatch`, `Image#export_pixels` and `Image#export_pixels_to_str` size the pixel buffer as `columns * rows * map_length` in unsigned arithmetic **with no overflow check**, then allocate a buffer of that size and hand it to ImageMagick's `ExportImagePixels`, which fills it based on the (caller-supplied) `columns` and `rows`.

When the multiplication wraps around, the buffer is allocated far too small while ImageMagick still writes the full region — corrupting the heap and crashing the process with a **SIGSEGV**.

```ruby
Magick::Image.new(8, 8).dispatch(0, 0, 2**32, 2**32, 'R')
# columns * rows * 1 == 2**64 -> wraps to 0 -> ALLOC_N(Quantum, 0)
# ExportImagePixels then writes the region -> heap overflow -> SIGSEGV
```

Reproduced as an immediate `SIGSEGV` (write through a near-null pointer) or, depending on heap state, a multi-GB allocation attempt / hang.

The existing `ALLOC_N` overflow guard does **not** help here: `npixels` has already wrapped in the C multiplication *before* it reaches `ALLOC_N`, so `ALLOC_N` is handed a small value and allocates a small buffer.

## Fix

Add `pixel_buffer_count()`, which performs `columns * rows * map_length` with an overflow check and raises `RangeError`, and use it in all three methods. `export_pixels_to_str` additionally guards the storage-type-size (`sz * npixels`) multiplication.

Geometries that are merely large (no wrap) still fail cleanly via `NoMemoryError`, exactly as before. Normal exports/imports are unaffected.

## Test

Added regression specs to `dispatch_spec.rb`, `export_pixels_spec.rb` and `export_pixels_to_str_spec.rb` asserting that an overflowing geometry (e.g. `2**32 x 2**32`) raises `RangeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)