### PR TITLE
Fix memory leak in ImageList#composite_layers with an unusable source list

### DIFF
--- a/ext/RMagick/rmilist.cpp
+++ b/ext/RMagick/rmilist.cpp
@@ -11,8 +11,16 @@
 
 #include "rmagick.h"
 
+struct ImagesFromImageList_Args
+{
+    VALUE imagelist;
+    VALUE *clones;
+    Image *images;
+};
+
 static Image *clone_imagelist(Image *);
 static Image *images_from_imagelist(VALUE, VALUE *);
+static VALUE images_from_imagelist_protected(VALUE);
 static long imagelist_length(VALUE);
 static long check_imagelist_length(VALUE);
 static void imagelist_push(VALUE, VALUE);
@@ -351,13 +359,23 @@ ImageList_composite_layers(int argc, VALUE *argv, VALUE self)
     }
 
     // Convert ImageLists to image sequences.
-    VALUE clones;
+    VALUE clones, source_clones = Qnil;
     dest = images_from_imagelist(self, &clones);
     new_images = clone_imagelist(dest);
     rm_split(dest);
     RB_GC_GUARD(clones);
 
-    source = images_from_imagelist(source_images, &clones);
+    // new_images is not owned by any Ruby object yet, so resolving the source
+    // list has to be able to unwind without abandoning it.
+    struct ImagesFromImageList_Args source_args = { source_images, &source_clones, NULL };
+    int state = 0;
+    rb_protect(images_from_imagelist_protected, (VALUE)&source_args, &state);
+    if (state)
+    {
+        DestroyImageList(new_images);
+        rb_jump_tag(state);
+    }
+    source = source_args.images;
 
     SetGeometry(new_images, &geometry);
     ParseAbsoluteGeometry(new_images->geometry, &geometry);
@@ -372,7 +390,7 @@ ImageList_composite_layers(int argc, VALUE *argv, VALUE self)
     GVL_STRUCT_TYPE(CompositeLayers) args = { new_images, composite_op, source, geometry.x, geometry.y, exception };
     CALL_FUNC_WITHOUT_GVL(GVL_FUNC(CompositeLayers), &args);
     rm_split(source);
-    RB_GC_GUARD(clones);
+    RB_GC_GUARD(source_clones);
     rm_check_exception(exception, new_images, DestroyOnError);
     DestroyExceptionInfo(exception);
 
@@ -863,6 +881,26 @@ images_from_imagelist(VALUE imagelist, VALUE *clones)
     RB_GC_GUARD(t);
 
     return head;
+}
+
+
+/**
+ * Call images_from_imagelist() so that it can be passed to rb_protect().
+ *
+ * No Ruby usage (internal function)
+ *
+ * @param arg a pointer to an ImagesFromImageList_Args, cast to a VALUE
+ * @return nil, the result is stored in the argument
+ * @see images_from_imagelist
+ */
+static VALUE
+images_from_imagelist_protected(VALUE arg)
+{
+    struct ImagesFromImageList_Args *args = (struct ImagesFromImageList_Args *)arg;
+
+    args->images = images_from_imagelist(args->imagelist, args->clones);
+
+    return Qnil;
 }
 
 

--- a/spec/rmagick/image_list/composite_layers_spec.rb
+++ b/spec/rmagick/image_list/composite_layers_spec.rb
@@ -17,4 +17,20 @@ RSpec.describe Magick::ImageList, '#composite_layers' do
 
     expect { image_list.composite_layers(image_list2, Magick::ModulusAddCompositeOp, 42) }.to raise_error(ArgumentError)
   end
+
+  # The receiver is deep-copied with clone_imagelist() before the source list is
+  # resolved, and the copy is owned by no Ruby object, so every one of these has
+  # to release it on the way out.
+  it 'raises given a source list it cannot use' do
+    image_list = described_class.new
+    image_list << Magick::Image.new(20, 20)
+
+    destroyed = described_class.new
+    destroyed << Magick::Image.new(20, 20)
+    destroyed.first.destroy!
+
+    expect { image_list.composite_layers(described_class.new) }.to raise_error(ArgumentError)
+    expect { image_list.composite_layers('x') }.to raise_error(Magick::ImageMagickError)
+    expect { image_list.composite_layers(destroyed) }.to raise_error(Magick::DestroyedImageError)
+  end
 end


