### PR TITLE
Fix Magick#set_log_event_mask()

### DIFF
--- a/ext/RMagick/rmagick.cpp
+++ b/ext/RMagick/rmagick.cpp
@@ -349,20 +349,42 @@ Magick_set_cache_threshold(VALUE klass, VALUE threshold)
  * Multiple events can be specified as the aruments. Event names may be capitalized.
  *
  * @param args [String] the mask of log event.
+ * @raise [ArgumentError] if an event name is invalid
  */
 VALUE
 Magick_set_log_event_mask(int argc, VALUE *argv, VALUE klass)
 {
+    VALUE events;
     int x;
 
     if (argc == 0)
     {
         rb_raise(rb_eArgError, "wrong number of arguments (at least 1 required)");
     }
+
+    // SetLogEventMask() does not provide a way to check if it failed
+    // since it returns the old mask.
     for (x = 0; x < argc; x++)
     {
-        SetLogEventMask(StringValueCStr(argv[x]));
+        const char *event = StringValueCStr(argv[x]);
+        if (ParseCommandOption(MagickLogEventOptions, MagickTrue, event) == -1)
+        {
+            rb_raise(rb_eArgError, "invalid log event type: %s", event);
+        }
     }
+
+    // SetLogEventMask() replaces the mask on each call rather than adding to it,
+    // so multiple events must be passed as a single comma-separated list.
+    events = rb_str_dup(argv[0]);
+    for (x = 1; x < argc; x++)
+    {
+        rb_str_cat_cstr(events, ",");
+        rb_str_append(events, argv[x]);
+    }
+    SetLogEventMask(StringValueCStr(events));
+
+    RB_GC_GUARD(events);
+
     return klass;
 }
 

--- a/ext/RMagick/rmagick.cpp
+++ b/ext/RMagick/rmagick.cpp
@@ -346,9 +346,9 @@ Magick_set_cache_threshold(VALUE klass, VALUE threshold)
  * - "user"
  * - "x11"
  *
- * Multiple events can be specified as the aruments. Event names may be capitalized.
+ * Multiple events can be specified as the arguments. Event names may be capitalized.
  *
- * @param args [String] the mask of log event.
+ * @param args [Array<String>] one or more log event types (comma-separated lists and/or multiple arguments).
  * @raise [ArgumentError] if an event name is invalid
  */
 VALUE

--- a/spec/rmagick/class_methods/set_log_event_mask_spec.rb
+++ b/spec/rmagick/class_methods/set_log_event_mask_spec.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe Magick, '.set_log_event_mask' do
+  after { described_class.set_log_event_mask('None') }
+
   it 'works' do
     expect { described_class.set_log_event_mask('Module,Coder') }.not_to raise_error
+    expect { described_class.set_log_event_mask('Cache', 'Blob') }.not_to raise_error
     expect { described_class.set_log_event_mask('None') }.not_to raise_error
+  end
+
+  it 'raises an error when an event name is invalid' do
+    expect { described_class.set_log_event_mask('Bogus') }.to raise_error(ArgumentError, 'invalid log event type: Bogus')
+    expect { described_class.set_log_event_mask('Cache,Bogus') }.to raise_error(ArgumentError, 'invalid log event type: Cache,Bogus')
+    expect { described_class.set_log_event_mask('Cache', 'Bogus') }.to raise_error(ArgumentError, 'invalid log event type: Bogus')
   end
 end


### PR DESCRIPTION
There are two issues with this implementation:
1) A typo in the argument to SetLogEventMask() will not signal to the
   caller that it failed. This is because the function returns the old
   mask and no exception info. The solution is to replicate its own
   internal parsing in a loop before the call.
2) Multiple SetLogEventMask() calls after one another just override the
   previous mask instead of OR-ing the mask. Given the current loop,
   this seems unintended. To solve this we concatenate the arguments
   ourselves into a comma-separated list.


This was detected with a hybrid static-dynamic analyser I'm developing.