### PR TITLE
Fix double free of the interpreted text in Draw#get_type_metrics

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -1668,6 +1668,7 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
         if (draw->info->text)
         {
             magick_free(draw->info->text);
+            draw->info->text = NULL;
         }
         rm_raise_exception(exception);
     }

--- a/spec/rmagick/draw/get_type_metrics_spec.rb
+++ b/spec/rmagick/draw/get_type_metrics_spec.rb
@@ -21,4 +21,20 @@ RSpec.describe Magick::Draw, '#get_type_metrics' do
     image_list.new_image(10, 10)
     expect { draw.get_type_metrics(image_list, 'ABCDEF') }.not_to raise_error
   end
+
+  it 'does not free the interpreted text twice when the text cannot be interpreted' do
+    image = Magick::Image.new(10, 10)
+
+    %i[get_type_metrics get_multiline_type_metrics].each do |method_name|
+      described_class.new.public_send(method_name, image, '%[fx:(]')
+    rescue StandardError
+      # ImageMagick 6 and 7 differ in whether they report this as an error.
+    end
+
+    # The Draw objects are garbage now. Reclaiming them must not free the
+    # interpreted text a second time.
+    GC.start
+
+    expect(described_class.new.get_type_metrics(image, 'ABCDEF')).to be_kind_of(Magick::TypeMetric)
+  end
 end


### PR DESCRIPTION
## Summary

The same defect as #1829, in the helper that backs both `Draw#get_type_metrics` and `Draw#get_multiline_type_metrics`. The error branch frees `draw->info->text` but leaves the dangling pointer in the `DrawInfo`, so the same block is freed again when the `Draw` object is reclaimed.

## The cause

`ext/RMagick/rmdraw.cpp:1665` (ImageMagick 7 path)

```c
draw->info->text = InterpretImageProperties(NULL, image, text, exception);
if (rm_should_raise_exception(exception, RetainExceptionRetention))
{
    if (draw->info->text)
    {
        magick_free(draw->info->text);
    }
    rm_raise_exception(exception);
}
```

`rm_raise_exception()` never returns, so the field is never cleared. `Draw_destroy()` → `DestroyDrawInfo()` then frees it a second time. The normal path at `:1692-1693` in the same function already does `magick_free()` followed by `= NULL`.

Reproduced on `e238c8bf`:

```ruby
image = Magick::Image.new(10, 10)
%i[get_type_metrics get_multiline_type_metrics].each do |m|
  begin
    Magick::Draw.new.public_send(m, image, '%[fx:(]')
  rescue StandardError
  end
end
GC.start
# double free or corruption (!prev)
# <internal:gc>:44: [BUG] Aborted
```

Both entry points reach the same branch, since they share this one static helper.

## The fix

Clear the field right after the free, mirroring the cleanup further down the same function.

## Testing

A regression spec is added to `spec/rmagick/draw/get_type_metrics_spec.rb`, covering both entry points. On an unpatched build it does not report a failure — it takes the whole run down with `[BUG] Aborted` at the `GC.start`, which is the signal.

- `bundle exec rspec` — 804 examples, 0 failures
- `bundle exec rubocop` — 842 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
