### PR TITLE
Suppress valgrind false positives from ImageMagick module loading

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -188,6 +188,12 @@ end
 if RUBY_PLATFORM.include?('linux')
   require 'ruby_memcheck'
   require 'ruby_memcheck/rspec/rake_task'
+
+  RubyMemcheck.config(
+    binary_name: 'RMagick2',
+    valgrind_suppressions_dir: 'spec/valgrind'
+  )
+
   namespace :spec do
     RubyMemcheck::RSpec::RakeTask.new(valgrind: :compile)
   end

--- a/spec/valgrind/ruby.supp
+++ b/spec/valgrind/ruby.supp
@@ -1,0 +1,36 @@
+# Valgrind suppressions for `rake spec:valgrind` (ruby_memcheck).
+#
+# The file name is dictated by ruby_memcheck, which only loads suppression files
+# named after the Ruby engine/version (ruby.supp applies to all MRI versions);
+# the directory is set via valgrind_suppressions_dir in the Rakefile.
+
+# ImageMagick built with --enable-modules (`magick -version` lists the "Modules"
+# feature) loads its coders as shared objects through libltdl. Each lt_dlopen()
+# ends in a glibc dlopen(), and when the newly loaded coder has to be added to
+# the symbol resolution scope of an object that was itself dlopen()ed -- here
+# RMagick2.so, loaded by `require` -- the dynamic linker grows that object's
+# l_scope array with a malloc() in resize_scopes(). glibc keeps the old array
+# reachable only from the link_map, hands the pointer to no one else, and never
+# frees it, so memcheck reports it as "definitely lost" at exit.
+#
+# There is nothing for RMagick to free: the allocation is made by ld.so, RMagick
+# never sees the pointer, and it survives MagickCoreTerminus() (which RMagick
+# does call, from an end proc in Init_RMagick2). It is also bounded -- calling
+# Magick.formats once and 30 times both report exactly 2,688 bytes in 3 blocks,
+# because the coder modules are dlopen()ed once per process. Reproducing the
+# same report through Fiddle, with none of RMagick's code on the stack, confirms
+# it comes from the glibc/libltdl pair rather than from this extension.
+#
+# The stanza is anchored on both resize_scopes (the glibc allocation site) and
+# lt_dlopenadvise (the libltdl entry point), so it only covers module loading and
+# cannot swallow an unrelated leak in RMagick itself.
+{
+   ImageMagick: glibc grows the dlopen scope array when libltdl loads a coder module (bounded, once per process)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:malloc
+   fun:resize_scopes
+   ...
+   fun:lt_dlopenadvise
+}

--- a/spec/valgrind/ruby.supp
+++ b/spec/valgrind/ruby.supp
@@ -34,3 +34,29 @@
    ...
    fun:lt_dlopenadvise
 }
+
+# Some of those coder modules are C++, and their static initializers allocate
+# process-lifetime state while the dynamic linker runs them (call_init) as part
+# of the same lt_dlopen(). That state is meant to live until the process exits;
+# the module is never dlclose()d, so the constructors' counterparts never run and
+# memcheck reports the allocation as lost.
+#
+# This is the same class of report as the one above -- it happens inside a
+# module RMagick merely caused to be loaded, so there is no pointer RMagick
+# could free -- and it is likewise bounded: calling Magick.formats once and 30
+# times both report exactly 152 (16 direct, 136 indirect) bytes in 1 block.
+#
+# The allocation site is left unanchored on purpose (both operator new and
+# operator new[] show up, and the frames inside the module have no symbols).
+# What pins the stanza down is the pair of frames around it: call_init, i.e. the
+# linker running an ELF initializer, reached from lt_dlopenadvise, i.e. libltdl
+# loading a module. Nothing RMagick allocates itself passes through those.
+{
+   ImageMagick: static initializer of a C++ coder module loaded by libltdl (bounded, once per process)
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:call_init*
+   ...
+   fun:lt_dlopenadvise
+}


### PR DESCRIPTION
## Problem

`rake spec:valgrind` reports two leaks with `Magick_init_formats` on the stack:

```
2,688 bytes in 3 blocks are definitely lost
  malloc → resize_scopes (dl-open.c:294) → dl_open_worker_begin → _dl_open
  → dlopen → tryall_dlopen (ltdl.c) → lt_dlopenadvise
  → GetMagickInfo → GetMagickInfoList → Magick_init_formats (rmagick.cpp:181)

152 (16 direct, 136 indirect) bytes in 1 blocks are definitely lost
  operator new → ??? → call_init (dl-init.c:74) → _dl_init → _dl_open
  → dlopen → tryall_dlopen (ltdl.c) → lt_dlopenadvise
  → GetMagickInfo → GetMagickInfoList → Magick_init_formats (rmagick.cpp:181)
```

