### PR TITLE
Fix typos in source code comments

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -123,7 +123,7 @@ module RMagick
         $LDFLAGS    += " #{ldflags} #{rpath}"
 
         unless try_link("int main() { }")
-          # if linker does not recognizes '-Wl,-rpath,somewhere' option, it revert to original option
+          # if linker does not recognize '-Wl,-rpath,somewhere' option, it reverts to original option
           $LDFLAGS = "#{original_ldflags} #{ldflags}"
         end
       end

--- a/ext/RMagick/rmagick.cpp
+++ b/ext/RMagick/rmagick.cpp
@@ -312,7 +312,7 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE klass)
 
 /**
  * Set the amount of free memory allocated for the pixel cache.  Once this
- * threshold is exceeded, all subsequent pixels cache operations are to/from
+ * threshold is exceeded, all subsequent pixel cache operations are to/from
  * disk.
  *
  * @param threshold [Numeric] the number of megabytes to set.
@@ -346,7 +346,7 @@ Magick_set_cache_threshold(VALUE klass, VALUE threshold)
  * - "user"
  * - "x11"
  *
- * Multiple events can be specified as the aruments. Event names may be capitalized.
+ * Multiple events can be specified as the arguments. Event names may be capitalized.
  *
  * @param args [String] the mask of log event.
  */

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -108,10 +108,10 @@ extern "C" {
 #define NUM2QUANTUM(n) (Quantum)NUM2UINT((n)) /**< Quantum <- Ruby Numeric conversion */
 #elif (MAGICKCORE_QUANTUM_DEPTH == 32)
 #define QUANTUM2NUM(q) UINT2NUM((q)) /**< Quantum -> Ruby Numeric conversion */
-#define NUM2QUANTUM(n) (Quantum)NUM2UINT((n)) /**< Quntum <- Ruby Numeric conversion */
+#define NUM2QUANTUM(n) (Quantum)NUM2UINT((n)) /**< Quantum <- Ruby Numeric conversion */
 #elif (MAGICKCORE_QUANTUM_DEPTH == 64)
 #define QUANTUM2NUM(q) ULL2NUM((q)) /**< Quantum -> Ruby Numeric conversion */
-#define NUM2QUANTUM(n) (Quantum)NUM2ULL((n)) /**< Quntum <- Ruby Numeric conversion */
+#define NUM2QUANTUM(n) (Quantum)NUM2ULL((n)) /**< Quantum <- Ruby Numeric conversion */
 #else
 #error Specified MAGICKCORE_QUANTUM_DEPTH is not supported.
 #endif
@@ -247,7 +247,7 @@ typedef enum {
 //! Draw#text_anchor AnchorType argument
 typedef enum {
     StartAnchor = 1,  /**< start */
-    MiddleAnchor = 2, /**< midle */
+    MiddleAnchor = 2, /**< middle */
     EndAnchor = 3     /**< end */
 } AnchorType;
 

--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -836,7 +836,7 @@ Draw_undercolor_eq(VALUE self, VALUE undercolor)
  * Annotates an image with text.
  *
  * - Additional Draw attribute methods may be called in the optional block,
- *   which is executed in the context of an Draw object.
+ *   which is executed in the context of a Draw object.
  *
  * @param image_arg [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *   imagelist, uses the current image.
@@ -1147,7 +1147,7 @@ Draw_dup(VALUE self)
  *     imagelist, uses the current image.
  *   @param text [String] The string to be rendered.
  *
- * @return [Magick::TypeMetric] The information for a specific string if rendered on a image.
+ * @return [Magick::TypeMetric] The information for a specific string if rendered on an image.
  */
 VALUE
 Draw_get_type_metrics(
@@ -1174,7 +1174,7 @@ Draw_get_type_metrics(
  *     imagelist, uses the current image.
  *   @param text [String] The string to be rendered.
  *
- * @return [Magick::TypeMetric] The information for a specific string if rendered on a image.
+ * @return [Magick::TypeMetric] The information for a specific string if rendered on an image.
  */
 VALUE
 Draw_get_multiline_type_metrics(
@@ -1340,7 +1340,7 @@ Draw_mark(void *drawptr)
 
 
 /**
- * Free the memory associated with an Draw object.
+ * Free the memory associated with a Draw object.
  *
  * No Ruby usage (internal function)
  *
@@ -1401,7 +1401,7 @@ new_DrawOptions(void)
 /**
  * Create a DrawOptions object.
  *
- * - The DrawOptions class is the same as the Draw class except is has only
+ * - The DrawOptions class is the same as the Draw class except it has only
  *   the attribute writer functions
  *
  * @return [Magick::Image::DrawOptions] a new DrawOptions object

--- a/ext/RMagick/rmenum.cpp
+++ b/ext/RMagick/rmenum.cpp
@@ -219,7 +219,7 @@ Enum_spaceship(VALUE self, VALUE other)
 /**
  * Bitwise OR for enums
  *
- * @param another [Magick::Enum] the another enum
+ * @param another [Magick::Enum] the other enum
  * @return [Magick::Enum] new Enum instance
  */
 VALUE
@@ -361,7 +361,7 @@ Enum_type_values(VALUE klass)
  *
  * @param klass the class type
  * @param value the value for enum
- * @return a enumerator
+ * @return an enumerator
  */
 
 VALUE
@@ -541,7 +541,7 @@ CompressionType_find(CompressionType ct)
 
 
 /**
- * Returns a DisposeType enum object for the specified value..new.
+ * Returns a DisposeType enum object for the specified value.
  *
  * No Ruby usage (internal function)
  *
@@ -661,7 +661,7 @@ PixelInterpolateMethod_find(PixelInterpolateMethod interpolate)
 
 
 /**
- * Construct an RenderingIntent enum object for the specified value.
+ * Construct a RenderingIntent enum object for the specified value.
  *
  * No Ruby usage (internal function)
  *
@@ -785,7 +785,7 @@ StyleType_find(StyleType style)
  *
  * No Ruby usage (internal function)
  *
- * @param style theVirtualPixelMethod
+ * @param style the VirtualPixelMethod
  * @return a new VirtualPixelMethod enumerator
  */
 VALUE

--- a/ext/RMagick/rmilist.cpp
+++ b/ext/RMagick/rmilist.cpp
@@ -859,7 +859,7 @@ imagelist_length(VALUE imagelist)
 
 
 /**
- * Raise exception if imagelist is emtpy.
+ * Raise exception if imagelist is empty.
  *
  * No Ruby usage (internal function)
  *
@@ -934,7 +934,7 @@ clone_imagelist(Image *images)
  * Analyzes the colors within a set of reference images and chooses a fixed number of colors to represent the set.
  * The goal of the algorithm is to minimize the difference between the input and output images while minimizing the processing time.
  *
- * @overload quantize(number_colors = 256, colorspace = Magick::RGBColorsapce, dither = true, tree_depth = 0, measure_error = false)
+ * @overload quantize(number_colors = 256, colorspace = Magick::RGBColorspace, dither = true, tree_depth = 0, measure_error = false)
  *   @param number_colors [Numeric] the maximum number of colors to use in the output images.
  *   @param colorspace [Magick::ColorspaceType] the colorspace to quantize in.
  *   @param dither [Magick::DitherMethod, Boolean] a DitherMethod value or true if you want apply dither.

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -1318,7 +1318,7 @@ Image_background_color(VALUE self)
 
 
 /**
- * Set the the background color to the specified color spec.
+ * Set the background color to the specified color spec.
  *
  * @param color [Magick::Pixel, String] the color
  * @return [Magick::Pixel, String] the given color
@@ -1916,12 +1916,12 @@ special_composite(Image *image, Image *overlay, double image_pct, double overlay
  * @overload blend(overlay, src_percent, dst_percent, gravity = Magick::NorthWestGravity, x_offset = 0, y_offset = 0)
  *   @param overlay [Magick::Image, Magick::ImageList] The source image for the composite operation.
  *     Either an imagelist or an image. If an imagelist, uses the current image.
- *   @param src_percent [Numeric, String] Either a non-negative number a string in the form "NN%".
+ *   @param src_percent [Numeric, String] Either a non-negative number or a string in the form "NN%".
  *     If src_percentage is a number it is interpreted as a percentage.
  *     Both 0.25 and "25%" mean 25%. This argument is required.
- *   @param dst_percent [Numeric, String] Either a non-negative number a string in the form "NN%".
+ *   @param dst_percent [Numeric, String] Either a non-negative number or a string in the form "NN%".
  *     If src_percentage is a number it is interpreted as a percentage.
- *     Both 0.25 and "25%" mean 25%. This argument may omitted if no other arguments follow it.
+ *     Both 0.25 and "25%" mean 25%. This argument may be omitted if no other arguments follow it.
  *     In this case the default is 100%-src_percentage.
  *   @param gravity [Magick::GravityType] the gravity for offset. the offsets are measured from the NorthWest corner by default.
  *   @param x_offset [Numeric] The offset that measured from the left-hand side of the target image.
@@ -2191,7 +2191,7 @@ Image_border_color(VALUE self)
 
 
 /**
- * Set the the border color.
+ * Set the border color.
  *
  * @param [Magick::Pixel, String] color the color
  * @return [Magick::Pixel, String] the given color
@@ -3397,7 +3397,7 @@ Image_columns(VALUE self)
  *   - options.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
  *   - options.lowlight_color = color
- *     - Demphasize pixel differences with this color. The default is partially transparent white.
+ *     - De-emphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
  *   @param metric [Magick::MetricType] The desired distortion metric.
@@ -3417,7 +3417,7 @@ Image_columns(VALUE self)
  *   - options.highlight_color = color
  *     - Emphasize pixel differences with this color. The default is partially transparent red.
  *   - options.lowlight_color = color
- *     - Demphasize pixel differences with this color. The default is partially transparent white.
+ *     - De-emphasize pixel differences with this color. The default is partially transparent white.
  *   @param image [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
  *     imagelist, uses the current image.
  *   @param metric [Magick::MetricType] The desired distortion metric.
@@ -3425,7 +3425,7 @@ Image_columns(VALUE self)
  *   @yield [opt_args]
  *   @yieldparam opt_args [Magick::OptionalMethodArguments]
  *
- * @return [Array] The first element is a difference image, the second is a the value of the
+ * @return [Array] The first element is a difference image, the second is the value of the
  *   computed distortion represented as a Float.
  */
 VALUE
@@ -4671,7 +4671,7 @@ Image_contrast_stretch_channel(int argc, VALUE *argv, VALUE self)
 }
 
 /**
- * Apply a user supplied kernel to the image according to the given mophology method.
+ * Apply a user supplied kernel to the image according to the given morphology method.
  *
  * @param method_v [Magick::MorphologyMethod] the morphology method
  * @param iterations [Numeric] apply the operation this many times (or no change).
@@ -4696,7 +4696,7 @@ Image_morphology(VALUE self, VALUE method_v, VALUE iterations, VALUE kernel_v)
 }
 
 /**
- * Apply a user supplied kernel to the image channel according to the given mophology method.
+ * Apply a user supplied kernel to the image channel according to the given morphology method.
  *
  * @param channel_v [Magick::ChannelType] a channel type
  * @param method_v [Magick::MorphologyMethod] the morphology method
@@ -5867,12 +5867,12 @@ Image_dispose_eq(VALUE self, VALUE dispose)
  * @overload dissolve(overlay, src_percent, dst_percent = -1.0, gravity = Magick::NorthWestGravity, x_offset = 0, y_offset = 0)
  *   @param overlay [Magick::Image, Magick::ImageList] The source image for the composite operation.
  *     Either an imagelist or an image. If an imagelist, uses the current image.
- *   @param src_percent [Numeric, String] Either a non-negative number a string in the form "NN%".
+ *   @param src_percent [Numeric, String] Either a non-negative number or a string in the form "NN%".
  *     If src_percentage is a number it is interpreted as a percentage.
  *     Both 0.25 and "25%" mean 25%. This argument is required.
- *   @param dst_percent [Numeric, String] Either a non-negative number a string in the form "NN%".
+ *   @param dst_percent [Numeric, String] Either a non-negative number or a string in the form "NN%".
  *     If src_percentage is a number it is interpreted as a percentage.
- *     Both 0.25 and "25%" mean 25%. This argument may omitted if no other arguments follow it.
+ *     Both 0.25 and "25%" mean 25%. This argument may be omitted if no other arguments follow it.
  *     In this case the default is 100%-src_percentage.
  *   @param gravity [Magick::GravityType] the gravity for offset. the offsets are measured from the
  *     NorthWest corner by default.
@@ -5952,7 +5952,7 @@ Image_dissolve(int argc, VALUE *argv, VALUE self)
  *       the image (with appropriate viewport changes, or post-distort cropping and resizing).
  *   - options.verbose(true)
  *     - Attempt to output the internal coefficients, and the -fx equivalent to the distortion, for
-         expert study, and debugging purposes. This many not be available for all distorts.
+         expert study, and debugging purposes. This may not be available for all distorts.
  *   @param type [Magick::DistortMethod] a DistortMethod value
  *   @param points [Array<Numeric>] an Array of Numeric values. The size of the array depends on the distortion type.
  *   @param bestfit [Boolean] If bestfit is enabled, and the distortion allows it, the destination
@@ -6158,7 +6158,7 @@ Image__dump(VALUE self, VALUE depth ATTRIBUTE_UNUSED)
 
 
 /**
- * Duplicates a image.
+ * Duplicates an image.
  *
  * @return [Magick::Image] a new image
  */
@@ -7143,7 +7143,7 @@ Image_flip_bang(VALUE self)
 
 
 /**
- * Create a horizonal mirror image by reflecting the pixels around the central y-axis.
+ * Create a horizontal mirror image by reflecting the pixels around the central y-axis.
  *
  * @return [Magick::Image] a new image
  * @see Image#flop!
@@ -7159,7 +7159,7 @@ Image_flop(VALUE self)
 
 
 /**
- * Create a horizonal mirror image by reflecting the pixels around the central y-axis.
+ * Create a horizontal mirror image by reflecting the pixels around the central y-axis.
  * In-place form of {Image#flop}.
  *
  * @return [Magick::Image] self
@@ -8069,7 +8069,7 @@ Image_implode(int argc, VALUE *argv, VALUE self)
  *   @param y [Numeric] The y-offset of the rectangle to be replaced.
  *   @param columns [Numeric] The number of columns in the rectangle.
  *   @param rows [Numeric] The number of rows in the rectangle.
- *   @param map [String] his string reflects the expected ordering of the pixel array.
+ *   @param map [String] This string reflects the expected ordering of the pixel array.
  *   @param pixels [Array] An array of pixels.
  *     The number of pixels in the array must be the same as the number
  *     of pixels in the rectangle, that is, rows*columns.
@@ -8932,7 +8932,7 @@ Image__load(VALUE klass ATTRIBUTE_UNUSED, VALUE str)
 
     blob = rm_str2cstr(str, &length);
 
-    // Must be as least as big as the 1st 4 fields in DumpedImage
+    // Must be at least as big as the 1st 4 fields in DumpedImage
     if (length <= (long)(sizeof(DumpedImage)-MaxTextExtent))
     {
         rb_raise(rb_eTypeError, "image is invalid or corrupted (too short)");
@@ -12809,7 +12809,7 @@ Image_sepiatone(int argc, VALUE *argv, VALUE self)
  *   @param colorspace [Magick::ColorspaceType] A ColorspaceType value. Empirical evidence suggests
  *     that distances in YUV or YIQ correspond to perceptual color differences more closely than do
  *     distances in RGB space. The image is then returned to RGB colorspace after color reduction.
- *   @param cluster_threshold [Numeric] The number of pixels in each cluster must exceed the the
+ *   @param cluster_threshold [Numeric] The number of pixels in each cluster must exceed the
  *     cluster threshold to be considered valid.
  *   @param smoothing_threshold [Numeric] The smoothing threshold eliminates noise in the second
  *     derivative of the histogram. As the value is increased, you can expect a smoother second
@@ -13151,7 +13151,7 @@ Image_sharpen_channel(int argc, VALUE *argv, VALUE self)
  * center.
  *
  * @param width [Numeric] the width to leave
- * @param height [Numeric] the hight to leave
+ * @param height [Numeric] the height to leave
  * @return [Magick::Image] a new image
  * @see Image#shave!
  */
@@ -13169,7 +13169,7 @@ Image_shave(VALUE self, VALUE width, VALUE height)
  * In-place form of {Image#shave}.
  *
  * @param width [Numeric] the width to leave
- * @param height [Numeric] the hight to leave
+ * @param height [Numeric] the height to leave
  * @return [Magick::Image] a new image
  * @see Image#shave
  */
@@ -14547,7 +14547,7 @@ Image_tint(int argc, VALUE *argv, VALUE self)
  * Return a "blob" (a String) from the image.
  *
  * - The magick member of the Image structure determines the format of the
- *   returned blob (GIG, JPEG,  PNG, etc.)
+ *   returned blob (GIF, JPEG,  PNG, etc.)
  *
  * @yield [info]
  * @yieldparam info [Magick::Image::Info]
@@ -14867,7 +14867,7 @@ Image_transparent_color(VALUE self)
 
 
 /**
- * Set the the transparent color to the specified color spec.
+ * Set the transparent color to the specified color spec.
  *
  * @param color [Magick::Pixel, String] the transparent color
  * @return [Magick::Pixel, String] the given color
@@ -15249,13 +15249,13 @@ Image_units_eq(VALUE self, VALUE restype)
 /**
  * Sharpen an image. "amount" is the percentage of the difference between the original and the blur
  * image that is added back into the original. "threshold" is the threshold in pixels needed to
- * apply the diffence amount.
+ * apply the difference amount.
  *
  * No Ruby usage (internal function)
  *
  * @param argc number of input arguments
  * @param argv array of input arguments
- * @param radious the radious
+ * @param radius the radius
  * @param sigma the sigma
  * @param amount the amount
  * @param threshold the threshold
@@ -15295,7 +15295,7 @@ unsharp_mask_args(int argc, VALUE *argv, double *radius, double *sigma,
             break;
 
             // This case can't occur if we're called from Image_unsharp_mask_channel
-            // because it has already raised an exception for the the argc > 4 case.
+            // because it has already raised an exception for the argc > 4 case.
         default:
             rb_raise(rb_eArgError, "wrong number of arguments (%d for 0 to 4)", argc);
     }
@@ -15305,7 +15305,7 @@ unsharp_mask_args(int argc, VALUE *argv, double *radius, double *sigma,
 /**
  * Sharpen an image. "amount" is the percentage of the difference between the original and the blur
  * image that is added back into the original. "threshold" is the threshold in pixels needed to
- * apply the diffence amount.
+ * apply the difference amount.
  *
  * @overload unsharp_mask(radius = 0.0, sigma = 1.0, amount = 1.0, threshold = 0.05)
  *   @param radius [Numeric] The radius of the Gaussian operator.
@@ -15340,7 +15340,7 @@ Image_unsharp_mask(int argc, VALUE *argv, VALUE self)
 /**
  * Sharpen an image. "amount" is the percentage of the difference between the original and the blur
  * image that is added back into the original. "threshold" is the threshold in pixels needed to
- * apply the diffence amount.
+ * apply the difference amount.
  *
  * Only the specified channels are sharpened.
  *
@@ -15518,7 +15518,7 @@ Image_virtual_pixel_method_eq(VALUE self, VALUE method)
  *     25%. The default is 100%.
  *   @param x_off [Numeric] The offset of the watermark, measured from the left-hand side of the
  *     target image.
- *   @param y_off [Numeri] The offset of the watermark, measured from the top of the target image.
+ *   @param y_off [Numeric] The offset of the watermark, measured from the top of the target image.
  *
  * @overload watermark(mark, brightness, saturation, gravity, x_off = 0, y_off = 0)
  *   @param mark [Magick::Image, Magick::ImageList] Either an imagelist or an image. If an
@@ -15535,7 +15535,7 @@ Image_virtual_pixel_method_eq(VALUE self, VALUE method)
  *     NorthWest corner by default.
  *   @param x_off [Numeric] The offset of the watermark, measured from the left-hand side of the
  *     target image.
- *   @param y_off [Numeri] The offset of the watermark, measured from the top of the target image.
+ *   @param y_off [Numeric] The offset of the watermark, measured from the top of the target image.
  *
  * @return [Magick::Image] a new image
  */

--- a/ext/RMagick/rminfo.cpp
+++ b/ext/RMagick/rminfo.cpp
@@ -1936,7 +1936,7 @@ Info_server_name_eq(VALUE self, VALUE server_arg)
 }
 
 /**
- * Get ths size
+ * Get the size
  *
  * @return [String] the size as a Geometry object
  * @see https://www.imagemagick.org/Magick++/Geometry.html
@@ -2374,7 +2374,7 @@ Info_alloc(VALUE klass)
 
 
 /**
- * Provide a Info.new method for internal use.
+ * Provide an Info.new method for internal use.
  *
  * No Ruby usage (internal function)
  *

--- a/ext/RMagick/rmkinfo.cpp
+++ b/ext/RMagick/rmkinfo.cpp
@@ -194,7 +194,7 @@ KernelInfo_scale_geometry(VALUE self, VALUE geometry)
 }
 
 /**
- * Creates a new clone of the object so that its can be modified without effecting the original.
+ * Creates a new clone of the object so that it can be modified without affecting the original.
  *
  * @return [Magick::KernelInfo] new KernelInfo object
  */

--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -120,7 +120,7 @@ rm_aligned_malloc_size(void *ptr)
 #elif defined(HAVE_MALLOC_SIZE)
     return malloc_size(ptr);
 #elif defined(HAVE__ALIGNED_MSIZE)
-// Refered to https://github.com/ImageMagick/ImageMagick/blob/master/MagickCore/memory-private.h
+// Referred to https://github.com/ImageMagick/ImageMagick/blob/master/MagickCore/memory-private.h
 #define MAGICKCORE_SIZEOF_VOID_P 8
 #define CACHE_LINE_SIZE  (8 * MAGICKCORE_SIZEOF_VOID_P)
     size_t _aligned_msize(void *memblock, size_t alignment, size_t offset);
@@ -1812,7 +1812,7 @@ test_Magick_version(void)
 
     /* ImageMagick versions are defined as major, minor and patch, each of which are defined as a value in 1 byte. */
     /* ImageMagick 6.9.12 has `#define MagickLibVersion  0x69C` */
-    /* It use only major and minor versions. */
+    /* It uses only major and minor versions. */
     size_t mask_major_minor_version = 0xFFFFFFF0;
 
     version_str = GetMagickVersion(&version_number);

--- a/ext/RMagick/rmmontage.cpp
+++ b/ext/RMagick/rmmontage.cpp
@@ -23,7 +23,7 @@ const rb_data_type_t rm_montage_data_type = {
 
 
 /**
- * Destory the MontageInfo struct and free the Montage struct.
+ * Destroy the MontageInfo struct and free the Montage struct.
  *
  * No Ruby usage (internal function)
  *

--- a/ext/RMagick/rmpixel.cpp
+++ b/ext/RMagick/rmpixel.cpp
@@ -463,7 +463,7 @@ Color_to_Pixel(Pixel *pp, VALUE color)
  * No Ruby usage (internal function)
  *
  * @param color the PixelColor to modify
- * @param name_arg the coor name
+ * @param name_arg the color name
  * @throw ArgumentError
  */
 static void
@@ -666,14 +666,14 @@ Pixel_fcmp(int argc, VALUE *argv, VALUE self)
 
 
 /**
- * Construct an {Magick::Pixel} corresponding to the given color name.
+ * Construct a {Magick::Pixel} corresponding to the given color name.
  *
  * - The "inverse" is {Image#to_color}, b/c the conversion of a pixel to a
  *   color name requires both a color depth and if the opacity value has
  *   meaning.
  *
  * @param name [String] the color name
- * @return [Magick::Pixel] a new Magic::Pixel object
+ * @return [Magick::Pixel] a new Magick::Pixel object
  * @see Magick::Image#to_color
  * @see Magick::Pixel#to_color
  */
@@ -1009,7 +1009,7 @@ Pixel_intensity(VALUE self)
 /**
  * Support Marshal.dump.
  *
- * @return [Hash] a representing the dumped pixel
+ * @return [Hash] a Hash representing the dumped pixel
  */
 VALUE
 Pixel_marshal_dump(VALUE self)

--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -509,7 +509,7 @@ rm_fuzz_to_dbl(VALUE fuzz_arg)
 
 
 /**
- * Convert a application-supplied number to a Quantum. If the object is a Float,
+ * Convert an application-supplied number to a Quantum. If the object is a Float,
  * truncate it before converting.
  *
  * No Ruby usage (internal function)
@@ -706,7 +706,7 @@ rm_set_magickpixel(MagickPixel *pp, const char *color)
  * No Ruby usage (internal function)
  *
  * Notes:
- *   - The `temp_name' argument must point to an char array of size
+ *   - The `temp_name' argument must point to a char array of size
  *     MaxTextExtent.
  *
  * @param image the image
@@ -785,7 +785,7 @@ rm_delete_temp_image(char *temp_name)
  *   - This funky technique allows me to safely add additional information to
  *     the ImageMagickError object in both 1.6.8 and 1.8.0.
  *
- * @param msg the error mesage
+ * @param msg the error message
  * @throw ImageMagickError
  * @see www.ruby_talk.org/36408.
  */
@@ -1487,7 +1487,7 @@ rm_clone_image(Image *image)
 
 
 /**
- * Remove the ImageMagick links between images in an scene sequence.
+ * Remove the ImageMagick links between images in a scene sequence.
  *
  * No Ruby usage (internal function)
  *
@@ -1573,7 +1573,7 @@ rm_check_image_exception(Image *imglist, ErrorRetention retention)
  * @param severity information about the severity of the error
  * @param reason the reason for the error
  * @param description description of the error
- * @param msg the buffer where the exception message should be formated in
+ * @param msg the buffer where the exception message should be formatted in
  */
 static void
 format_exception(const ExceptionType severity, const char *reason, const char *description, char *msg)
@@ -1629,7 +1629,7 @@ rm_warning_handler(const ExceptionType severity, const char *reason, const char 
 
 
 /**
- * Called from ImageMagick for a error.
+ * Called from ImageMagick for an error.
  *
  * No Ruby usage (internal function)
  *

--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -151,7 +151,7 @@ module Magick
   end
 
   class Draw
-    # Thse hashes are used to map Magick constant
+    # These hashes are used to map Magick constant
     # values to the strings used in the primitives.
     ALIGN_TYPE_NAMES = {
       LeftAlign.to_i => 'left',
@@ -799,7 +799,7 @@ module Magick
     def color_reset!(fill)
       save = background_color
       # Change the background color _outside_ the begin block
-      # so that if this object is frozen the exeception will be
+      # so that if this object is frozen the exception will be
       # raised before we have to handle it explicitly.
       self.background_color = fill
       begin

--- a/lib/rvg/stylable.rb
+++ b/lib/rvg/stylable.rb
@@ -80,10 +80,10 @@ module Magick
       # the hash keys. The style names and values are:
       # [:baseline_shift] modify the text baseline
       # [:clip_path] clipping path defined by clip_path
-      # [:clip_rule] 'evenodd' or 'nozero'
+      # [:clip_rule] 'evenodd' or 'nonzero'
       # [:fill] color name
       # [:fill_opacity] the fill opacity, 0.0<=N<=1.0
-      # [:fill_rule] 'evenodd' or 'nozero'
+      # [:fill_rule] 'evenodd' or 'nonzero'
       # [:font] font name or font file name
       # [:font_family] font family name, ex. 'serif'
       # [:font_size] font size in points


### PR DESCRIPTION
## Summary

Fixes spelling typos and grammatical errors found **only inside comments** under `ext/` and `lib/`. Comment text only — no code was changed (verified: every changed line is inside a C++ `/** */`/`//` comment or a Ruby `#` comment).

15 files changed, 69 in-place word fixes.

## What changed

**Spelling**
`Quntum`→`Quantum` (×2), `midle`→`middle`, `mesage`→`message`, `formated`→`formatted`, `Refered`→`Referred`, `Destory`→`Destroy`, `coor`→`color`, `Magic`→`Magick`, `emtpy`→`empty`, `RGBColorsapce`→`RGBColorspace`, `aruments`→`arguments`, `mophology`→`morphology` (×2), `horizonal`→`horizontal` (×2), `diffence`→`difference` (×3), `hight`→`height` (×2), `GIG`→`GIF`, `Numeri`→`Numeric` (×2), `radious`→`radius`, `Thse`→`These`, `exeception`→`exception`, `nozero`→`nonzero` (×2), `Demphasize`→`De-emphasize` (×2).

**Articles (a/an)**
`a application`→`an`, `an char`→`a char`, `an scene`→`a scene`, `a error`→`an error`, `an Draw`→`a Draw` (×2), `a image`→`an image` (×3), `a Info`→`an Info`, `an RenderingIntent`→`a`, `a enumerator`→`an`, `an {Magick::Pixel}`→`a`.

**Grammar / duplicated / missing words**
`the the` (×5), `number a string`→`number or a string` (×4), `may omitted`→`may be omitted` (×2), `a the value`→`the value`, `its ... effecting`→`it ... affecting`, `many not`→`may not`, `his string`→`This string`, `except is has`→`except it has`, `It use`→`It uses`, `does not recognizes ... it revert`→`recognize ... reverts`, `a representing`→`a Hash representing`, `as least`→`at least`, `value..new.`→`value.`, `theVirtualPixelMethod`→`the VirtualPixelMethod`, `the another enum`→`the other enum`.

## Not addressed (need a decision — comment content, not a plain typo)

- `ext/RMagick/rmimage.cpp` (artifact function doc): "**Associates makes** a copy of the given string arguments and inserts it into the artifact tree." — two consecutive verbs; the intended wording is unclear.
- `lib/rvg/embellishable.rb` (RVG::Image#initialize): "Use the `RVG::ImageConstructors#image` method to create **Text** objects in a container." — looks like a copy-paste error ("Text" should be "Image"), but it is a semantic change rather than a spelling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
