### PR TITLE
Fix heap over-read in Image#import_pixels with a long or empty map

### DIFF
--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -8122,7 +8122,11 @@ Image_import_pixels(int argc, VALUE *argv, VALUE self)
         rb_raise(rb_eArgError, "invalid import geometry");
     }
 
-    map_l = rm_strnlen_s(map, MaxTextExtent);
+    map_l = strlen(map);
+    if (map_l == 0)
+    {
+        rb_raise(rb_eArgError, "map must not be empty");
+    }
     npixels = pixel_buffer_count((size_t)cols, (size_t)rows, map_l);
 
     // Assume that any object that responds to :to_str is a string buffer containing

--- a/spec/rmagick/image/import_pixels_spec.rb
+++ b/spec/rmagick/image/import_pixels_spec.rb
@@ -50,6 +50,25 @@ RSpec.describe Magick::Image, '#import_pixels' do
     expect { image.import_pixels(0, 0, 2**62, 1, 'RGBA', '') }.to raise_error(RangeError)
   end
 
+  # Regression: the map length was measured with rm_strnlen_s(map, MaxTextExtent),
+  # capping it at 4096, while ImageMagick walks the map with the real strlen() for
+  # every pixel. A longer map therefore under-counted the buffer and
+  # ImportImagePixels read past its end.
+  it 'measures the map with its real length' do
+    image = described_class.new(10, 10)
+    map = 'R' * 8192 # longer than MaxTextExtent
+
+    expect { image.import_pixels(0, 0, 10, 10, map, "\0".b * (10 * 10 * 4096)) }.to raise_error(ArgumentError)
+    expect { image.import_pixels(0, 0, 10, 10, map, "\0".b * (10 * 10 * 8192)) }.not_to raise_error
+  end
+
+  # Regression: an empty map made map_l zero, and the buffer checks divided by it.
+  it 'raises ArgumentError given an empty map' do
+    image = described_class.new(10, 10)
+
+    expect { image.import_pixels(0, 0, 2, 2, '', '') }.to raise_error(ArgumentError, /map must not be empty/)
+  end
+
   it 'raises an error given UndefinedPixel' do
     image = described_class.new(20, 20)
     pixels = image.export_pixels(0, 0, 20, 20, 'RGB').pack('D*')


### PR DESCRIPTION
`Image#import_pixels` measured the pixel map with `rm_strnlen_s(map, MaxTextExtent)`, capping it at 4096, while MagickCore's `ImportImagePixels` walks the map with the real `strlen(map)` for every pixel.

```c
map = StringValueCStr(argv[4]);
...
map_l = rm_strnlen_s(map, MaxTextExtent);   // capped at 4096
npixels = pixel_buffer_count(cols, rows, map_l);
```

`npixels` is what the buffer-size check validates against, so it under-counted the bytes ImageMagick would consume from the caller's Ruby String (or `ALLOC_N` buffer). The extra channels were read past the end of the allocation and stored into the image's pixels, where they are readable via `Image#export_pixels` / `Image#to_blob`.

## Reproducer

```ruby
img = Magick::Image.new(100, 100)
img.import_pixels(0, 0, 100, 100, 'RGB' * 2048, "\0".b * (100 * 100 * 4096))
p img.export_pixels(0, 0, 100, 100, 'RGB').count { |v| v != 0 }
```

RMagick computed `map_l = 4096` (truncated from 6144), so the 40 MB buffer passed the size check while `ImportImagePixels` consumed 100 * 100 * 6144 = 61,440,000 bytes.

Before — the buffer is entirely zero, yet 6612 of 30000 exported channels carry non-zero data that can only have come from beyond its end:

```
map length          = 6144
RMagick counts      = 40960000
ImageMagick consumes= 61440000
buffer bytes        = 40960000
survived import
non-zero channels out of 30000: 6612
```

valgrind confirms the over-read:

```
==184178== Invalid read of size 1
==184178==    at 0x239AD823: ??? (in /usr/lib/libMagickCore-7.Q16HDRI.so.10.0.3)
==184178==    by 0x239B71B5: ImportImagePixels (in /usr/lib/libMagickCore-7.Q16HDRI.so.10.0.3)
==184178==    by 0x23795D0E: ImportImagePixels_gvl(void*) (rmimage.cpp:146)
==184178==    by 0x4BE736A: rb_nogvl (thread.c:1628)
==184178==    by 0x2379CDE7: Image_import_pixels (rmimage.cpp:8237)
```

After — `ArgumentError: pixel buffer too small (need 61440000 channel values, got 40960000)`, and valgrind reports no invalid access.

## Empty map

An empty map was worse. `map_l` became zero, and both the buffer path and the array path divide by it:

```c
if ((buffer_l / type_sz) % map_l != 0)      { ... }
if (RARRAY_LEN(pixel_ary) % map_l != 0)     { ... }
```

so this killed the process outright with SIGFPE:

```ruby
Magick::Image.new(4, 4).import_pixels(0, 0, 2, 2, '', '')   # exit 136
```

It now raises `ArgumentError: map must not be empty`.

## The fix

Measure the map with `strlen()`, which is exact here because `StringValueCStr()` has already guaranteed the string is NUL-terminated and free of embedded NULs — the same thing `Image#export_pixels` and `Image#export_pixels_to_str` already do — and reject an empty map before dividing by its length.

A map longer than `MaxTextExtent` now requires a correspondingly larger buffer; one that is correctly sized still imports exactly as before:

```
map=8192, buffer sized for 4096  -> ArgumentError: pixel buffer too small (need 819200 channel values, got 409600)
map=8192, buffer sized for 8192  -> OK Magick::Image
map=6144 ('RGB' * 2048), correct -> OK Magick::Image
```

## Verification

- The reproducer above: silent heap disclosure -> `ArgumentError`; valgrind clean.
- The SIGFPE reproducer: `exit 136` -> `ArgumentError`.
- `bundle exec rspec` — 810 examples, 0 failures.
- `bundle exec rubocop` — 842 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.
- Normal string/array/float imports and every `RGB`/`RGBA`/`I` map behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
