### PR TITLE
Fix copy_options() using the option value as the artifact key

### DIFF
--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -993,7 +993,6 @@ rm_get_optional_arguments(VALUE img)
  */
 static void copy_options(Image *image, Info *info)
 {
-    char property[MaxTextExtent];
     const char *option;
 
     ResetImageOptionIterator(info);
@@ -1004,8 +1003,7 @@ static void copy_options(Image *image, Info *info)
         value = GetImageOption(info, option);
         if (value)
         {
-            strlcpy(property, value, sizeof(property));
-            if (!SetImageArtifact(image, property, value))
+            if (!SetImageArtifact(image, option, value))
             {
                 rb_raise(rb_eNoMemError, "not enough memory to continue");
             }

--- a/spec/rmagick/image/info/define_spec.rb
+++ b/spec/rmagick/image/info/define_spec.rb
@@ -9,4 +9,23 @@ RSpec.describe Magick::Image::Info, '#define' do
     expect { info.define('tiff', 'bits-per-sample', 2, 2) }.to raise_error(ArgumentError)
     expect { info.define('tiff', 'a' * 10_000) }.to raise_error(ArgumentError)
   end
+
+  it 'copies the image option to an artifact keyed by the option name' do
+    image = Magick::Image.new(50, 50)
+    image.to_blob do |info|
+      info.format = 'PNG'
+      info.define('reg', 'probe', 'HELLOARTIFACT')
+    end
+
+    draw = Magick::Draw.new
+    via_artifact = draw.get_type_metrics(image, '%[artifact:reg:probe]').width
+    literal = draw.get_type_metrics(image, 'HELLOARTIFACT').width
+
+    expect(literal).to be_positive
+    expect(via_artifact).to eq(literal)
+
+    # The value must not be used as the artifact key.
+    via_value_as_key = draw.get_type_metrics(image, '%[artifact:HELLOARTIFACT]').width
+    expect(via_value_as_key).to eq(0)
+  end
 end


### PR DESCRIPTION

## Summary

This fixes a bug in `copy_options()` in `ext/RMagick/rmutil.cpp` (an internal function called from `rm_sync_image_options()`), which used the option's **value** rather than the option's name as the artifact key.

`GetImageOption()` returns the option's value, but that value was copied into `property` with `strlcpy` and then passed to `SetImageArtifact()` as the key:

```c
value = GetImageOption(info, option);
if (value)
{
    strlcpy(property, value, sizeof(property));      // copies value, not option
    if (!SetImageArtifact(image, property, value))   // both key and value are value
    {
        rb_raise(rb_eNoMemError, "not enough memory to continue");
    }
}
```

As a result, every artifact was registered as `value => value`, and the option name (the `"format:key"` string that `Info#define` builds) — which should have been the key — was discarded. This `strlcpy` line has been there since #1754. The recently merged #1822 only added the null check and did not touch this key mix-up.

## Fix

Pass the option name directly as the key. The intermediate buffer is unnecessary because `SetImageArtifact()` takes copies of both the key and the value via `ConstantString()`. The now-unused `char property[MaxTextExtent];` declaration is removed as well. The null check added in #1822 (raising `rb_eNoMemError` on failure) is preserved; the only thing that changes is the key.

```c
value = GetImageOption(info, option);
if (value)
{
    if (!SetImageArtifact(image, option, value))
    {
        rb_raise(rb_eNoMemError, "not enough memory to continue");
    }
}
```

`option` points into the option tree returned by `GetNextImageOption()` and stays valid for the duration of the iteration, so passing it directly is safe.

## Notes on the impact

The bug does not show up through `Magick::Image.new`. When an image is acquired, ImageMagick itself copies the options of the `ImageInfo` into the image's artifacts **using the correct key**, so on that path the `value => value` entry written by `copy_options()` was merely extra garbage.

The paths that actually lose data are the ones where `copy_options()` is the only writer of the artifacts — that is, where `rm_sync_image_options()` runs against an already existing image, such as `Image#write` and `Image#to_blob`. On those paths the option was never registered as an artifact under its real key and could not be looked up at all.

I also checked the reading side for fallout. Every place in RMagick that reads an artifact (`convolve:bias`, `compose:args`, `user`, and so on) sets and gets it with an explicit key, so no code depends on the bogus value-as-key behavior.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
