### PR TITLE
Fix grammar, typos, and content errors in the documentation

### DIFF
--- a/doc/comtasks.html
+++ b/doc/comtasks.html
@@ -145,7 +145,7 @@ thumb.write "thumb.gif"
 
     <p>
       <a href="https://www.flickr.com">flickr</a> thumbnails are 75 pixels wide and 75 pixels tall. If the original image isn't square, the thumbnail is cropped
-      in its larger dimension so that the image isn't distorted. You can get make this kind of thumbnail with the
+      in its larger dimension so that the image isn't distorted. You can make this kind of thumbnail with the
       <a href="image3.html#resize_to_fill">resize_to_fill</a> method.
     </p>
     <pre class="example language-ruby">
@@ -196,7 +196,7 @@ thumb = img.resize_to_fit(75, 75)
       Use the <a href="image1.html#from_blob">Image.from_blob</a>
       method to construct an Image object from a string. Use the
       <a href="image3.html#to_blob">Image#to_blob</a> method to convert an image to a string. A blob is simply an in-memory version of an image file. That is,
-      you could use <code>File.read</code> to read an JPEG file into a string, then create an image by using that string as an argument to
+      you could use <code>File.read</code> to read a JPEG file into a string, then create an image by using that string as an argument to
       <code>from_blob</code>. Similarly, if you create a string version of an image with <code>to_blob</code>, then write the string to a file, any image viewer
       will be able to display it just as if you had written the image directly to a file. Blobs are very useful in web applications when you want to modify an
       image and then stream it back to the client.

--- a/doc/comtasks.html
+++ b/doc/comtasks.html
@@ -93,8 +93,7 @@ ARGV.each do |file|
     puts %(      #{name} = "#{value}")
   end
 end
-</pre
-    >
+</pre>
 
     <h2 id="convert">Converting an image to another format</h2>
 
@@ -117,8 +116,7 @@ end
 img = Magick::Image.new "bigimage.gif"
 thumb = img.scale(125, 125)
 thumb.write "thumb.gif"
-</pre
-    >
+</pre>
 
     <p>
       Alternatively, just pass a single <code>Float</code> argument that represents the change in size. For example, to proportionally reduce the size of an
@@ -128,8 +126,7 @@ thumb.write "thumb.gif"
 img = Magick::Image.new "bigimage.gif"
 thumb = img.scale(0.25)
 thumb.write "thumb.gif"
-</pre
-    >
+</pre>
 
     <p>
       The <code>resize</code> method gives you more control by allowing you to specify a <a href="constants.html#FilterType">filter</a> to use when scaling the
@@ -150,8 +147,7 @@ thumb.write "thumb.gif"
     </p>
     <pre class="example language-ruby">
 thumb = img.resize_to_fill(75, 75)
-</pre
-    >
+</pre>
 
     <h2 id="resizing">Resizing to a maximum (or minimum) size</h2>
 
@@ -185,8 +181,7 @@ thumb = img.resize_to_fill(75, 75)
     </p>
     <pre class="example language-ruby">
 thumb = img.resize_to_fit(75, 75)
-</pre
-    >
+</pre>
 
     <h2>
       <a id="blob" name="blob">Writing to or reading from a string instead of a file</a>
@@ -239,8 +234,7 @@ thumb = img.resize_to_fit(75, 75)
     </p>
     <pre class="example language-ruby">
 img.write("myimage.jpg") { |options| options.quality = 50 }
-</pre
-    >
+</pre>
 
     <h2 id="shadow">Making a drop shadow</h2>
 

--- a/doc/comtasks.html
+++ b/doc/comtasks.html
@@ -137,7 +137,7 @@ thumb.write "thumb.gif"
       specifies how much blurriness or sharpness the resize method should introduce.
     </p>
 
-    <p>The <code>sample</code> method, unlike the other two, does not do any color interpolation when resizing.</p>
+    <p>The <code>sample</code> method, unlike the other three, does not do any color interpolation when resizing.</p>
 
     <p>The <code>thumbnail</code> method is faster than <code>resize</code> if the thumbnail is less than 10% of the size of the original image.</p>
 

--- a/doc/constants.html
+++ b/doc/constants.html
@@ -205,7 +205,7 @@
 
       <dd>
         The maximum value of a <em>Quantum</em>. A quantum is one of the red, green, blue, or opacity elements of a pixel in the RGB colorspace, or cyan,
-        yellow, magenta, or black elements in the CYMK colorspace.
+        magenta, yellow, or black elements in the CMYK colorspace.
       </dd>
 
       <dt>QuantumDepth</dt>
@@ -1360,7 +1360,7 @@
 
       <dt>ColorSeparationType</dt>
 
-      <dd class="imquote">Cyan/Yellow/Magenta/Black (CYMK) image</dd>
+      <dd class="imquote">Cyan/Magenta/Yellow/Black (CMYK) image</dd>
 
       <dt>ColorSeparationMatteType</dt>
 

--- a/doc/constants.html
+++ b/doc/constants.html
@@ -322,7 +322,7 @@
 
     <p>
       Specify an image channel. A channel is a color component of a pixel. In the RGB colorspace the channels are red, green, and blue. There may also be an
-      alpha (transparency/opacity) channel. In the CMYK colorspace the channels area cyan, magenta, yellow, and black. In the HSL colorspace the channels are
+      alpha (transparency/opacity) channel. In the CMYK colorspace the channels are cyan, magenta, yellow, and black. In the HSL colorspace the channels are
       hue, saturation, and lightness. In the Gray colorspace the only channel is gray. See
       <a href="image1.html#channel">Image#channel</a> and <a href="info.html#channel">Image::Info#channel</a>.
     </p>
@@ -431,7 +431,7 @@
       <dt>CMYKColorspace</dt>
 
       <dd class="imquote">
-        Cyan-Magenta-Yellow-Black colorspace. CYMK is a subtractive color system used by printers and photographers for the rendering of colors with ink or
+        Cyan-Magenta-Yellow-Black colorspace. CMYK is a subtractive color system used by printers and photographers for the rendering of colors with ink or
         emulsion, normally on a white surface.
       </dd>
 
@@ -607,7 +607,7 @@
       <dt>ChangeMaskCompositeOp</dt>
 
       <dd class="imquote">
-        Replace any destination pixel that is the similar to the source image's pixel (as defined by the current fuzz factor), with transparency.
+        Replace any destination pixel that is similar to the source image's pixel (as defined by the current fuzz factor), with transparency.
       </dd>
 
       <dt>ClearCompositeOp</dt>
@@ -757,7 +757,7 @@
 
       <dt>LinearBurnCompositeOp</dt>
 
-      <dd>Same as <code>LinearDodgeCompositeOp</code>, but also subtract one from the result. Sort of a additive 'Screen' of the images.</dd>
+      <dd>Same as <code>LinearDodgeCompositeOp</code>, but also subtract one from the result. Sort of an additive 'Screen' of the images.</dd>
 
       <dt>LinearDodgeCompositeOp</dt>
 
@@ -809,7 +809,7 @@
 
       <dd>
         <span class="imquote"
-          >The result is the union of the the two image shapes with <code>composite image</code> obscuring <code>image</code> in the region of overlap.</span
+          >The result is the union of the two image shapes with <code>composite image</code> obscuring <code>image</code> in the region of overlap.</span
         >
         The matte channel of the composite image is respected, so that if the composite pixel is part or all transparent, the corresponding image pixel will
         show through.
@@ -825,7 +825,7 @@
       <dt>PegtopLightCompositeOp</dt>
 
       <dd class="imquote">
-        Almost equivalent to <code>SoftLightCompositeOp</code>, but using a continuious mathematical formula rather than two conditionally selected formulae.
+        Almost equivalent to <code>SoftLightCompositeOp</code>, but using a continuous mathematical formula rather than two conditionally selected formulae.
       </dd>
 
       <dt>PinLightCompositeOp</dt>
@@ -871,7 +871,7 @@
 
       <dt>SrcInCompositeOp</dt>
 
-      <dd class="imquote">he part of the source lying inside of the destination replaces the destination.</dd>
+      <dd class="imquote">The part of the source lying inside of the destination replaces the destination.</dd>
 
       <dt>SrcOutCompositeOp</dt>
 
@@ -1615,7 +1615,7 @@
     <h3 class="const" id="Opacity">Opacity</h3>
 
     <p>
-      represent the maximum and minimum levels of opacity. You can specify a partial level of opacity by choosing a number between OpaqueOpacity and
+      Represent the maximum and minimum levels of opacity. You can specify a partial level of opacity by choosing a number between OpaqueOpacity and
       TransparentOpacity. For example, 25% opacity is
       <code>abs(Magick::TransparentOpacity-Magick::OpaqueOpacity) * 0.25</code>
     </p>

--- a/doc/draw.html
+++ b/doc/draw.html
@@ -375,8 +375,7 @@ title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
   options.font_weight = BoldWeight
   options.gravity = NorthGravity
 }
-</pre
-      >
+</pre>
 
       <h4>Special characters</h4>
 
@@ -824,8 +823,7 @@ draw.inspect
   #   line 20,100 380,100
   #   stroke transparent
   #   fill black"
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -1135,8 +1133,7 @@ gc.clip_path('mypath')
 # drawing primitives within the clip path
 gc.pop
 gc.draw
-</pre
-      >
+</pre>
 
       <p>Also see the example below.</p>
 
@@ -1258,8 +1255,7 @@ gc.draw
       <pre class="language-ruby">
 draw.border_color = 'black'
 draw.color(x, y, FillToBorderMethod)
-</pre
-      >
+</pre>
 
       <h4>See Also</h4>
 
@@ -1796,8 +1792,7 @@ draw.color(x, y, FillToBorderMethod)
 gc.line(50,50, 50,200)
 gc.line(50,200, 200,200)
 gc.line(200,200, 50,50)
-</pre
-      >
+</pre>
 
       <p>
         <a href="javascript:popup('line.rb.html')"><img src="ex/line.gif" alt="line example" title="Click to see the example script" /></a>
@@ -1951,8 +1946,7 @@ gc.line(200,200, 50,50)
       <pre class="language-ruby">
 gc.path('M110,100 h-75 a75,75 0 1,0 75,-75 z')
 gc.path('M97.5,87.5 v-75 a75,75 0 0,0 -75,75 z')
-</pre
-      >
+</pre>
 
       <p>
         <a href="javascript:popup('arcpath.rb.html')"><img src="ex/arcpath.gif" alt="path example 1" title="Click to see the example script" /></a>
@@ -2626,8 +2620,7 @@ gc.path('M97.5,87.5 v-75 a75,75 0 0,0 -75,75 z')
       <pre class="language-ruby">
 draw.stroke_opacity(0.4)
 draw.stroke_opacity('40%')
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
       <a href="#fill_opacity">fill_opacity</a>,
@@ -2706,8 +2699,7 @@ gc.text(10,10, '"Hello there!"')   #=&gt; Hello there!
 gc.text(10,10, "'What\'s up?'")    #=&gt; What's up?
 gc.text(10,10, %q/"What's up?"/)   #=&gt; What's up?
 gc.text(10,10, %q/{"What's up?"}/) #=&gt; "What's up?"
-</pre
-      >
+</pre>
 
       <h4>Example</h4>
 

--- a/doc/draw.html
+++ b/doc/draw.html
@@ -317,7 +317,7 @@
       <h4>Description</h4>
 
       <p>
-        Annotates a image with text. The text is positioned according to the
+        Annotates an image with text. The text is positioned according to the
         <code>gravity</code> attribute around the rectangle described by the <span class="arg">x</span>, <span class="arg">y</span>,
         <span class="arg">width</span>, and <span class="arg">height</span> arguments. If either of the <span class="arg">width</span> or
         <span class="arg">height</span> arguments are 0, uses the image width-<span class="arg">x</span> and the image height-<span class="arg">y</span>
@@ -579,7 +579,7 @@ title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
     <div class="desc">
       <h4>Description</h4>
 
-      <p>This method draw the image using <a href="constants.html#CompositeOperator">CompositeOperator</a>.</p>
+      <p>This method draws the image using <a href="constants.html#CompositeOperator">CompositeOperator</a>.</p>
 
       <h4>Arguments</h4>
       <dl>
@@ -588,7 +588,7 @@ title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
         <dt>width</dt>
         <dt>height</dt>
         <dt>image</dt>
-        <dd>Either an imagelist or a image. If an imagelist, draws on the current image.</dd>
+        <dd>Either an imagelist or an image. If an imagelist, draws on the current image.</dd>
 
         <dt>operator</dt>
         <dd>Specify one of <a href="constants.html#CompositeOperator">CompositeOperator</a> enum.</dd>
@@ -618,7 +618,7 @@ title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
 
       <h4>Arguments</h4>
 
-      <p>Either an imagelist or a image. If an imagelist, draws on the current image.</p>
+      <p>Either an imagelist or an image. If an imagelist, draws on the current image.</p>
 
       <h4>Returns</h4>
 