### PR DESCRIPTION
`ImageList_composite_layers()` deep-copies every frame of the receiver with `clone_imagelist()` **before** it resolves the source argument:

```c
dest = images_from_imagelist(self, &clones);
new_images = clone_imagelist(dest);        // raw Image list, owned by nothing
rm_split(dest);
RB_GC_GUARD(clones);

source = images_from_imagelist(source_images, &clones);   // raises
```

`new_images` is a raw `Image *` list that no Ruby object owns, and the very next call raises for a caller-supplied argument that is an empty list, is not an `ImageList`, or holds a destroyed image. The longjmp skips every path that would have called `DestroyImageList()`, so the copy is abandoned.

## Reproducer

```ruby
list  = Magick::ImageList.new
3.times { list << Magick::Image.new(600, 600) }
empty = Magick::ImageList.new
loop { list.composite_layers(empty) rescue nil }   # ArgumentError: no images in this image list
```

RSS before the fix, measured from `/proc/self/status`:

```
frames=3  base RSS = 41604 kB
after  50 more failed calls: RSS = 45652 kB  (+4048 kB)
after 100 more failed calls: RSS = 53916 kB  (+12312 kB)
after 200 more failed calls: RSS = 70448 kB  (+28848 kB)
```

Linear and unbounded — roughly 27 kB per frame per call, and independent of the pixel dimensions (a 20x20 list leaks as fast as a 600x600 one), so it is the `Image` structs rather than the pixel cache. The growth is outside Ruby's GC accounting, so nothing bounds it.

valgrind attributes the blocks directly:

```
==201105== 214,896 (131,072 direct, 83,824 indirect) bytes ... are definitely lost
==201105==    by 0x23957C55: CloneImage (in libMagickCore-7.Q16HDRI.so.10.0.3)
==201105==    by 0x237924DD: clone_imagelist(_Image*) (rmilist.cpp:953)
==201105==    by 0x2379356C: ImageList_composite_layers (rmilist.cpp:356)
```

After the fix, the same loop is flat (`+0 kB` over 200 calls on each of the three failure paths) and no leak record mentions `clone_imagelist` or `ImageList_composite_layers`; `definitely lost` drops by exactly the 10 blocks the 10-iteration valgrind run had leaked.

## The fix

Resolve the source list through `rb_protect()` and destroy the clone before re-raising. `rb_protect` is already used elsewhere in the extension (`rmimage.cpp:1767`, `rminfo.cpp:803`).

### Why not just reorder the two calls

Moving `images_from_imagelist(source_images)` above `clone_imagelist()` is a smaller diff, but it is not safe: it leaves both lists linked at the same time. When the two ImageLists share an `Image` — which the **existing spec does**, building `image_list2` out of `image_list[5..9]` — the second call sees `GetPreviousImageInList(image) != NULL` for the trailing frames and clones them, and `AppendImageToList()` then walks to the tail of the *receiver's* chain and splices the clone onto it. The destination list silently grows a frame.

The chosen fix does not touch the success path at all: the frames are linked and split in exactly the same order as before.

## Verification

- The reproducer above: `+28848 kB` over 350 rescued calls -> `+0 kB`; valgrind clean for this call path.
- All three failure paths (empty list, non-ImageList, destroyed frame) keep their exception class and message: `ArgumentError: no images in this image list`, `Magick::ImageMagickError: @images is not of type Array`, `Magick::DestroyedImageError: destroyed image`.
- Success paths unchanged: 3x1 frames, 1x3 frames (which grows the result to 3 — `CompositeLayers` appends to the destination list), explicit `composite_op`, receiver as its own source, and two lists sharing one `Image`.
- `bundle exec rspec` — 811 examples, 0 failures.
- `bundle exec rubocop` — 842 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.

The added spec covers the three unwind paths; it is **not** a leak detector. An RSS-based regression test was tried and dropped: `/proc/self/status` is Linux-only, and even there it did not discriminate, because by the time it runs the suite has already freed enough memory that the leaked 16 MB is satisfied from the allocator's existing pool without RSS moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
