### PR TITLE
Fix SEGV in Draw#marshal_load with a non-String pattern

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -500,6 +500,8 @@ Image *str_to_image(VALUE str)
         Info *info;
         ExceptionInfo *exception;
 
+        StringValue(str);
+
         info = CloneImageInfo(NULL);
         exception = AcquireExceptionInfo();
         GVL_STRUCT_TYPE(BlobToImage) args = { info, RSTRING_PTR(str), (size_t)RSTRING_LEN(str), exception };

--- a/spec/rmagick/draw/marshal_load_spec.rb
+++ b/spec/rmagick/draw/marshal_load_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe Magick::Draw, '#marshal_load' do
     expect { draw.marshal_load(nil) }.to raise_error(TypeError)
     expect { draw.marshal_load([]) }.to raise_error(TypeError)
   end
+
+  # Regression: a non-String pattern used to be reinterpreted as a String, so
+  # its buffer pointer and length were read from unrelated object fields and
+  # handed to BlobToImage. It must raise TypeError instead.
+  it 'raises TypeError for a pattern that is not a String' do
+    dumped = described_class.new.marshal_dump
+
+    [0, :symbol, [1, 'x'], {}].each do |value|
+      expect { described_class.new.marshal_load(dumped.merge(fill_pattern: value)) }.to raise_error(TypeError)
+      expect { described_class.new.marshal_load(dumped.merge(stroke_pattern: value)) }.to raise_error(TypeError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`str_to_image()` applies `RSTRING_PTR`/`RSTRING_LEN` to the `:fill_pattern` and `:stroke_pattern` values of the Hash given to `Draw#marshal_load`, having checked only that they are not `nil`. A value that is not a String is therefore reinterpreted as one.

```ruby
h = Magick::Draw.new.marshal_dump
Magick::Draw.allocate.marshal_load(h.merge(fill_pattern: 12345))
# [BUG] Segmentation fault at 0x0000000000006074
```

A Symbol crashes the same way. An `Array` does not crash but reaches `BlobToImage` with a pointer and length taken from the array's own fields.

## The cause

`ext/RMagick/rmdraw.cpp:505`

```c
if (str != Qnil)
{
    ...
    GVL_STRUCT_TYPE(BlobToImage) args = { info, RSTRING_PTR(str), (size_t)RSTRING_LEN(str), exception };
```

In a release build `RSTRING_PTR`/`RSTRING_LEN` are unchecked casts — the type assertion is compiled out — so the buffer pointer and length are read from whatever fields happen to sit at those offsets. An immediate dereferences an invalid address; a heap object yields an arbitrary pointer plus a length the caller influences, and `BlobToImage` reads that many bytes from it.

This is reachable from `Marshal.load` on untrusted bytes: Ruby reconstructs a `Magick::Draw` by calling `Draw.allocate` and then `#marshal_load` with the payload's Hash, so every value in it is attacker-chosen. `Image_marshal_load` already guards against the same shape with `Check_Type` and `StringValue`; this path does not.

## The fix

Convert with `StringValue()` before dereferencing, so a non-String raises `TypeError`.

## Testing

A regression case is added to `spec/rmagick/draw/marshal_load_spec.rb`, next to the existing non-Hash-argument regression, covering both pattern keys with an Integer, a Symbol, an Array and a Hash. On an unpatched build it takes the whole run down with `[BUG] Segmentation fault`.

- `bundle exec rspec` — 806 examples, 0 failures
- `bundle exec rubocop` — 842 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
