### PR TITLE
Fix SEGV in Info#stroke_width= and Info#attenuate= with a large Float

### DIFF
--- a/ext/RMagick/rminfo.cpp
+++ b/ext/RMagick/rminfo.cpp
@@ -199,7 +199,15 @@ static VALUE set_dbl_option(VALUE self, const char *option, VALUE value)
         {
             len = snprintf(buff, sizeof(buff), "%-10.2f", d);
         }
-        memset(buff+len, '\0', sizeof(buff)-len);
+        if (len < 0)
+        {
+            len = 0;
+        }
+        else if ((size_t)len > sizeof(buff) - 1)
+        {
+            len = (int)(sizeof(buff) - 1);
+        }
+        memset(buff+len, '\0', sizeof(buff)-(size_t)len);
         SetImageOption(info, option, buff);
     }
 

--- a/spec/rmagick/image/info/attenuate_spec.rb
+++ b/spec/rmagick/image/info/attenuate_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe Magick::Image::Info, '#attenuate' do
     expect { info.attenuate = nil }.not_to raise_error
     expect(info.attenuate).to be(nil)
   end
+
+  it 'accepts a value whose formatted form is longer than the internal buffer' do
+    info = described_class.new
+
+    [1e47, 1e300, Float::MAX].each do |value|
+      expect { info.attenuate = value }.not_to raise_error
+    end
+  end
 end

--- a/spec/rmagick/image/info/stroke_width_spec.rb
+++ b/spec/rmagick/image/info/stroke_width_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe Magick::Image::Info, '#stroke_width' do
     expect(info.stroke_width).to be(nil)
     expect { info.stroke_width = 'xxx' }.to raise_error(TypeError)
   end
+
+  it 'accepts a value whose formatted form is longer than the internal buffer' do
+    info = described_class.new
+
+    # "%-10.2f" of these needs more than the 50-byte buffer, so snprintf
+    # returns a length greater than the buffer size.
+    [1e47, 1e300, Float::MAX].each do |value|
+      expect { info.stroke_width = value }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Info#stroke_width=` and `Info#attenuate=` crash the process when given a large Float. `set_dbl_option()` uses `snprintf`'s return value as both a pointer offset and the subtrahend of an unsigned length, but that return value is the number of bytes the result *would* have needed, not the number written.

## The cause

`ext/RMagick/rminfo.cpp:202`

```c
char buff[50];
...
len = snprintf(buff, sizeof(buff), "%-10.2f", d);
memset(buff+len, '\0', sizeof(buff)-len);
```

`"%-10.2f"` of `1e47` needs 51 bytes. `snprintf` writes 49 plus the terminator and returns 51, so the `memset` receives a destination of `buff+51` — already past the end of the 50-byte stack buffer — and a length of `sizeof(buff) - 51`, which as a `size_t` wraps to near `SIZE_MAX`. `snprintf` can also return a negative value on error, which would offset the pointer backwards.

Reproduced on `130d1531`:

```ruby
info = Magick::Image::Info.new
info.stroke_width = 1e47
# [BUG] Segmentation fault at 0x0000000000000000
```

## The fix

Clamp the length into the range actually written before the `memset` uses it, so `buff+len` stays inside `buff` and `sizeof(buff)-len` cannot underflow.

## Testing

Regression cases are added to the existing `stroke_width` and `attenuate` specs, covering `1e47`, `1e300` and `Float::MAX`. Each of them segfaults the process on an unpatched build.

- `bundle exec rspec` — 802 examples, 0 failures
- `bundle exec rubocop` — 842 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
