### PR TITLE
Fix double free of the annotation text in Draw#annotate

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -892,6 +892,7 @@ VALUE Draw_annotate(
         if (draw->info->text)
         {
             magick_free(draw->info->text);
+            draw->info->text = NULL;
         }
         rm_raise_exception(exception);
     }

--- a/spec/rmagick/draw/annotate_spec.rb
+++ b/spec/rmagick/draw/annotate_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe Magick::Draw, '#annotate' do
       end
     end.not_to raise_error
   end
+
+  it 'does not free the annotation text twice when the text raises an exception' do
+    image = Magick::Image.new(10, 10)
+
+    expect do
+      described_class.new.annotate(image, 0, 0, 0, 20, '%[fx:(]')
+    end.to raise_error(Magick::ImageMagickError)
+
+    # The Draw object is garbage now. Reclaiming it must not free the
+    # annotation text a second time.
+    GC.start
+  end
 end


### PR DESCRIPTION
## Summary

`Draw#annotate` frees `draw->info->text` on its error branch but leaves the dangling pointer in the `DrawInfo`, so the same block is freed again when the `Draw` object is reclaimed. Rescuing the raised `Magick::ImageMagickError` and letting the object go out of scope aborts the interpreter at the next GC.

## The cause

`ext/RMagick/rmdraw.cpp:889` (ImageMagick 7 path)

```c
draw->info->text = InterpretImageProperties(NULL, image, embed_text, exception);
if (rm_should_raise_exception(exception, RetainExceptionRetention))
{
    if (draw->info->text)
    {
        magick_free(draw->info->text);
    }
    rm_raise_exception(exception);
}
```

`rm_raise_exception()` never returns, so the field is never cleared. `Draw_destroy()` → `DestroyDrawInfo()` then frees it a second time. The success path at `:936-937` already does `magick_free()` followed by `= NULL`; only this branch is missing it.

Reproduced on `300169e6`:

```ruby
image = Magick::Image.new(10, 10)
begin
  Magick::Draw.new.annotate(image, 0, 0, 0, 20, '%[fx:(]')
rescue StandardError
end
GC.start
# corrupted size vs. prev_size while consolidating
# <internal:gc>:44: [BUG] Aborted
```

`InterpretImageProperties()` returns an interpreted string *and* records an error-severity exception for a malformed FX expression, which is what takes this branch.

## The fix

Clear the field right after the free, mirroring the success path.

## Testing

A regression spec is added to `spec/rmagick/draw/annotate_spec.rb`. On an unpatched build it does not report a failure — it takes the whole run down with `[BUG] Segmentation fault` at the `GC.start`, which is the signal.

- `bundle exec rspec` — 803 examples, 0 failures
- `bundle exec rubocop` — 842 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