@@ -671,7 +671,7 @@ title.annotate(montage, 0,0,0,40, 'Named Colors') { |options|
       <h4>Description</h4>
 
       <p>
-        Returns information for a specific string if rendered on a image. Metrics are derived from either the
+        Returns information for a specific string if rendered on an image. Metrics are derived from either the
         <a href="#attributes"> annotate attributes</a> or from the <a href="info.html">image info attributes</a>, but not from any drawing primitive methods.
         The <code>get_multiline_type_metrics</code> method is the same as <code>get_type_metrics</code>, except the former returns the maximum height and width
         for multiple lines of text. (Text lines are separated by "\n" characters.)
@@ -1172,7 +1172,7 @@ gc.draw
       <h4>Description</h4>
 
       <p>
-        Specify how to determine if a point on the image is inside clipping region. See
+        Specify how to determine if a point on the image is inside the clipping region. See
         <a href="https://www.w3.org/TR/SVG/painting.html#FillRuleProperty"
           ><code> the <b>'fill-rule'</b> property</code></a
         >
@@ -1294,7 +1294,7 @@ draw.color(x, y, FillToBorderMethod)
 
         <dt>composite_image</dt>
 
-        <dd>Either an imagelist or a image. If an imagelist, uses the current image.</dd>
+        <dd>Either an imagelist or an image. If an imagelist, uses the current image.</dd>
 
         <dt>op</dt>
 
@@ -2589,7 +2589,7 @@ gc.path('M97.5,87.5 v-75 a75,75 0 0,0 -75,75 z')
       <h4>Description</h4>
 
       <p>
-        Specify a constraint on the length of the "miter" formed by two lines meeting at an angle. If the angle if very sharp, the miter could be very long
+        Specify a constraint on the length of the "miter" formed by two lines meeting at an angle. If the angle is very sharp, the miter could be very long
         relative to the line thickness. The miter limit is a limit on the ratio of the miter length to the line width.
       </p>
 

--- a/doc/draw.html
+++ b/doc/draw.html
@@ -2473,7 +2473,7 @@ gc.path('M97.5,87.5 v-75 a75,75 0 0,0 -75,75 z')
       <h4>Example</h4>
 
       <p>
-        <a href="javascript:popup('stroke_dasharray.rb.html'"
+        <a href="javascript:popup('stroke_dasharray.rb.html')"
           ><img src="ex/stroke_dasharray.gif" alt="stroke_dasharray example" title="Click to see the example script"
         /></a>
       </p>
@@ -3190,7 +3190,7 @@ gc.text(10,10, %q/{"What's up?"}/) #=&gt; "What's up?"
     <div class="sig">
       <h3 id="stroke_width_eq">stroke_width=</h3>
 
-      <p><span class="arg">draw</span>.stroke = <em>integer</em></p>
+      <p><span class="arg">draw</span>.stroke_width = <em>integer</em></p>
     </div>
 
     <div class="desc">

--- a/doc/ilist.html
+++ b/doc/ilist.html
@@ -165,8 +165,7 @@
       <pre class="language-ruby">
 i = Magick::ImageList.new
 i = Magick::ImageList.new("Button_A.gif", "Cheetah.jpg")
-</pre
-      >
+</pre>
     </div>
 
     <h2 class="methods">attributes</h2>
@@ -216,8 +215,8 @@ i = Magick::ImageList.new("Button_A.gif", "Cheetah.jpg")
       <p>Sets the number of times an animated image should loop.</p>
 
       <p>
-        The <a href="#animate">animate</a> method and the ImageMagick animate command do not respect this number. Both will repeat the animation until you
-        stop them. Mozilla (and presumably Netscape) do respect the value.
+        The <a href="#animate">animate</a> method and the ImageMagick animate command do not respect this number. Both will repeat the animation until you stop
+        them. Mozilla (and presumably Netscape) do respect the value.
       </p>
 
       <h4>Arguments</h4>
@@ -249,8 +248,7 @@ i = Magick::ImageList.new("Button_A.gif", "Cheetah.jpg")
       <pre class="language-ruby">
 i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
 i.length #=&gt; 2
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -272,8 +270,7 @@ i.length #=&gt; 2
       <pre class="language-ruby">
 ilist.scene = 10
 ilist.scene #=&gt; 10
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -385,8 +382,7 @@ ilist.scene #=&gt; 10
 example = Magick::ImageList.new
 model = Magick::ImageList.new "model.miff"
 example &lt;&lt; model.add_noise Magick::LaplacisanNoise
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -454,8 +450,7 @@ example &lt;&lt; model.add_noise Magick::LaplacisanNoise
       <pre class="language-ruby">
 ilist.animate
 ilist.animate { |options| options.server_name = "other:0.0" }
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -520,7 +515,11 @@ ilist.animate { |options| options.server_name = "other:0.0" }
           <img
             style="display: none"
             id="notaveraged"
-            onmouseout="this.style.display='none'; averaged.style.display=''; averagedspin.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              averaged.style.display = '';
+              averagedspin.style.display = '';
+            "
             title="Click to see the example script"
             src="ex/average_before.gif"
             alt="average example" /><!--
@@ -528,7 +527,11 @@ ilist.animate { |options| options.server_name = "other:0.0" }
                                   --><img
             style="display:"
             id="averaged"
-            onmouseover="this.style.display='none'; notaveraged.style.display=''; averagedspin.style.display='none';"
+            onmouseover="
+              this.style.display = 'none';
+              notaveraged.style.display = '';
+              averagedspin.style.display = 'none';
+            "
             src="ex/average_after.gif"
             alt="average example"
         /></a>
@@ -595,8 +598,8 @@ ilist.animate { |options| options.server_name = "other:0.0" }
       <p class="rollover">
         <a href="javascript:popup('coalesce.rb.html')"
           ><img
-            onmouseover="this.src='ex/coalesce_anim.gif'"
-            onmouseout="this.src='ex/coalesce.gif'"
+            onmouseover="this.src = 'ex/coalesce_anim.gif'"
+            onmouseout="this.src = 'ex/coalesce.gif'"
             src="ex/coalesce.gif"
             alt="coalesce example"
             title="Click the image to see the example script" /></a
@@ -657,8 +660,8 @@ ilist.animate { |options| options.server_name = "other:0.0" }
       <p class="rollover">
         <a href="javascript:popup('composite_layers.rb.html')"
           ><img
-            onmouseover="this.src='ex/composite_layers.gif'"
-            onmouseout="this.src='ex/composite_layers1.gif'"
+            onmouseover="this.src = 'ex/composite_layers.gif'"
+            onmouseout="this.src = 'ex/composite_layers1.gif'"
             src="ex/composite_layers1.gif"
             alt="composite_layers example"
             title="Click the image to see the example script" /></a
@@ -900,8 +903,7 @@ blob = f.read
 ilist = Magick::ImageList.new
 ilist.from_blob(blob)
 ilist.display
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
       <a href="#to_blob">to_blob</a>, <a href="image3.html#to_blob">Image#to_blob</a>,
@@ -976,8 +978,7 @@ imgl = Magick::ImageList.new
 imgl &lt;&lt; Magick::Image.new(64, 64) { |options| options.background_color = 'black'}
 
 res = imgl.fx('1/2', Magick::BlueChannel)
-</pre
-      >
+</pre>
 
       <h4>ImageMagick API</h4>
 
@@ -1018,8 +1019,7 @@ i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
 #=&gt; [images/Button_A.gif GIF 127x120+0+0 PseudoClass 256c 8-bit 18136b
 #   images/Button_B.gif GIF 127x120+0+0 PseudoClass 256c 8-bit 5157b]
 #   scene=1
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -1231,8 +1231,8 @@ i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
       <p class="rollover">
         <a href="javascript:popup('morph.rb.html')"
           ><img
-            onmouseover="this.src='ex/morph.gif'"
-            onmouseout="this.src='ex/images/Button_0.gif'"
+            onmouseover="this.src = 'ex/morph.gif'"
+            onmouseout="this.src = 'ex/images/Button_0.gif'"
             src="ex/images/Button_0.gif"
             alt="morph example"
             title="Click the image to see the example script" /></a
@@ -1318,8 +1318,7 @@ i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
       <pre class="language-ruby">
 ilist = Magick::ImageList.new
 ilist.new_image(100, 100) { |options| options.background_color = "red" }
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -1535,8 +1534,7 @@ ilist = Magick::ImageList.new
 ilist.ping "Button_A.gif"
 puts "The image has #{i.columns} columns and #{i.rows} rows."
 #=&gt; The image has 127 columns and 120 rows.
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
       <a href="#read">read</a>
@@ -1626,8 +1624,8 @@ puts "The image has #{i.columns} columns and #{i.rows} rows."
             src="ex/quantize_m_after.jpg"
             alt="quantize example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/quantize_m_before.jpg'"
-            onmouseout="this.src='ex/quantize_m_after.jpg'"
+            onmouseover="this.src = 'ex/quantize_m_before.jpg'"
+            onmouseout="this.src = 'ex/quantize_m_after.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" style="left: 505px" title="Mouse over the example to see the original image" />
       </p>
@@ -1682,8 +1680,7 @@ number = '0'
   i.read "images/Button_" + number + ".gif"
   number.succ!
 end
-</pre
-      >
+</pre>
 
       <p>Also see the morph.rb example and the demo.rb example.</p>
 
@@ -1790,8 +1787,7 @@ end
       <pre class="language-ruby">
 i = Magick::ImageList.new "birthday.png"
 s = i.to_blob #=&gt; a string representing the image.
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -1882,8 +1878,7 @@ i.write "test.png"
 # ImageMagick's MIFF format does support multi-frame
 # files, so all 3 images are written to one file.
 i.write "animated.miff" #=&gt; animated.miff
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 

--- a/doc/ilist.html
+++ b/doc/ilist.html
@@ -216,8 +216,8 @@ i = Magick::ImageList.new("Button_A.gif", "Cheetah.jpg")
       <p>Sets the number of times an animated image should loop.</p>
 
       <p>
-        The <a href="#animate">animate</a> method and the ImageMagick animate command does not respect this number. Both will repeat the animation until you
-        stop them. Mozilla (and presumably Netscape) do respect the value..
+        The <a href="#animate">animate</a> method and the ImageMagick animate command do not respect this number. Both will repeat the animation until you
+        stop them. Mozilla (and presumably Netscape) do respect the value.
       </p>
 
       <h4>Arguments</h4>
@@ -367,7 +367,7 @@ ilist.scene #=&gt; 10
       </table>
 
       <p>
-        Adding anything other than a image to an imagelist has undefined results. Most of the time RMagick will raise an ArgumentError exception. For example,
+        Adding anything other than an image to an imagelist has undefined results. Most of the time RMagick will raise an ArgumentError exception. For example,
         if you call <code>collect!</code> on an imagelist you should make sure that the members of the imagelist remain images. If you need to replace images in
         an imagelist with non-image objects, convert the imagelist to an array with the <code>to_a</code> method, then modify the array.
       </p>
@@ -490,7 +490,7 @@ ilist.animate { |options| options.server_name = "other:0.0" }
 
       <h4>Returns</h4>
 
-      <p>A image composed of all the images in the imagelist.</p>
+      <p>An image composed of all the images in the imagelist.</p>
 
       <h4>Magick API</h4>
 
@@ -506,7 +506,7 @@ ilist.animate { |options| options.server_name = "other:0.0" }
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Averages all the images together. Each image in the image must have the same width and height.</p>
+      <p>Averages all the images together. Each image in the imagelist must have the same width and height.</p>
 
       <h4>Returns</h4>
 
@@ -635,7 +635,7 @@ ilist.animate { |options| options.server_name = "other:0.0" }
         <span class="imquote"
           >Unlike a normal composite operation, the canvas offset is also included to the composite positioning. If one of the image lists only contains one
           image, that image is applied to all the images in the other image list, regardless of which list it is. In this case it is the image meta-data of the
-          list which preserved.</span
+          list which is preserved.</span
         >
       </p>
 
@@ -721,7 +721,7 @@ ilist.animate { |options| options.server_name = "other:0.0" }
       <p>
         Both the ImageList class and the Image class support the
         <code>cur_image</code> method. Of course, in the Image class, <code>cur_image</code> simply returns <code>self</code>. When a method accepts either an
-        image or a imagelist as an argument, it sends the <code>cur_image</code> method to the argument to get the current image.
+        image or an imagelist as an argument, it sends the <code>cur_image</code> method to the argument to get the current image.
       </p>
 
       <h4>Returns</h4>
@@ -828,7 +828,7 @@ ilist.animate { |options| options.server_name = "other:0.0" }
       <h4>Description</h4>
 
       <p>
-        Combines all the images in the imagelist into a single image by overlaying each successive image onto the preceding images. If a image has transparent
+        Combines all the images in the imagelist into a single image by overlaying each successive image onto the preceding images. If an image has transparent
         areas, the underlying image will show through. Use the
         <a href="imageattrs.html#page">page</a> attribute to specify the position of each image with respect to the preceding images.
       </p>
@@ -931,7 +931,7 @@ ilist.display
       <dl>
         <dt>expression</dt>
 
-        <dd>A mathematical expression of the form accepted by the -fx operator..</dd>
+        <dd>A mathematical expression of the form accepted by the -fx operator.</dd>
 
         <dt>channel...</dt>
 
@@ -1148,7 +1148,7 @@ i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
         <dt>texture=</dt>
 
         <dd>
-          A image to be tiled on the background of the composite image. If present, this attribute overrides the background color. For example, to use
+          An image to be tiled on the background of the composite image. If present, this attribute overrides the background color. For example, to use
           ImageMagick's built-in "granite" texture as the background, use:
           <pre class="language-ruby">options.texture = Magick::Image.read("granite:").first</pre>
 
@@ -1208,7 +1208,7 @@ i = Magick::ImageList.new("images/Button_A.gif", "images/Button_B.gif")
       <h4>Description</h4>
 
       <p>
-        Transforms a image into another image by inserting
+        Transforms an image into another image by inserting
         <code>n</code> in-between images. Requires at least two images. If more images are present, the 2nd image is transformed into the 3rd, the 3rd to the
         4th, etc.
       </p>
@@ -1342,7 +1342,7 @@ ilist.new_image(100, 100) { |options| options.background_color = "red" }
         <a href="https://www.imagemagick.org/Usage/">Examples of ImageMagick Usage</a>
         site has very detailed
         <a href="https://www.imagemagick.org/Usage/anim_opt/">information and examples</a>
-        of the <code>-layers</code> option and and the optimization methods .
+        of the <code>-layers</code> option and the optimization methods.
       </p>
 
       <h4>Arguments</h4>

--- a/doc/image1.html
+++ b/doc/image1.html
@@ -1840,7 +1840,7 @@ img = Magick::Image.read_inline(content)
 
         <dd>
           Either a non-negative number or a string in the form "NN%". If
-          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
+          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
           other arguments follow it. In this case the default is 100%-<span class="arg">src_percentage</span>.
         </dd>
       </dl>
@@ -4303,7 +4303,7 @@ f.colors #=&gt; 108
 
         <dd>
           Either a non-negative number or a string in the form "NN%". If
-          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
+          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
           other arguments follow it. In this case <span class="arg">img</span>'s opacity is unchanged.
         </dd>
       </dl>

--- a/doc/image1.html
+++ b/doc/image1.html
@@ -352,8 +352,7 @@
 img = Magick::Image.capture { |options|
   options.filename = "root"
 }
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -537,8 +536,7 @@ img = Magick::Image.capture { |options|
 img = Magick::Image.new(256, 64) { |options|
   options.background_color = 'red'
 }
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -584,8 +582,7 @@ img = Magick::Image.new(256, 64) { |options|
 cheetah = Magick::Image.ping("Cheetah.jpg") #=&gt; [Cheetah.jpg JPEG 1024x768 DirectClass 8-bit 101684b]
 p cheetah[0].rows    #=&gt; 768
 p cheetah[0].columns #=&gt; 1024
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -637,8 +634,7 @@ animated = Magick::Image.read("animated.gif")
 #=&gt; [animated.gif GIF 127x120+0+0 PseudoClass 256c 8-bit 54395b
 #   animated.gif[1] GIF 127x120+0+0 PseudoClass 256c 8-bit 54395b,
 #   animated.gif[2] GIF 127x120+0+0 PseudoClass 256c 8-bit 54395b]
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -688,8 +684,7 @@ animated = Magick::Image.read("animated.gif")
       <pre class="language-ruby">
 content = "R0lGODlhnAEuAferAAAAAAcIBggJBgw..."
 img = Magick::Image.read_inline(content)
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -1121,8 +1116,8 @@ img = Magick::Image.read_inline(content)
         <a href="javascript:popup('adaptive_threshold.rb.html')"
           ><img
             src="ex/adaptive_threshold.jpg"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/adaptive_threshold.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/adaptive_threshold.jpg'"
             alt="adaptive_threshold example"
             title="Click to see the example script"
         /></a>
@@ -1433,8 +1428,8 @@ img = Magick::Image.read_inline(content)
       <p class="rollover">
         <a href="javascript:popup('affine_transform.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/affine_transform.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/affine_transform.jpg'"
             src="ex/affine_transform.jpg"
             alt="affine_transform example"
             title="Click to see the example script"
@@ -1737,8 +1732,8 @@ img = Magick::Image.read_inline(content)
       <p class="rollover">
         <a href="javascript:popup('bilevel_channel.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/bilevel_channel.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/bilevel_channel.jpg'"
             src="ex/bilevel_channel.jpg"
             alt="bilevel_channel example"
             title="Click to see the example script"
@@ -1840,8 +1835,8 @@ img = Magick::Image.read_inline(content)
 
         <dd>
           Either a non-negative number or a string in the form "NN%". If
-          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
-          other arguments follow it. In this case the default is 100%-<span class="arg">src_percentage</span>.
+          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if
+          no other arguments follow it. In this case the default is 100%-<span class="arg">src_percentage</span>.
         </dd>
       </dl>
 
@@ -1984,8 +1979,8 @@ img = Magick::Image.read_inline(content)
       <p class="rollover">
         <a href="javascript:popup('blur_image.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/blur_image.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/blur_image.jpg'"
             src="ex/blur_image.jpg"
             alt="blur_image example"
             title="Click to see the example script"
@@ -2050,11 +2045,21 @@ img = Magick::Image.read_inline(content)
           ><img
             style="padding: 10px; display: none"
             id="borderless"
-            onmouseout="this.style.display='none'; bordered.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              bordered.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="border example"
             title="Click to see the example script" />
-          <img id="bordered" onmouseover="this.style.display='none'; borderless.style.display='';" src="ex/border.jpg" alt="border example" /></a
+          <img
+            id="bordered"
+            onmouseover="
+              this.style.display = 'none';
+              borderless.style.display = '';
+            "
+            src="ex/border.jpg"
+            alt="border example" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" style="left: 224px" title="Mouse over the example to see the original image" />
       </p>
 
@@ -2160,8 +2165,7 @@ mona = Magick::Image.read('MonaLisa.jpg').first
 mona.change_geometry!('320x240') { |cols, rows, img|
   img.resize!(cols, rows)
 }
-</pre
-      >
+</pre>
 
       <h4>Magick API</h4>
 
@@ -2361,8 +2365,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('charcoal.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/charcoal.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/charcoal.jpg'"
             src="ex/charcoal.jpg"
             alt="charcoal example"
             title="Click the image to see the example script"
@@ -2439,8 +2443,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('chop.rb.html')"
           ><img
-            onmouseover="this.src='ex/chop_before.jpg'"
-            onmouseout="this.src='ex/chop_after.jpg'"
+            onmouseover="this.src = 'ex/chop_before.jpg'"
+            onmouseout="this.src = 'ex/chop_after.jpg'"
             src="ex/chop_after.jpg"
             alt="chop example"
             title="Click the image to see the example script"
@@ -2577,8 +2581,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('color_fill_to_border.rb.html')"
           ><img
-            onmouseover="this.src='ex/color_fill_to_border_before.gif'"
-            onmouseout="this.src='ex/color_fill_to_border_after.gif'"
+            onmouseover="this.src = 'ex/color_fill_to_border_before.gif'"
+            onmouseout="this.src = 'ex/color_fill_to_border_after.gif'"
             src="ex/color_fill_to_border_after.gif"
             alt="color_fill_to_border example"
             title="Click the image to see the example script" /></a
@@ -2643,8 +2647,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('color_floodfill.rb.html')"
           ><img
-            onmouseover="this.src='ex/color_floodfill_before.gif'"
-            onmouseout="this.src='ex/color_floodfill_after.gif'"
+            onmouseover="this.src = 'ex/color_floodfill_before.gif'"
+            onmouseout="this.src = 'ex/color_floodfill_after.gif'"
             src="ex/color_floodfill_after.gif"
             alt="color_floodfill example"
             title="Click the image to see the example script"
@@ -2751,8 +2755,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('colorize.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/colorize.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/colorize.jpg'"
             src="ex/colorize.jpg"
             alt="colorize example"
             title="Click the image to see the example script"
@@ -3320,8 +3324,8 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p class="rollover">
         <a href="javascript:popup('composite_tiled.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/composite_tiled.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/composite_tiled.jpg'"
             src="ex/composite_tiled.jpg"
             alt="composite_tiled example"
             title="Click the image to see the example script"
@@ -3370,8 +3374,7 @@ f = Magick::Image.read('cbezier1.gif').first #=&gt; cbezier1.gif GIF 500x350+0+0
 f.colors #=&gt; 128
 f.compress_colormap! #=&gt; cbezier1.gif GIF 500x350+0+0 PseudoClass 108c 8-bit 177503b
 f.colors #=&gt; 108
-</pre
-      >
+</pre>
 
       <h4>Magick API</h4>
 
@@ -3730,8 +3733,8 @@ f.colors #=&gt; 108
       <p class="rollover">
         <a href="javascript:popup('crop.rb.html')"
           ><img
-            onmouseover="this.src='ex/crop_before.png'"
-            onmouseout="this.src='ex/crop_after.png'"
+            onmouseover="this.src = 'ex/crop_before.png'"
+            onmouseout="this.src = 'ex/crop_after.png'"
             src="ex/crop_after.png"
             alt="crop example"
             title="Click the image to see the example script" /></a
@@ -3823,8 +3826,8 @@ f.colors #=&gt; 108
       <p class="rollover">
         <a href="javascript:popup('cycle_colormap.rb.html')"
           ><img
-            onmouseover="this.src='ex/cycle_colormap.gif'"
-            onmouseout="this.src='ex/images/Hot_Air_Balloons.jpg'"
+            onmouseover="this.src = 'ex/cycle_colormap.gif'"
+            onmouseout="this.src = 'ex/images/Hot_Air_Balloons.jpg'"
             src="ex/images/Hot_Air_Balloons.jpg"
             alt="cycle_colormap example"
             title="Click the image to see the example script" /></a
@@ -4303,8 +4306,8 @@ f.colors #=&gt; 108
 
         <dd>
           Either a non-negative number or a string in the form "NN%". If
-          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
-          other arguments follow it. In this case <span class="arg">img</span>'s opacity is unchanged.
+          <span class="arg">dst_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if
+          no other arguments follow it. In this case <span class="arg">img</span>'s opacity is unchanged.
         </dd>
       </dl>
 
@@ -4328,8 +4331,8 @@ f.colors #=&gt; 108
       <p class="rollover">
         <a href="javascript:popup('dissolve.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/dissolve.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/dissolve.jpg'"
             src="ex/dissolve.jpg"
             alt="dissolve example"
             title="Click to see the example script"
@@ -4451,8 +4454,7 @@ result = img.distort(Magick::ScaleRotateTranslateDistortion, [0]) do |options|
   options.define "distort:viewport", "44x44+15+0"
   options.define "distort:scale", 2
 end
-</pre
-      >
+</pre>
 
       <h4>Note</h4>
 

--- a/doc/image1.html
+++ b/doc/image1.html
@@ -293,7 +293,7 @@
 
       <p>
         Within the optional arguments block, specify
-        <code>options.filename = "root"</code> to capture the entire desktop. To programatically specify the window to be captured, use
+        <code>options.filename = "root"</code> to capture the entire desktop. To programmatically specify the window to be captured, use
         <code>options.filename = window_id</code>, where window_id is the id displayed by xwininfo(1).
       </p>
 
@@ -1494,7 +1494,7 @@ img = Magick::Image.read_inline(content)
         <dt>OffAlphaChannel</dt>
 
         <dd class="imquote">
-          Disables the image's transparency channel. Does not delete or change the existing data, just turns of the use of that data. This is the same as
+          Disables the image's transparency channel. Does not delete or change the existing data, just turns off the use of that data. This is the same as
           assigning false to the old matte= attribute.
         </dd>
 
@@ -1523,7 +1523,7 @@ img = Magick::Image.read_inline(content)
         <dt>TransparentAlphaChannel</dt>
 
         <dd class="imquote">
-          Turns on the alpha/matte channel and forces it to be fully transparent. This effectivally creates a transparent image the same size as the original,
+          Turns on the alpha/matte channel and forces it to be fully transparent. This effectively creates a transparent image the same size as the original,
           with all its meta-data still attached.
         </dd>
       </dl>
@@ -1693,7 +1693,7 @@ img = Magick::Image.read_inline(content)
 
       <h4>Returns</h4>
 
-      <p>self. or <code>nil</code> if the image is already properly oriented</p>
+      <p>self, or <code>nil</code> if the image is already properly oriented</p>
 
       <h4>See also</h4>
 
@@ -1832,15 +1832,15 @@ img = Magick::Image.read_inline(content)
         <dt>src_percentage</dt>
 
         <dd>
-          Either a non-negative number a string in the form "NN%". If
+          Either a non-negative number or a string in the form "NN%". If
           <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument is required.
         </dd>
 
         <dt>dst_percentage</dt>
 
         <dd>
-          Either a non-negative number a string in the form "NN%". If
-          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may omitted if no
+          Either a non-negative number or a string in the form "NN%". If
+          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
           other arguments follow it. In this case the default is 100%-<span class="arg">src_percentage</span>.
         </dd>
       </dl>
@@ -2136,7 +2136,7 @@ img = Magick::Image.read_inline(content)
       <h4>Description</h4>
 
       <p>
-        The <code>change_geometry</code> method supports resizing a method by specifying constraints. For example, you can specify that the image should be
+        The <code>change_geometry</code> method supports resizing an image by specifying constraints. For example, you can specify that the image should be
         resized such that the aspect ratio should be retained but the resulting image should be no larger than 640 pixels wide and 480 pixels tall.
       </p>
 
@@ -2147,7 +2147,7 @@ img = Magick::Image.read_inline(content)
       </p>
 
       <h4>Arguments</h4>
-      An <a href="imusage.html#geometry">geometry string</a> or a <code>Geometry</code> object
+      A <a href="imusage.html#geometry">geometry string</a> or a <code>Geometry</code> object
 
       <h4>Returns</h4>
 
@@ -2557,7 +2557,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
         <dt>fill_color</dt>
 
         <dd>
-          The fill color. The fill color can be either color name or a
+          The fill color. The fill color can be either a color name or a
           <a href="struct.html#Pixel">Pixel</a> object.
         </dd>
       </dl>
@@ -2571,7 +2571,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p>
         In this example, the aquamarine fill starts at the center of the circle and fills to the black border. All non-black pixels are replaced by the fill
         color. Contrast the result of
-        <code>color_fill_to_border</code> with that of <code>color_floodfill</code> example, below.
+        <code>color_fill_to_border</code> with that of the <code>color_floodfill</code> example, below.
       </p>
 
       <p class="rollover">
@@ -2624,7 +2624,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
         <dt>fill_color</dt>
 
         <dd>
-          The fill color, either color name or a
+          The fill color, either a color name or a
           <a href="struct.html#Pixel">Pixel</a> object.
         </dd>
       </dl>
@@ -2836,7 +2836,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
         <dt>fill</dt>
 
         <dd>
-          The fill color, either color name or a
+          The fill color, either a color name or a
           <a href="struct.html#Pixel">Pixel</a> object.
         </dd>
       </dl>
@@ -2873,7 +2873,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p>Sets all the pixels in the image to the specified fill color.</p>
 
       <h4>Arguments</h4>
-      The fill color, either color name or a
+      The fill color, either a color name or a
       <a href="struct.html#Pixel">Pixel</a> object.
 
       <h4>Returns</h4>
@@ -2940,14 +2940,14 @@ mona.change_geometry!('320x240') { |cols, rows, img|
 
             <dt>options.lowlight_color = color</dt>
 
-            <dd>Demphasize pixel differences with this color. The default is partially transparent white.</dd>
+            <dd>De-emphasize pixel differences with this color. The default is partially transparent white.</dd>
           </dl>
         </dd>
       </dl>
 
       <h4>Returns</h4>
 
-      <p>An array. The first element is a difference image, the second is a the value of the computed distortion represented as a <code>Float</code>.</p>
+      <p>An array. The first element is a difference image, the second is the value of the computed distortion represented as a <code>Float</code>.</p>
 
       <h4>See also</h4>
 
@@ -3213,7 +3213,7 @@ mona.change_geometry!('320x240') { |cols, rows, img|
       <p>
         Equivalent to the
         <code>-compose Mathematics -set option:compose:args a,b,c,d</code>
-        options to ImagMagick's <code>convert</code> command. See
+        options to ImageMagick's <code>convert</code> command. See
         <a href="https://www.imagemagick.org/Usage/compose/#mathematics">Examples of ImageMagick Usage</a>.
       </p>
 
@@ -4197,7 +4197,7 @@ f.colors #=&gt; 108
         <dt>y_amplitude</dt>
 
         <dd>
-          The maximum displacement on the y-axis. This argument may omitted if no other arguments follow it. In this case the default is the value of
+          The maximum displacement on the y-axis. This argument may be omitted if no other arguments follow it. In this case the default is the value of
           <span class="arg">x_amplitude</span>.
         </dd>
       </dl>
@@ -4295,15 +4295,15 @@ f.colors #=&gt; 108
         <dt>src_percentage</dt>
 
         <dd>
-          Either a non-negative number a string in the form "NN%". If
+          Either a non-negative number or a string in the form "NN%". If
           <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument is required.
         </dd>
 
         <dt>dst_percentage</dt>
 
         <dd>
-          Either a non-negative number a string in the form "NN%". If
-          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may omitted if no
+          Either a non-negative number or a string in the form "NN%". If
+          <span class="arg">src_percentage</span> is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. This argument may be omitted if no
           other arguments follow it. In this case <span class="arg">img</span>'s opacity is unchanged.
         </dd>
       </dl>
@@ -4433,7 +4433,7 @@ f.colors #=&gt; 108
             <dt>options.verbose(true)</dt>
 
             <dd class="imquote">
-              Attempt to output the internal coefficients, and the -fx equivalent to the distortion, for expert study, and debugging purposes. This many not be
+              Attempt to output the internal coefficients, and the -fx equivalent to the distortion, for expert study, and debugging purposes. This may not be
               available for all distorts.
             </dd>
           </dl>

--- a/doc/image2.html
+++ b/doc/image2.html
@@ -326,8 +326,8 @@
       <p class="rollover">
         <a href="javascript:popup('edge.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/edge.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/edge.jpg'"
             src="ex/edge.jpg"
             alt="edge example"
             title="Click the image to see the example script"
@@ -371,8 +371,8 @@
       <p class="rollover">
         <a href="javascript:popup('emboss.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/emboss.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/emboss.jpg'"
             src="ex/emboss.jpg"
             alt="emboss example"
             title="Click the image to see the example script" /></a
@@ -475,8 +475,8 @@
       <p class="rollover">
         <a href="javascript:popup('equalize.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/equalize.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/equalize.jpg'"
             src="ex/equalize.jpg"
             alt="equalize example"
             title="Click to see the example script"
@@ -671,8 +671,7 @@
       <pre class="language-ruby">
 # Export the r'th scanline from an image in red-green-blue order
 scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -876,8 +875,8 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
       <p class="rollover">
         <a href="javascript:popup('flip.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/flip.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/flip.jpg'"
             src="ex/flip.jpg"
             alt="flip example"
             title="Click to see the example script"
@@ -934,8 +933,8 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
       <p class="rollover">
         <a href="javascript:popup('flop.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/flop.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/flop.jpg'"
             src="ex/flop.jpg"
             alt="flop example"
             title="Click to see the example script"
@@ -1033,12 +1032,21 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
           <img
             style="padding: 25px; display: none"
             id="frameless"
-            onmouseout="this.style.display='none';framed.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              framed.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="frame example"
             title="Click to see the example script" />
           <!-- This img tag displays the framed image when the mouse is not over -->
-          <img onmouseover="this.style.display='none';frameless.style.display='';" src="ex/frame.jpg" alt="frame example"
+          <img
+            onmouseover="
+              this.style.display = 'none';
+              frameless.style.display = '';
+            "
+            src="ex/frame.jpg"
+            alt="frame example"
         /></a>
         <img src="ex/images/spin.gif" alt="" style="margin-bottom: 280px" title="Mouse over the example to see the original image" />
       </p>
@@ -1250,8 +1258,8 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
       <p class="rollover">
         <a href="javascript:popup('gaussian_blur.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/gaussian_blur.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/gaussian_blur.jpg'"
             src="ex/gaussian_blur.jpg"
             alt="gaussian_blur example"
             title="Click to see the example script"
@@ -1355,8 +1363,7 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
 image.get_exif_by_entry('Make')              #=&gt; [["Make", "Canon"]]
 image.get_exif_by_entry("ShutterSpeedValue") #=&gt; [["ShutterSpeedValue", "189/32"]]
 image.get_exif_by_entry()                    #=&gt; [["Make", "Canon"], ["ShutterSpeedValue", "189/32"] ...]
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -1394,8 +1401,7 @@ image.get_exif_by_entry()                    #=&gt; [["Make", "Canon"], ["Shutte
 image.get_exif_by_number(271)   #=&gt; {271=&gt;"Canon"}
 image.get_exif_by_number(37377) #=&gt; {37377=&gt;"189/32"}
 image.get_exif_by_number()      #=&gt; {271=&gt;"Canon", 37377=&gt;"189/32" ...}
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -1986,8 +1992,8 @@ image.get_exif_by_number()      #=&gt; {271=&gt;"Canon", 37377=&gt;"189/32" ...}
           ><img
             width="384"
             height="249"
-            onmouseover="this.src='ex/images/Red_Rocks.jpg'"
-            onmouseout="this.src='ex/get_pixels.jpg'"
+            onmouseover="this.src = 'ex/images/Red_Rocks.jpg'"
+            onmouseout="this.src = 'ex/get_pixels.jpg'"
             src="ex/get_pixels.jpg"
             title="Click to see the example script"
             alt="get_pixels example"
@@ -2101,8 +2107,8 @@ image.get_exif_by_number()      #=&gt; {271=&gt;"Canon", 37377=&gt;"189/32" ...}
       <p class="rollover">
         <a href="javascript:popup('implode.rb.html')"
           ><img
-            onmouseover="this.src='ex/implode.gif'"
-            onmouseout="this.src='ex/images/Flower_Hat.jpg'"
+            onmouseover="this.src = 'ex/implode.gif'"
+            onmouseout="this.src = 'ex/images/Flower_Hat.jpg'"
             src="ex/images/Flower_Hat.jpg"
             alt="implode example"
             title="Click the image to see the example script" /></a
@@ -2202,8 +2208,7 @@ image.get_exif_by_number()      #=&gt; {271=&gt;"Canon", 37377=&gt;"189/32" ...}
 # Replace the r'th scanline of the image using
 # pixel data stored in red-green-blue order.
 img.import_pixels(0, r, img.columns, 1, "RGB", scanline);
-</pre
-      >
+</pre>
 
       <h4>Example</h4>
 
@@ -2218,8 +2223,7 @@ pixels = hat.export_pixels(0, 0, hat.columns, hat.rows, "RGB")
 char_buffer = pixels.pack("C*")
 img = Magick::Image.new(hat.columns, hat.rows)
 img.import_pixels(0, 0, hat.columns, hat.rows, "RGB", char_buffer, CharPixel)
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -2348,8 +2352,8 @@ img.import_pixels(0, 0, hat.columns, hat.rows, "RGB", char_buffer, CharPixel)
       <p class="rollover">
         <a href="javascript:popup('level.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/level.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/level.jpg'"
             src="ex/level.jpg"
             title="Click to see the example script"
             alt="level example"
@@ -2365,8 +2369,7 @@ img.import_pixels(0, 0, hat.columns, hat.rows, "RGB", char_buffer, CharPixel)
       </p>
       <pre class="language-ruby">
 img.level(white_point, gamma, black_point) -&gt; image # wrong!
-</pre
-      >
+</pre>
 
       <p>
         That is, the <code>gamma</code> and <code>white_point</code>
@@ -2486,8 +2489,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
       <p class="rollover">
         <a href="javascript:popup('level_colors.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/level_colors.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/level_colors.jpg'"
             src="ex/level_colors.jpg"
             title="Click to see the example script"
             alt="level_colors example"
@@ -2734,8 +2737,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
             src="ex/mask.jpg"
             alt="mask example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/mask.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/mask.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -2785,8 +2788,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
         <a href="javascript:popup('matte_fill_to_border.rb.html')"
           ><img
             src="ex/matte_fill_to_border_after.gif"
-            onmouseover="this.src='ex/matte_fill_to_border_before.gif'"
-            onmouseout="this.src='ex/matte_fill_to_border_after.gif'"
+            onmouseover="this.src = 'ex/matte_fill_to_border_before.gif'"
+            onmouseout="this.src = 'ex/matte_fill_to_border_after.gif'"
             alt="matte_fill_to_border example"
             title="Click to see the example script"
         /></a>
@@ -2838,8 +2841,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
         <a href="javascript:popup('matte_floodfill.rb.html')"
           ><img
             src="ex/matte_floodfill_after.gif"
-            onmouseover="this.src='ex/matte_floodfill_before.gif'"
-            onmouseout="this.src='ex/matte_floodfill_after.gif'"
+            onmouseover="this.src = 'ex/matte_floodfill_before.gif'"
+            onmouseout="this.src = 'ex/matte_floodfill_after.gif'"
             alt="matte_floodfill example"
             title="Click to see the example script"
         /></a>
@@ -2916,8 +2919,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
       <p class="rollover">
         <a href="javascript:popup('matte_replace.rb.html')"
           ><img
-            onmouseover="this.src='ex/matte_replace_before.gif'"
-            onmouseout="this.src='ex/matte_replace_after.gif'"
+            onmouseover="this.src = 'ex/matte_replace_before.gif'"
+            onmouseout="this.src = 'ex/matte_replace_after.gif'"
             src="ex/matte_replace_after.gif"
             alt="matte_replace example"
             title="Click to see the example script"
@@ -3086,8 +3089,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
           ><img
             src="ex/modulate.jpg"
             alt="modulate example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/modulate.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/modulate.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -3168,8 +3171,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
             src="ex/motion_blur.jpg"
             alt="motion_blur example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/motion_blur.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/motion_blur.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -3212,8 +3215,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
           ><img
             src="ex/negate.jpg"
             alt="negate example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/negate.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/negate.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -3268,8 +3271,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
           ><img
             src="ex/negate_channel.jpg"
             alt="negate_channel example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/negate_channel.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/negate_channel.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -3307,8 +3310,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
             src="ex/normalize.jpg"
             alt="normalize example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Hot_Air_Balloons.jpg'"
-            onmouseout="this.src='ex/normalize.jpg'"
+            onmouseover="this.src = 'ex/images/Hot_Air_Balloons.jpg'"
+            onmouseout="this.src = 'ex/normalize.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" style="left: 191px" title="Mouse over the example to see the original image" />
       </p>
@@ -3386,8 +3389,8 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
           ><img
             src="ex/oil_paint.jpg"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/oil_paint.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/oil_paint.jpg'"
             alt="oil_paint example"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -3436,8 +3439,7 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
       <pre class="language-ruby">
 img.fuzz = 25
 img = img.opaque('white', 'red')
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -3557,8 +3559,7 @@ img = img.opaque('white', 'red')
       <p>The <span class="arg">threshold_map</span> argument can be any of the strings listed by this command:</p>
       <pre class="language-console">
 convert -list Thresholds
-</pre
-      >
+</pre>
 
       <p>
         If you have a sufficiently new version of ImageMagick, you can add
@@ -3579,8 +3580,8 @@ convert -list Thresholds
           ><img
             src="ex/ordered_dither.jpg"
             alt="ordered_dither example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/ordered_dither.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/ordered_dither.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />

--- a/doc/image2.html
+++ b/doc/image2.html
@@ -514,7 +514,7 @@
 
         <dd>
           0 or more
-          <a href="constants.html#ChannelType">ChannelType</a> arguments. If no channels are specified, all the channels are normalized. Specifying no channel
+          <a href="constants.html#ChannelType">ChannelType</a> arguments. If no channels are specified, all the channels are equalized. Specifying no channel
           arguments has the same effect as the equalize method, above.
         </dd>
       </dl>
@@ -2325,7 +2325,7 @@ img.import_pixels(0, 0, hat.columns, hat.rows, "RGB", char_buffer, CharPixel)
 
         <dd>A black point level in the range 0-<a href="constants.html#Miscellaneous_constants">QuantumRange</a>. The default is 0.0.</dd>
 
-        <dt>mid_point</dt>
+        <dt>white_point</dt>
 
         <dd>
           A white point level in the range 0..QuantumRange. The default is
@@ -2855,7 +2855,7 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
 
       <h4>Magick API</h4>
 
-      <p>MatteFloodfilImage</p>
+      <p>MatteFloodfillImage</p>
     </div>
 
     <div class="sig">

--- a/doc/image2.html
+++ b/doc/image2.html
@@ -494,7 +494,7 @@
     </div>
 
     <div class="sig">
-      <h3 id="equalize_channel">equalize_chanel</h3>
+      <h3 id="equalize_channel">equalize_channel</h3>
 
       <p><span class="arg">img</span>.equalize_channel(<span class="arg">[channel...]</span>) -&gt; <em>image</em></p>
     </div>
@@ -802,7 +802,7 @@ scanline = img.export_pixels(0, r, img.columns, 1, "RGB");
       <h4>Notes</h4>
 
       <p>
-        The new image is composed over the background using the composite operator specified by target image's
+        The new image is composed over the background using the composite operator specified by the target image's
         <a href="imageattrs.html#compose">compose</a> attribute.
       </p>
 
@@ -2334,7 +2334,7 @@ img.import_pixels(0, 0, hat.columns, hat.rows, "RGB", char_buffer, CharPixel)
 
         <dt>gamma</dt>
 
-        <dd>A gamma correction in the range 0.0-10.0 The default is 1.0.</dd>
+        <dd>A gamma correction in the range 0.0-10.0. The default is 1.0.</dd>
       </dl>
 
       <h4>Returns</h4>
@@ -2423,7 +2423,7 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
 
         <dt>gamma</dt>
 
-        <dd>A gamma correction in the range 0.0-10.0 The default is 1.0.</dd>
+        <dd>A gamma correction in the range 0.0-10.0. The default is 1.0.</dd>
       </dl>
 
       <h4>Returns</h4>
@@ -2538,7 +2538,7 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
 
         <dt>gamma</dt>
 
-        <dd>A gamma correction in the range 0.0-10.0 The default is 1.0.</dd>
+        <dd>A gamma correction in the range 0.0-10.0. The default is 1.0.</dd>
 
         <dt>channel...</dt>
 
@@ -3278,7 +3278,6 @@ img.level(white_point, gamma, black_point) -&gt; image # wrong!
       <h4>See also</h4>
 
       <p><a href="#negate">negate</a></p>
-      .
 
       <h4>Magick API</h4>
 
@@ -3562,7 +3561,7 @@ convert -list Thresholds
       >
 
       <p>
-        If you have a sufficiently new version of ImageMagick, you can add a
+        If you have a sufficiently new version of ImageMagick, you can add
         <span class="imquote">a uniform color map with the number of levels per color channel</span>
         immediately following the <span class="arg">threshold_map</span>, separated by a comma. See the documentation for
         <a href="https://imagemagick.org/script/command-line-options.php#ordered-dither"> ImageMagick's -ordered-dither option</a>

--- a/doc/image3.html
+++ b/doc/image3.html
@@ -413,8 +413,7 @@ img.polaroid do |options|
   options.shadow_color = "gray40"
   options.pointsize = 12
 end
-</pre
-      >
+</pre>
 
       <h4>Arguments</h4>
 
@@ -476,8 +475,8 @@ end
           ><img
             src="ex/posterize.jpg"
             alt="posterize example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/posterize.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/posterize.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -912,8 +911,8 @@ end
         <a href="javascript:popup('radial_blur.rb.html')"
           ><img
             src="ex/radial_blur.jpg"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/radial_blur.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/radial_blur.jpg'"
             alt="radial_blur example"
             title="Click to see the example script"
         /></a>
@@ -1012,8 +1011,8 @@ end
         <a href="javascript:popup('raise.rb.html')"
           ><img
             src="ex/raise.jpg"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/raise.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/raise.jpg'"
             alt="raise example"
             title="Click to see the example script"
         /></a>
@@ -1070,8 +1069,7 @@ end
       <pre class="language-ruby">
 geom = Magick::Geometry.new(Magick::QuantumRange/2)
 random_threshold_channel(geom, Magick::RedChannel)
-</pre
-      >
+</pre>
 
       <p class="rollover">
         <a href="javascript:popup('random_threshold_channel.rb.html')"
@@ -1079,8 +1077,8 @@ random_threshold_channel(geom, Magick::RedChannel)
             src="ex/random_threshold_channel.jpg"
             alt="random_threshold_channel example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/random_threshold_channel.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/random_threshold_channel.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -1221,8 +1219,8 @@ random_threshold_channel(geom, Magick::RedChannel)
       <p class="rollover">
         <a href="javascript:popup('remap.rb.html')"
           ><img
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/remap.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/remap.jpg'"
             src="ex/remap.jpg"
             alt="remap example"
             title="Click to see the example script"
@@ -1425,14 +1423,20 @@ random_threshold_channel(geom, Magick::RedChannel)
             src="ex/resize_to_fill.jpg"
             style="padding-left: 62px; padding-right: 62px; padding-top: 87px; padding-bottom: 87px"
             id="after_resize_to_fill"
-            onmouseover="this.style.display='none'; before_resize_to_fill.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              before_resize_to_fill.style.display = '';
+            "
             alt="resize_to_fill example" />
           <!-- This img tag displays the before image when moused over -->
           <img
             src="ex/images/Flower_Hat.jpg"
             style="display: none"
             id="before_resize_to_fill"
-            onmouseout="this.style.display='none'; after_resize_to_fill.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              after_resize_to_fill.style.display = '';
+            "
             alt="resize_to_fill example"
             title="Click to see the example script"
         /></a>
@@ -1524,7 +1528,10 @@ random_threshold_channel(geom, Magick::RedChannel)
           <img
             id="rtfless"
             style="display: none"
-            onmouseout="this.style.display='none';rtf.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              rtf.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="resize_to_fit example"
             title="Click to see the example script" />
@@ -1532,7 +1539,10 @@ random_threshold_channel(geom, Magick::RedChannel)
           <img
             style="padding-left: 69px; padding-right: 69px; padding-top: 87px; padding-bottom: 87px"
             id="rtf"
-            onmouseover="this.style.display='none';rtfless.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              rtfless.style.display = '';
+            "
             src="ex/resize_to_fit.jpg"
             alt="resize_to_fit example"
         /></a>
@@ -1607,8 +1617,8 @@ random_threshold_channel(geom, Magick::RedChannel)
             src="ex/roll.jpg"
             title="Click to see the example script"
             alt="roll example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/roll.jpg'" /></a
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/roll.jpg'" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
 
@@ -1661,7 +1671,10 @@ random_threshold_channel(geom, Magick::RedChannel)
                                                                     same space as the rotated image. --><img
             style="padding-top: 34px; padding-bottom: 34px; display: none"
             id="notrotated"
-            onmouseout="this.style.display='none'; rotated.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              rotated.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="rotate example"
             title="Click to see the example script" /><!--
@@ -1669,7 +1682,10 @@ random_threshold_channel(geom, Magick::RedChannel)
                                                                       --><img
             class="hide"
             id="rotated"
-            onmouseover="this.style.display='none'; notrotated.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              notrotated.style.display = '';
+            "
             src="ex/rotate_f.jpg"
             alt="rotate example"
         /></a>
@@ -1900,8 +1916,8 @@ random_threshold_channel(geom, Magick::RedChannel)
             src="ex/segment.jpg"
             alt="segment example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/segment.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/segment.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -2036,8 +2052,8 @@ random_threshold_channel(geom, Magick::RedChannel)
           ><img
             src="ex/sepiatone.jpg"
             alt="sepiatone example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/sepiatone.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/sepiatone.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -2139,8 +2155,8 @@ random_threshold_channel(geom, Magick::RedChannel)
           ><img
             src="ex/shade.jpg"
             alt="shade example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/shade.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/shade.jpg'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -2203,7 +2219,10 @@ random_threshold_channel(geom, Magick::RedChannel)
           <img
             style="padding: 8px; display: none"
             id="shadowless"
-            onmouseout="this.style.display='none';shadowed.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              shadowed.style.display = '';
+            "
             src="ex/shadow_before.png"
             alt="shadow example"
             title="Click to see the example script" /><!--
@@ -2211,7 +2230,10 @@ random_threshold_channel(geom, Magick::RedChannel)
                                                           --><img
             class="hide"
             id="shadowed"
-            onmouseover="this.style.display='none';shadowless.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              shadowless.style.display = '';
+            "
             src="ex/shadow_after.png"
             alt="shadow example"
         /></a>
@@ -2342,8 +2364,8 @@ random_threshold_channel(geom, Magick::RedChannel)
         <a href="javascript:popup('shave.rb.html')"
           ><img
             src="ex/shave.jpg"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/shave.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/shave.jpg'"
             alt="shave example"
             title="Click to see the example script"
         /></a>
@@ -2408,14 +2430,24 @@ random_threshold_channel(geom, Magick::RedChannel)
                                                                       --><img
             style="padding-top: 34px; padding-bottom: 33px; padding-left: 49px; padding-right: 49px; display: none"
             id="noshear"
-            onmouseout="this.style.display='none'; sheared.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              sheared.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="shear example"
             title="Click to see the example script" />
           <!--
                                                                        This img tag displays the sheared image when the mouse is not over
                                                                        -->
-          <img id="sheared" onmouseover="this.style.display='none'; noshear.style.display='';" src="ex/shear.jpg" alt="shear example" /></a
+          <img
+            id="sheared"
+            onmouseover="
+              this.style.display = 'none';
+              noshear.style.display = '';
+            "
+            src="ex/shear.jpg"
+            alt="shear example" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" style="left: 253px; top: 34px" title="Mouse over the example to see the original image" />
       </p>
 
@@ -2517,8 +2549,7 @@ img.signature  #=&gt; "485e01ecba1a1f47924d67b887cb07b474f695841733796dfa3c28769
 img.properties
 #=&gt; {"signature"=&gt;"485e01ecba1a1f47924d67b887cb07b474f695841733796dfa3c2876965c7e8b",
 #   "comment"=&gt;"File written by Adobe Photoshop\250 4.0"}
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -2570,8 +2601,8 @@ img.properties
             src="ex/sketch.jpg"
             title="Click to see the example script"
             alt="sketch example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/sketch.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/sketch.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -2614,8 +2645,8 @@ img.properties
             src="ex/solarize.jpg"
             title="Click to see the example script"
             alt="solarize example"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/solarize.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/solarize.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -2758,7 +2789,10 @@ img.properties
           <img
             style="padding-left: 8px; padding-right: 8px; padding-top: 10px; padding-bottom: 10px; display: none"
             id="nosplice"
-            onmouseout="this.style.display='none';spliced.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              spliced.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="splice example"
             title="Click to see the example script" /><!--
@@ -2766,7 +2800,10 @@ img.properties
                                                                                                                 --><img
             class="hide"
             id="spliced"
-            onmouseover="this.style.display='none';nosplice.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              nosplice.style.display = '';
+            "
             src="ex/splice.jpg"
             alt="splice example"
         /></a>
@@ -2812,8 +2849,8 @@ img.properties
             src="ex/spread.jpg"
             alt="spread example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/spread.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/spread.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -3021,8 +3058,8 @@ img.properties
       <p class="rollover">
         <a href="javascript:popup('swirl.rb.html')"
           ><img
-            onmouseover="this.src='ex/swirl.gif'"
-            onmouseout="this.src='ex/images/Flower_Hat.jpg'"
+            onmouseover="this.src = 'ex/swirl.gif'"
+            onmouseout="this.src = 'ex/images/Flower_Hat.jpg'"
             src="ex/images/Flower_Hat.jpg"
             alt="swirl example"
             title="Click the image to see the example script" /></a
@@ -3109,8 +3146,8 @@ img.properties
           ><img
             src="ex/texture_fill_to_border_after.gif"
             alt="texture_fill_to_border example"
-            onmouseover="this.src='ex/texture_fill_to_border_before.gif'"
-            onmouseout="this.src='ex/texture_fill_to_border_after.gif'"
+            onmouseover="this.src = 'ex/texture_fill_to_border_before.gif'"
+            onmouseout="this.src = 'ex/texture_fill_to_border_after.gif'"
             title="Click to see the example script"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" style="left: 206px" title="Mouse over the example to see the original image" />
@@ -3176,8 +3213,8 @@ img.properties
           ><img
             src="ex/texture_floodfill_after.gif"
             alt="texture_floodfill example"
-            onmouseover="this.src='ex/texture_floodfill_before.gif'"
-            onmouseout="this.src='ex/texture_floodfill_after.gif'"
+            onmouseover="this.src = 'ex/texture_floodfill_before.gif'"
+            onmouseout="this.src = 'ex/texture_floodfill_after.gif'"
             title="Click to see the example script" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" style="left: 206px" title="Mouse over the example to see the original image" />
       </p>
@@ -3224,8 +3261,8 @@ img.properties
         <a href="javascript:popup('threshold.rb.html')"
           ><img
             src="ex/threshold.jpg"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/threshold.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/threshold.jpg'"
             title="Click to see the example script"
             alt="threshold example" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
@@ -3282,8 +3319,7 @@ img.properties
       <pre class="language-ruby">
 img = Magick::Image.read("images/Cheetah.jpg").first
 thumbnail = img.thumbnail(img.columns * 0.09, img.rows * 0.09)
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -3381,8 +3417,7 @@ thumbnail = img.thumbnail(img.columns * 0.09, img.rows * 0.09)
 img = Magick::Image.read('ex/images/Flower_Hat.jpg').first #=&gt; ex/images/Flower_Hat.jpg JPEG 200x250 DirectClass 8-bit 9761b
 pixel = img.pixel_color(img.columns/2, img.rows/2)         #=&gt; #&lt;struct Pixel red=216, green=147, blue=106, opacity=0&gt;
 img.to_color(pixel)                                        #=&gt; "#D8936A"
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -3442,8 +3477,8 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
           ><img
             src="ex/transparent_after.gif"
             title="Click to see the example script"
-            onmouseover="this.src='ex/transparent_before.gif'"
-            onmouseout="this.src='ex/transparent_after.gif'"
+            onmouseover="this.src = 'ex/transparent_before.gif'"
+            onmouseout="this.src = 'ex/transparent_after.gif'"
             alt="transparent example" /></a
         ><img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -3480,8 +3515,8 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
       <p class="imquote">
         As there is one fuzz value for all the channels, the
         <a href="#transparent">transparent</a> method is not suitable for the operations like chroma, where the tolerance for similarity of two color components
-        (RGB) can be different, Thus we define this method to take two target pixels (one low and one high) and all the pixels of an image which are lying between
-        these two pixels are made transparent.
+        (RGB) can be different, Thus we define this method to take two target pixels (one low and one high) and all the pixels of an image which are lying
+        between these two pixels are made transparent.
       </p>
 
       <h4>Arguments</h4>
@@ -3535,8 +3570,8 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
             src="ex/transpose.jpg"
             alt="transpose example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/transpose.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/transpose.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" style="left: 252px" title="Mouse over the example to see the original image" />
       </p>
@@ -3593,8 +3628,8 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
             src="ex/transverse.jpg"
             alt="transverse example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/transverse.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/transverse.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" style="left: 252px" title="Mouse over the example to see the original image" />
       </p>
@@ -3661,8 +3696,8 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
         <a href="javascript:popup('trim.rb.html')"
           ><img
             src="ex/trim_after.jpg"
-            onmouseover="this.src='ex/trim_before.jpg'"
-            onmouseout="this.src='ex/trim_after.jpg'"
+            onmouseover="this.src = 'ex/trim_before.jpg'"
+            onmouseout="this.src = 'ex/trim_after.jpg'"
             alt="trim example"
             title="Click to see the example script"
         /></a>
@@ -3932,8 +3967,7 @@ img.view( 10, 5, 20, 20) do |view|
   # on column 10.
   view[4,8][10].blue = Magick::QuantumRange
 end
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 
@@ -4007,8 +4041,8 @@ end
             src="ex/vignette.jpg"
             alt="vignette example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/vignette.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/vignette.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -4146,8 +4180,8 @@ end
             src="ex/watermark.jpg"
             alt="watermark example"
             title="Click to see the example script"
-            onmouseover="this.src='ex/images/Flower_Hat.jpg'"
-            onmouseout="this.src='ex/watermark.jpg'"
+            onmouseover="this.src = 'ex/images/Flower_Hat.jpg'"
+            onmouseout="this.src = 'ex/watermark.jpg'"
         /></a>
         <img src="ex/images/spin.gif" alt="" class="spin" title="Mouse over the example to see the original image" />
       </p>
@@ -4187,7 +4221,10 @@ end
             style="padding-top: 25px; padding-bottom: 25px; display: none"
             id="nowave"
             title="Click to see the example script"
-            onmouseout="this.style.display='none'; waved.style.display='';"
+            onmouseout="
+              this.style.display = 'none';
+              waved.style.display = '';
+            "
             src="ex/images/Flower_Hat.jpg"
             alt="wave example" />
           <!--
@@ -4195,7 +4232,10 @@ end
                                                               --><img
             class="hide"
             id="waved"
-            onmouseover="this.style.display='none'; nowave.style.display='';"
+            onmouseover="
+              this.style.display = 'none';
+              nowave.style.display = '';
+            "
             src="ex/wave.jpg"
             alt="wave example"
         /></a>
@@ -4359,8 +4399,7 @@ end
       <pre class="language-ruby">
 temp = Tempfile.new("image")
 img.write("jpeg:"+ temp.path)
-</pre
-      >
+</pre>
 
       <h4>See also</h4>
 

--- a/doc/image3.html
+++ b/doc/image3.html
@@ -610,7 +610,7 @@ end
       <h4>Description</h4>
 
       <p>
-        <span class="imquote">Adds or removes a ICM, IPTC, or generic profile from an image.</span>
+        <span class="imquote">Adds or removes an ICM, IPTC, or generic profile from an image.</span>
         If <code>profile</code> is <code>nil</code>, the specified profile is removed from the image. Use <code>profile('*', nil)</code> to remove all profiles
         from the image.
       </p>
@@ -857,7 +857,7 @@ end
 
         <dt>channel</dt>
 
-        <dd>A <a href="constants.html#ChannelType">ChannelType</a> value. The default is to operate on the R, G. and B channels.</dd>
+        <dd>A <a href="constants.html#ChannelType">ChannelType</a> value. The default is to operate on the R, G, and B channels.</dd>
       </dl>
 
       <h4>Returns</h4>
@@ -1048,7 +1048,7 @@ end
 
         <dd>
           <span class="imquote">A geometry string containing LOWxHIGH thresholds.</span>
-          The string is in the form `XxY'. The Y value may be omitted, in which case it is assigned the value QuantumRange-X. If an % appears in the string then
+          The string is in the form `XxY'. The Y value may be omitted, in which case it is assigned the value QuantumRange-X. If a % appears in the string then
           the values are assumed to be percentages of QuantumRange.
           <span class="imquote">If the string contains 2x2, 3x3, or 4x4, then an ordered dither of order 2, 3, or 4 will be performed instead.</span>
           A <a href="struct.html#Geometry">Geometry</a> object may be used as well.
@@ -1869,7 +1869,7 @@ random_threshold_channel(geom, Magick::RedChannel)
 
         <dt>cluster_threshold</dt>
 
-        <dd class="imquote">The number of pixels in each cluster must exceed the the cluster threshold to be considered valid.</dd>
+        <dd class="imquote">The number of pixels in each cluster must exceed the cluster threshold to be considered valid.</dd>
 
         <dt>smoothing_threshold</dt>
 
@@ -2672,11 +2672,11 @@ img.properties
 
             <dt>ShepardsColorInterpolate</dt>
 
-            <dd class="imquote">Colors points basied on the ratio of inverse distance squared. Generating spots of color in a sea of the average of colors.</dd>
+            <dd class="imquote">Colors points based on the ratio of inverse distance squared. Generating spots of color in a sea of the average of colors.</dd>
 
             <dt>VoronoiColorInterpolate</dt>
 
-            <dd class="imquote">Simply map each pixel to the to nearest color point given. The result are polygonal 'cells' of solid color.</dd>
+            <dd class="imquote">Simply map each pixel to the nearest color point given. The result is polygonal 'cells' of solid color.</dd>
           </dl>
         </dd>
 
@@ -3478,9 +3478,9 @@ img.to_color(pixel)                                        #=&gt; "#D8936A"
       </p>
 
       <p class="imquote">
-        As there is one fuzz value for the all the channels, the
+        As there is one fuzz value for all the channels, the
         <a href="#transparent">transparent</a> method is not suitable for the operations like chroma, where the tolerance for similarity of two color components
-        (RGB) can be different, Thus we define this method take two target pixels (one low and one high) and all the pixels of an image which are lying between
+        (RGB) can be different, Thus we define this method to take two target pixels (one low and one high) and all the pixels of an image which are lying between
         these two pixels are made transparent.
       </p>
 

--- a/doc/image3.html
+++ b/doc/image3.html
@@ -4064,7 +4064,7 @@ end
 
         <dd>
           The fraction of the saturation component of the watermark pixels to be composited onto the target image. Must be a non-negative number or a string in
-          the form "NN%". If lightness is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. The default is 100%.
+          the form "NN%". If saturation is a number it is interpreted as a percentage. Both 0.25 and "25%" mean 25%. The default is 100%.
         </dd>
 
         <dt>x_offset</dt>

--- a/doc/imageattrs.html
+++ b/doc/imageattrs.html
@@ -647,11 +647,11 @@
 
       <h4>Argument</h4>
 
-      <p>A <a href="constants.html#EndianType">EndianType</a> constant.</p>
+      <p>An <a href="constants.html#EndianType">EndianType</a> constant.</p>
 
       <h4>Returns</h4>
 
-      <p>A <a href="constants.html#EndianType">EndianType</a> constant.</p>
+      <p>An <a href="constants.html#EndianType">EndianType</a> constant.</p>
     </div>
 
     <div class="sig">
@@ -934,7 +934,7 @@
       <h4>Argument</h4>
 
       <p>
-        A IPTC profile is represented as a string. If the argument is
+        An IPTC profile is represented as a string. If the argument is
         <code>nil</code> instead of <span class="arg">string</span> then any IPTC profile present in the image is deleted.
       </p>
 
@@ -980,7 +980,7 @@
       <h4>Description</h4>
 
       <p>
-        <span class="imquote">The mean error per pixel computed when a image is color reduced.</span>
+        <span class="imquote">The mean error per pixel computed when an image is color reduced.</span>
         This attribute is only valid if the <code>measure_error</code> argument to <code>quantize</code><a href="ilist.html#quantize">[ImageList]</a>
         <a href="image3.html#quantize">[Image]</a> is set to <code>true</code>. Get-only.
       </p>
@@ -1165,11 +1165,11 @@
 
       <h4>Argument</h4>
 
-      <p>An <a href="constants.html#PixelInterpolateMethod">PixelInterpolateMethod</a> enum value.</p>
+      <p>A <a href="constants.html#PixelInterpolateMethod">PixelInterpolateMethod</a> enum value.</p>
 
       <h4>Returns</h4>
 
-      <p>An <a href="constants.html#PixelInterpolateMethod">PixelInterpolateMethod</a> enum value.</p>
+      <p>A <a href="constants.html#PixelInterpolateMethod">PixelInterpolateMethod</a> enum value.</p>
     </div>
 
     <div class="sig">
@@ -1294,7 +1294,7 @@
 
       <p>
         Gets/sets the number of ticks per second. This attribute is used in conjunction with the <a href="#delay">delay</a> attribute to establish the amount of
-        time that must elapse between frames in an animation.The default is 100.
+        time that must elapse between frames in an animation. The default is 100.
       </p>
 
       <h4>Returns</h4>

--- a/doc/imageattrs.html
+++ b/doc/imageattrs.html
@@ -1044,7 +1044,7 @@
       <h4>Description</h4>
 
       <p>
-        <span class="imquote">The normalized mean error per pixel computed when an image is color reduced.</span>
+        <span class="imquote">The normalized maximum error per pixel computed when an image is color reduced.</span>
         This attribute is only valid if the <code>measure_error</code> argument to <code>quantize</code><a href="ilist.html#quantize">[ImageList]</a
         ><a href="image3.html#quantize">[Image]</a> is set to <code>true</code>. Get-only.
       </p>

--- a/doc/imusage.html
+++ b/doc/imusage.html
@@ -347,7 +347,7 @@
 
     <div class="imquote">
       <p>
-        DirectClass images are continuous-tone images stored as RGB (red, green, blue), RGBA (red, green, blue, alpha), or CMYK (cyan, yellow, magenta, black)
+        DirectClass images are continuous-tone images stored as RGB (red, green, blue), RGBA (red, green, blue, alpha), or CMYK (cyan, magenta, yellow, black)
         intensity values as defined by the
         <code>colorspace</code> [attribute].
       </p>
@@ -360,7 +360,7 @@
     </div>
 
     <p>
-      GIF format images are PseudoClass. JPEG format images are DirectClass. You can change the class of a image with the
+      GIF format images are PseudoClass. JPEG format images are DirectClass. You can change the class of an image with the
       <code><a href="imageattrs.html#class_type">class_type</a></code>
       method.
     </p>
@@ -375,7 +375,7 @@
     <p>
       These are the built-in formats that I know something about. (There are more but I've never used them.) When the format is marked with an
       <sup>*</sup>, you must supply the desired size of the image in order to "read" it. Specify the size by assigning a string in the form "WxH" to the
-      <code>size</code> attribute in the <code>read</code> method's additional parms block. For example, to create a image in the gradient format that is 100
+      <code>size</code> attribute in the <code>read</code> method's additional parms block. For example, to create an image in the gradient format that is 100
       pixels wide and 200 pixels high, use:
     </p>
     <pre class="example language-ruby">i = Magick::Image.read("gradient:red-blue") { |options| options.size = "100x200" }</pre>

--- a/doc/imusage.html
+++ b/doc/imusage.html
@@ -288,8 +288,7 @@
     <p>This is the format of the geometry string. Any of the values may be omitted, depending on the context:</p>
     <pre id="geostr">
 &lt;width&gt;x&lt;height&gt;+-&lt;x&gt;+-&lt;y&gt;{%@!&lt;&gt;}
-</pre
-    >
+</pre>
 
     <p>
       <a href="https://www.imagemagick.org/script/command-line-options.php#resize"> This</a>

--- a/doc/index.html
+++ b/doc/index.html
@@ -336,8 +336,7 @@ This is RMagick 5.2.0 ($Date: 2009/12/20 02:33:33 $) Copyright (C) 2009 by Timot
 Built with ImageMagick 7.1.1-8 Q16-HDRI x86_64 21129 https://imagemagick.org
 Built for ruby 3.2.2
 Web page: https://rmagick.github.io/
-</pre
-    >
+</pre>
 
     <p>It will help a lot if you supply a small Ruby program that reproduces the problem. Don't forget to include any input image files!</p>
 

--- a/doc/info.html
+++ b/doc/info.html
@@ -373,7 +373,7 @@ end
 
         <dd>
           The value of the option. <span class="arg">Value</span> can be any object that responds to <code>to_s</code>. If omitted, the key is simply defined to
-          an null value.
+          a null value.
         </dd>
       </dl>
 
@@ -579,7 +579,7 @@ p img.first['caption'] #=&gt; "a new caption"
 
       <p>
         Specifies the type of compression used when writing the image. Only some image formats support compression. For those that do, only some compression
-        types are supported. If you specify an compression type that is not supported, the default compression type (usually NoCompression) is used instead.
+        types are supported. If you specify a compression type that is not supported, the default compression type (usually NoCompression) is used instead.
       </p>
 
       <p>
@@ -896,7 +896,7 @@ p img.first['caption'] #=&gt; "a new caption"
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Specifies the fill color to use when creating an image with the "caption:" format..</p>
+      <p>Specifies the fill color to use when creating an image with the "caption:" format.</p>
 
       <h4>Arguments</h4>
 
@@ -1038,7 +1038,7 @@ p img.first['caption'] #=&gt; "a new caption"
       <p>
         <span class="imquote"
           >Use this option to assign a specific label to the image, when writing to an image format that supports labels, such as TIFF, PNG, MIFF, or
-          PostScript. You can include the the image filename, type, width, height, or other image attribute by embedding special format characters.</span
+          PostScript. You can include the image filename, type, width, height, or other image attribute by embedding special format characters.</span
         >
         See <a href="draw.html#annotate">annotate</a> for details.
       </p>
@@ -1166,7 +1166,7 @@ p img.first['caption'] #=&gt; "a new caption"
       <h4>Description</h4>
 
       <p>
-        The compression level for JPEG, MPEG, JPEG-2000, MIFF, MNG, and PNG image format. Corresponds to ImageMagick's -quality option. The default is 75. See
+        The compression level for JPEG, MPEG, JPEG-2000, MIFF, MNG, and PNG image formats. Corresponds to ImageMagick's -quality option. The default is 75. See
         <em><a href="comtasks.html#compressing">Compressing image files</a></em
         >.
       </p>
@@ -1264,7 +1264,7 @@ p img.first['caption'] #=&gt; "a new caption"
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Specifies the stroke color to use when creating an image with the "caption:" format..</p>
+      <p>Specifies the stroke color to use when creating an image with the "caption:" format.</p>
 
       <h4>Arguments</h4>
 
@@ -1280,7 +1280,7 @@ p img.first['caption'] #=&gt; "a new caption"
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Specifies the stroke width to use when creating an image with the "caption:" format..</p>
+      <p>Specifies the stroke width to use when creating an image with the "caption:" format.</p>
 
       <h4>Arguments</h4>
 
@@ -1321,9 +1321,9 @@ p img.first['caption'] #=&gt; "a new caption"
       </p>
 
       <p class="imquote">
-        This attribute allows you to have both a opaque visible color as well as a transparent color of the same color value without conflict. That is you can
-        use the same color for both the transparent and opaque color areas within an image. This in turn frees to you to select a transparent color that is
-        appropriate when a image is displayed by application that does not handle a transparent color index, while allowing RMagick to correctly handle images
+        This attribute allows you to have both an opaque visible color as well as a transparent color of the same color value without conflict. That is you can
+        use the same color for both the transparent and opaque color areas within an image. This in turn frees you to select a transparent color that is
+        appropriate when an image is displayed by an application that does not handle a transparent color index, while allowing RMagick to correctly handle images
         of this type.
       </p>
     </div>
@@ -1355,7 +1355,7 @@ p img.first['caption'] #=&gt; "a new caption"
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Specifies the undercolor color to use when creating an image with the "caption:" format..</p>
+      <p>Specifies the undercolor color to use when creating an image with the "caption:" format.</p>
 
       <h4>Arguments</h4>
 

--- a/doc/info.html
+++ b/doc/info.html
@@ -257,8 +257,7 @@ img = Magick::Image.new(10,10) do |options|
   options['user'] = __FILE__ + ':' + __LINE__.to_s
 end
 #=&gt; 10x10 DirectClass 16-bit user:test.rb:3
-</pre
-      >
+</pre>
 
       <p>
         These methods propagate the value of the "user" option to new image(s):
@@ -523,8 +522,7 @@ img = Magick::Image.read("xc:white") do |options|
 end
 p img.first.properties #=&gt; {"caption"=&gt;"a new caption"}
 p img.first['caption'] #=&gt; "a new caption"
-</pre
-      >
+</pre>
 
       <h4>Arguments</h4>
 
@@ -1323,8 +1321,8 @@ p img.first['caption'] #=&gt; "a new caption"
       <p class="imquote">
         This attribute allows you to have both an opaque visible color as well as a transparent color of the same color value without conflict. That is you can
         use the same color for both the transparent and opaque color areas within an image. This in turn frees you to select a transparent color that is
-        appropriate when an image is displayed by an application that does not handle a transparent color index, while allowing RMagick to correctly handle images
-        of this type.
+        appropriate when an image is displayed by an application that does not handle a transparent color index, while allowing RMagick to correctly handle
+        images of this type.
       </p>
     </div>
 

--- a/doc/magick.html
+++ b/doc/magick.html
@@ -341,7 +341,7 @@ p Magick.formats
 
         <dd>
           If present, the limit for the resource. This argument is always an integer number. If the <span class="arg">resource_type</span> is
-          <code>:file</code>, the limit is the number of open files. If <code>:memory</code> or <code>:map</code>, the limit is measured megabytes. If
+          <code>:file</code>, the limit is the number of open files. If <code>:memory</code> or <code>:map</code>, the limit is measured in megabytes. If
           <code>:disk</code>, the limit is measured in gigabytes. If the <span class="arg">resource_type</span> is <code>:area</code> the limit is the maximum
           width * height of an image in pixels that can reside in pixel cache memory. If <code>:time</code>, the limit is measured in seconds. If this argument
           is omitted the limit is not changed.
@@ -372,7 +372,7 @@ p Magick.formats
       <h4>Description</h4>
 
       <p>
-        Set the amount of free memory allocated for the pixel cache. Once this threshold is exceeded, all subsequent pixels cache operations are to/from disk.
+        Set the amount of free memory allocated for the pixel cache. Once this threshold is exceeded, all subsequent pixel cache operations are to/from disk.
       </p>
 
       <h4>Argument</h4>

--- a/doc/magick.html
+++ b/doc/magick.html
@@ -293,8 +293,7 @@ p Magick.formats
 #  "G"=&gt;"*rw+",
 #  "GIF"=&gt;"*rw+",
 #  "PDB"=&gt;"*rw+"}
-</pre
-      >
+</pre>
 
       <h4>Magick API</h4>
 

--- a/doc/package.json
+++ b/doc/package.json
@@ -3,6 +3,6 @@
     "format": "prettier --config .prettier.json --write *"
   },
   "devDependencies": {
-    "prettier": "^3.0.0"
+    "prettier": "^3.9.5"
   }
 }

--- a/doc/rvg.html
+++ b/doc/rvg.html
@@ -240,8 +240,7 @@
       <pre class="language-ruby">
 canvas.background_fill = 'white'
 canvas.background_fill_opacity = 0.50
-</pre
-      >
+</pre>
 
       <h4>Returns</h4>
       <span class="arg">value</span>
@@ -341,8 +340,7 @@ canvas.background_fill_opacity = 0.50
       <pre class="language-ruby">
 canvas.background_image = Magick::Image.read('myBackground.gif').first
 canvas.background_position = :scaled
-</pre
-      >
+</pre>
 
       <h4>Returns</h4>
       <span class="arg">pos</span>
@@ -522,8 +520,7 @@ canvas.background_position = :scaled
       <pre class="language-ruby">
 img = rvg.draw
 img.write('myDrawing.jpg')
-</pre
-      >
+</pre>
     </div>
 
     <div class="sig">
@@ -855,8 +852,7 @@ img.write('myDrawing.jpg')
       <pre class="language-ruby">
 Magick::RVG.dpi = 90
 length = 10.in  # =&gt; 900 pixels
-</pre
-      >
+</pre>
 
       <p>
         If the dpi is defined, the following methods are added to

--- a/doc/rvg.html
+++ b/doc/rvg.html
@@ -608,7 +608,7 @@ img.write('myDrawing.jpg')
 
             <dt>xMid</dt>
 
-            <dd>vertically center the content within the viewport.</dd>
+            <dd>horizontally center the content within the viewport.</dd>
 
             <dt>xMax</dt>
 
@@ -624,7 +624,7 @@ img.write('myDrawing.jpg')
 
             <dt>YMid</dt>
 
-            <dd>horizontally center the content within the viewport.</dd>
+            <dd>vertically center the content within the viewport.</dd>
 
             <dt>YMax</dt>
 

--- a/doc/rvg.html
+++ b/doc/rvg.html
@@ -288,7 +288,7 @@ canvas.background_fill_opacity = 0.50
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Specify an <a href="struct.html#fill">Fill object</a> to fill the canvas background. This attribute has no effect on nested RVG objects.</p>
+      <p>Specify a <a href="struct.html#fill">Fill object</a> to fill the canvas background. This attribute has no effect on nested RVG objects.</p>
 
       <h4>Example</h4>
 
@@ -902,7 +902,7 @@ length = 10.in  # =&gt; 900 pixels
 
         <dt>pct</dt>
 
-        <dd>This conversion takes an numeric argument and returns a percentage of the argument. For example 20.pct(150) -&gt; 30</dd>
+        <dd>This conversion takes a numeric argument and returns a percentage of the argument. For example 20.pct(150) -&gt; 30</dd>
       </dl>
 
       <p>SVG also supports <em>em</em> and <em>ex</em>, which are measurements based on the font size. RVG does not.</p>

--- a/doc/rvgclip.html
+++ b/doc/rvgclip.html
@@ -98,7 +98,7 @@
         <dd>
           Defines the coordinate system for the contents of the clipping path. This argument can take either of two values,
           <strong>userSpaceOnUse</strong>, or <strong>objectBoundingBox</strong>. If <code>userSpaceOnUse</code>, the contents of the clipping path represent
-          values in the current user coordinate system in place at the time when the clipping path is referenced. if objectBoundingBox, then the user coordinate
+          values in the current user coordinate system in place at the time when the clipping path is referenced. If objectBoundingBox, then the user coordinate
           system for the contents of the clipping path is established using the bounding box of the object to which the clipping path is applied. The default is
           <code>userSpaceOnUse</code>.
         </dd>
@@ -201,7 +201,7 @@
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to constructs a <code>use</code> object and adds it to the clipping path.</p>
+      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to construct a <code>use</code> object and adds it to the clipping path.</p>
 
       <p>
         When the referenced argument is another RVG object,

--- a/doc/rvggroup.html
+++ b/doc/rvggroup.html
@@ -256,7 +256,7 @@
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to construct a <code>use</code> object and adds it to the RVG object.</p>
+      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to construct a <code>use</code> object and adds it to the group.</p>
 
       <p>
         When the referenced argument is an RVG object,

--- a/doc/rvggroup.html
+++ b/doc/rvggroup.html
@@ -256,7 +256,7 @@
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to constructs a <code>use</code> object and adds it to the RVG object.</p>
+      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to construct a <code>use</code> object and adds it to the RVG object.</p>
 
       <p>
         When the referenced argument is an RVG object,

--- a/doc/rvgimage.html
+++ b/doc/rvgimage.html
@@ -181,7 +181,7 @@
 
             <dt>xMid</dt>
 
-            <dd>vertically center the image within the viewport.</dd>
+            <dd>horizontally center the image within the viewport.</dd>
 
             <dt>xMax</dt>
 
@@ -197,7 +197,7 @@
 
             <dt>YMid</dt>
 
-            <dd>horizontally center the image within the viewport.</dd>
+            <dd>vertically center the image within the viewport.</dd>
 
             <dt>YMax</dt>
 

--- a/doc/rvgpattern.html
+++ b/doc/rvgpattern.html
@@ -376,8 +376,8 @@
       <h4>Description</h4>
 
       <p>
-        The area of the pattern is called the <em>viewport</em>. By default the origin of the coordinate system for a pattern is (0,0). The user coordinates
-        are pixels and the width and height are established by the <span class="arg">width</span> and <span class="arg">height</span> arguments to
+        The area of the pattern is called the <em>viewport</em>. By default the origin of the coordinate system for a pattern is (0,0). The user coordinates are
+        pixels and the width and height are established by the <span class="arg">width</span> and <span class="arg">height</span> arguments to
         <code>RVG::Pattern.new</code>.
       </p>
 

--- a/doc/rvgpattern.html
+++ b/doc/rvgpattern.html
@@ -200,7 +200,7 @@
 
             <dt>xMid</dt>
 
-            <dd>vertically center the content within the viewport.</dd>
+            <dd>horizontally center the content within the viewport.</dd>
 
             <dt>xMax</dt>
 
@@ -216,7 +216,7 @@
 
             <dt>YMid</dt>
 
-            <dd>horizontally center the content within the viewport.</dd>
+            <dd>vertically center the content within the viewport.</dd>
 
             <dt>YMax</dt>
 

--- a/doc/rvgpattern.html
+++ b/doc/rvgpattern.html
@@ -345,7 +345,7 @@
     <div class="desc">
       <h4>Description</h4>
 
-      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to constructs a <code>use</code> object and adds it to the pattern.</p>
+      <p>Calls <a href="rvguse.html#new">RVG::Use.new</a> to construct a <code>use</code> object and adds it to the pattern.</p>
 
       <p>
         When the referenced argument is an RVG object,
@@ -376,7 +376,7 @@
       <h4>Description</h4>
 
       <p>
-        The area of the pattern is called the <em>viewport</em>. By default the origin of the coordinate system for an pattern is (0,0). The user coordinates
+        The area of the pattern is called the <em>viewport</em>. By default the origin of the coordinate system for a pattern is (0,0). The user coordinates
         are pixels and the width and height are established by the <span class="arg">width</span> and <span class="arg">height</span> arguments to
         <code>RVG::Pattern.new</code>.
       </p>

--- a/doc/rvgshape.html
+++ b/doc/rvgshape.html
@@ -305,7 +305,7 @@ canvas.polygon(x, y)
     <div class="desc">
       <h5>Description</h5>
 
-      <p>Adds a set of connected lines segments to the target object. Typically a polyline defines an open shape.</p>
+      <p>Adds a set of connected line segments to the target object. Typically a polyline defines an open shape.</p>
 
       <h5>Arguments</h5>
 

--- a/doc/rvgshape.html
+++ b/doc/rvgshape.html
@@ -275,8 +275,7 @@ x = [1, 3, 5, 7, 9]
 y = [2,4]
 canvas.polygon(x, y)
 # is equivalent to canvas.polygon(1,2, 3,4, 5,2, 7,4, 9,2)
-</pre
-          >
+</pre>
         </li>
       </ol>
 

--- a/doc/rvgstyle.html
+++ b/doc/rvgstyle.html
@@ -73,12 +73,12 @@
       <dl>
         <dt>:clip_path</dt>
 
-        <dd>An outline used to clip a shape or collection of shapes. The value is an <a href="rvgclip.html#new">clipping path</a>.</dd>
+        <dd>An outline used to clip a shape or collection of shapes. The value is a <a href="rvgclip.html#new">clipping path</a>.</dd>
 
         <dt>:clip_rule</dt>
 
         <dd>
-          If the <code>clip_path</code> style is used, how to determine if a point is inside or outside a the clip path. The value is a string, either 'nonzero'
+          If the <code>clip_path</code> style is used, how to determine if a point is inside or outside the clip path. The value is a string, either 'nonzero'
           or 'evenodd'. The default is 'nonzero'. See the <code>fill_rule</code> example below.
         </dd>
 

--- a/doc/rvgtext.html
+++ b/doc/rvgtext.html
@@ -277,7 +277,7 @@
       <p>
         The basic styles include font styles and text styles. Note that ImageMagick uses the font styles to select a font from the available fonts. If it cannot
         find a font that exactly matches it will use the closest matching font. Unlike MS Windows, ImageMagick will
-        <em>not</em> alter a font - by artificially slanting it to to simulate italics, for example - to produce a match.
+        <em>not</em> alter a font - by artificially slanting it to simulate italics, for example - to produce a match.
       </p>
 
       <h4>Styles</h4>

--- a/doc/rvgtspan.html
+++ b/doc/rvgtspan.html
@@ -123,8 +123,8 @@
       <h4>Description</h4>
 
       <p>
-        The <span class="arg">dx</span> and <span class="arg">dy</span> arguments are added to the current text position to form a new current text
-        position. Yields to a block if one is present.
+        The <span class="arg">dx</span> and <span class="arg">dy</span> arguments are added to the current text position to form a new current text position.
+        Yields to a block if one is present.
       </p>
 
       <h4>Arguments</h4>

--- a/doc/rvgtspan.html
+++ b/doc/rvgtspan.html
@@ -123,7 +123,7 @@
       <h4>Description</h4>
 
       <p>
-        The <span class="arg">dx</span> and <span class="arg">dy</span> arguments are added to the the current text position to form a new current text
+        The <span class="arg">dx</span> and <span class="arg">dy</span> arguments are added to the current text position to form a new current text
         position. Yields to a block if one is present.
       </p>
 

--- a/doc/rvgtut.html
+++ b/doc/rvgtut.html
@@ -138,7 +138,7 @@
 
     <p>
       <code>RVG::dpi</code> enables the use of <em>unit methods</em> in RVG. When you set <code>RVG::dpi</code> to a non-nil value, RVG adds a number of
-      conversion methods to the Integer and Float classes . These methods allow you to specify measurements in units such as inches, millimeters, and
+      conversion methods to the Integer and Float classes. These methods allow you to specify measurements in units such as inches, millimeters, and
       centimeters. <em>DPI</em>
       stands for "dots per inch," the image resolution. Here I set
       <code>RVG::dpi</code> to 72, a common value for displays.
@@ -268,7 +268,7 @@
 
     <p>
       The <code>styles</code> method is a real workhorse. It's defined in almost every class in RVG and there are many other style names in addition to these
-      three..
+      three.
     </p>
 
     <h3>Basic shapes</h3>
@@ -425,7 +425,7 @@
       All I need now is a title for the picture. Text in RVG is a job for the
       <code>text</code> method. Like the shape methods, <code>text</code> can be used with any container object. <code>Text</code> itself is a container, except
       that it can only contain text-related objects. The <code>text</code> method takes 2 or 3 arguments, an (x,y) pair and optionally a string. The (x,y) pair
-      define a <em>current text position</em> at which rendering starts. If there is a string argument, it will be rendered starting at the current text
+      defines a <em>current text position</em> at which rendering starts. If there is a string argument, it will be rendered starting at the current text
       position. Rendering text changes the current text position to the end of the text.
     </p>
 
@@ -449,7 +449,7 @@
 </pre
     >
 
-    <p>I'm almost done. All I need to do it add a blue border. (I'm going to remove the graph paper background because we don't need it any more.)</p>
+    <p>I'm almost done. All I need to do is add a blue border. (I'm going to remove the graph paper background because we don't need it any more.)</p>
 
     <p>
       <img src="ex/images/duck15.gif" width="180" height="180" alt="duck with border" />

--- a/doc/rvgtut.html
+++ b/doc/rvgtut.html
@@ -99,8 +99,7 @@
 36  end
 37
 38  rvg.draw.write('duck.gif')
-</pre
-    >
+</pre>
 
     <h2>Summary</h2>
 
@@ -123,8 +122,7 @@
     <pre class="example language-ruby">
  1  require 'rvg/rvg'
  2  include Magick
-</pre
-    >
+</pre>
 
     <p>These are just the usual Ruby code to load the RVG extension. To save some typing, I've included the Magick module into Object's namespace.</p>
 
@@ -133,8 +131,7 @@
  4  RVG::dpi = 72
  5
  6  rvg = RVG.new(2.5.in, 2.5.in).viewbox(0,0,250,250) do |canvas|
-</pre
-    >
+</pre>
 
     <p>
       <code>RVG::dpi</code> enables the use of <em>unit methods</em> in RVG. When you set <code>RVG::dpi</code> to a non-nil value, RVG adds a number of
@@ -189,8 +186,7 @@
     <h2>Line 7</h2>
     <pre class="example language-ruby">
  7       canvas.background_fill = 'white'
-</pre
-    >
+</pre>
 
     <p>
       By default, RVG graphics are drawn on a transparent background. This is convenient when you want to display your image over another image. You can
@@ -205,8 +201,7 @@
 11      body.ellipse(50, 30)
 12      body.rect(45, 20, -20, -10).skewX(-35)
 13    end
-</pre
-    >
+</pre>
 
     <p>There's a lot going on in these few lines - seven method calls - so let's take it one method at a time.</p>
 
@@ -334,8 +329,7 @@
 18      head.circle(5, 10, -5).styles(:fill=&gt;'black')
 19      head.polygon(30,0, 70,5, 30,10, 62,25, 23,20).styles(:fill=&gt;'orange')
 20    end
-</pre
-    >
+</pre>
 
     <p>
       This section is very similar to the previous one. I'm defining a group to contain the graphic objects that draw the duck's head, eye, and beak. First I
@@ -368,8 +362,7 @@
 23      _foot.path('m0,0 v30 l30,10 l5,-10, l-5,-10 l-30,10z').
 24      styles(:stroke_width=&gt;2, :fill=&gt;'orange', :stroke=&gt;'black')
 25    end
-</pre
-    >
+</pre>
 
     <p>
       Here I create a group by directly calling <code>new</code> instead of calling the <code>g</code> method on a container. This creates a group object that
@@ -384,8 +377,7 @@
     <pre class="example language-ruby">
 26    canvas.use(foot).translate(75, 188).rotate(15)
 27    canvas.use(foot).translate(100, 185).rotate(-15)
-</pre
-    >
+</pre>
 
     <p>
       To add the group to the canvas I use the <code>use</code>
@@ -418,8 +410,7 @@
 32      title.tspan("type").styles(:font_size=&gt;22,
 33                                 :font_family=&gt;'times', :font_style=&gt;'italic', :fill=&gt;'red')
 34    end
-</pre
-    >
+</pre>
 
     <p>
       All I need now is a title for the picture. Text in RVG is a job for the
@@ -446,8 +437,7 @@
     <h2>Line 35</h2>
     <pre class="example language-ruby">
 35    canvas.rect(249,249).styles(:stroke=&gt;'blue', :fill=&gt;'none')
-</pre
-    >
+</pre>
 
     <p>I'm almost done. All I need to do is add a blue border. (I'm going to remove the graph paper background because we don't need it any more.)</p>
 
@@ -458,8 +448,7 @@
     <h2>Line 38</h2>
     <pre class="example language-ruby">
 38  rvg.draw.write('duck.gif')
-</pre
-    >
+</pre>
 
     <p>
       The <code>draw</code> method call doesn't occupy a lot of space - just 4 letters - but does a lot of work. The <code>draw</code> method goes through all
@@ -473,8 +462,7 @@
     <p>Are RVG images really scalable? Let's try. Change the RVG.new call to make an image that's 4 times as big. That's 5 inches on a side:</p>
     <pre class="example language-ruby">
  6  rvg = RVG.new(5.in, 5.in).viewbox(0,0,250,250) do |canvas|
-</pre
-    >
+</pre>
 
     <p>Change nothing else. Run the program again and see what you get.</p>
 

--- a/doc/rvgtut.html
+++ b/doc/rvgtut.html
@@ -472,7 +472,7 @@
 
     <p>Are RVG images really scalable? Let's try. Change the RVG.new call to make an image that's 4 times as big. That's 5 inches on a side:</p>
     <pre class="example language-ruby">
- 6  rvg = RVG.new(2.5.in, 2.5.in).viewbox(0,0,250,250) do |canvas|
+ 6  rvg = RVG.new(5.in, 5.in).viewbox(0,0,250,250) do |canvas|
 </pre
     >
 

--- a/doc/rvguse.html
+++ b/doc/rvguse.html
@@ -87,7 +87,7 @@
         <dt>width, height</dt>
 
         <dd>
-          The width and height of the rectangular region in which this object is placed. These arguments are ignored unless object is an RVG object. In this
+          The width and height of the rectangular region in which this object is placed. These arguments are ignored unless the object is an RVG object. In this
           case, the values of <span class="arg">width</span> and <span class="arg">height</span> override the values of the width and height arguments that were
           specified when the RVG object was created.
         </dd>

--- a/doc/struct.html
+++ b/doc/struct.html
@@ -481,7 +481,7 @@
             <td valign="top" align="center">!</td>
 
             <td>
-              Use this flag when you want to force the new image to have exactly the size specified by the the <code>width</code> and
+              Use this flag when you want to force the new image to have exactly the size specified by the <code>width</code> and
               <code>height</code> attributes.
             </td>
           </tr>
@@ -492,7 +492,7 @@
             <td valign="top" align="center">&lt;</td>
 
             <td>
-              Use this flag when you want to change the size of the image only if both its width and height are smaller the values specified by those
+              Use this flag when you want to change the size of the image only if both its width and height are smaller than the values specified by those
               attributes. The image size is changed proportionally.
             </td>
           </tr>
@@ -563,7 +563,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
     <div class="desc">
       <h5>Description</h5>
 
-      <p>Returns the string equivalent of the <code>Geometry</code> object..</p>
+      <p>Returns the string equivalent of the <code>Geometry</code> object.</p>
     </div>
 
     <div class="subhd" id="Pixel">
@@ -794,7 +794,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
 
         <p>
           Returns the
-          <a href="imusage.html#color_names">color name</a> corresponding the the pixel values. If there is no such named color in the specified color standard,
+          <a href="imusage.html#color_names">color name</a> corresponding to the pixel values. If there is no such named color in the specified color standard,
           returns a string in the form "rgb(r,g,b,a)".
         </p>
 
@@ -965,7 +965,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
 
         <p>
           The value of the <code>pixels_per_em</code> attribute in the TypeMetric struct returned by
-          <a href="draw.html#get_type_metrics">Draw#get_type_metrics</a> is a <code>Point</code> object..
+          <a href="draw.html#get_type_metrics">Draw#get_type_metrics</a> is a <code>Point</code> object.
         </p>
 
         <h5>Attributes</h5>

--- a/doc/struct.html
+++ b/doc/struct.html
@@ -211,8 +211,7 @@
   pixels = view[[1,3,5]][[2,4,6]]
   # Use ranges to specify a contiguous set of rows and columns
   pixels = view[1..5][2..6]
-</pre
-        >
+</pre>
       </div>
 
       <div class="sig">
@@ -249,8 +248,7 @@
   # Get the maximum value of the red channel
   # for all the pixels in the top row of the view.
   m = view[0][].red.max
-</pre
-        >
+</pre>
       </div>
 
       <div class="sig">
@@ -309,8 +307,7 @@
   # Set the green channel of the pixel at [20][30] to
   # half that of its left-hand neighbor.
   view[20][30].green = view[20][29].green * 0.5
-</pre
-        >
+</pre>
       </div>
 
       <div id="view_sync" class="sig">
@@ -537,8 +534,7 @@
         <h5>Example</h5>
         <pre class="language-ruby">
 g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
-</pre
-        >
+</pre>
       </div>
     </div>
 

--- a/doc/struct.html
+++ b/doc/struct.html
@@ -418,7 +418,7 @@
         <h5>Attributes</h5>
 
         <p>
-          A geometry string has the general form "WxH+x+y[!@%&lt;&gt;]. In a
+          A geometry string has the general form "WxH+x+y[!@%&lt;&gt;]". In a
           <code>Geometry</code> object,
         </p>
 
@@ -470,7 +470,7 @@
 
             <td>
               Normally the attributes are treated as pixels. Use this flag when the <code>width</code> and <code>height</code> attributes represent
-              <em>percentages</em>. For example, 125x75 means 125% of the height and 75% of the width. The <code>x</code> and <code>y</code> attributes are not
+              <em>percentages</em>. For example, 125x75 means 125% of the width and 75% of the height. The <code>x</code> and <code>y</code> attributes are not
               affected by this flag.
             </td>
           </tr>
@@ -840,7 +840,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
       <div class="sig">
         <h4 id="to_hsla">to_hsla</h4>
 
-        <p><span class="arg">pixel</span>.to_HSL -&gt; <em>array</em></p>
+        <p><span class="arg">pixel</span>.to_hsla -&gt; <em>array</em></p>
       </div>
 
       <div class="desc">
@@ -1095,7 +1095,7 @@ g = Magick::Geometry.new(100,200,nil,nil,Magick::AspectGeometry)
       </p>
 
       <p>
-        RMagick supplies three Fill classes,
+        RMagick supplies four Fill classes,
         <code><strong>HatchFill</strong></code
         >, <code><strong>GradientFill</strong></code
         >, <code><strong>SolidFill</strong></code> and <code><strong>TextureFill</strong></code

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -131,8 +131,7 @@ require "rmagick"
 cat = Magick::ImageList.new("Cheetah.jpg")
 cat.display
 exit
-</pre
-    >
+</pre>
 
     <p class="example_cutline">
       MS Windows users note: The
@@ -185,8 +184,7 @@ cat = Magick::ImageList.new("Cheetah.jpg")
 smallcat = cat.minify
 smallcat.display
 exit
-</pre
-    >
+</pre>
 
     <p>
       The difference is the statement on line 5. This statement sends the
@@ -210,8 +208,7 @@ smallcat = cat.minify
 smallcat.display
 smallcat.write("Small-Cheetah.gif")
 exit
-</pre
-    >
+</pre>
 
     <p>
       The statement on line 7 writes the image to a file. Notice that the filename extension is <code>gif</code>. When writing images, ImageMagick uses the
@@ -266,8 +263,7 @@ require "rmagick"
 f = Magick::Image.new(100,100) { |options| options.background_color = "red" }
 f.display
 exit
-</pre
-    >
+</pre>
 
     <p>Within the parameter block you must use <code>self</code> so that Ruby knows that this statement is a method call, not an assignment to a variable.</p>
 
@@ -302,8 +298,7 @@ require "rmagick"
 anim = Magick::ImageList.new("start.gif", "middle.gif", "finish.gif")
 anim.write("animated.gif")
 exit
-</pre
-    >
+</pre>
 
     <h2 id="displaying">Displaying images</h2>
 
@@ -1287,8 +1282,7 @@ circle.stroke_linejoin('round')
 circle.ellipse(canvas.rows/2,canvas.columns/2, 80, 80, 0, 315)
 circle.polyline(180,70, 173,78, 190,78, 191,62)
 circle.draw(canvas)
-</pre
-    >
+</pre>
 
     <p>
       The statements on lines 4 and 5 create the drawing canvas with a single 250x250 image. The <code>HatchFill</code> object fills the image with light-gray
@@ -1361,8 +1355,7 @@ text.annotate(canvas, 0,0,0,0, Text) { |options|
 
 canvas.write('rubyname.gif')
 exit
-</pre
-    >
+</pre>
 
     <p>
       This program uses three calls to <code>annotate</code> to produce the "etched" appearance. All three calls have some parameters in common but the fill
@@ -1397,9 +1390,9 @@ exit
       The next section,
       <a href="imusage.html">"ImageMagick Conventions,"</a> describes some conventions that you need to know, such as how ImageMagick determines the graphic
       format of an image file, etc. The ImageMagick (www.imagemagick.org) web site (from which much of the information in these pages has been taken) offers a
-      lot of detail about ImageMagick. While this web site doesn't describe RMagick, you can often use the documentation to learn more about a RMagick method
-      by reading about the Magick API the method calls. (In the Reference section of this document, most of the method descriptions include the name of the
-      Magick API that the method calls.) Check out the example programs. Almost every one of the methods is demonstrated in one of the examples.
+      lot of detail about ImageMagick. While this web site doesn't describe RMagick, you can often use the documentation to learn more about a RMagick method by
+      reading about the Magick API the method calls. (In the Reference section of this document, most of the method descriptions include the name of the Magick
+      API that the method calls.) Check out the example programs. Almost every one of the methods is demonstrated in one of the examples.
     </p>
 
     <p>Good luck!</p>

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -288,7 +288,7 @@ exit
     <p>
       If an ImageList object contains only one image, then
       <a href="ilist.html#write"><code>ImageList#write</code></a> is the same as <code>Image#write</code>. However, if the imagelist contains multiple images
-      and the file format (determined by the file name extension, as I mentioned earlier) supports multi-frame images, <code>Image#write</code> will
+      and the file format (determined by the file name extension, as I mentioned earlier) supports multi-frame images, <code>ImageList#write</code> will
       automatically create a multi-frame image file.
     </p>
 

--- a/doc/usage.html
+++ b/doc/usage.html
@@ -160,7 +160,7 @@ exit
     <p>
       The Image and ImageList classes are closely related. An
       <em>Image</em> object describes one image or one frame in an image with multiple frames. (An animated GIF or a Photoshop image with multiple layers are
-      examples of images with multiple frames.) You can create a image object from an image file such as a GIF, PNG, or JPEG. You can create a image from
+      examples of images with multiple frames.) You can create an image object from an image file such as a GIF, PNG, or JPEG. You can create an image from
       scratch by specifying its dimensions. You can write an image to disk, display it on a screen, change its size or orientation, convert it to another
       format, or otherwise modify it using one of over 100 methods.
     </p>
@@ -216,7 +216,7 @@ exit
     <p>
       The statement on line 7 writes the image to a file. Notice that the filename extension is <code>gif</code>. When writing images, ImageMagick uses the
       filename extension to determine what image format to write. In this example, the <code>Small-Cheetah.gif</code> file will be in the GIF format. Notice how
-      easy it is to covert an image from one format to another? (For more details, see <a href="imusage.html#formats">Image formats and filenames</a>.)
+      easy it is to convert an image from one format to another? (For more details, see <a href="imusage.html#formats">Image formats and filenames</a>.)
     </p>
 
     <p>
@@ -474,7 +474,7 @@ exit
 
         <dt><a href="image2.html#histogram_q">histogram?</a></dt>
 
-        <dd>Does the image have &lt;= 1024 unique colors??</dd>
+        <dd>Does the image have &lt;= 1024 unique colors?</dd>
 
         <dt><a href="image2.html#import_pixels">import_pixels</a></dt>
 
@@ -1304,7 +1304,7 @@ circle.draw(canvas)
     </p>
 
     <p>
-      The <code>ellipse</code> method call on line 14 describes an circle in the center of the canvas with a radius of 80 pixels. The ellipse occupies 315&deg;
+      The <code>ellipse</code> method call on line 14 describes a circle in the center of the canvas with a radius of 80 pixels. The ellipse occupies 315&deg;
       of a circle, starting at 0&deg; (that is, 3 o'clock). The <code>polyline</code> call on line 15 adds the arrowhead to the circle. The arguments (always an
       even number) are the x- and y-coordinates of the points the line passes through.
     </p>
@@ -1380,7 +1380,7 @@ exit
     <p>
       The first <code>annotate</code> argument is the image on which the text will be drawn. Arguments 2-5, <code>width</code>, <code>height</code>,
       <code>x</code>, and <code>y</code>, describe a rectangle about which the text is drawn. This rectangle, combined with the value of <code>gravity</code>,
-      define the position of the text. When the <code>gravity</code> value is <a href="constants.html#GravityType"><code>CenterGravity</code></a> the values of
+      defines the position of the text. When the <code>gravity</code> value is <a href="constants.html#GravityType"><code>CenterGravity</code></a> the values of
       <code>width</code> and <code>height</code> are unused.
     </p>
 
@@ -1397,7 +1397,7 @@ exit
       The next section,
       <a href="imusage.html">"ImageMagick Conventions,"</a> describes some conventions that you need to know, such as how ImageMagick determines the graphic
       format of an image file, etc. The ImageMagick (www.imagemagick.org) web site (from which much of the information in these pages has been taken) offers a
-      lot of detail about ImageMagick. While this web sites doesn't describe RMagick, you can often use the documentation to learn more about a RMagick method
+      lot of detail about ImageMagick. While this web site doesn't describe RMagick, you can often use the documentation to learn more about a RMagick method
       by reading about the Magick API the method calls. (In the Reference section of this document, most of the method descriptions include the name of the
       Magick API that the method calls.) Check out the example programs. Almost every one of the methods is demonstrated in one of the examples.
     </p>


### PR DESCRIPTION
## Summary

A proofreading and correctness pass over the HTML documentation under `doc/`. All changes are limited to `doc/`.

## What changed

**Grammar & typo fixes** — commit `Fix grammar errors and typos in documentation`
- Article errors (`a`/`an`), subject-verb agreement, duplicated and missing words, misspellings (e.g. `programatically`, `covert`, `ImagMagick`, `basied`, `continuious`, `effectivally`), and stray punctuation (double periods, extra spaces, `colors??`).
- Typos inside verbatim ImageMagick quote blocks (`class="imquote"`) are corrected as well.

**Content / correctness fixes** — commit `Fix content errors in documentation`
- `preserve_aspect_ratio`: `xMid`/`YMid` described the wrong axis (rvg, rvgpattern, rvgimage).
- Copy-paste argument references corrected: `watermark` saturation, `blend`/`dissolve` `dst_percentage`, `equalize_channel` ("equalized"), `level` `white_point` label.
- Wrong counts: comtasks "the other three", struct "four Fill classes".
- `PercentGeometry` width/height were swapped.
- Signatures / identifiers: `stroke_width=`, `to_hsla`, `MatteFloodfillImage`.
- `Image#write` → `ImageList#write` for multi-frame output.
- rvggroup `use` adds it to "the group".
- rvgtut scalable example uses `5.in` to match the 4×-larger result.
- Geometry string missing its closing quote; the `draw` `popup()` example link.
- `normalized_maximum_error` now describes the maximum error.
- Two more non-standard `CYMK` → `CMYK` in constants (commit `Fix remaining CYMK typos in constants doc`).

**Docs reformatting** — commit `Re-format the docs`
- Prettier reformat of the docs (whitespace/wrapping only; no text changes).

## Not addressed (need a maintainer decision)

These are flagged but intentionally left untouched because they need a content decision or new text:
- image2 `opaque_channel`: the `invert` default sentence looks misattached (it describes `fuzz`).
- struct `GreaterGeometry`: "if either its width and height exceed" (both vs. either).
- info `number_scenes`: description is a copy of `scene`.
- info `monochrome`: empty description.
- imageattrs `opacity`: heading/signature and TOC entry appear to be missing (a dangling description sits under `offset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