## Neither is an RMagick leak

`Magick_init_formats` already frees the array returned by `GetMagickInfoList` with `magick_free`, and the `MagickInfo` elements are owned by ImageMagick's registry. Both allocations happen further down, while a coder module is being loaded.

When ImageMagick is built with `--enable-modules` (`magick -version` lists the `Modules` feature), its coders are loaded as shared objects through libltdl, and each `lt_dlopen()` ends in a glibc `dlopen()`. Two process-lifetime allocations fall out of that:

1. **`resize_scopes`** — adding the newly loaded coder to the symbol resolution scope of an object that was itself `dlopen()`ed (`RMagick2.so`, loaded by `require`) makes the dynamic linker grow that object's `l_scope` array with a `malloc()`. glibc keeps the old array reachable only from the `link_map` and never frees it. The allocation is made by `ld.so`; RMagick never sees the pointer, and it survives the `MagickCoreTerminus()` call that `Init_RMagick2` registers as an end proc.

2. **`call_init`** — some coder modules are C++, and their static initializers allocate process-lifetime state while the linker runs them, as part of the same `lt_dlopen()`. The module is never `dlclose()`d, so the counterparts of those constructors never run.

In both cases the memory lives inside a module RMagick merely caused to be loaded. There is no pointer RMagick could free.

## Evidence

**Both are bounded.** Calling `Magick.formats` once and 30 times report *exactly* the same figures — the coder modules are `dlopen()`ed once per process:

```console
$ N=1  valgrind --leak-check=full ruby -Ilib -e 'require "rmagick"; ENV["N"].to_i.times { Magick.formats }'
2,688 bytes in 3 blocks are definitely lost                        # resize_scopes
152 (16 direct, 136 indirect) bytes in 1 blocks are definitely lost # call_init
$ N=30 ...  # identical: 2,688 / 3 blocks and 152 / 1 block
```

**Not caused by RMagick.** `identify -list format` (ImageMagick's own CLI, which links libMagickCore at startup) shows no such leak. But driving the same call path through Fiddle — with none of RMagick's code on the stack — reproduces it:

```ruby
require 'fiddle'
lib = Fiddle.dlopen('libMagickCore-7.Q16HDRI.so.11')
Fiddle::Function.new(lib['MagickCoreGenesis'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_VOID).call(nil, 0)
exc = Fiddle::Function.new(lib['AcquireExceptionInfo'], [], Fiddle::TYPE_VOIDP).call
n = Fiddle::Pointer.malloc(8)
Fiddle::Function.new(lib['GetMagickInfoList'], [Fiddle::TYPE_VOIDP] * 3, Fiddle::TYPE_VOIDP)
      .call(Fiddle::Pointer["*"], n, exc)
```

The difference is the dlopen'ed-vs-startup-linked consumer, not RMagick.

## Fix

Add valgrind suppressions, following the layout used in [ohler55/oj#1028](https://github.com/ohler55/oj/pull/1028): the file lives under the test directory (`spec/valgrind/`) and `Rakefile` points `valgrind_suppressions_dir` at it. The name `ruby.supp` is dictated by ruby_memcheck, which only loads suppression files named after the Ruby engine/version.

Each stanza is pinned between the allocation site inside the loader (`resize_scopes` / `call_init`) and `lt_dlopenadvise`, libltdl's entry point, so they only cover module loading. Nothing RMagick allocates itself passes through those frames.

Verified they suppress exactly those two reports and nothing else:

| | before | after | delta |
|---|---|---|---|
| definitely lost | 1,700,354 bytes in 8,679 blocks | 1,697,650 bytes in 8,675 blocks | −2,704 in 4 |
| indirectly lost | 1,537,108 bytes in 20,782 blocks | 1,536,972 bytes in 20,777 blocks | −136 in 5 |
| suppressed | 32 bytes in 1 blocks | 2,872 bytes in 10 blocks | +2,840 in 9 |

The deltas account for the two reports precisely: 2,688 / 3 blocks (`resize_scopes`) plus 16 direct / 1 block and 136 indirect / 5 blocks (`call_init`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)