### PR TITLE
Reject embedded NUL bytes in pathname arguments

### DIFF
--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -1163,6 +1163,7 @@ extern VALUE  rm_check_ary_type(VALUE ary);
 extern Image *rm_check_destroyed(VALUE);
 extern Image *rm_check_frozen(VALUE);
 extern char  *rm_str2cstr(VALUE, size_t *);
+extern char  *rm_path2cstr(VALUE, size_t *);
 extern int    rm_check_num2dbl(VALUE);
 extern double rm_fuzz_to_dbl(VALUE);
 extern Quantum rm_app2quantum(VALUE);

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -11598,7 +11598,7 @@ rd_image(VALUE klass ATTRIBUTE_UNUSED, VALUE file, gvl_function_t fp)
         // Convert arg to string. If an exception occurs raise an error condition.
         file = rb_rescue(RESCUE_FUNC(rb_String), file, RESCUE_EXCEPTION_HANDLER_FUNC(file_arg_rescue), file);
 
-        filename = rm_str2cstr(file, &filename_l);
+        filename = rm_path2cstr(file, &filename_l);
         filename_l = min(filename_l, MaxTextExtent-1);
         if (filename_l == 0)
         {
@@ -15887,7 +15887,7 @@ void add_format_prefix(Info *info, VALUE file)
     }
     file = rb_rescue(RESCUE_FUNC(rb_String), file, RESCUE_EXCEPTION_HANDLER_FUNC(file_arg_rescue), file);
 
-    filename = rm_str2cstr(file, &filename_l);
+    filename = rm_path2cstr(file, &filename_l);
 
     if (*info->magick == '\0')
     {

--- a/ext/RMagick/rmutil.cpp
+++ b/ext/RMagick/rmutil.cpp
@@ -339,6 +339,36 @@ rm_str2cstr(VALUE str, size_t *len)
 
 
 /**
+ * Same as rm_str2cstr, but for arguments that name a file. Use this one for a
+ * pathname and rm_str2cstr for a blob.
+ *
+ * ImageMagick keeps a pathname in a fixed-size buffer and reads it back as a
+ * NUL-terminated C string, so a NUL byte in the middle of the argument would
+ * cut the pathname short and the file opened or created would not be the one
+ * the caller named. Ruby's own file methods reject such a pathname; going
+ * through StringValueCStr makes these do the same.
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param str the Ruby string
+ * @param len pointer to a size_t in which to store the number of characters
+ * @return a C string version of str
+ * @throw ArgumentError if str contains a NUL byte
+ */
+char *
+rm_path2cstr(VALUE str, size_t *len)
+{
+    char *path = StringValueCStr(str);
+
+    if (len)
+    {
+        *len = (size_t)RSTRING_LEN(str);
+    }
+    return path;
+}
+
+
+/**
  * Called when `rb_str_to_str' raises an exception.
  *
  * No Ruby usage (internal function)

--- a/spec/rmagick/image/ping_spec.rb
+++ b/spec/rmagick/image/ping_spec.rb
@@ -11,4 +11,8 @@ RSpec.describe Magick::Image, '#ping' do
     expect(image.rows).to eq 120
     expect(image.filename).to match(/Button_0.gif/)
   end
+
+  it 'raises an error when the filename contains a null byte' do
+    expect { described_class.ping("#{IMAGES_DIR}/Button_0.gif\0.png") }.to raise_error(ArgumentError)
+  end
 end

--- a/spec/rmagick/image/read_spec.rb
+++ b/spec/rmagick/image/read_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Magick::Image, '#read' do
     end
   end
 
+  it 'raises an error when the filename contains a null byte' do
+    expect { described_class.read("#{IMAGES_DIR}/Button_0.gif\0.png") }.to raise_error(ArgumentError)
+  end
+
   it 'sync Image::Info' do
     result = described_class.read(IMAGES_DIR + '/Button_0.gif') do |options|
       options.colorspace = Magick::LabColorspace

--- a/spec/rmagick/image/write_spec.rb
+++ b/spec/rmagick/image/write_spec.rb
@@ -65,4 +65,16 @@ RSpec.describe Magick::Image, '#write' do
     expect(image2.first.format).to eq('JPEG')
     FileUtils.rm('test.0')
   end
+
+  it 'raises an error when the filename contains a null byte' do
+    image = described_class.new(20, 20)
+    image.format = 'PNG'
+
+    Dir.mktmpdir do |dir|
+      truncated = File.join(dir, 'temp.php')
+
+      expect { image.write("#{truncated}\0.png") }.to raise_error(ArgumentError)
+      expect(File.exist?(truncated)).to be(false)
+    end
+  end
 end

--- a/spec/rmagick/image_list/write_spec.rb
+++ b/spec/rmagick/image_list/write_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe Magick::ImageList, "#write" do
     FileUtils.rm('test.0')
   end
 
+  it "raises an error when the filename contains a null byte" do
+    image_list = described_class.new
+    image_list.read(IMAGES_DIR + '/Button_0.gif')
+
+    Dir.mktmpdir do |dir|
+      truncated = File.join(dir, 'temp.php')
+
+      expect { image_list.write("#{truncated}\0.gif") }.to raise_error(ArgumentError)
+      expect(File.exist?(truncated)).to be(false)
+    end
+  end
+
   it "issue #1375" do
     # https://commons.wikimedia.org/wiki/File:Animhorse.gif
     image_list = described_class.new(File.join(FIXTURE_PATH, 'animhorse.gif'))


### PR DESCRIPTION
## Summary

`Image.read`, `Image.ping`, `Image#write` and `ImageList#write` accept a pathname containing an embedded NUL byte and silently truncate the path there, so the file actually opened or created is not the one the caller named. Ruby's own file methods raise `ArgumentError: path name contains null byte` rather than truncate; these entry points should behave the same way.

## The cause

All four entry points convert their pathname argument with `rm_str2cstr()`, which is deliberately binary-safe — it returns `RSTRING_PTR` with the byte length and never looks for a NUL. The bytes are then `memcpy`'d into `info->filename`, which ImageMagick reads back as a C string, so everything after the NUL is discarded.

- `rd_image()` — `ext/RMagick/rmimage.cpp:11601`
- `add_format_prefix()` — `ext/RMagick/rmimage.cpp:15890` (reached from `Image#write` and `ImageList#write`)

`add_format_prefix()` does call `FilePathStringValue()`, which would have rejected the NUL, but only for objects that respond to `#path` — and a String does not.

## The fix

Add `rm_path2cstr()` alongside `rm_str2cstr()` and use it for pathname arguments. It converts through Ruby's public `StringValueCStr()`, so a NUL byte raises `ArgumentError` before the bytes reach `info->filename`.

Blob arguments keep `rm_str2cstr()`, and that distinction is the point of the change. `rm_str2cstr()` is used at 23 sites, five of which take genuine binary data where NUL bytes are normal — `set_profile()`, `Image_from_blob()`, `Image_import_pixels()`, `Image__load()` and `Image_read_inline()`. Tightening `rm_str2cstr()` itself instead was tried and breaks 12 examples across `from_blob`, `to_blob`, `profile!`, `color_profile`, `import_pixels`, `export_pixels` and `Marshal`, since a PNG contains a NUL in its first eight bytes.

## Testing

Four specs are added, one per entry point. All four fail on the unpatched build and pass with the change.

- `bundle exec rspec` — 800 examples, 0 failures
- `bundle exec rubocop` — 843 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

## Compatibility

The only inputs whose behaviour changes are pathnames containing a NUL byte, which previously produced a silently different file and now raise `ArgumentError` — the same class and the same reason as `File.open`. Blob APIs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
