### PR TITLE
Fix MVG injection in Draw#text from unescaped backslashes

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -612,7 +612,10 @@ module Magick
     def text(x, y, text)
       text = to_string(text)
       Kernel.raise ArgumentError, 'missing text argument' if text.empty?
-      if text.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(text)
+      # escape existing backslashes, so that they cannot escape the delimiter
+      # added below and let the rest of the string be parsed as MVG
+      text = text.gsub('\\') { |b| '\\' + b }
+      if text.length > 2 && /\A(?:"[^"\\]+"|'[^'\\]+'|\{[^}\\]+\})\z/.match(text)
       # text already quoted
       elsif !text['\'']
         text = '\'' + text + '\''

--- a/spec/rmagick/draw/text_spec.rb
+++ b/spec/rmagick/draw/text_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe Magick::Draw, '#text' do
   it 'works' do
     draw = described_class.new
@@ -32,5 +34,49 @@ RSpec.describe Magick::Draw, '#text' do
     expect { draw.text(50, 50, '') }.to raise_error(ArgumentError)
     expect { draw.text('x', 50, 'Hello world') }.to raise_error(ArgumentError)
     expect { draw.text(50, 'x', 'Hello world') }.to raise_error(ArgumentError)
+  end
+
+  it 'escapes backslashes in the text' do
+    draw = described_class.new
+    draw.text(50, 50, 'Hello\\')
+    expect(draw.inspect).to eq("text 50,50 'Hello\\\\'")
+
+    draw = described_class.new
+    draw.text(50, 50, "Hello 'world\\")
+    expect(draw.inspect).to eq("text 50,50 \"Hello 'world\\\\\"")
+
+    draw = described_class.new
+    draw.text(50, 50, "Hello '\"world\\}")
+    expect(draw.inspect).to eq("text 50,50 {Hello '\"world\\\\\\}}")
+  end
+
+  # Regression: the text was wrapped in quotes without escaping backslashes, so
+  # ImageMagick's tokenizer read a backslash before the closing delimiter as an
+  # escape, the token ran on, and the rest of the primitive list was parsed as
+  # MVG. The injected `image` primitive then read an arbitrary file into the
+  # rendered output.
+  it 'does not let the text break out of the MVG token' do
+    Dir.mktmpdir do |dir|
+      secret = File.join(dir, 'secret.png')
+      Magick::Image.new(60, 60) { |options| options.background_color = 'red' }.write(secret)
+
+      drew_secret = lambda do |*texts|
+        image = Magick::Image.new(200, 100) { |options| options.background_color = 'white' }
+        draw = described_class.new
+        texts.each_with_index { |text, i| draw.text(0, 10 + (i * 20), text) }
+        draw.draw(image)
+        image.export_pixels(0, 0, 200, 100, 'RGB').each_slice(3)
+             .any? { |red, green, blue| red > 50_000 && green < 15_000 && blue < 15_000 }
+      end
+
+      primitive = %(image Over 0,0 0,0 "#{secret}")
+
+      # A trailing backslash escaped the closing quote.
+      expect(drew_secret.call('hello\\', primitive)).to be(false)
+      # Such a string also matched the "text already quoted" fast path.
+      expect(drew_secret.call("'hello\\'", primitive)).to be(false)
+      # In the brace branch, \} closed the token early.
+      expect(drew_secret.call(%(x'"\\} #{primitive}\n#))).to be(false)
+    end
   end
 end


### PR DESCRIPTION
`Draw#text` wraps the caller's text in quotes but never escapes backslashes:

```ruby
if text.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(text)
# text already quoted
elsif !text['\'']
  text = '\'' + text + '\''
...
```

ImageMagick's tokenizer treats a backslash before the closing delimiter — or before another backslash — as an escape (`MagickCore/token.c`), so text ending in `\` swallows the delimiter, the token runs on, and the rest of the primitive list is parsed as MVG and executed by `DrawImage()`.

## Reproducer

```ruby
img  = Magick::Image.new(200, 100) { |o| o.background_color = 'white' }
draw = Magick::Draw.new
draw.text(0, 10, "hello\\")                            # user-supplied caption 1
draw.text(0, 30, %(image Over 0,0 0,0 "#{secret}"))    # user-supplied caption 2
draw.draw(img)
```

```
MVG: text 0,10 'hello\'
     text 0,30 'image Over 0,0 0,0 "/tmp/.../secret.png"'
```

`\'` is read as an escaped apostrophe, so the first token runs to the apostrophe that opens the second one; everything after it — `image Over 0,0 0,0 "..."` — is parsed as a primitive and executed. The `image` primitive reads an arbitrary local file into the rendered output.

Verified by writing a 60x60 red sentinel PNG and counting its pixels in the result. **Three** of the four branches are reachable:

| branch | payload | red pixels before | after |
| --- | --- | --- | --- |
| unquoted (`'…'`) | `hello\` | 3721 | 0 |
| brace (`{…}`) | `x'"\} image Over … ` + `\n#` | 3721 | 0 |
| "text already quoted" | `'hello\'` | 3721 | 0 |

The third one is worth calling out: `/\A'[^']+'\z/` matches `'hello\'`, so a string that merely *looks* pre-quoted was handed to MVG untouched. That path is reachable from ordinary user input, not just from a caller that deliberately pre-quotes.

## The fix

Escape backslashes before choosing a delimiter, and stop treating text that contains a backslash as already quoted.

```ruby
text = text.gsub('\\') { |b| '\\' + b }
if text.length > 2 && /\A(?:"[^"\\]+"|'[^'\\]+'|\{[^}\\]+\})\z/.match(text)
```

Escaping first is equivalent to escaping inside each branch: the delimiter choice only inspects `'`, `"`, `{` and `}`, which escaping neither adds nor removes, and a string containing a backslash can never match the tightened "already quoted" pattern either way.

## Behaviour

Rendered 18 strings through `Draw#text` + `Draw#draw` and compared the pixels before and after:

- the 14 without a backslash are **byte-identical**;
- of the 4 with one, `C:\path\to\file`, `quoted with backslash '\'` and `brace and backslash \}` are **also byte-identical** — a backslash that is not before the delimiter in use was never an escape, so ImageMagick already drew it literally;
- only `trailing backslash\` changes, and only because it used to escape the closing delimiter instead of being drawn.

```
"C:\\path\\to\\file"         | 0e421d662a59 -> 0e421d662a59 | text 5,20 'C:\path\to\file'   -> 'C:\\path\\to\\file'
"trailing backslash\\"       | 8ce61d0f642f -> e4c164e6dec3 | text 5,20 'trailing backslash\' -> 'trailing backslash\\'
"quoted with backslash '\\'" | 8f1f4b32e6a1 -> 8f1f4b32e6a1
"brace and backslash \\}"    | 24b5fde37096 -> 24b5fde37096
```

The existing spec's five quoting cases are unchanged; none of them contains a backslash.

## Verification

- Both added specs fail on `main` and pass with this change.
- `bundle exec rspec` — 815 examples, 0 failures.
- `bundle exec rubocop` — 842 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.

`Magick::RVG::Utility::TextStrategy#enquote` in `lib/rvg/misc.rb` has the same defect and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
