### PR TITLE
Fix heap over-read in Image#recolor

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -11685,7 +11685,7 @@ Image_recolor(VALUE self, VALUE color_matrix)
         }
     }
 
-    order = (unsigned long)sqrt((double)(len + 1.0));
+    order = (unsigned long)sqrt((double)len);
 
     exception = AcquireExceptionInfo();
 #if defined(IMAGEMAGICK_7)

--- a/spec/rmagick/image/recolor_spec.rb
+++ b/spec/rmagick/image/recolor_spec.rb
@@ -8,4 +8,15 @@ RSpec.describe Magick::Image, '#recolor' do
     expect { image.recolor('x') }.to raise_error(TypeError)
     expect { image.recolor([1, 1, 'x', 1]) }.to raise_error(TypeError)
   end
+
+  # Regression: the matrix order used to be derived from `len + 1`, so an array
+  # one element short of a perfect square produced a kernel that read past the
+  # end of the allocation and mixed the adjacent heap contents into the result.
+  it 'uses only as much of the matrix as forms a square' do
+    image = described_class.new(4, 4) { |options| options.background_color = 'red' }
+    matrix = [0.9, 0.1, 0.0, 0.0, 0.8, 0.2, 0.1, 0.0]
+
+    expect(image.recolor(matrix).export_pixels).to eq(image.recolor(matrix[0, 4]).export_pixels)
+    expect { image.recolor([]) }.not_to raise_error
+  end
 end


### PR DESCRIPTION
## Summary

`Image#recolor` allocates one `double` per element of the caller's array but sizes the kernel from `sqrt(len + 1.0)`. Whenever `len + 1` is a perfect square — 0, 3, 8, 15, 24, 35, … — the kernel claims `order * order == len + 1` elements while the buffer holds only `len`, and `ColorMatrixImage()` reads 8 bytes past the end of the allocation.

```
Invalid read of size 8
   at ColorMatrixImage (in libMagickCore-7.Q16HDRI.so)
   by Image_recolor (rmimage.cpp:11716)
 Address 0x26ddacd0 is 0 bytes after a block of size 64 alloc'd
   by Image_recolor (rmimage.cpp:11672)
```

That is valgrind on `img.recolor(Array.new(8) { 0.5 })` against `ab52ece1`: 8 elements × 8 bytes = the 64-byte block, read one qword past the end.

The qword that is read becomes the last coefficient of the colour transform, so it reaches every output pixel. It is observable: recolouring with an 8-element array produced *exactly* the result of a 9-element one whose last value had just been freed — the stale heap contents came back out in the image.

| array | result before | result after |
| --- | --- | --- |
| 4 elements (2×2) | `a2515b442ee36c5a` | `a2515b442ee36c5a` |
| 9 elements (3×3) | `5329a85194a9dcc7` | `5329a85194a9dcc7` |
| 16 elements (4×4) | `b2a752783dee1872` | `b2a752783dee1872` |
| 8 elements | `5329a85194a9dcc7` ← the freed 9th value | `a2515b442ee36c5a` |

## The cause

`ext/RMagick/rmimage.cpp:11688`

```c
len = RARRAY_LEN(color_matrix);
matrix = ALLOC_N(double, len);
...
order = (unsigned long)sqrt((double)(len + 1.0));
...
kernel_info->width  = order;
kernel_info->height = order;
kernel_info->values = (double *) matrix;
```

## The fix

Drop the `+ 1.0`. It was presumably guarding against `sqrt()` rounding down, but IEEE 754 `sqrt` is correctly rounded and the values involved are exactly representable, so `sqrt(9.0)` is exactly `3.0`.

| len | 0 | 3 | 4 | 8 | 9 | 15 | 16 | 24 | 25 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| order before | 1 ✗ | 2 ✗ | 2 | 3 ✗ | 3 | 4 ✗ | 4 | 5 ✗ | 5 |
| order after | 0 | 1 | 2 | 2 | 3 | 3 | 4 | 4 | 5 |

Every square matrix keeps the order it had, so no valid call changes behaviour; a non-square array is truncated to the largest square that fits, which is what the buffer actually holds. Rejecting non-square arrays outright was the other option, but that would newly raise on lengths such as 5 or 6 that work today.

## Testing

A regression case is added to `spec/rmagick/image/recolor_spec.rb`; it fails on an unpatched build. Valgrind reports zero invalid reads for lengths 0, 3, 8 and 24 after the change, against one before.

- `bundle exec rspec` — 807 examples, 0 failures
- `bundle exec rubocop` — 842 files, 0 offenses
- `bundle exec rake rbs:validate` — clean
- `bundle exec steep check` — no type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
