### PR TITLE
Add Image#artifact to read the artifacts Image#define writes

### DIFF
--- a/doc/image1.html
+++ b/doc/image1.html
@@ -130,6 +130,8 @@
 
             <li><a href="#annotate">annotate</a></li>
 
+            <li><a href="#artifact">artifact</a></li>
+
             <li><a href="#auto_gamma_channel">auto_gamma_channel</a></li>
 
             <li><a href="#auto_level_channel">auto_level_channel</a></li>
@@ -1585,6 +1587,48 @@ img = Magick::Image.read_inline(content)
       <h4>Returns</h4>
 
       <p>self</p>
+    </div>
+
+    <div class="sig">
+      <h3 id="artifact">artifact</h3>
+
+      <p><span class="arg">img</span>.artifact(<span class="arg">name</span>) -&gt; <em>string or nil</em></p>
+    </div>
+
+    <div class="desc">
+      <h4>Description</h4>
+
+      <p>
+        Return the value of an artifact. Artifacts are set by <code>Image#define</code>, by the
+        <a href="info.html#define">Image::Info#define</a> method in a block passed to <code>write</code> or <code>to_blob</code>, and by the
+        <code>OptionalMethodArguments</code> class. They are separate from image properties, so neither <code>Image#[]</code> nor
+        <a href="image3.html#properties">properties</a> returns them.
+      </p>
+
+      <h4>Arguments</h4>
+
+      <dl>
+        <dt>name</dt>
+
+        <dd>The name of the artifact. An artifact set by <code>Image::Info#define(format, key, value)</code> is named <code>"format:key"</code>.</dd>
+      </dl>
+
+      <h4>Returns</h4>
+
+      <p>The value of the artifact, or <code>nil</code> if it is not set.</p>
+
+      <h4>Example</h4>
+
+      <pre class="language-ruby">
+img = Magick::Image.new(50, 50)
+img.define('myapp:tag', 'hello')
+img.artifact('myapp:tag')      #=&gt; "hello"
+img.artifact('myapp:missing')  #=&gt; nil
+</pre>
+
+      <h4>Magick API</h4>
+
+      <p>GetImageArtifact</p>
     </div>
 
     <div class="sig">

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -813,6 +813,7 @@ extern VALUE Image_affine_transform(VALUE, VALUE);
 extern VALUE Image_alpha(int, VALUE *, VALUE);
 extern VALUE Image_alpha_q(VALUE);
 extern VALUE Image_aref(VALUE, VALUE);
+extern VALUE Image_artifact(VALUE, VALUE);
 extern VALUE Image_aset(VALUE, VALUE, VALUE);
 extern VALUE Image_auto_gamma_channel(int, VALUE *, VALUE);
 extern VALUE Image_auto_level_channel(int, VALUE *, VALUE);

