### PR TITLE
CI: Fetch ImageMagick source from GitHub tag archives

### DIFF
--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -33,10 +33,17 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/archive/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  repo="ImageMagick/ImageMagick"
+  archive_dir="ImageMagick-${IMAGEMAGICK_VERSION}"
+  if [ "${version[0]}" = "6" ]; then
+    repo="ImageMagick/ImageMagick6"
+    archive_dir="ImageMagick6-${IMAGEMAGICK_VERSION}"
+  fi
+
+  wget -O "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz" "https://github.com/${repo}/archive/refs/tags/${IMAGEMAGICK_VERSION}.tar.gz"
+  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz"
+  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz"
+  mv "${archive_dir}" "${build_dir}"
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then

--- a/before_install_osx.sh
+++ b/before_install_osx.sh
@@ -30,10 +30,17 @@ build_imagemagick() {
   mkdir -p build-ImageMagick
 
   version=(${IMAGEMAGICK_VERSION//./ })
-  wget "https://imagemagick.org/archive/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
-  mv "ImageMagick-${IMAGEMAGICK_VERSION}" "${build_dir}"
+  repo="ImageMagick/ImageMagick"
+  archive_dir="ImageMagick-${IMAGEMAGICK_VERSION}"
+  if [ "${version[0]}" = "6" ]; then
+    repo="ImageMagick/ImageMagick6"
+    archive_dir="ImageMagick6-${IMAGEMAGICK_VERSION}"
+  fi
+
+  wget -O "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz" "https://github.com/${repo}/archive/refs/tags/${IMAGEMAGICK_VERSION}.tar.gz"
+  tar -xf "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz"
+  rm "ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz"
+  mv "${archive_dir}" "${build_dir}"
 
   options="--with-magick-plus-plus=no --disable-docs"
   if [ -v CONFIGURE_OPTIONS ]; then


### PR DESCRIPTION
## Why

`imagemagick.org` no longer serves the release tarballs, so the source builds in `before_install_linux.sh` / `before_install_osx.sh` fail at the download step.

## What

Switch the download/extract block to the GitHub tag archive:

- Pick the repository by major version — `6.x` → `ImageMagick/ImageMagick6`, otherwise `ImageMagick/ImageMagick` — matching the 6.* check the MSWin job in `ci.yml` already does. The existing `version=(${IMAGEMAGICK_VERSION//./ })` (previously unused) is reused for the check.
- Fetch `https://github.com/<repo>/archive/refs/tags/${IMAGEMAGICK_VERSION}.tar.gz` with `wget -O` so the local filename is deterministic.
- The extracted top directory is named after the repository, so `ImageMagick6-${VERSION}` is now handled alongside `ImageMagick-${VERSION}` before the `mv` into `build_dir`.

`configure` is committed in the tag archives, so the `./configure` and `make` steps are untouched. The linux and osx scripts get the identical block.

## Verification

Both versions currently in the CI matrix were checked against the real archives:

| version | repo | top directory | `configure` present |
| --- | --- | --- | --- |
| 6.9.13-46 | ImageMagick/ImageMagick6 | `ImageMagick6-6.9.13-46/` | yes |
| 7.1.2-21 | ImageMagick/ImageMagick | `ImageMagick-7.1.2-21/` | yes |

shellcheck (0.11.0) reports no new warnings; the pre-existing SC2034 for the unused `version` is gone now that it is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)