### PR TITLE
Fix RVG text being quoted twice and the added quotes being drawn

### DIFF
--- a/lib/rvg/misc.rb
+++ b/lib/rvg/misc.rb
@@ -74,25 +74,6 @@ module Magick
           @ctx.shadow.affine = @ctx.text_attrs.affine
         end
 
-        def enquote(text)
-          return text if text.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(text)
-
-          if !text['\'']
-            text = '\'' + text + '\''
-            return text
-          elsif !text['"']
-            text = '"' + text + '"'
-            return text
-          elsif !(text['{'] || text['}'])
-            text = '{' + text + '}'
-            return text
-          end
-
-          # escape existing braces, surround with braces
-          text.gsub!(/[}]/) { |b| '\\' + b }
-          '{' + text + '}'
-        end
-
         def glyph_metrics(glyph_orientation, glyph)
           gm = @ctx.shadow.get_type_metrics('a' + glyph + 'a')
           gm2 = @ctx.shadow.get_type_metrics('aa')
@@ -151,13 +132,13 @@ module Magick
 
         def render_glyph(glyph_orientation, x, y, glyph)
           if glyph_orientation.zero?
-            @ctx.gc.text(x, y, enquote(glyph))
+            @ctx.gc.text(x, y, glyph)
           else
             @ctx.gc.push
             @ctx.gc.translate(x, y)
             @ctx.gc.rotate(glyph_orientation)
             @ctx.gc.translate(-x, -y)
-            @ctx.gc.text(x, y, enquote(glyph))
+            @ctx.gc.text(x, y, glyph)
             @ctx.gc.pop
           end
         end
@@ -295,7 +276,7 @@ module Magick
       # Handle "easy" text
       class DefaultTextStrategy < TextStrategy
         def render(x, y, text)
-          @ctx.gc.text(x, y, enquote(text))
+          @ctx.gc.text(x, y, text)
           tm = @ctx.shadow.get_type_metrics(text)
           dx = case @ctx.text_attrs.text_anchor
                when :start

--- a/sig/rvg/misc.rbs
+++ b/sig/rvg/misc.rbs
@@ -24,7 +24,6 @@ module Magick
         @ctx: GraphicContext
 
         def initialize: (GraphicContext context) -> void
-        def enquote: (String text) -> String
         def glyph_metrics: (Integer | Float glyph_orientation, string glyph) -> [Integer | Float, Integer | Float]
         def text_rel_coords: (string text) -> [Array[Integer | Float], Array[Integer | Float]]
         def shift_baseline: (Integer | Float glyph_orientation, string glyph) -> (Integer | Float)

--- a/spec/rmagick/rvg/text_spec.rb
+++ b/spec/rmagick/rvg/text_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe Magick::RVG, '#text' do
+  # The quoted operand of every `text` primitive in the MVG the canvas builds.
+  def text_tokens(text, **styles)
+    rvg = described_class.new(300, 60) do |canvas|
+      element = canvas.text(10, 30, text)
+      element.styles(**styles) unless styles.empty?
+    end
+    gc = Magick::RVG::Utility::GraphicContext.new
+    rvg.add_outermost_primitives(gc)
+    gc.inspect.lines.grep(/\Atext /).map { |line| line.chomp.split(' ', 3).last }
+  end
+
+  # The same operand, quoted by Magick::Draw#text alone.
+  def draw_token(text)
+    draw = Magick::Draw.new
+    draw.text(10, 30, text)
+    draw.inspect.split(' ', 3).last
+  end
+
+  # Regression: TextStrategy#enquote wrapped the text in quotes before handing it
+  # to Magick::Draw#text, which quotes it itself. Draw#text does not trust a
+  # string that merely looks quoted -- it cannot, because that is how text ending
+  # in a backslash used to break out of the MVG token -- so the quotes enquote had
+  # added were drawn as part of the text.
+  it 'quotes the text exactly once' do
+    ['plain text', "a'b", 'a"b', "a'b\"c", 'a{b}c', 'C:\\path', 'trailing backslash\\', "a'b\"c\\}"].each do |text|
+      expect(text_tokens(text)).to eq([draw_token(text)])
+    end
+  end
+
+  it 'quotes vertical text exactly once' do
+    expect(text_tokens("x\\", writing_mode: 'tb')).to eq([draw_token('x'), draw_token("\\")])
+  end
+end


### PR DESCRIPTION
`Magick::RVG::Utility::TextStrategy#enquote` is a second copy of `Magick::Draw#text`'s quoting logic, with the same defect it had: it never escapes backslashes, so text ending in `\` escapes its own closing delimiter.

```ruby
def enquote(text)
  return text if text.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(text)

  if !text['\'']
    text = '\'' + text + '\''
  ...
```

Its output goes straight to `Magick::Draw#text`, which quotes it again — all three call sites are `@ctx.gc.text(x, y, enquote(...))`.

## What is broken now

Since 8eb2ad06, `Draw#text` escapes backslashes and no longer trusts a string that merely *looks* pre-quoted — it cannot, because that is exactly how such a string used to break out of the MVG token. So RVG text containing a backslash is now quoted a second time, and **the quotes `enquote` added are drawn as part of the text**:

```ruby
canvas.text(10, 30, 'x\\')
```

| | MVG | drawn |
| --- | --- | --- |
| with `enquote` | `text 10,30 "'x\\'"` | `'x\'` |
| without | `text 10,30 'x\\'` | `x\` |

The brace branch is worse — `a'b"c\}` produced `text 10,30 {{a'b"c\\\\\}\}}`, drawing both the braces and the escapes.

## The fix

`Draw#text` is the only consumer, so drop the redundant layer and let it do the quoting.

Rendering was compared through the RVG API across 15 strings (`plain text`, `a'b`, `a"b`, `a'b"c`, `a{b}c`, `ends with }`, the three pre-quoted forms, unicode, `100% & <tag>`, and four containing backslashes):

- the **11 without a backslash render byte-identically**;
- the 4 with one change, and each is a case whose quoting characters were being drawn.

The same holds for the vertical, glyph-at-a-time path (`render_glyph`): `plain` and `a'b` unchanged, `x\` fixed.

## On the injection

The MVG injection this finding describes is **already closed** on `main`: 8eb2ad06 re-escapes whatever `enquote` produced, so the payload no longer breaks out.

```
=== DefaultTextStrategy ===
赤ピクセル数: 0
```

(Sentinel image composited via an injected `image` primitive; the same harness reports 3721 against the pre-8eb2ad06 `Draw#text`, where the RVG `push`/`pop graphic-context` framing turns it into a `Magick::ImageMagickError` rather than a successful read.)

So this change is not what closes the hole — it removes the duplicated, incorrectly-escaping quoting layer rather than leaving a second wrong implementation sitting behind the fixed one, and fixes the rendering corruption that the double-quoting causes.

## Verification

- Both added specs fail on `main` and pass with this change. They compare the MVG operand RVG emits against what `Draw#text` alone produces, exactly rather than by substring.
- `bundle exec rspec` — 820 examples, 0 failures.
- `bundle exec rubocop` — 844 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean (the `enquote` signature is removed from `sig/rvg/misc.rbs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
