### PR TITLE
v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to this project are documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## RMagick 7.1.0
+
+> [!IMPORTANT]
+> `Draw#annotate` and `Draw#get_type_metrics` no longer interpret the text they are given.
+> A `%[...]` or `%x` escape in it is now drawn as written instead of being replaced by an image property.
+> Everything those escapes provided is available directly from Ruby -- `Image#columns`, `Image#rows`, `Image#format`, `Image#filesize`, `Image#filename`, `Image#[]`, `Image#artifact`, `Image#channel_mean`, `Image#pixel_color` and `Image#fx` -- so build the string in Ruby and pass the result.
+>
+> The interpolation was undocumented, and it handed any caller that passed user-supplied text an expression evaluator, a pixel and metadata reader, and an unbounded CPU sink. It also corrupted ordinary captions: `"%d items"` was drawn as the directory the image had been read from.
+
+Breaking Changes
+
+* Draw annotation text as given instead of interpreting it (#1843)
+* Draw text starting with '@' instead of reading it from that file (#1837)
+* Validate RVG path data against the SVG path grammar (#1839)
+* Escape values and quote the clip-path and encoding names in the MVG program (#1841)
+* Reject embedded NUL bytes in pathname arguments (#1827)
+
+Improvements
+
+* Add Image#artifact to read the artifacts Image#define writes (#1842)
+* Fix grammar, typos, and content errors in the documentation (#1824)
+
+Bug Fixes
+
+* Fix RVG text being quoted twice and the added quotes being drawn (#1840)
+* Fix MVG injection in Draw#text from unescaped backslashes (#1838)
+* Fix memory leak in ImageList#composite_layers with an unusable source list (#1836)
+* Fix heap over-read in Image#import_pixels with a long or empty map (#1835)
+* Fix SEGV from integer overflow in Image#import_pixels geometry (#1834)
+* Fix heap over-read in Image#recolor (#1833)
+* Fix SEGV in Draw#marshal_load with a non-String pattern (#1832)
+* Fix use-after-free of cloned images in images_from_imagelist() (#1831)
+* Fix double free of the interpreted text in Draw#get_type_metrics (#1830)
+* Fix double free of the annotation text in Draw#annotate (#1829)
+* Fix SEGV in Info#stroke_width= and Info#attenuate= with a large Float (#1828)
+* Fix Magick#set_log_event_mask() (#1826)
+* Fix copy_options() using the option value as the artifact key (#1823)
+* Fix unchecked SetImageArtifact() calls (#1822)
+
 ## RMagick 7.0.5
 
 Bug Fixes

--- a/lib/rmagick/version.rb
+++ b/lib/rmagick/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Magick
-  VERSION = '7.0.5'
+  VERSION = '7.1.0'
   MIN_RUBY_VERSION = '3.2.0'
   MIN_IM6_VERSION = '6.9.0'
   MIN_IM7_VERSION = '7.1.0'


### PR DESCRIPTION
Bumps the version to 7.1.0 and adds the changelog entry, following `v7.0.5` (#1817).

## Why a minor, not a major

This release contains breaking changes, but each one is confined to something most callers never touch: `%[...]` interpolation in annotation text, `@file` reading in annotation text, and characters outside the SVG path grammar in RVG path data.

Going to 8.0.0 would mean the release does not reach anyone whose Gemfile says `gem 'rmagick', '~> 7.0'` — which resolves to `>= 7.0, < 8.0`. Given that the bulk of this release is security fixes, not reaching those users costs more than the formal correctness of the version number. There is precedent in this project: 4.1.0 carries a `Breaking Changes:` section.

## Contents

Twelve of the merged pull requests (#1822, #1823, #1827, #1829 through #1843) come from a security review of `ext/` and `lib/`. Each was reproduced on `main` before being fixed, and the fix was measured against the unpatched build to show that behaviour for valid input did not change — for example the `Draw#enquote` change was exercised over 180 (call site x value) combinations, and the RVG path validation against every `.path` argument in the 191 example scripts under `doc/ex/`.

The headline change is that `Draw#annotate` and `Draw#get_type_metrics` no longer run their text through `InterpretImageProperties()`. That interpolation exists so the command line can compute a value; from Ruby it never has to, and every escape it offered has a direct accessor — the changelog entry lists them. Leaving it in place meant a caller passing user-supplied text was also passing it to an expression evaluator (`%[fx:...]`), a pixel and metadata reader (`%[pixel:p{x,y}]`, `%[EXIF:*]`), and an unbounded CPU sink: on a 1500x1500 image each `%[mean]` or `%[fx:mean]` cost about 79 ms and the count was bounded only by the caption length, so a 10 KB caption took 78 seconds. It is now 0.06 s.

It was also corrupting ordinary text. `%d` expanded to the directory the image had been read from, so a caption of `"%d items"` was drawn as `/srv/app/uploads items`.

`Image#artifact` (#1842) was added along the way: `Image#define` and `Image::Info#define` write artifacts and `Image#undefine` removes them, but nothing could read one back except that same interpolation.

## Verification

* `bundle exec rspec` — 830 examples, 0 failures.
* `bundle exec rubocop` — 847 files, no offenses.
* `bundle exec rake rbs:validate`, `bundle exec steep check` — clean.
* `Magick::VERSION` and, after a clean build, `Magick::Version` both report 7.1.0; `Gem::Specification.load('rmagick.gemspec')` resolves to `rmagick 7.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