--- a/ext/RMagick/rmimage.cpp
+++ b/ext/RMagick/rmimage.cpp
@@ -5257,6 +5257,28 @@ Image_decipher(VALUE self, VALUE passphrase)
 
 
 /**
+ * Return the value of an artifact set by {Magick::Image#define} or by
+ * {Magick::Image::Info#define}.
+ *
+ * @param artifact [String] the artifact to look up
+ * @return [String, nil] the value, or nil if the artifact is not set
+ * @see Magick::Image#define
+ */
+VALUE
+Image_artifact(VALUE self, VALUE artifact)
+{
+    Image *image;
+    const char *value;
+
+    image = rm_check_destroyed(self);
+    artifact = rb_String(artifact);
+    value = GetImageArtifact(image, StringValueCStr(artifact));
+
+    return value ? rb_str_new2(value) : Qnil;
+}
+
+
+/**
  * Associates makes a copy of the given string arguments and
  * inserts it into the artifact tree.
  *

--- a/ext/RMagick/rmmain.cpp
+++ b/ext/RMagick/rmmain.cpp
@@ -407,6 +407,7 @@ Init_RMagick2(void)
     rb_define_method(Class_Image, "alpha?", RUBY_METHOD_FUNC(Image_alpha_q), 0);
     rb_define_method(Class_Image, "[]", RUBY_METHOD_FUNC(Image_aref), 1);
     rb_define_method(Class_Image, "[]=", RUBY_METHOD_FUNC(Image_aset), 2);
+    rb_define_method(Class_Image, "artifact", RUBY_METHOD_FUNC(Image_artifact), 1);
     rb_define_method(Class_Image, "auto_gamma_channel", RUBY_METHOD_FUNC(Image_auto_gamma_channel), -1);
     rb_define_method(Class_Image, "auto_level_channel", RUBY_METHOD_FUNC(Image_auto_level_channel), -1);
     rb_define_method(Class_Image, "auto_orient", RUBY_METHOD_FUNC(Image_auto_orient), 0);

--- a/sig/rmagick/_image_common_methods.rbs
+++ b/sig/rmagick/_image_common_methods.rbs
@@ -147,6 +147,7 @@ module Magick
     def alpha: () -> bool
              | (AlphaChannelOption value) -> AlphaChannelOption
     def alpha?: () -> bool
+    def artifact: (string artifact) -> String?
     def auto_gamma_channel: (*ChannelType channel) -> Image
     def auto_level_channel: (*ChannelType channel) -> Image
     def auto_orient: () -> Image

--- a/spec/rmagick/image/artifact_spec.rb
+++ b/spec/rmagick/image/artifact_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Magick::Image, '#artifact' do
+  it 'returns the value set by Image#define' do
+    image = described_class.new(10, 10)
+
+    expect(image.artifact('mykey')).to be(nil)
+
+    image.define('mykey', 'myvalue')
+    expect(image.artifact('mykey')).to eq('myvalue')
+    expect(image.artifact(:mykey)).to eq('myvalue')
+
+    image.undefine('mykey')
+    expect(image.artifact('mykey')).to be(nil)
+  end
+
+  it 'returns the value set by Image::Info#define' do
+    image = described_class.new(10, 10)
+    image.to_blob do |info|
+      info.format = 'PNG'
+      info.define('reg', 'probe', 'HELLOARTIFACT')
+    end
+
+    expect(image.artifact('reg:probe')).to eq('HELLOARTIFACT')
+  end
+
+  it 'raises an error on a destroyed image' do
+    image = described_class.new(10, 10)
+    image.destroy!
+
+    expect { image.artifact('mykey') }.to raise_error(Magick::DestroyedImageError)
+  end
+end

--- a/spec/rmagick/image/info/define_spec.rb
+++ b/spec/rmagick/image/info/define_spec.rb
@@ -17,15 +17,9 @@ RSpec.describe Magick::Image::Info, '#define' do
       info.define('reg', 'probe', 'HELLOARTIFACT')
     end
 
-    draw = Magick::Draw.new
-    via_artifact = draw.get_type_metrics(image, '%[artifact:reg:probe]').width
-    literal = draw.get_type_metrics(image, 'HELLOARTIFACT').width
-
-    expect(literal).to be_positive
-    expect(via_artifact).to eq(literal)
+    expect(image.artifact('reg:probe')).to eq('HELLOARTIFACT')
 
     # The value must not be used as the artifact key.
-    via_value_as_key = draw.get_type_metrics(image, '%[artifact:HELLOARTIFACT]').width
-    expect(via_value_as_key).to eq(0)
+    expect(image.artifact('HELLOARTIFACT')).to be(nil)
   end
 end


### PR DESCRIPTION
`Image#define` and `Image::Info#define` write into the image's artifact tree and `Image#undefine` removes an entry, but nothing reads one back.

Artifacts are not properties, so neither `Image#[]` nor `Image#properties` returns them:

```ruby
image = Magick::Image.new(50, 50)
image.to_blob { |info| info.format = 'PNG'; info.define('reg', 'probe', 'HELLOARTIFACT') }

image['reg:probe']   #=> nil
image.properties     #=> [["png:bit-depth-written", "\x01"]]
```

Until now the only way to observe an artifact from Ruby was the `%[artifact:KEY]` interpolation of `Draw#annotate` / `Draw#get_type_metrics` — going through ImageMagick's property template engine to read back a value the same process had just written.

## The change

```ruby
img.define('myapp:tag', 'hello')
img.artifact('myapp:tag')      #=> "hello"
img.artifact('myapp:missing')  #=> nil
```

`GetImageArtifact`, returning a `String` or `nil`. An artifact set through `Image::Info#define(format, key, value)` is named `"format:key"`, matching how ImageMagick composes it.

It follows `Image#define`'s conventions: the name goes through `rb_String`, so a Symbol works, and a destroyed image raises `Magick::DestroyedImageError`.

## The spec it replaces

`spec/rmagick/image/info/define_spec.rb` has the regression test for #1823 — `copy_options()` registering an artifact under the option's *value* instead of its *name*. That commit's message notes it observed the artifact "through the `%[artifact:KEY]` interpolation of `Draw#get_type_metrics`", because nothing else could:

```ruby
via_artifact = draw.get_type_metrics(image, '%[artifact:reg:probe]').width
literal      = draw.get_type_metrics(image, 'HELLOARTIFACT').width
expect(via_artifact).to eq(literal)
```

It now says what it means:

```ruby
expect(image.artifact('reg:probe')).to eq('HELLOARTIFACT')
expect(image.artifact('HELLOARTIFACT')).to be(nil)
```

Checked that this still catches the original bug: with `ext/RMagick/rmutil.cpp` reverted to `a417acc7^`, the rewritten example fails. `png:compression-level` and the other defines that change encoder output do **not** work as a substitute — they reach the coder as options and behave identically before and after the `copy_options()` fix, so the artifact table is genuinely the only place the bug is visible.

## Verification

- `bundle exec rspec` — 830 examples, 0 failures.
- `bundle exec rubocop` — 847 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.
- `doc/image1.html` gains an `artifact` entry and index link; all anchors it references exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
