### PR TITLE
Fix MVG injection from unescaped values in Draw#enquote

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -217,10 +217,13 @@ module Magick
 
     def enquote(str)
       str = to_string(str)
-      if str.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(str)
+      # escape existing backslashes, so that they cannot escape the delimiter
+      # added below and let the rest of the string be parsed as MVG
+      str = str.gsub('\\') { |b| '\\' + b }
+      if str.length > 2 && /\A(?:"[^"\\]+"|'[^'\\]+'|\{[^}\\]+\})\z/.match(str)
         str
       else
-        '"' + str + '"'
+        '"' + str.gsub('"') { |c| '\\' + c } + '"'
       end
     end
 
@@ -282,7 +285,7 @@ module Magick
 
     # Invoke a clip-path defined by def_clip_path.
     def clip_path(name)
-      primitive "clip-path #{to_string(name)}"
+      primitive "clip-path #{enquote(name)}"
     end
 
     # Define the clipping rule.
@@ -343,7 +346,7 @@ module Magick
     # Let anything through, but the only defined argument
     # is "UTF-8". All others are apparently ignored.
     def encoding(encoding)
-      primitive "encoding #{to_string(encoding)}"
+      primitive "encoding #{enquote(encoding)}"
     end
 
     # Specify object fill, a color name or pattern name

--- a/spec/rmagick/draw/clip_path_spec.rb
+++ b/spec/rmagick/draw/clip_path_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Draw, '#clip_path' do
     image = Magick::Image.new(200, 200)
 
     draw.clip_path('test')
-    expect(draw.inspect).to eq('clip-path test')
+    expect(draw.inspect).to eq('clip-path "test"')
     expect { draw.draw(image) }.not_to raise_error
   end
 

--- a/spec/rmagick/draw/encoding_spec.rb
+++ b/spec/rmagick/draw/encoding_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Magick::Draw, '#encoding' do
     image = Magick::Image.new(200, 200)
 
     draw.encoding('UTF-8')
-    expect(draw.inspect).to eq('encoding UTF-8')
+    expect(draw.inspect).to eq('encoding "UTF-8"')
     expect { draw.draw(image) }.not_to raise_error
 
     expect { draw.encoding(Object.new) }.to raise_error(TypeError)

