### PR TITLE
Fix arbitrary file read in Draw#annotate with text starting with '@'

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -835,6 +835,46 @@ Draw_undercolor_eq(VALUE self, VALUE undercolor)
 
 
 /**
+ * Expand the property and percent-escape references in text to be drawn.
+ *
+ * No Ruby usage (internal function)
+ *
+ * Notes:
+ *   - InterpretImageProperties() treats text whose first non-blank character is
+ *     '@' as the name of a file to read the text from. The argument is
+ *     documented as the text to draw, so draw it as-is instead.
+ *
+ * @param image the image
+ * @param text the text to draw
+ * @return the interpreted text, to be freed by the caller with magick_free()
+ */
+static char *
+interpret_text(Image *image, const char *text
+#if defined(IMAGEMAGICK_7)
+               , ExceptionInfo *exception
+#endif
+              )
+{
+    const char *p = text;
+
+    while (isspace((int) ((unsigned char) *p)))
+    {
+        p++;
+    }
+    if (*p == '@')
+    {
+        return ConstantString(text);
+    }
+
+#if defined(IMAGEMAGICK_7)
+    return InterpretImageProperties(NULL, image, text, exception);
+#else
+    return InterpretImageProperties(NULL, image, text);
+#endif
+}
+
+
+/**
  * Annotates an image with text.
  *
  * - Additional Draw attribute methods may be called in the optional block,
@@ -888,7 +928,7 @@ VALUE Draw_annotate(
     embed_text = StringValueCStr(text);
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
-    draw->info->text = InterpretImageProperties(NULL, image, embed_text, exception);
+    draw->info->text = interpret_text(image, embed_text, exception);
     if (rm_should_raise_exception(exception, RetainExceptionRetention))
     {
         if (draw->info->text)
@@ -899,7 +939,7 @@ VALUE Draw_annotate(
         rm_raise_exception(exception);
     }
 #else
-    draw->info->text = InterpretImageProperties(NULL, image, embed_text);
+    draw->info->text = interpret_text(image, embed_text);
 #endif
     if (!draw->info->text)
     {
@@ -1664,7 +1704,7 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
     draw = get_draw(self);
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
-    draw->info->text = InterpretImageProperties(NULL, image, text, exception);
+    draw->info->text = interpret_text(image, text, exception);
     if (rm_should_raise_exception(exception, RetainExceptionRetention))
     {
         if (draw->info->text)
@@ -1675,7 +1715,7 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
         rm_raise_exception(exception);
     }
 #else
-    draw->info->text = InterpretImageProperties(NULL, image, text);
+    draw->info->text = interpret_text(image, text);
 #endif
     if (!draw->info->text)
     {

--- a/spec/rmagick/draw/annotate_spec.rb
+++ b/spec/rmagick/draw/annotate_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe Magick::Draw, '#annotate' do
   it 'works' do
     draw = described_class.new
@@ -32,6 +34,38 @@ RSpec.describe Magick::Draw, '#annotate' do
       yield_obj = draw2
     end
     expect(yield_obj).to be_instance_of(described_class)
+  end
+
+  # Regression: the text was handed to InterpretImageProperties(), which reads
+  # the annotation text out of the named file when the first non-blank character
+  # is '@'. Caller-supplied text was therefore an arbitrary local file read whose
+  # contents were rasterized into the image.
+  it 'draws text starting with @ instead of the contents of that file' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'canary.txt')
+      File.write(path, 'SECRET')
+
+      draw = described_class.new
+      draw.pointsize = 12
+
+      rendered = lambda do |text|
+        image = Magick::Image.new(300, 40) { |options| options.background_color = 'white' }
+        described_class.new.tap { |d| d.pointsize = 12 }.annotate(image, 0, 0, 0, 20, text)
+        image.export_pixels(0, 0, 300, 40, 'I')
+      end
+
+      expect(rendered.call("@#{path}")).not_to eq(rendered.call('SECRET'))
+      expect(draw.get_type_metrics(Magick::Image.new(10, 10), "@#{path}").width)
+        .not_to eq(draw.get_type_metrics(Magick::Image.new(10, 10), 'SECRET').width)
+    end
+  end
+
+  it 'still expands percent escapes' do
+    image = Magick::Image.new(123, 10)
+    draw = described_class.new
+
+    expect(draw.get_type_metrics(image, '%[width]').width)
+      .to eq(draw.get_type_metrics(image, '123').width)
   end
 
   it 'accepts an ImageList argument' do


### PR DESCRIPTION
`Draw#annotate` and `Draw#get_type_metrics` hand the caller's text to `InterpretImageProperties()`:

```c
embed_text = StringValueCStr(text);
draw->info->text = InterpretImageProperties(NULL, image, embed_text, exception);
```

That function treats a string whose first non-blank character is `'@'` as **the name of a file to read the text from**. Text supplied to a parameter documented as `@param text [String] the annotation text` is therefore an arbitrary local file read whose contents are rasterized into the returned image.

## Reproducer

```ruby
img  = Magick::Image.new(800, 400) { |o| o.background_color = 'white' }
draw = Magick::Draw.new
draw.pointsize = 12

caption = '@/etc/passwd'          # or @config/master.key, @.env, @~/.aws/credentials

img.annotate(draw, 0, 0, 10, 20, caption)
img.write('out.png')              # out.png contains the file
```

Rendering `@<path>` and rendering the file's contents directly produce **byte-identical pixels**:

```
annotate("@canary.txt")        = c28d4dc0f164e629761f09be542027c1
annotate("SECRET-CANARY-12345") = c28d4dc0f164e629761f09be542027c1   <- the file's contents
annotate("@<nonexistent>")     = 934d30e28cf54e3babcf4441525e3342
```

`Draw#get_type_metrics` takes the same route (`rmdraw.cpp:1707`/`:1718`), so the file is read there too — `get_type_metrics(img, "@canary.txt").width` returned the width of `SECRET-CANARY-12345`, not of the string that was passed.

ImageMagick ships the policy that would block this commented out:

```
/etc/ImageMagick-7/policy.xml:144:  <!-- <policy domain="path" rights="none" pattern="@*"/> -->
```

## The fix

Which of the two behaviours you get today depends on whether the path happens to exist on the server: `"@Hello world"` is drawn as text because no such file is there, while `"@/etc/passwd"` is replaced by its contents. Draw the string as-is in both cases, which is what the parameter is documented to mean.

```c
static char *
interpret_text(Image *image, const char *text, ExceptionInfo *exception)
{
    const char *p = text;

    while (isspace((int) ((unsigned char) *p)))
    {
        p++;
    }
    if (*p == '@')
    {
        return ConstantString(text);
    }

    return InterpretImageProperties(NULL, image, text, exception);
}
```

`ConstantString()` is what `InterpretImageProperties()` itself returns for the trivial cases, so the memory contract at the call sites (`magick_free`/`DestroyString`) is unchanged.

### Why draw it rather than raise

Text starting with `'@'` is ordinary input. `"@username"` is a normal caption, and this repository already has a spec asserting that such text is accepted:

```ruby
# spec/rmagick/draw/annotate_spec.rb:24
it 'works with string started with @ (issue 38)' do
  expect { draw.annotate(image, 0, 0, 0, 20, '@Hello world') }.not_to raise_error
```

Raising would break those callers. Drawing the string makes the behaviour uniform instead of dependent on the server's filesystem, and the existing spec passes unchanged.

| input | before | after |
| --- | --- | --- |
| `@Hello world` | drawn as text | drawn as text |
| `@username` | drawn as text | drawn as text |
| `@/etc/passwd` | **file contents drawn** | drawn as text |
| `%[width]`, `%[fx:...]` | expanded | expanded |

## Verification

- The reproducer above: pixel-identical to the file's contents -> the literal string; `get_type_metrics` likewise.
- Percent escapes still expand — `get_type_metrics(Magick::Image.new(123, 10), '%[width]').width` equals the width of `'123'`.
- The added regression spec fails on `main` (`expected: value != [...] got: [...]`) and passes with this change.
- `bundle exec rspec` — 813 examples, 0 failures.
- `bundle exec rubocop` — 842 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.

This closes three findings from the same line: the arbitrary file read, the template-injection framing of the same call, and the info-disclosure framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
