### PR TITLE
Draw annotation text as given instead of interpreting it

### DIFF
--- a/ext/RMagick/rmdraw.cpp
+++ b/ext/RMagick/rmdraw.cpp
@@ -835,46 +835,6 @@ Draw_undercolor_eq(VALUE self, VALUE undercolor)
 
 
 /**
- * Expand the property and percent-escape references in text to be drawn.
- *
- * No Ruby usage (internal function)
- *
- * Notes:
- *   - InterpretImageProperties() treats text whose first non-blank character is
- *     '@' as the name of a file to read the text from. The argument is
- *     documented as the text to draw, so draw it as-is instead.
- *
- * @param image the image
- * @param text the text to draw
- * @return the interpreted text, to be freed by the caller with magick_free()
- */
-static char *
-interpret_text(Image *image, const char *text
-#if defined(IMAGEMAGICK_7)
-               , ExceptionInfo *exception
-#endif
-              )
-{
-    const char *p = text;
-
-    while (isspace((int) ((unsigned char) *p)))
-    {
-        p++;
-    }
-    if (*p == '@')
-    {
-        return ConstantString(text);
-    }
-
-#if defined(IMAGEMAGICK_7)
-    return InterpretImageProperties(NULL, image, text, exception);
-#else
-    return InterpretImageProperties(NULL, image, text);
-#endif
-}
-
-
-/**
  * Annotates an image with text.
  *
  * - Additional Draw attribute methods may be called in the optional block,
@@ -924,30 +884,15 @@ VALUE Draw_annotate(
         rb_yield(self);
     }
 
-    // Translate & store in Draw structure
+    // Store in Draw structure. The text is drawn as given: it is not run
+    // through InterpretImageProperties(), so a `%[...]` or `%x` escape in it is
+    // not expanded. Everything those escapes provide is available directly from
+    // Ruby -- Image#columns, Image#filename, Image#artifact and so on.
     embed_text = StringValueCStr(text);
+    draw->info->text = ConstantString(embed_text);
 #if defined(IMAGEMAGICK_7)
     exception = AcquireExceptionInfo();
-    draw->info->text = interpret_text(image, embed_text, exception);
-    if (rm_should_raise_exception(exception, RetainExceptionRetention))
-    {
-        if (draw->info->text)
-        {
-            magick_free(draw->info->text);
-            draw->info->text = NULL;
-        }
-        rm_raise_exception(exception);
-    }
-#else
-    draw->info->text = interpret_text(image, embed_text);
 #endif
-    if (!draw->info->text)
-    {
-#if defined(IMAGEMAGICK_7)
-        DestroyExceptionInfo(exception);
-#endif
-        rb_raise(rb_eArgError, "no text");
-    }
 
     // Create geometry string, copy to Draw structure, overriding
     // any previously existing value.
@@ -1702,30 +1647,11 @@ get_type_metrics(int argc, VALUE *argv, VALUE self, gvl_function_t fp)
     }
 
     draw = get_draw(self);
-#if defined(IMAGEMAGICK_7)
-    exception = AcquireExceptionInfo();
-    draw->info->text = interpret_text(image, text, exception);
-    if (rm_should_raise_exception(exception, RetainExceptionRetention))
-    {
-        if (draw->info->text)
-        {
-            magick_free(draw->info->text);
-            draw->info->text = NULL;
-        }
-        rm_raise_exception(exception);
-    }
-#else
-    draw->info->text = interpret_text(image, text);
-#endif
-    if (!draw->info->text)
-    {
-#if defined(IMAGEMAGICK_7)
-        DestroyExceptionInfo(exception);
-#endif
-        rb_raise(rb_eArgError, "no text to measure");
-    }
+    // Measured as given: see the comment in Draw_annotate().
+    draw->info->text = ConstantString(text);
 
 #if defined(IMAGEMAGICK_7)
+    exception = AcquireExceptionInfo();
     GVL_STRUCT_TYPE(get_type_metrics) args = { image, draw->info, &metrics, exception };
 #else
     GVL_STRUCT_TYPE(get_type_metrics) args = { image, draw->info, &metrics };

--- a/spec/rmagick/draw/annotate_spec.rb
+++ b/spec/rmagick/draw/annotate_spec.rb
@@ -60,12 +60,17 @@ RSpec.describe Magick::Draw, '#annotate' do
     end
   end
 
-  it 'still expands percent escapes' do
-    image = Magick::Image.new(123, 10)
+  # The text is no longer run through InterpretImageProperties(), so an escape
+  # in it is drawn rather than replaced. If it were still expanded, the same
+  # text would measure differently against images of different sizes.
+  it 'does not expand percent escapes' do
     draw = described_class.new
+    small = Magick::Image.new(1, 1)
+    large = Magick::Image.new(1234, 1)
 
-    expect(draw.get_type_metrics(image, '%[width]').width)
-      .to eq(draw.get_type_metrics(image, '123').width)
+    ['%[width]', '%w', '%[fx:w]', '%[fx:1+1]', '%[artifact:probe]'].each do |text|
+      expect(draw.get_type_metrics(small, text).width).to eq(draw.get_type_metrics(large, text).width)
+    end
   end
 
   it 'accepts an ImageList argument' do
@@ -89,15 +94,11 @@ RSpec.describe Magick::Draw, '#annotate' do
     end.not_to raise_error
   end
 
-  it 'does not free the annotation text twice when the text raises an exception' do
+  # This used to raise, because ImageMagick could not parse the escape. The text
+  # is drawn as-is now, so a malformed escape is just text.
+  it 'draws a malformed percent escape as text' do
     image = Magick::Image.new(10, 10)
 
-    expect do
-      described_class.new.annotate(image, 0, 0, 0, 20, '%[fx:(]')
-    end.to raise_error(Magick::ImageMagickError)
-
-    # The Draw object is garbage now. Reclaiming it must not free the
-    # annotation text a second time.
-    GC.start
+    expect { described_class.new.annotate(image, 0, 0, 0, 20, '%[fx:(]') }.not_to raise_error
   end
 end

--- a/spec/rmagick/draw/get_type_metrics_spec.rb
+++ b/spec/rmagick/draw/get_type_metrics_spec.rb
@@ -22,19 +22,18 @@ RSpec.describe Magick::Draw, '#get_type_metrics' do
     expect { draw.get_type_metrics(image_list, 'ABCDEF') }.not_to raise_error
   end
 
-  it 'does not free the interpreted text twice when the text cannot be interpreted' do
-    image = Magick::Image.new(10, 10)
+  # The text is no longer run through InterpretImageProperties(), so an escape in
+  # it is measured rather than replaced -- including a malformed one, which used
+  # to make the interpretation fail.
+  it 'measures a percent escape as text' do
+    draw = described_class.new
+    small = Magick::Image.new(1, 1)
+    large = Magick::Image.new(1234, 1)
 
     %i[get_type_metrics get_multiline_type_metrics].each do |method_name|
-      described_class.new.public_send(method_name, image, '%[fx:(]')
-    rescue StandardError
-      # ImageMagick 6 and 7 differ in whether they report this as an error.
+      expect { draw.public_send(method_name, small, '%[fx:(]') }.not_to raise_error
+      expect(draw.public_send(method_name, small, '%[width]').width)
+        .to eq(draw.public_send(method_name, large, '%[width]').width)
     end
-
-    # The Draw objects are garbage now. Reclaiming them must not free the
-    # interpreted text a second time.
-    GC.start
-
-    expect(described_class.new.get_type_metrics(image, 'ABCDEF')).to be_kind_of(Magick::TypeMetric)
   end
 end


### PR DESCRIPTION
`Draw#annotate` and `Draw#get_type_metrics` ran the caller's text through ImageMagick's `InterpretImageProperties()`, so a `%[...]` or `%x` escape in it was replaced.

That notation exists because the command line has no other way to compute a value. From Ruby it never does — everything the escapes provide is already reachable directly:

| escape | Ruby |
| --- | --- |
| `%[width]` / `%w`, `%[height]` / `%h` | `Image#columns`, `Image#rows` |
| `%f`, `%d` | `Image#filename` |
| `%m`, `%b` | `Image#format`, `Image#filesize` |
| `%[EXIF:Model]`, `%[<property>]` | `Image#[]` |
| `%[artifact:<key>]` | `Image#artifact` (added in #1842) |
| `%[mean]`, `%[standard-deviation]` | `Image#channel_mean`, `Image#statistics` |
| `%[pixel:p{x,y}]` | `Image#pixel_color` |
| `%[fx:…]` | `Image#fx`, or just Ruby |

So the interpolation bought nothing, and cost three things.

## 1. Arbitrary computation and disclosure

`%[fx:…]` is an unbounded expression evaluator. `%[fx:p{10,10}.r]` and `%[pixel:p{10,10}]` read pixels of an image the caller may not otherwise see, and `%[EXIF:*]` / `%[<any-property>]` read metadata.

`Draw#get_type_metrics` returns a width, so all of it is readable **without the image ever being returned**. Confirmed by matching widths exactly — for a pixel whose value is R58853 G46774 B34952:

```
%[pixel:p{10,10}]  width 103.0  ==  "srgb(229,182,136)"  width 103.0
%[fx:p{10,10}.r]   width  54.0  ==  "0.898039"           width  54.0
%[secret-property] width  96.0  ==  "CANARY-VALUE"       width  96.0
```

## 2. CPU exhaustion

Every occurrence of a computed property costs a full pass over the image, and the number of occurrences is bounded only by the length of the text. Measured on a 1500x1500 image, per occurrence:

```
%[fx:mean]             79 ms      %[skewness]            79 ms
%[mean]                80 ms      %[kurtosis]            79 ms
%[standard-deviation]  80 ms      %[width]             0.01 ms
```

Note it is **not** an `fx:` problem — the plain statistics properties cost the same. Scaling with image area: 0.93 ms at 64², 8.9 ms at 500², 78 ms at 1500². So a 10 KB caption (1000 occurrences) pinned a worker for **78 seconds**.

After this change the same call takes **0.06 s**. What is left is text layout, not evaluation: 200 KB of `%[fx:mean]` takes 5.54 s — the same as 200 KB of `"a"` (5.65 s), and no longer dependent on the image size (5.54 s at 1500², 5.55 s at 64²).

## 3. Ordinary captions being corrupted

This is not only an attack surface. `%d` expanded to the directory the image was read from and `%f` to its basename, so an innocent caption was drawn as a server path:

```
"%d 個"  ->  "/home/watson/prj/rmagick/doc/ex/images 個"
```

`"50% off"` and `"使用率 80%"` survived only because the character after `%` was not a letter. Now every one of them is drawn as written.

None of this is documented — the parameter's documentation is `@param text [String] the annotation text`.

## The specs that changed

`annotate_spec.rb` and `get_type_metrics_spec.rb` used `%[fx:(]` as regression tests for the double frees fixed in e238c8bf and 1708230a. Both of those freed a pointer that came from `InterpretImageProperties()` **on its failure path**; with no such call and no such path, the double free cannot recur, and the error those specs expected is no longer raised. They now assert the new behaviour instead — that the escape is drawn and measured as text, and that the same text measures identically against images of different sizes (which it could not if it were still expanded).

## Verification

- `bundle exec rspec` — 830 examples, 0 failures.
- `bundle exec rubocop` — 847 files, no offenses.
- `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.
- The C side gets **74 lines smaller**: the `interpret_text()` helper and both exception-handling blocks go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