--- a/spec/rmagick/draw/enquote_spec.rb
+++ b/spec/rmagick/draw/enquote_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+# Regression: Draw#enquote wrapped a value in double quotes without escaping an
+# embedded quote, so a value could close the MVG token and have the rest of the
+# string executed as further primitives -- including `image`, which reads an
+# attacker-named file or URL into the rendered output. Draw#clip_path and
+# Draw#encoding did not quote at all.
+RSpec.describe Magick::Draw, '#fill' do
+  it 'escapes a quote character in the value' do
+    draw = described_class.new
+    draw.fill('none" image Over 0,0 1,1 "/etc/passwd')
+
+    expect(draw.inspect).to eq('fill "none\\" image Over 0,0 1,1 \\"/etc/passwd"')
+  end
+
+  it 'escapes a backslash so it cannot escape the closing quote' do
+    draw = described_class.new
+    draw.stroke('red\\')
+
+    expect(draw.inspect).to eq('stroke "red\\\\"')
+  end
+
+  it 'quotes the clip-path and encoding names' do
+    draw = described_class.new
+    draw.clip_path('c image Over 0,0 1,1 "/etc/passwd"')
+    draw.encoding('UTF-8 image Over 0,0 1,1 "/etc/passwd"')
+
+    expect(draw.inspect.lines.map(&:chomp)).to eq(
+      [
+        'clip-path "c image Over 0,0 1,1 \\"/etc/passwd\\""',
+        'encoding "UTF-8 image Over 0,0 1,1 \\"/etc/passwd\\""'
+      ]
+    )
+  end
+
+  it 'still passes an already quoted value through' do
+    %w[red].each do |value|
+      expect(described_class.new.tap { |d| d.fill(%("#{value}")) }.inspect).to eq(%(fill "#{value}"))
+      expect(described_class.new.tap { |d| d.fill(%('#{value}')) }.inspect).to eq(%(fill '#{value}'))
+      expect(described_class.new.tap { |d| d.fill("{#{value}}") }.inspect).to eq("fill {#{value}}")
+    end
+  end
+
+  it 'leaves ordinary values alone' do
+    ['red', '#ff0000', 'rgb(255,0,0)', 'none', 'DejaVu Sans', '/path/with space/font.ttf'].each do |value|
+      expect(described_class.new.tap { |d| d.fill(value) }.inspect).to eq(%(fill "#{value}"))
+    end
+  end
+
+  it 'does not let a style value inject an MVG primitive' do
+    Dir.mktmpdir do |dir|
+      secret = File.join(dir, 'secret.png')
+      Magick::Image.new(80, 80) { |options| options.background_color = 'red' }.write(secret)
+
+      image = Magick::Image.new(200, 120) { |options| options.background_color = 'white' }
+      draw = described_class.new
+      draw.fill(%(none" image Over 0,0 80,80 "#{secret}" "))
+      draw.rectangle(0, 0, 1, 1)
+
+      # The value is no longer a colour, so ImageMagick rejects it -- what must
+      # not happen is the injected `image` primitive being executed.
+      begin
+        draw.draw(image)
+      rescue Magick::ImageMagickError
+        nil
+      end
+
+      drew_secret = image.export_pixels(0, 0, 200, 120, 'RGB').each_slice(3)
+                         .any? { |red, green, blue| red > 50_000 && green < 15_000 && blue < 15_000 }
+      expect(drew_secret).to be(false)
+    end
+  end
+end

--- a/spec/rmagick/rvg/stylable_spec.rb
+++ b/spec/rmagick/rvg/stylable_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+describe Magick::RVG::Stylable do
+  # Regression: a style value was dispatched straight onto Magick::Draw, whose
+  # primitive builders wrapped it with Draw#enquote without escaping an embedded
+  # quote (and did not quote :clip_path at all), so the value could close the MVG
+  # token and inject an `image` primitive that reads an arbitrary file.
+  it 'does not let a style value inject an MVG primitive' do
+    Dir.mktmpdir do |dir|
+      secret = File.join(dir, 'secret.png')
+      Magick::Image.new(80, 80) { |options| options.background_color = 'red' }.write(secret)
+
+      %i[fill stroke].each do |style|
+        rvg = Magick::RVG.new(200, 120) do |canvas|
+          canvas.background_fill = 'white'
+          canvas.text(10, 30, 'hi').styles(style => %(none" image Over 0,0 80,80 "#{secret}" "))
+        end
+
+        image = begin
+          rvg.draw
+        rescue Magick::ImageMagickError
+          nil
+        end
+        next if image.nil?
+
+        drew_secret = image.export_pixels(0, 0, 200, 120, 'RGB').each_slice(3)
+                           .any? { |red, green, blue| red > 50_000 && green < 15_000 && blue < 15_000 }
+        expect(drew_secret).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Draw#enquote` wraps a value in double quotes and never escapes an embedded quote:

```ruby
def enquote(str)
  str = to_string(str)
  if str.length > 2 && /\A(?:"[^"]+"|'[^']+'|\{[^}]+\})\z/.match(str)
    str
  else
    '"' + str + '"'
  end
end
```

So a `"` in a colour, font or path value closes the MVG token and the rest of the string is parsed by ImageMagick as further primitives, executed by `DrawImage()`. `Draw#clip_path` and `Draw#encoding` were worse — they interpolated the value with **no quoting at all**, so no quote character was even needed.

## Reproducer

```ruby
rvg = Magick::RVG.new(200, 120) do |canvas|
  canvas.background_fill = 'white'
  canvas.text(10, 30, 'hi').styles(fill: params[:color])
end
rvg.draw
```

with `color = %(none" image Over 0,0 80,80 "/path/secret.png)`:

```
MVG: fill "none" image Over 0,0 80,80 "/path/secret.png"
```

Verified with an 80x80 red sentinel image and a pixel count of the render:

| entry point | before | after |
| --- | --- | --- |
| RVG `styles(fill:)` | 6561 | 0 |
| RVG `styles(stroke:)` | 6518 | 0 |
| `Draw#encoding` | 6557 | 0 |
| `Draw#fill` / `Draw#stroke` direct | injected | 0 |

## The fix

Escape backslashes first, then the quote character being added, and stop treating a value that contains a backslash as already quoted — the same shape as the `Draw#text` fix in 8eb2ad06:

```ruby
str = str.gsub('\\') { |b| '\\' + b }
if str.length > 2 && /\A(?:"[^"\\]+"|'[^'\\]+'|\{[^}\\]+\})\z/.match(str)
  str
else
  '"' + str.gsub('"') { |c| '\\' + c } + '"'
end
```

`clip_path` and `encoding` now go through `enquote` too. `push clip-path` (line 326) already quoted its name, so the two forms now agree, and a clip path referenced by a quoted name still clips correctly (checked: exactly 5000 of 10000 pixels filled through a half-width clip path).

## Behaviour

Exercised 180 combinations — 9 call sites reached by `enquote` (`fill`, `stroke`, `font`, `font_family`, `decorate`, `clip_path`, `encoding`, `path`, `text_undercolor`) x 20 values (colour keywords, `#rgb`, `rgb()`, `rgba()`, `gray(50%)`, `url(#grad)`, font names with spaces, unix and Windows font paths, paths with spaces, the three pre-quoted forms, SVG path data, `UTF-8`). The **only** differences are:

- `clip-path` and `encoding` names are now quoted — intentional, and the reason two existing specs' expectations changed;
- backslashes are doubled.

Everything else, including all three pre-quoted forms (`"red"`, `'red'`, `{red}`), is byte-identical.

Doubling preserves what ImageMagick resolves. Checked directly rather than argued: files named `plain.png`, `back\slash.png` and `trailing\.png` were each loaded through an `image` primitive, and all three resolve to the same file before and after (1681 sentinel pixels in every case). So a Windows font path such as `C:\Windows\Fonts\arial.ttf` keeps working.

## Not changed

`Draw#push` and `Draw#pop` still interpolate raw. They take MVG keywords — `'graphic-context'`, `'defs'`, `'pattern name 0 0 8 8'` (RMagick itself calls the last form) — not values, so quoting them would break every legitimate call. An application must not pass untrusted data there, the same as for `Draw#primitive`. `Draw#pattern`'s name is interpolated through `push` for the same reason; the injection harness above does not fire through it.

## Verification

- The four added specs fail on `main` and pass with this change.
- `bundle exec rspec` — 827 examples, 0 failures.
- `bundle exec rubocop` — 846 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
