### PR TITLE
Fix MVG injection from unvalidated RVG::Path data

### DIFF
--- a/lib/rvg/embellishable.rb
+++ b/lib/rvg/embellishable.rb
@@ -66,8 +66,15 @@ module Magick
       # Use the RVG::ShapeConstructors#path method to create Path objects in a container.
       def initialize(path)
         super()
+        path = path.to_s
+        # SVG path data is command letters, numbers, commas and whitespace only.
+        # Anything else could close the MVG token that Draw#path wraps this in
+        # and have the rest of the string executed as further MVG primitives.
+        invalid = path[/[^MmZzLlHhVvCcSsQqTtAa0-9eE.,+\-\s]/]
+        raise ArgumentError, "invalid character in path data (#{invalid.inspect} given)" if invalid
+
         @primitive = :path
-        @args = [path.to_s]
+        @args = [path]
       end
     end # class Path
 

--- a/spec/rmagick/rvg/path_spec.rb
+++ b/spec/rmagick/rvg/path_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe Magick::RVG::Path do
+  it 'accepts SVG path data' do
+    path_data = Magick::RVG::PathData.new
+    path_data.moveto(true, 0, 0)
+    path_data.arc(true, 1, 2, 3, 1, 0, 4, 5)
+    path_data.closepath
+
+    expect(described_class.new(path_data)).to be_instance_of(described_class)
+    expect { described_class.new('M0,0 L10,10 C1,2 3,4 5,6 Z') }.not_to raise_error
+    expect { described_class.new('M1e+20,-1e-20 h1.5 v-2') }.not_to raise_error
+    expect { described_class.new("M0,0\n\tL1,1") }.not_to raise_error
+    expect { described_class.new('') }.not_to raise_error
+  end
+
+  # Regression: the path string was stored unvalidated, and Draw#path wraps it in
+  # double quotes without escaping, so a '"' in the path closed the MVG token and
+  # the rest of the string was executed as further MVG primitives -- including
+  # `image`, which reads an arbitrary file into the rendered output.
+  it 'rejects characters outside the SVG path grammar' do
+    ['M0,0" image Over 0,0 1,1 "/etc/passwd', "M0,0' x", 'M0,0} x', 'M0,0\\ x'].each do |path|
+      expect { described_class.new(path) }.to raise_error(ArgumentError, /invalid character in path data/)
+    end
+  end
+
+  it 'rejects injected path data given to RVG#path' do
+    expect do
+      Magick::RVG.new(200, 200) do |canvas|
+        canvas.background_fill = 'white'
+        canvas.path('M0,0" image Over 0,0 80,80 "/etc/passwd')
+      end
+    end.to raise_error(ArgumentError, /invalid character in path data/)
+  end
+end


### PR DESCRIPTION
`RVG::Path#initialize` stores the caller's path argument with no validation:

```ruby
def initialize(path)
  super()
  @primitive = :path
  @args = [path.to_s]
end
```

`Magick::Draw#path` then builds the MVG program with `primitive "path #{enquote(cmds)}"`, and `Draw#enquote` only wraps the string in double quotes — it never escapes an embedded `"`. So a quote in the path data closes the token and the remainder is parsed by ImageMagick as further MVG primitives and executed by `DrawImage()`.

## Reproducer

```ruby
rvg = Magick::RVG.new(200, 200) do |canvas|
  canvas.background_fill = 'white'
  canvas.path(%(M0,0" image Over 0,0 80,80 "#{secret}))   # user-submitted <path d="...">
end
rvg.draw
```

```
MVG: path "M0,0" image Over 0,0 80,80 "/tmp/.../secret.png"
```

The `image` primitive runs and composites the named file into the canvas. Verified with an 80x80 red sentinel image and a pixel count of the result:

```
RVG::Path 経由の赤ピクセル数: 6561  <= 注入成立
```

After this change the path is rejected before any MVG is built, and the count is zero. A local path can be swapped for a URL, which makes ImageMagick fetch it server-side.

## The fix

SVG path data is command letters, numbers, commas and whitespace and nothing else, so reject anything outside that grammar in `Path#initialize`:

```ruby
path = path.to_s
invalid = path[/[^MmZzLlHhVvCcSsQqTtAa0-9eE.,+\-\s]/]
raise ArgumentError, "invalid character in path data (#{invalid.inspect} given)" if invalid
```

Raising `ArgumentError` matches how the neighbouring shapes already reject bad input (`Circle`: `"radius must be >= 0"`, `Rect`: `"width, height must be >= 0"`). The message names the offending character rather than echoing the whole string.

## Behaviour

| input | result |
| --- | --- |
| `M0,0 L10,10 C1,2 3,4 5,6 Z` | accepted |
| `M1e+20,-1e-20 h1.5 v-2` | accepted |
| `M0,0\n\tL1,1`, `''` | accepted |
| `PathData` output, all commands | accepted |
| `M0,0" image Over …` | `ArgumentError: invalid character in path data ("\"" given)` |
| `M0,0' x` / `M0,0} x` / `M0,0\ x` | `ArgumentError` |

Checked against the shipped examples: every `.path` argument across the **191 scripts in `doc/ex/`** — string literals and heredocs — is inside the grammar.

The one non-attack input that is newly rejected is a `PathData` holding an infinite or NaN coordinate: `sprintf('%g')` renders those as `Inf` / `NaN`, which was never valid path data and could not be drawn anyway.

## Scope

This closes the RVG entry point. `Magick::Draw#path` called directly is still injectable, because `Draw#enquote` (`lib/rmagick_internal.rb:218`) still wraps without escaping — that is a separate fix.

## Verification

- The reproducer above: 6561 sentinel pixels -> the call raises.
- Both added specs fail on `main` and pass with this change.
- `bundle exec rspec` — 818 examples, 0 failures.
- `bundle exec rubocop` — 843 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
